### PR TITLE
Update Name.h

### DIFF
--- a/openvdb/util/Name.h
+++ b/openvdb/util/Name.h
@@ -49,6 +49,8 @@ readString(std::istream& is)
     uint32_t size;
     is.read(reinterpret_cast<char*>(&size), sizeof(uint32_t));
     std::string buffer(size, ' ');
+    if (size == 0)	return "";
+
     is.read(&buffer[0], size);
     return buffer;
 }


### PR DESCRIPTION
when loading a GridDescriptor::mInstanceParentName, if the string is not present avoid reading the buffer or it will fail a debug assertion
