### PR TITLE
Merge changes from Houdini trunk. Notable changes:

### DIFF
--- a/openvdb_houdini/Makefile
+++ b/openvdb_houdini/Makefile
@@ -337,6 +337,8 @@ ifneq (,$(strip $(HCUSTOM_EXTRA_CFLAGS)$(HCUSTOM_EXTRA_LDFLAGS)))
 endif
 ifneq (,$(strip $(HCUSTOM_EXPORT)))
     HCUSTOM_EXPORT := export $(HCUSTOM_EXPORT)
+else
+    HCUSTOM_EXPORT := true
 endif
 
 DEPEND := houdini_deps

--- a/openvdb_houdini/houdini/GU_PrimVDB.cc
+++ b/openvdb_houdini/houdini/GU_PrimVDB.cc
@@ -59,7 +59,6 @@
 #endif
 #include <GU/GU_PrimVolume.h>
 #include <GU/GU_RayIntersect.h>
-#include <GU/GU_Surfacer.h>
 
 #include <GEO/GEO_AttributeHandleList.h>
 #include <GEO/GEO_Closure.h>
@@ -90,7 +89,6 @@ typedef UT_Vector3T<int32> UT_Vector3i;
 #endif
 
 #include <UT/UT_StopWatch.h>
-#include <UT/UT_Version.h>
 
 #if (UT_VERSION_INT >= 0x0c050000) // 12.5.0 or later
 #include <SYS/SYS_Inline.h>
@@ -2188,10 +2186,10 @@ template <typename MetadataT> struct MetaAttr;
 #define META_ATTR(METADATA_T, STORAGE, TUPLE_T, TUPLE_SIZE) \
     template <> \
     struct MetaAttr<METADATA_T> { \
-   typedef TUPLE_T TupleT; \
-   typedef GA_HandleT<TupleT>::RWType RWHandleT; \
-   static const int theTupleSize = TUPLE_SIZE; \
-   static const GA_Storage theStorage = STORAGE; \
+	typedef TUPLE_T TupleT; \
+	typedef GA_HandleT<TupleT>::RWType RWHandleT; \
+	static const int theTupleSize = TUPLE_SIZE; \
+	static const GA_Storage theStorage = STORAGE; \
     }; \
     /**/
 
@@ -2546,7 +2544,10 @@ GU_PrimVDB::createMetadataFromAttrsAdapter(
             if (entries == 1) {
                 GA_ROHandleS handle(attrib);
                 meta_map.removeMeta(name);
-                meta_map.insertMeta(name, StringMetadata(handle.get(element)));
+                const char* str = handle.get(element);
+		if (!str)
+		    str = "";
+                meta_map.insertMeta(name, StringMetadata(str));
             } else {
                 /// @todo Add warning:
                 //std::ostringstream ostr;

--- a/openvdb_houdini/houdini/GeometryUtil.cc
+++ b/openvdb_houdini/houdini/GeometryUtil.cc
@@ -270,6 +270,7 @@ frustumTransformFromCamera(
         UT_Matrix4 M;
         OBJ_Node *meobj = node.getCreator()->castToOBJNode();
         if (meobj) {
+	    node.addExtraInput(meobj, OP_INTEREST_DATA);
             if (!cam.getRelativeTransform(*meobj, M, context))
                 node.addTransformError(cam, "relative");
         } else {

--- a/openvdb_houdini/houdini/ParmFactory.cc
+++ b/openvdb_houdini/houdini/ParmFactory.cc
@@ -38,9 +38,13 @@
 #include <GU/GU_Detail.h>
 #include <GU/GU_PrimPoly.h>
 #include <GU/GU_Selection.h>
+#include <GA/GA_AIFSharedStringTuple.h>
+#include <GA/GA_Attribute.h>
+#include <GA/GA_AttributeRef.h>
 #include <OP/OP_OperatorTable.h>
 #include <PRM/PRM_Parm.h>
 #include <PRM/PRM_SharedFunc.h>
+#include <UT/UT_IntArray.h>
 #include <UT/UT_Version.h>
 #include <UT/UT_WorkArgs.h>
 #include <cstring> // for ::strdup()
@@ -215,7 +219,34 @@ ParmFactory&
 ParmFactory::setCallbackFunc(const PRM_Callback& f) { mImpl->callbackFunc = f; return *this; }
 
 ParmFactory&
-ParmFactory::setChoiceList(const PRM_ChoiceList* c) { mImpl->choicelist = c; return *this; }
+ParmFactory::setChoiceList(const PRM_ChoiceList* c)
+{
+    mImpl->choicelist = c;
+
+#if (UT_VERSION_INT >= 0x0e000075) // 14.0.117 or later
+    if (c == &PrimGroupMenuInput1)
+	setSpareData(SOP_Node::getGroupSelectButton(GA_GROUP_PRIMITIVE,
+						    NULL, 0,
+						    &SOP_Node::theFirstInput));
+    else if (c == &PrimGroupMenuInput2)
+	setSpareData(SOP_Node::getGroupSelectButton(GA_GROUP_PRIMITIVE,
+						    NULL, 1,
+						    &SOP_Node::theSecondInput));
+    else if (c == &PrimGroupMenuInput3)
+	setSpareData(SOP_Node::getGroupSelectButton(GA_GROUP_PRIMITIVE,
+						    NULL, 2,
+						    &SOP_Node::theThirdInput));
+#else
+    if (c == &PrimGroupMenuInput1)
+	setSpareData(&SOP_Node::theFirstInput);
+    else if (c == &PrimGroupMenuInput2)
+	setSpareData(&SOP_Node::theSecondInput);
+    else if (c == &PrimGroupMenuInput3)
+	setSpareData(&SOP_Node::theThirdInput);
+#endif
+
+    return *this;
+}
 
 /// @todo Merge this into setChoiceListItems() once the deprecated
 /// setChoiceList() overloads have been removed.
@@ -743,7 +774,9 @@ DWAOpPolicy::getHelpURL(const OpFactory& factory)
 
 #if (UT_VERSION_INT >= 0x0d000000) // 13.0.0 or later
 
-const PRM_ChoiceList PrimGroupMenu = SOP_Node::primGroupMenu;
+const PRM_ChoiceList PrimGroupMenuInput1 = SOP_Node::primGroupMenu;
+const PRM_ChoiceList PrimGroupMenuInput2 = SOP_Node::primGroupMenu;
+const PRM_ChoiceList PrimGroupMenuInput3 = SOP_Node::primGroupMenu;
 
 #else // earlier than 13.0.0
 
@@ -911,9 +944,19 @@ sopBuildGridMenu(void *data, PRM_Name *menuEntries, int themenusize,
 
 
 #ifdef _MSC_VER
-OPENVDB_HOUDINI_API const PRM_ChoiceList PrimGroupMenu(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
+OPENVDB_HOUDINI_API const PRM_ChoiceList
+PrimGroupMenuInput1(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
+OPENVDB_HOUDINI_API const PRM_ChoiceList
+PrimGroupMenuInput2(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
+OPENVDB_HOUDINI_API const PRM_ChoiceList
+PrimGroupMenuInput3(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
 #else
-const PRM_ChoiceList PrimGroupMenu(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
+const PRM_ChoiceList
+PrimGroupMenuInput1(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
+const PRM_ChoiceList
+PrimGroupMenuInput2(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
+const PRM_ChoiceList
+PrimGroupMenuInput3(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
 #endif
 
 #endif // earlier than 13.0.0

--- a/openvdb_houdini/houdini/ParmFactory.h
+++ b/openvdb_houdini/houdini/ParmFactory.h
@@ -466,7 +466,9 @@ private:
 
 
 // Extended group name drop-down menu incorporating "@<attr>=<value" syntax
-OPENVDB_HOUDINI_API extern const PRM_ChoiceList PrimGroupMenu;
+OPENVDB_HOUDINI_API extern const PRM_ChoiceList PrimGroupMenuInput1;
+OPENVDB_HOUDINI_API extern const PRM_ChoiceList PrimGroupMenuInput2;
+OPENVDB_HOUDINI_API extern const PRM_ChoiceList PrimGroupMenuInput3;
 
 
 } // namespace houdini_utils

--- a/openvdb_houdini/houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.cc
@@ -212,8 +212,9 @@ createEmptyGridGlyph(GU_Detail& gdp, GridCRef grid)
 
 
 OP_ERROR
-SOP_NodeVDB::cookMyGuide1(OP_Context&)
+SOP_NodeVDB::cookMyGuide1(OP_Context& context)
 {
+#ifndef SESI_OPENVDB
     myGuide1->clearAndDestroy();
     UT_Vector3 color(0.1f, 0.1f, 1.0f);
     UT_Vector3 corners[8];
@@ -226,8 +227,8 @@ SOP_NodeVDB::cookMyGuide1(OP_Context&)
             createEmptyGridGlyph(*myGuide1, it->getGrid());
         }
     }
-
-    return error();
+#endif
+    return SOP_Node::cookMyGuide1(context);
 }
 
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Level_Set.cc
@@ -171,14 +171,12 @@ newSopOperator(OP_OperatorTable* table)
     // Level set grid
     parms.add(hutil::ParmFactory(PRM_STRING, "lsGroup", "Group")
         .setHelpText("Level set grid(s) to advect.")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theFirstInput));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     // Velocity grid
     parms.add(hutil::ParmFactory(PRM_STRING, "velGroup", "Velocity")
         .setHelpText("Velocity grid")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theSecondInput));
+        .setChoiceList(&hutil::PrimGroupMenuInput2));
 
     parms.add(hutil::ParmFactory(PRM_HEADING, "advectionHeading", "Advection"));
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Points.cc
@@ -611,14 +611,12 @@ newSopOperator(OP_OperatorTable* table)
     // Velocity grid
     parms.add(hutil::ParmFactory(PRM_STRING, "velGroup", "Velocity VDB")
         .setHelpText("Velocity grid")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theSecondInput));
+        .setChoiceList(&hutil::PrimGroupMenuInput2));
 
     // Closest point grid
     parms.add(hutil::ParmFactory(PRM_STRING, "cptGroup", "Closest-Point VDB")
         .setHelpText("Vector grid that in each voxel stores the closest point on a surface.")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theThirdInput ));
+        .setChoiceList(&hutil::PrimGroupMenuInput3));
 
     // Propagation scheme
     {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Analysis.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Analysis.cc
@@ -109,7 +109,7 @@ newSopOperator(OP_OperatorTable* table)
     // Group pattern
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to be processed.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     // Operator
     {
@@ -131,8 +131,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "maskname", "Mask VDB")
         .setHelpText("VDB (from the second input) used to define the iteration space")
-        .setSpareData(&SOP_Node::theSecondInput)
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput2));
 
     { // Output name
         const char* items[] = {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
@@ -73,7 +73,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Source Group")
         .setHelpText("Specify a subset of the input VDB grids to be clipped.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "usemask", "")
         .setHelpText(
@@ -84,8 +84,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "mask", "Mask VDB")
         .setHelpText("Specify a VDB grid whose active voxels are to be used as a clipping mask.")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theSecondInput));
+        .setChoiceList(&hutil::PrimGroupMenuInput2));
 
     hvdb::OpenVDBOpFactory("OpenVDB Clip", SOP_OpenVDB_Clip::factory, parms, *table)
         .addInput("VDBs")

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
@@ -184,13 +184,12 @@ newSopOperator(OP_OperatorTable* table)
 
     // Group A
     parms.add(hutil::ParmFactory(PRM_STRING, "groupA", "Group A")
-        .setChoiceList(&hutil::PrimGroupMenu)
+        .setChoiceList(&hutil::PrimGroupMenuInput1)
         .setHelpText("Use a subset of the first input as the A grid(s)."));
 
     // Group B
     parms.add(hutil::ParmFactory(PRM_STRING, "groupB", "Group B")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theSecondInput)
+        .setChoiceList(&hutil::PrimGroupMenuInput2)
         .setHelpText("Use a subset of the second input as the B grid(s)."));
 
     // Toggle to enable flattening B into A.

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
@@ -171,7 +171,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to surface.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
 
     { // Convert To Menu
@@ -310,12 +310,11 @@ newSopOperator(OP_OperatorTable* table)
    parms.add(hutil::ParmFactory(PRM_TOGGLE, "surfacemask", "")
         .setDefault(PRMoneDefaults)
         .setTypeExtended(PRM_TYPE_TOGGLE_JOIN)
-        .setHelpText("Enable / disable the surface mask."));
+        .setHelpText("Enable / disable the surface mask"));
 
     parms.add(hutil::ParmFactory(PRM_STRING, "surfacemaskname", "Surface Mask")
         .setHelpText("A single level-set or sdf grid whose interior defines the region to mesh")
-        .setSpareData(&SOP_Node::theThirdInput)
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput3));
 
     parms.add(hutil::ParmFactory(PRM_FLT_J, "surfacemaskoffset", "Mask Offset")
         .setDefault(PRMzeroDefaults)
@@ -333,8 +332,7 @@ newSopOperator(OP_OperatorTable* table)
     parms.add(hutil::ParmFactory(PRM_STRING, "adaptivityfieldname", "Adaptivity Field")
         .setHelpText(
             "A single scalar grid used as a spatial multiplier for the adaptivity threshold")
-        .setSpareData(&SOP_Node::theThirdInput)
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput3));
 
 
 
@@ -813,7 +811,7 @@ SOP_OpenVDB_Convert::updateParmsFlags()
     bool toSDF = (evalInt("vdbclass", 0, time) == CLASS_SDF);
 
     changed |= enableParm("adaptivity", toPoly);
-    changed |= enableParm("isoValue", toPoly || (toOpenVDB && toSDF));
+    changed |= enableParm("isoValue", toPoly);
     changed |= enableParm("fogisovalue", toOpenVDB && toSDF);
 
     if (toOpenVDB) {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Fill.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Fill.cc
@@ -84,7 +84,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to be processed.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     {
         const char* items[] = {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter.cc
@@ -217,7 +217,7 @@ SOP_OpenVDB_Filter::registerSop(OP_OperatorTable* table)
     // Input group
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to be processed.")
-              .setChoiceList(&hutil::PrimGroupMenu));
+              .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "mask", "")
               .setDefault(PRMoneDefaults)
@@ -226,8 +226,7 @@ SOP_OpenVDB_Filter::registerSop(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "maskname", "Alpha Mask")
               .setHelpText("Optional VDB used for alpha masking. Assumes values 0->1.")
-              .setSpareData(&SOP_Node::theSecondInput)
-              .setChoiceList(&hutil::PrimGroupMenu));
+              .setChoiceList(&hutil::PrimGroupMenuInput2));
 
     // Menu of operations
     {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
@@ -436,7 +436,7 @@ newSopOperator(OP_OperatorTable* table)
         // Define a string-valued group name pattern parameter and add it to the list.
         parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
             .setHelpText("Specify a subset of the input VDB grids to be processed.")
-            .setChoiceList(&hutil::PrimGroupMenu));
+            .setChoiceList(&hutil::PrimGroupMenuInput1));
 
         if (OP_TYPE_RENORM != op && OP_TYPE_TRIM != op) { // Filter menu
 
@@ -447,8 +447,7 @@ newSopOperator(OP_OperatorTable* table)
 
             parms.add(hutil::ParmFactory(PRM_STRING, "maskname", "Alpha Mask")
                 .setHelpText("Optional VDB used for alpha masking. Assumes values 0->1.")
-                .setSpareData(&SOP_Node::theSecondInput)
-                .setChoiceList(&hutil::PrimGroupMenu));
+                .setChoiceList(&hutil::PrimGroupMenuInput2));
 
             std::vector<std::string> items;
 
@@ -468,7 +467,7 @@ newSopOperator(OP_OperatorTable* table)
         // steps
         parms.add(hutil::ParmFactory(PRM_INT_J, "iterations", "Iterations")
             .setDefault(PRMfourDefaults)
-                  .setRange(PRM_RANGE_RESTRICTED, 0, PRM_RANGE_UI, 10));
+            .setRange(PRM_RANGE_RESTRICTED, 0, PRM_RANGE_UI, 10));
 
         // Narrow-Band half-width
         parms.add(hutil::ParmFactory(PRM_INT_J, "halfWidth", "Half-Width")

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Fracture.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Fracture.cc
@@ -115,7 +115,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "inputgroup", "Group")
         .setHelpText("Select a subset of the input OpenVDB grids to fracture.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
 
     //////////
@@ -260,17 +260,6 @@ SOP_OpenVDB_Fracture::cookMySop(OP_Context& context)
             evalString(str, "inputgroup", 0, time);
             group = matchGroup(*gdp, str.toStdString());
         }
-
-        //@{
-        /// @todo Is this needed?
-        UT_ValArray<const GA_ElementGroup*>::const_iterator groupIt;
-#if (UT_VERSION_INT >= 0x0d000000) // 13.0.0 or later
-        UT_ValArray<const GA_ElementGroup*> primitiveGroups;
-#else
-        UT_PtrArray<const GA_ElementGroup*> primitiveGroups;
-#endif
-        gdp->primitiveGroups().getList(primitiveGroups);
-        //@}
 
         std::list<openvdb::GridBase::Ptr> grids;
         std::vector<GU_PrimVDB*> origvdbs;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_From_Particles.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_From_Particles.cc
@@ -43,9 +43,7 @@
 #include <openvdb_houdini/Utils.h>
 #include <openvdb_houdini/SOP_NodeVDB.h>
 #include <openvdb/Grid.h>
-#include <openvdb/util/CpuTimer.h>
 #include <openvdb/tools/LevelSetUtil.h>
-#include <openvdb/tools/LevelSetTracker.h>
 #include <openvdb/tools/ParticlesToLevelSet.h>
 #include <CH/CH_Manager.h>
 #include <GA/GA_Types.h> // for GA_ATTRIB_POINT
@@ -220,67 +218,6 @@ sopBuildAttrMenu(void* data, PRM_Name* menuEntries, int themenusize,
 const PRM_ChoiceList PrimAttrMenu(PRM_ChoiceListType(PRM_CHOICELIST_EXCLUSIVE |
                                                      PRM_CHOICELIST_REPLACE), sopBuildAttrMenu);
 
-// Add new items to the *end* of this list, and update NUM_ACCURACY_TYPES.
-enum Accuracy {
-    ACCURACY_UPWIND_FIRST = 0,
-    ACCURACY_UPWIND_SECOND,
-    ACCURACY_UPWIND_THIRD,
-    ACCURACY_WENO,
-    ACCURACY_HJ_WENO
-};
-
-enum { NUM_ACCURACY_TYPES = ACCURACY_HJ_WENO + 1 };
-
-std::string
-accuracyToString(Accuracy ac)
-{
-    std::string ret;
-    switch (ac) {
-        case ACCURACY_UPWIND_FIRST: ret     = "upwind first";       break;
-        case ACCURACY_UPWIND_SECOND: ret    = "upwind second";      break;
-        case ACCURACY_UPWIND_THIRD: ret     = "upwind third";       break;
-        case ACCURACY_WENO: ret             = "weno";               break;
-        case ACCURACY_HJ_WENO: ret          = "hj weno";            break;
-    }
-    return ret;
-}
-
-std::string
-accuracyToMenuName(Accuracy ac)
-{
-    std::string ret;
-    switch (ac) {
-        case ACCURACY_UPWIND_FIRST: ret     = "First-order upwinding";      break;
-        case ACCURACY_UPWIND_SECOND: ret    = "Second-order upwinding";     break;
-        case ACCURACY_UPWIND_THIRD: ret     = "Third-order upwinding";      break;
-        case ACCURACY_WENO: ret             = "Fifth-order WENO";           break;
-        case ACCURACY_HJ_WENO: ret          = "Fifth-order HJ-WENO";        break;
-    }
-    return ret;
-}
-
-
-Accuracy
-stringToAccuracy(const std::string& s)
-{
-    Accuracy ret = ACCURACY_UPWIND_FIRST;
-
-    std::string str = s;
-    boost::trim(str);
-    boost::to_lower(str);
-
-    if (str == accuracyToString(ACCURACY_UPWIND_SECOND)) {
-        ret = ACCURACY_UPWIND_SECOND;
-    } else if (str == accuracyToString(ACCURACY_UPWIND_THIRD)) {
-        ret = ACCURACY_UPWIND_THIRD;
-    } else if (str == accuracyToString(ACCURACY_WENO)) {
-        ret = ACCURACY_WENO;
-    } else if (str == accuracyToString(ACCURACY_HJ_WENO)) {
-        ret = ACCURACY_HJ_WENO;
-    }
-
-    return ret;
-}
 
 } // unnamed namespace
 
@@ -414,8 +351,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // Group name (Transform reference)
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Reference VDB")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theSecondInput)
+        .setChoiceList(&hutil::PrimGroupMenuInput2)
         .setHelpText("References the first/selected grid's transform."));
 
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "writeintoref", "Merge With Reference VDB"));

--- a/openvdb_houdini/houdini/SOP_OpenVDB_From_Polygons.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_From_Polygons.cc
@@ -313,8 +313,7 @@ newSopOperator(OP_OperatorTable* table)
     parms.add(hutil::ParmFactory(PRM_HEADING, "conversionHeading", "Conversion settings"));
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Reference VDB")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theSecondInput)
+        .setChoiceList(&hutil::PrimGroupMenuInput2)
         .setHelpText("References the first/selected grid's transform. The "
             "narrow band width can also be matched if the reference "
             "grid is a level set."));

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Metadata.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Metadata.cc
@@ -66,7 +66,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to be modified.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "setclass", "")
         .setTypeExtended(PRM_TYPE_TOGGLE_JOIN));

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Noise.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Noise.cc
@@ -158,7 +158,7 @@ newSopOperator(OP_OperatorTable* table)
     // Define a string-valued group name pattern parameter and add it to the list.
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to be processed.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     // amplitude
     parms.add(hutil::ParmFactory(PRM_FLT_J, "amp", "Amplitude")
@@ -217,8 +217,7 @@ newSopOperator(OP_OperatorTable* table)
     // Group
     parms.add(
         hutil::ParmFactory(PRM_STRING, "maskGroup",  "Mask Group")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theSecondInput));
+        .setChoiceList(&hutil::PrimGroupMenuInput2));
 
     {   // Use mask
         const char* items[] = {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Occlusion_Mask.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Occlusion_Mask.cc
@@ -80,7 +80,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Grids")
         .setHelpText("Specify a subset of the input VDB grids to be clip.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     parms.add(hutil::ParmFactory(PRM_STRING, "camera", "Camera")
         .setHelpText("Reference camera path")

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
@@ -35,10 +35,10 @@
 /// @brief SOP to prune tree branches from OpenVDB grids
 
 #include <houdini_utils/ParmFactory.h>
-#include <openvdb/tools/Prune.h>
 #include <openvdb_houdini/Utils.h>
 #include <openvdb_houdini/SOP_NodeVDB.h>
 #include <UT/UT_Interrupt.h>
+#include <openvdb/tools/Prune.h>
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
@@ -71,7 +71,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input grids to be processed.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     {
         const char* items[] = {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Ray.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Ray.cc
@@ -42,8 +42,10 @@
 #include <openvdb/tools/RayIntersector.h>
 
 #include <UT/UT_Interrupt.h>
+#include <UT/UT_ParallelUtil.h>
 #include <UT/UT_Version.h>
-#include <GA/GA_PageIterator.h>
+#include <GA/GA_PageHandle.h>
+#include <GA/GA_SplittableRange.h>
 #include <GU/GU_Detail.h>
 #include <PRM/PRM_Parm.h>
 #include <GU/GU_PrimSphere.h>
@@ -88,7 +90,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to surface.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     { // Method
         const char* items[] = {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
@@ -83,7 +83,7 @@ newSopOperator(OP_OperatorTable* table)
     hutil::ParmList parms;
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
-        .setChoiceList(&hutil::PrimGroupMenu)
+        .setChoiceList(&hutil::PrimGroupMenuInput1)
         .setHelpText(
             "Specify a subset of the input VDB grids to be processed\n"
             "(scalar, floating-point grids only)"));

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Resample.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Resample.cc
@@ -86,13 +86,12 @@ newSopOperator(OP_OperatorTable* table)
 
     // Group pattern
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
-        .setChoiceList(&hutil::PrimGroupMenu)
+        .setChoiceList(&hutil::PrimGroupMenuInput1)
         .setHelpText("Specify a subset of the input\nVDB grids to be resampled"));
 
     // Reference grid group
     parms.add(hutil::ParmFactory(PRM_STRING, "reference_grid", "Reference")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theSecondInput)
+        .setChoiceList(&hutil::PrimGroupMenuInput2)
         .setHelpText(
             "Specify a single reference grid from the\n"
             "first input whose transform is to be matched.\n"

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Sample_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Sample_Points.cc
@@ -247,8 +247,7 @@ newSopOperator(OP_OperatorTable* table)
     // Group pattern
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to be processed.")
-        .setChoiceList(&hutil::PrimGroupMenu)
-        .setSpareData(&SOP_Node::theSecondInput));
+        .setChoiceList(&hutil::PrimGroupMenuInput2));
 
     // verbose option toggle
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "verbose", "Verbose")

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
@@ -77,7 +77,7 @@ newSopOperator(OP_OperatorTable* table)
     // Group pattern
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to be processed.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     // Export VDBs
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "keep", "Keep input VDB grids")

--- a/openvdb_houdini/houdini/SOP_OpenVDB_To_Spheres.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_To_Spheres.cc
@@ -93,7 +93,7 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to surface.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
 
     parms.add(hutil::ParmFactory(PRM_FLT_J, "isovalue", "Isovalue")

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Transform.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Transform.cc
@@ -66,7 +66,7 @@ newSopOperator(OP_OperatorTable* table)
     // Group pattern
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to be transformed.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     // Translation
     parms.add(hutil::ParmFactory(PRM_XYZ_J, "t", "Translate")

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
@@ -95,7 +95,7 @@ newSopOperator(OP_OperatorTable* table)
             "as the x components of the merged vector grids.\n"
             "Each x grid will be paired with a y and a z grid\n"
             "(if provided) to produce an output vector grid.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     // Group of Y grids
     parms.add(hutil::ParmFactory(PRM_STRING, "scalar_y_group", "Y Group")
@@ -105,7 +105,7 @@ newSopOperator(OP_OperatorTable* table)
             "as the y components of the merged vector grids.\n"
             "Each y grid will be paired with an x and a z grid\n"
             "(if provided) to produce an output vector grid.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     // Group of Z grids
     parms.add(hutil::ParmFactory(PRM_STRING, "scalar_z_group", "Z Group")
@@ -115,7 +115,7 @@ newSopOperator(OP_OperatorTable* table)
             "as the z components of the merged vector grids.\n"
             "Each z grid will be paired with an x and a y grid\n"
             "(if provided) to produce an output vector grid.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     // Use X name
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "usexname",  "Use Basename of X VDB")

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Split.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Split.cc
@@ -71,7 +71,7 @@ newSopOperator(OP_OperatorTable* table)
             "Specify a subset of the input VDB grids to be split.\n"
             "Vector-valued grids will be split into component scalar grids;\n"
             "all other grids will be unchanged.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
     // Toggle to keep/remove source grids
     parms.add(

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Visualize.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Visualize.cc
@@ -121,7 +121,7 @@ newSopOperator(OP_OperatorTable* table)
     // Group pattern
     parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
         .setHelpText("Specify a subset of the input VDB grids to be processed.")
-        .setChoiceList(&hutil::PrimGroupMenu));
+        .setChoiceList(&hutil::PrimGroupMenuInput1));
 
 #if HAVE_SURFACING_PARM
     // Surfacing

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Write.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Write.cc
@@ -90,7 +90,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // Group
     parms.add(hutil::ParmFactory(PRM_STRING, "group",  "Group")
-        .setChoiceList(&hutil::PrimGroupMenu)
+        .setChoiceList(&hutil::PrimGroupMenuInput1)
         .setHelpText("Write only a subset of the input grids."));
 
     // Compression
@@ -150,7 +150,7 @@ newSopOperator(OP_OperatorTable* table)
         parms.add(hutil::ParmFactory(PRM_HEADING, "float_header", "Float Precision"));
 
         parms.add(hutil::ParmFactory(PRM_STRING, "float_16_group", "Write 16-Bit")
-            .setChoiceList(&hutil::PrimGroupMenu)
+            .setChoiceList(&hutil::PrimGroupMenuInput1)
             .setHelpText(
                 "For grids that belong to the group(s) listed here,\n"
                 "write floating-point scalar or vector voxel values\n"
@@ -159,7 +159,7 @@ newSopOperator(OP_OperatorTable* table)
                 "using their existing precision settings."));
 
         parms.add(hutil::ParmFactory(PRM_STRING, "float_full_group", "Write Full-Precision")
-            .setChoiceList(&hutil::PrimGroupMenu)
+            .setChoiceList(&hutil::PrimGroupMenuInput1)
             .setHelpText(
                 "For grids that belong to the group(s) listed here,\n"
                 "write floating-point scalar or vector voxel values\n"

--- a/openvdb_houdini/houdini/UT_VDBUtils.h
+++ b/openvdb_houdini/houdini/UT_VDBUtils.h
@@ -586,7 +586,7 @@ inline UT_BoundingBoxD
 UTvdbConvert(const openvdb::CoordBBox &bbox)
 {
     return UT_BoundingBoxD(UTvdbConvert(bbox.getStart().asVec3d()),
-	UTvdbConvert(bbox.getEnd().asVec3d()));
+                           UTvdbConvert(bbox.getEnd().asVec3d()));
 }
 
 


### PR DESCRIPTION
- (openvdb_houdini/Makefile) Fix bash error when HCUSTOM_EXPORT is empty
- (GEO_PrimVDB) Voxel evaluation now also handles bool grids
- (GEO_PrimVDB) Copy visualization options
- (GU_PrimVDB) Fix crash when saving NULL string attribute values to .vdb
- (Various) Save .vdb with blosc enabled unless HOUDINI13_VOLUME_COMPATIBILITY
  is set.
- (Various) Load .vdb with delay loading always set to false
- (Various) Add missing "include what you use" headers
- (GeometryUtil) Add missing node interest in frustumTransformFromCamera()
- (ParmFactory and SOPs) Group parameters now have a selection button that
  allows one to use it for reselecting in the viewport.

Conflicts:

```
openvdb_houdini/houdini/GEO_PrimVDB.cc
```
