### PR TITLE
Fix math::Abs() truncation for non-Windows platforms

### DIFF
--- a/openvdb/math/Math.h
+++ b/openvdb/math/Math.h
@@ -247,12 +247,12 @@ inline int64_t Abs(int64_t i)
 #ifdef _MSC_VER
     return (i < int64_t(0) ? -i : i);
 #else
-    return abs(i);
+    return labs(i);
 #endif
 }
 inline float Abs(float x) { return fabs(x); }
 inline double Abs(double x) { return fabs(x); }
-inline long double Abs(long double x) { return fabs(x); }
+inline long double Abs(long double x) { return fabsl(x); }
 inline uint32_t Abs(uint32_t i) { return i; }
 inline uint64_t Abs(uint64_t i) { return i; }
 // On OSX size_t and uint64_t are different types


### PR DESCRIPTION
For Abs(int64_t), use labs() for non-Windows, because abs() on glibc only takes
a int32 parameter. On Windows, we can't use labs() because sizeof(long) is
always 4. We could use llabs() instead on Windows but as of Visual Studio 2012,
it's implemented as a library function that does a ternary operator.

For Abs(long double), use fabsl() which takes a long double instead of fabs()
which takes a double. This exists on all 3 platforms that we currently support.
Previously, fabs() would work on Windows because it provides a long double
overload that called fabsl().
