### PR TITLE
ScaleMap Default Constructor Fix

### DIFF
--- a/openvdb/math/Maps.h
+++ b/openvdb/math/Maps.h
@@ -629,7 +629,8 @@ public:
     typedef boost::shared_ptr<const ScaleMap> ConstPtr;
 
     ScaleMap(): MapBase(), mScaleValues(Vec3d(1,1,1)), mVoxelSize(Vec3d(1,1,1)),
-                mInvScaleSqr(1,1,1), mInvTwiceScale(0.5,0.5,0.5){}
+                mScaleValuesInverse(1,1,1), mInvScaleSqr(1,1,1), 
+                mInvTwiceScale(0.5,0.5,0.5){}
 
     ScaleMap(const Vec3d& scale):
         MapBase(),


### PR DESCRIPTION
The default constructor of class ScaleMap (used by the default constructor of class Transform) leaves its data member 'mScaleValuesInverse' uninitialized causing undefined behavior.
