### PR TITLE
convert some boost functionality into c++11

### DIFF
--- a/openvdb/io/Queue.cc
+++ b/openvdb/io/Queue.cc
@@ -201,8 +201,11 @@ struct Queue::Impl
                     "unable to queue I/O task; " << mTimeout << "-second time limit expired");
             }
         }
-        Queue::Notifier notify = std::bind(&Impl::setStatusWithNotification, this,
-            std::placeholders::_1, std::placeholders::_2);
+
+        Queue::Notifier notify = [this](Queue::Id id, Queue::Status status) {
+            return Impl::setStatusWithNotification(id,status) ;
+        };
+
         task.setNotifier(notify);
         this->setStatus(task.id(), Queue::PENDING);
         tbb::task::enqueue(task);

--- a/openvdb/io/Stream.cc
+++ b/openvdb/io/Stream.cc
@@ -37,7 +37,6 @@
 #include <cstdint>
 #include <boost/iostreams/copy.hpp>
 #include <cstdio> // for remove()
-#include <functional> // for std::bind()
 #include <iostream>
 #include <vector>
 
@@ -113,7 +112,11 @@ Stream::Stream(std::istream& is, bool delayLoad): mImpl(new Impl)
             mImpl->mFile->setCopyMaxBytes(0); // don't make a copy of the temporary file
             /// @todo Need to pass auto-deletion flag to MappedFile.
             mImpl->mFile->open(delayLoad,
-                std::bind(&removeTempFile, filename, std::placeholders::_1));
+                               [filename](std::string fName){
+                        return removeTempFile(filename, fName);
+            });
+
+
         }
     }
 

--- a/openvdb/tools/Filter.h
+++ b/openvdb/tools/Filter.h
@@ -255,13 +255,19 @@ Filter<GridT, MaskT, InterruptT>::mean(int width, int iterations, const MaskType
     LeafManagerType leafs(mGrid->tree(), 1, mGrainSize==0);
 
     for (int i=0; i<iterations && !this->wasInterrupted(); ++i) {
-        mTask = std::bind(&Filter::doBoxX, std::placeholders::_1, std::placeholders::_2, w);
+        mTask = [w](Filter* filter, const RangeType& range) {
+            return filter->doBoxX(range, w);
+        };
         this->cook(leafs);
 
-        mTask = std::bind(&Filter::doBoxY, std::placeholders::_1, std::placeholders::_2, w);
+        mTask = [w](Filter* filter, const RangeType& range) {
+            return filter->doBoxY(range, w);
+        };
         this->cook(leafs);
 
-        mTask = std::bind(&Filter::doBoxZ, std::placeholders::_1, std::placeholders::_2, w);
+        mTask = [w](Filter* filter, const RangeType& range) {
+            return filter->doBoxZ(range, w);
+        };
         this->cook(leafs);
     }
 
@@ -283,13 +289,19 @@ Filter<GridT, MaskT, InterruptT>::gaussian(int width, int iterations, const Mask
 
     for (int i=0; i<iterations; ++i) {
         for (int n=0; n<4 && !this->wasInterrupted(); ++n) {
-            mTask = std::bind(&Filter::doBoxX, std::placeholders::_1, std::placeholders::_2, w);
+            mTask = [w](Filter* filter, const RangeType& range) {
+                return filter->doBoxX(range, w);
+            };
             this->cook(leafs);
 
-            mTask = std::bind(&Filter::doBoxY, std::placeholders::_1, std::placeholders::_2, w);
+            mTask = [w](Filter* filter, const RangeType& range) {
+                return filter->doBoxY(range, w);
+            };
             this->cook(leafs);
 
-            mTask = std::bind(&Filter::doBoxZ, std::placeholders::_1, std::placeholders::_2, w);
+            mTask = [w](Filter* filter, const RangeType& range) {
+                return filter->doBoxZ(range, w);
+            };
             this->cook(leafs);
         }
     }
@@ -308,7 +320,9 @@ Filter<GridT, MaskT, InterruptT>::median(int width, int iterations, const MaskTy
 
     LeafManagerType leafs(mGrid->tree(), 1, mGrainSize==0);
 
-    mTask = std::bind(&Filter::doMedian, std::placeholders::_1, std::placeholders::_2, std::max(1, width));
+    mTask = [width](Filter* filter, const RangeType& range) {
+        return filter->doMedian(range, std::max(1, width));
+    };
     for (int i=0; i<iterations && !this->wasInterrupted(); ++i) this->cook(leafs);
 
     if (mInterrupter) mInterrupter->end();
@@ -325,7 +339,9 @@ Filter<GridT, MaskT, InterruptT>::offset(ValueType value, const MaskType* mask)
 
     LeafManagerType leafs(mGrid->tree(), 0, mGrainSize==0);
 
-    mTask = std::bind(&Filter::doOffset, std::placeholders::_1, std::placeholders::_2, value);
+    mTask = [value](Filter* filter, const RangeType& range) {
+        return filter->doOffset(range, value);
+    };
     this->cook(leafs);
 
     if (mInterrupter) mInterrupter->end();

--- a/openvdb/tools/GridTransformer.h
+++ b/openvdb/tools/GridTransformer.h
@@ -677,8 +677,9 @@ template<typename InterrupterType>
 void
 GridResampler::setInterrupter(InterrupterType& interrupter)
 {
-    mInterrupt = std::bind(&InterrupterType::wasInterrupted,
-        /*this=*/&interrupter, /*percent=*/-1);
+    mInterrupt = [&interrupter]() -> bool {
+        return interrupter.wasInterrupted(/*percent=*/-1 );
+    };
 }
 
 

--- a/openvdb/tools/LevelSetAdvect.h
+++ b/openvdb/tools/LevelSetAdvect.h
@@ -46,6 +46,7 @@
 #include "VelocityFields.h" // for EnrightField
 #include <openvdb/math/FiniteDifference.h>
 #include <boost/math/constants/constants.hpp>
+#include <functional>
 //#include <openvdb/util/CpuTimer.h>
 
 namespace openvdb {
@@ -215,7 +216,7 @@ private:
         VectorType*        mVelocity;
         size_t*            mOffsets;
         const MapT*        mMap;
-        typename boost::function<void (Advect*, const LeafRange&)> mTask;
+        typename std::function<void (Advect*, const LeafRange&)> mTask;
         const bool         mIsMaster;
     }; // end of private Advect struct
 
@@ -385,7 +386,7 @@ advect(ValueType time0, ValueType time1)
         case math::TVD_RK1:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * VdotG_t0(0)
-            mTask = boost::bind(&Advect::euler01, _1, _2, dt);
+            mTask = std::bind(&Advect::euler01, std::placeholders::_1, std::placeholders::_2, dt);
 
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook("Advecting level set using TVD_RK1", 1);
@@ -393,14 +394,14 @@ advect(ValueType time0, ValueType time1)
         case math::TVD_RK2:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * VdotG_t0(0)
-            mTask = boost::bind(&Advect::euler01, _1, _2, dt);
+            mTask = std::bind(&Advect::euler01, std::placeholders::_1, std::placeholders::_2, dt);
 
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook("Advecting level set using TVD_RK1 (step 1 of 2)", 1);
 
             // Convex combine explict Euler step: t2 = t0 + dt
             // Phi_t2(1) = 1/2 * Phi_t0(1) + 1/2 * (Phi_t1(0) - dt * V.Grad_t1(0))
-            mTask = boost::bind(&Advect::euler12, _1, _2, dt);
+            mTask = std::bind(&Advect::euler12, std::placeholders::_1, std::placeholders::_2, dt);
 
             // Cook and swap buffer 0 and 1 such that Phi_t2(0) and Phi_t1(1)
             this->cook("Advecting level set using TVD_RK1 (step 2 of 2)", 1);
@@ -408,21 +409,21 @@ advect(ValueType time0, ValueType time1)
         case math::TVD_RK3:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * VdotG_t0(0)
-            mTask = boost::bind(&Advect::euler01, _1, _2, dt);
+            mTask = std::bind(&Advect::euler01, std::placeholders::_1, std::placeholders::_2, dt);
 
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook("Advecting level set using TVD_RK3 (step 1 of 3)", 1);
 
             // Convex combine explict Euler step: t2 = t0 + dt/2
             // Phi_t2(2) = 3/4 * Phi_t0(1) + 1/4 * (Phi_t1(0) - dt * V.Grad_t1(0))
-            mTask = boost::bind(&Advect::euler34, _1, _2, dt);
+            mTask = std::bind(&Advect::euler34, std::placeholders::_1, std::placeholders::_2, dt);
 
             // Cook and swap buffer 0 and 2 such that Phi_t2(0) and Phi_t1(2)
             this->cook("Advecting level set using TVD_RK3 (step 2 of 3)", 2);
 
             // Convex combine explict Euler step: t3 = t0 + dt
             // Phi_t3(2) = 1/3 * Phi_t0(1) + 2/3 * (Phi_t2(0) - dt * V.Grad_t2(0)
-            mTask = boost::bind(&Advect::euler13, _1, _2, dt);
+            mTask = std::bind(&Advect::euler13, std::placeholders::_1, std::placeholders::_2, dt);
 
             // Cook and swap buffer 0 and 2 such that Phi_t3(0) and Phi_t2(2)
             this->cook("Advecting level set using TVD_RK3 (step 3 of 3)", 2);
@@ -462,9 +463,9 @@ sampleField(ValueType time0, ValueType time1)
 
     // Sample the velocity field
     if (mParent.mField.transform() == mParent.mTracker.grid().transform()) {
-        mTask = boost::bind(&Advect::sampleAligned, _1, _2, time0, time1);
+        mTask = std::bind(&Advect::sampleAligned, std::placeholders::_1, std::placeholders::_2, time0, time1);
     } else {
-        mTask = boost::bind(&Advect::sampleXformed, _1, _2, time0, time1);
+        mTask = std::bind(&Advect::sampleXformed, std::placeholders::_1, std::placeholders::_2, time0, time1);
     }
     assert(voxelCount == mParent.mTracker.grid().activeVoxelCount());
     mVelocity = new VectorType[ voxelCount ];

--- a/openvdb/tools/LevelSetMorph.h
+++ b/openvdb/tools/LevelSetMorph.h
@@ -252,7 +252,7 @@ private:
         inline void euler34(const LeafRange& r, ValueType t) {this->euler<3,4>(r, t, 1, 2, 3);}
         inline void euler13(const LeafRange& r, ValueType t) {this->euler<1,3>(r, t, 1, 2, 3);}
 
-        typedef typename boost::function<void (Morph*, const LeafRange&)> FuncType;
+        typedef typename std::function<void (Morph*, const LeafRange&)> FuncType;
         LevelSetMorphing* mParent;
         ValueType         mMinAbsS, mMaxAbsS;
         const MapT*       mMap;
@@ -408,7 +408,7 @@ advect(ValueType time0, ValueType time1)
         case math::TVD_RK1:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * Speed(2) * |Grad[Phi(0)]|
-            mTask = boost::bind(&Morph::euler01, _1, _2, dt, /*speed*/2);
+            mTask = std::bind(&Morph::euler01, std::placeholders::_1, std::placeholders::_2, dt, /*speed*/2);
 
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook(PARALLEL_FOR, 1);
@@ -416,14 +416,14 @@ advect(ValueType time0, ValueType time1)
         case math::TVD_RK2:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * Speed(2) * |Grad[Phi(0)]|
-            mTask = boost::bind(&Morph::euler01, _1, _2, dt, /*speed*/2);
+            mTask = std::bind(&Morph::euler01, std::placeholders::_1, std::placeholders::_2, dt, /*speed*/2);
 
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook(PARALLEL_FOR, 1);
 
             // Convex combine explict Euler step: t2 = t0 + dt
             // Phi_t2(1) = 1/2 * Phi_t0(1) + 1/2 * (Phi_t1(0) - dt * Speed(2) * |Grad[Phi(0)]|)
-            mTask = boost::bind(&Morph::euler12, _1, _2, dt);
+            mTask = std::bind(&Morph::euler12, std::placeholders::_1, std::placeholders::_2, dt);
 
             // Cook and swap buffer 0 and 1 such that Phi_t2(0) and Phi_t1(1)
             this->cook(PARALLEL_FOR, 1);
@@ -431,21 +431,21 @@ advect(ValueType time0, ValueType time1)
         case math::TVD_RK3:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * Speed(3) * |Grad[Phi(0)]|
-            mTask = boost::bind(&Morph::euler01, _1, _2, dt, /*speed*/3);
+            mTask = std::bind(&Morph::euler01, std::placeholders::_1, std::placeholders::_2, dt, /*speed*/3);
 
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook(PARALLEL_FOR, 1);
 
             // Convex combine explict Euler step: t2 = t0 + dt/2
             // Phi_t2(2) = 3/4 * Phi_t0(1) + 1/4 * (Phi_t1(0) - dt * Speed(3) * |Grad[Phi(0)]|)
-            mTask = boost::bind(&Morph::euler34, _1, _2, dt);
+            mTask = std::bind(&Morph::euler34, std::placeholders::_1, std::placeholders::_2, dt);
 
             // Cook and swap buffer 0 and 2 such that Phi_t2(0) and Phi_t1(2)
             this->cook(PARALLEL_FOR, 2);
 
             // Convex combine explict Euler step: t3 = t0 + dt
             // Phi_t3(2) = 1/3 * Phi_t0(1) + 2/3 * (Phi_t2(0) - dt * Speed(3) * |Grad[Phi(0)]|)
-            mTask = boost::bind(&Morph::euler13, _1, _2, dt);
+            mTask = std::bind(&Morph::euler13, std::placeholders::_1, std::placeholders::_2, dt);
 
             // Cook and swap buffer 0 and 2 such that Phi_t3(0) and Phi_t2(2)
             this->cook(PARALLEL_FOR, 2);
@@ -482,9 +482,9 @@ sampleSpeed(ValueType time0, ValueType time1, Index speedBuffer)
     const math::Transform& xform  = mParent->mTracker.grid().transform();
     if (mParent->mTarget->transform() == xform &&
         (mParent->mMask == nullptr || mParent->mMask->transform() == xform)) {
-        mTask = boost::bind(&Morph::sampleAlignedSpeed, _1, _2, speedBuffer);
+        mTask = std::bind(&Morph::sampleAlignedSpeed, std::placeholders::_1, std::placeholders::_2, speedBuffer);
     } else {
-        mTask = boost::bind(&Morph::sampleXformedSpeed, _1, _2, speedBuffer);
+        mTask = std::bind(&Morph::sampleXformedSpeed, std::placeholders::_1, std::placeholders::_2, speedBuffer);
     }
     this->cook(PARALLEL_REDUCE);
     if (math::isApproxEqual(mMinAbsS, mMaxAbsS)) return ValueType(0);//speed is essentially zero

--- a/openvdb/tools/LevelSetPlatonic.h
+++ b/openvdb/tools/LevelSetPlatonic.h
@@ -49,7 +49,6 @@
 #include <openvdb/tools/MeshToVolume.h>
 #include <openvdb/util/NullInterrupter.h>
 #include <boost/utility.hpp>
-#include <boost/type_traits/is_floating_point.hpp>
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
@@ -338,7 +337,7 @@ createLevelSetPlatonic(int faceCount,float scale, const Vec3f& center,
     float voxelSize, float halfWidth, InterruptT *interrupt)
 {
     // GridType::ValueType is required to be a floating-point scalar.
-    BOOST_STATIC_ASSERT(boost::is_floating_point<typename GridType::ValueType>::value);
+    BOOST_STATIC_ASSERT(std::is_floating_point<typename GridType::ValueType>::value);
 
     const math::Transform::Ptr xform = math::Transform::createLinearTransform( voxelSize );
 

--- a/openvdb/tools/LevelSetTracker.h
+++ b/openvdb/tools/LevelSetTracker.h
@@ -511,45 +511,51 @@ normalize()
         case math::TVD_RK1:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(0) = Phi_t0(0) - dt * VdotG_t0(1)
-            mTask = std::bind(&Normalizer::euler01, std::placeholders::_1, std::placeholders::_2);
-
+            mTask = [](Normalizer* normalizer, const LeafRange& range) {
+                return normalizer->euler01(range);
+            };
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook("Normalizing level set using TVD_RK1", 1);
             break;
         case math::TVD_RK2:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * VdotG_t0(1)
-            mTask = std::bind(&Normalizer::euler01, std::placeholders::_1, std::placeholders::_2);
-
+            mTask = [](Normalizer* normalizer, const LeafRange& range) {
+                return normalizer->euler01(range);
+            };
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook("Normalizing level set using TVD_RK1 (step 1 of 2)", 1);
 
             // Convex combine explicit Euler step: t2 = t0 + dt
             // Phi_t2(1) = 1/2 * Phi_t0(1) + 1/2 * (Phi_t1(0) - dt * V.Grad_t1(0))
-            mTask = std::bind(&Normalizer::euler12, std::placeholders::_1, std::placeholders::_2);
-
+            mTask = [](Normalizer* normalizer, const LeafRange& range) {
+                return normalizer->euler12(range);
+            };
             // Cook and swap buffer 0 and 1 such that Phi_t2(0) and Phi_t1(1)
             this->cook("Normalizing level set using TVD_RK1 (step 2 of 2)", 1);
             break;
         case math::TVD_RK3:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * VdotG_t0(1)
-            mTask = std::bind(&Normalizer::euler01, std::placeholders::_1, std::placeholders::_2);
-
+            mTask = [](Normalizer* normalizer, const LeafRange& range) {
+                return normalizer->euler01(range);
+            };
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook("Normalizing level set using TVD_RK3 (step 1 of 3)", 1);
 
             // Convex combine explicit Euler step: t2 = t0 + dt/2
             // Phi_t2(2) = 3/4 * Phi_t0(1) + 1/4 * (Phi_t1(0) - dt * V.Grad_t1(0))
-            mTask = std::bind(&Normalizer::euler34, std::placeholders::_1, std::placeholders::_2);
-
+            mTask = [](Normalizer* normalizer, const LeafRange& range) {
+                return normalizer->euler34(range);
+            };
             // Cook and swap buffer 0 and 2 such that Phi_t2(0) and Phi_t1(2)
             this->cook("Normalizing level set using TVD_RK3 (step 2 of 3)", 2);
 
             // Convex combine explicit Euler step: t3 = t0 + dt
             // Phi_t3(2) = 1/3 * Phi_t0(1) + 2/3 * (Phi_t2(0) - dt * V.Grad_t2(0)
-            mTask = std::bind(&Normalizer::euler13, std::placeholders::_1, std::placeholders::_2);
-
+            mTask = [](Normalizer* normalizer, const LeafRange& range) {
+                return normalizer->euler13(range);
+            };
             // Cook and swap buffer 0 and 2 such that Phi_t3(0) and Phi_t2(2)
             this->cook("Normalizing level set using TVD_RK3 (step 3 of 3)", 2);
             break;

--- a/openvdb/tools/LevelSetTracker.h
+++ b/openvdb/tools/LevelSetTracker.h
@@ -40,9 +40,8 @@
 #define OPENVDB_TOOLS_LEVEL_SET_TRACKER_HAS_BEEN_INCLUDED
 
 #include <tbb/parallel_for.h>
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
 #include <type_traits>
+#include <functional>
 #include <openvdb/Types.h>
 #include <openvdb/math/Math.h>
 #include <openvdb/math/FiniteDifference.h>
@@ -229,7 +228,7 @@ private:
         LevelSetTracker& mTracker;
         const MaskT*     mMask;
         const ValueType  mDt, mInvDx;
-        typename boost::function<void (Normalizer*, const LeafRange&)> mTask;
+        typename std::function<void (Normalizer*, const LeafRange&)> mTask;
     }; // Normalizer struct
 
     template<math::BiasedGradientScheme SpatialScheme, typename MaskT>
@@ -512,7 +511,7 @@ normalize()
         case math::TVD_RK1:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(0) = Phi_t0(0) - dt * VdotG_t0(1)
-            mTask = boost::bind(&Normalizer::euler01, _1, _2);
+            mTask = std::bind(&Normalizer::euler01, std::placeholders::_1, std::placeholders::_2);
 
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook("Normalizing level set using TVD_RK1", 1);
@@ -520,14 +519,14 @@ normalize()
         case math::TVD_RK2:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * VdotG_t0(1)
-            mTask = boost::bind(&Normalizer::euler01, _1, _2);
+            mTask = std::bind(&Normalizer::euler01, std::placeholders::_1, std::placeholders::_2);
 
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook("Normalizing level set using TVD_RK1 (step 1 of 2)", 1);
 
             // Convex combine explicit Euler step: t2 = t0 + dt
             // Phi_t2(1) = 1/2 * Phi_t0(1) + 1/2 * (Phi_t1(0) - dt * V.Grad_t1(0))
-            mTask = boost::bind(&Normalizer::euler12, _1, _2);
+            mTask = std::bind(&Normalizer::euler12, std::placeholders::_1, std::placeholders::_2);
 
             // Cook and swap buffer 0 and 1 such that Phi_t2(0) and Phi_t1(1)
             this->cook("Normalizing level set using TVD_RK1 (step 2 of 2)", 1);
@@ -535,21 +534,21 @@ normalize()
         case math::TVD_RK3:
             // Perform one explicit Euler step: t1 = t0 + dt
             // Phi_t1(1) = Phi_t0(0) - dt * VdotG_t0(1)
-            mTask = boost::bind(&Normalizer::euler01, _1, _2);
+            mTask = std::bind(&Normalizer::euler01, std::placeholders::_1, std::placeholders::_2);
 
             // Cook and swap buffer 0 and 1 such that Phi_t1(0) and Phi_t0(1)
             this->cook("Normalizing level set using TVD_RK3 (step 1 of 3)", 1);
 
             // Convex combine explicit Euler step: t2 = t0 + dt/2
             // Phi_t2(2) = 3/4 * Phi_t0(1) + 1/4 * (Phi_t1(0) - dt * V.Grad_t1(0))
-            mTask = boost::bind(&Normalizer::euler34, _1, _2);
+            mTask = std::bind(&Normalizer::euler34, std::placeholders::_1, std::placeholders::_2);
 
             // Cook and swap buffer 0 and 2 such that Phi_t2(0) and Phi_t1(2)
             this->cook("Normalizing level set using TVD_RK3 (step 2 of 3)", 2);
 
             // Convex combine explicit Euler step: t3 = t0 + dt
             // Phi_t3(2) = 1/3 * Phi_t0(1) + 2/3 * (Phi_t2(0) - dt * V.Grad_t2(0)
-            mTask = boost::bind(&Normalizer::euler13, _1, _2);
+            mTask = std::bind(&Normalizer::euler13, std::placeholders::_1, std::placeholders::_2);
 
             // Cook and swap buffer 0 and 2 such that Phi_t3(0) and Phi_t2(2)
             this->cook("Normalizing level set using TVD_RK3 (step 3 of 3)", 2);

--- a/openvdb/tools/Morphology.h
+++ b/openvdb/tools/Morphology.h
@@ -706,14 +706,20 @@ Morphology<TreeType>::ErodeVoxelsOp::runParallel(NearestNeighbors nn)
     namespace ph = std::placeholders;
     switch (nn) {
     case NN_FACE_EDGE:
-        mTask = std::bind(&ErodeVoxelsOp::erode18, ph::_1, ph::_2);
+        mTask = [](ErodeVoxelsOp* erodeOp, const RangeT& range){
+            return erodeOp->erode18(range);
+        };
         break;
     case NN_FACE_EDGE_VERTEX:
-        mTask = std::bind(&ErodeVoxelsOp::erode26, ph::_1, ph::_2);
+        mTask = [](ErodeVoxelsOp* erodeOp, const RangeT& range){
+            return erodeOp->erode26(range);
+        };
         break;
     case NN_FACE:
     default:
-        mTask = std::bind(&ErodeVoxelsOp::erode6, ph::_1, ph::_2);
+        mTask = [](ErodeVoxelsOp* erodeOp, const RangeT& range){
+            return erodeOp->erode6(range);
+        };
     }
     tbb::parallel_for(mManager.getRange(), *this);
 }

--- a/openvdb/tools/ParticlesToLevelSet.h
+++ b/openvdb/tools/ParticlesToLevelSet.h
@@ -473,7 +473,9 @@ struct ParticlesToLevelSet<SdfGridT, AttributeT, InterrupterT>::Raster
         if (mParent.mInterrupter) {
             mParent.mInterrupter->start("Rasterizing particles to level set using spheres");
         }
-        mTask = std::bind(&Raster::rasterSpheres, std::placeholders::_1, std::placeholders::_2);
+        mTask = [](Raster* raster, const tbb::blocked_range<size_t>& range) {
+            return raster->rasterSpheres(range);
+        };
         this->cook();
         if (mParent.mInterrupter) mParent.mInterrupter->end();
     }
@@ -492,7 +494,9 @@ struct ParticlesToLevelSet<SdfGridT, AttributeT, InterrupterT>::Raster
                 mParent.mInterrupter->start(
                     "Rasterizing particles to level set using const spheres");
             }
-            mTask = std::bind(&Raster::rasterFixedSpheres, std::placeholders::_1, std::placeholders::_2, SdfT(radius));
+            mTask = [radius](Raster* raster, const tbb::blocked_range<size_t>& range) {
+                return raster->rasterFixedSpheres(range, SdfT(radius));
+            };
             this->cook();
             if (mParent.mInterrupter) mParent.mInterrupter->end();
         }
@@ -517,7 +521,9 @@ struct ParticlesToLevelSet<SdfGridT, AttributeT, InterrupterT>::Raster
         if (mParent.mInterrupter) {
             mParent.mInterrupter->start("Rasterizing particles to level set using trails");
         }
-        mTask = std::bind(&Raster::rasterTrails, std::placeholders::_1, std::placeholders::_2, SdfT(delta));
+        mTask = [delta](Raster* raster, const tbb::blocked_range<size_t>& range) {
+            return raster->rasterTrails(range, SdfT(delta));
+        };
         this->cook();
         if (mParent.mInterrupter) mParent.mInterrupter->end();
     }

--- a/openvdb/tools/RayIntersector.h
+++ b/openvdb/tools/RayIntersector.h
@@ -67,7 +67,6 @@
 #include <openvdb/Types.h>
 #include "Morphology.h"
 #include <boost/utility.hpp>
-#include <boost/type_traits/is_floating_point.hpp>
 
 
 namespace openvdb {
@@ -117,7 +116,7 @@ public:
     typedef typename GridT::TreeType      TreeT;
 
     BOOST_STATIC_ASSERT( NodeLevel >= -1 && NodeLevel < int(TreeT::DEPTH)-1);
-    BOOST_STATIC_ASSERT(boost::is_floating_point<ValueT>::value);
+    BOOST_STATIC_ASSERT(std::is_floating_point<ValueT>::value);
 
     /// @brief Constructor
     /// @param grid level set grid to intersect rays against.

--- a/openvdb/tools/VelocityFields.h
+++ b/openvdb/tools/VelocityFields.h
@@ -71,7 +71,7 @@ class DiscreteField
 public:
     typedef typename VelGridT::ValueType     VectorType;
     typedef typename VectorType::ValueType   ValueType;
-    BOOST_STATIC_ASSERT(boost::is_floating_point<ValueType>::value);
+    BOOST_STATIC_ASSERT(std::is_floating_point<ValueType>::value);
 
     DiscreteField(const VelGridT &vel)
         : mAccessor(vel.tree())
@@ -129,7 +129,7 @@ class EnrightField
 public:
     typedef ScalarT             ValueType;
     typedef math::Vec3<ScalarT> VectorType;
-    BOOST_STATIC_ASSERT(boost::is_floating_point<ScalarT>::value);
+    BOOST_STATIC_ASSERT(std::is_floating_point<ScalarT>::value);
 
     EnrightField() {}
 

--- a/openvdb/tools/VolumeAdvect.h
+++ b/openvdb/tools/VolumeAdvect.h
@@ -421,36 +421,55 @@ struct VolumeAdvection<VelocityGridT, StaggeredVelocity, InterrupterType>::Advec
         LeafManagerT manager(outGrid.tree(), mParent->spatialOrder()==2 ? 1 : 0);
         const LeafRangeT range = manager.leafRange(mParent->mGrainSize);
         const RealT dt = static_cast<RealT>(-time_step);//method of characteristics backtracks
-        using std::placeholders::_1;
-        using std::placeholders::_2;
 
         if (mParent->mIntegrator == Scheme::MAC) {
-
-
-            mTask = std::bind(&Advect::rk,  _1, _2, dt, 0, mInGrid);//out[0]=forward
+            mTask = [this, dt](Advect* advect, const LeafRangeT& range) { //out[0]=forward
+                return advect->rk(range, dt, 0, mInGrid);
+            };
             this->cook(range);
-            mTask = std::bind(&Advect::rk,  _1, _2,-dt, 1, &outGrid);//out[1]=backward
+
+            mTask = [&outGrid, dt](Advect* advect, const LeafRangeT& range) { //out[1]=backward
+                return advect->rk(range, -dt, 1, &outGrid);
+            };
             this->cook(range);
-            mTask = std::bind(&Advect::mac, _1, _2);//out[0] = out[0] + (in[0] - out[1])/2
+
+            mTask = [](Advect* advect, const LeafRangeT& range) { //out[0] = out[0] + (in[0] - out[1])/2
+                return advect->mac(range);
+            };
             this->cook(range);
         } else if (mParent->mIntegrator == Scheme::BFECC) {
-            mTask = std::bind(&Advect::rk, _1, _2, dt, 0, mInGrid);//out[0]=forward
+            mTask = [this, dt](Advect* advect, const LeafRangeT& range) { //out[0]=forward
+                return advect->rk(range, dt, 0, mInGrid);
+            };
             this->cook(range);
-            mTask = std::bind(&Advect::rk, _1, _2,-dt, 1, &outGrid);//out[1]=backward
+
+            mTask = [&outGrid, dt](Advect* advect, const LeafRangeT& range) { //out[1]=backward
+                return advect->rk(range, -dt, 1, &outGrid);
+            };
             this->cook(range);
-            mTask = std::bind(&Advect::bfecc, _1, _2);//out[0] = (3*in[0] - out[1])/2
+
+            mTask = [](Advect* advect, const LeafRangeT& range) { //out[0] = (3*in[0] - out[1])/2
+                return advect->bfecc(range);
+            };
             this->cook(range);
-            mTask = std::bind(&Advect::rk, _1, _2, dt, 1, &outGrid);//out[1]=forward
+
+            mTask = [&outGrid, dt](Advect* advect, const LeafRangeT& range) { //out[1]=forward
+                return advect->rk(range, dt, 1, &outGrid);
+            };
             this->cook(range);
             manager.swapLeafBuffer(1);// out[0] = out[1]
         } else {// SEMI, MID, RK3 and RK4
-            mTask = std::bind(&Advect::rk, _1, _2,  dt, 0, mInGrid);//forward
+            mTask = [this, dt](Advect* advect, const LeafRangeT& range) { //forward
+                return advect->rk(range, dt, 0, mInGrid);
+            };
             this->cook(range);
         }
 
         if (mParent->spatialOrder()==2) manager.removeAuxBuffers();
         
-        mTask = std::bind(&Advect::limiter, _1, _2, dt);// out[0] = limiter( out[0] )
+        mTask = [dt](Advect* advect, const LeafRangeT& range) { // out[0] = limiter( out[0] )
+            return advect->limiter(range, dt);
+        };
         this->cook(range);
         
         mParent->stop();

--- a/openvdb/unittest/TestFile.cc
+++ b/openvdb/unittest/TestFile.cc
@@ -45,7 +45,6 @@
 #include <algorithm> // for std::sort()
 #include <cstdio> // for remove() and rename()
 #include <fstream>
-#include <functional> // for std::bind()
 #include <iostream>
 #include <map>
 #include <memory>
@@ -2323,8 +2322,9 @@ struct TestAsyncHelper
 
     io::Queue::Notifier notifier()
     {
-        return std::bind(&TestAsyncHelper::validate, this,
-            std::placeholders::_1, std::placeholders::_2);
+        return [this](io::Queue::Id id, io::Queue::Status status){
+            TestAsyncHelper::validate(id, status);
+        };
     }
 
     void insert(io::Queue::Id id, const std::string& filename)

--- a/openvdb_houdini/houdini/GU_PrimVDB.cc
+++ b/openvdb_houdini/houdini/GU_PrimVDB.cc
@@ -1067,10 +1067,10 @@ namespace // anonymous
 {
 
 #define SCALAR_RET(T) \
-	typename boost::enable_if< boost::is_arithmetic< T >, T >::type
+    typename boost::enable_if< std::is_arithmetic< T >, T >::type
 
 #define NON_SCALAR_RET(T) \
-	typename boost::disable_if< boost::is_arithmetic< T >, T >::type
+    typename boost::disable_if< std::is_arithmetic< T >, T >::type
 
 /// Houdini Volume wrapper to abstract multiple volumes with a consistent API.
 template <int TUPLE_SIZE>

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc.autosave
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc.autosave
@@ -1,0 +1,1255 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+
+/// @file SOP_OpenVDB_Filter_Level_Set.cc
+///
+/// @author FX R&D OpenVDB team
+///
+/// @brief Performs various types of level set deformations with
+/// interface tracking. These unrestricted deformations include
+/// surface smoothing (e.g., Laplacian flow), filtering (e.g., mean
+/// value) and morphological operations (e.g., morphological opening).
+/// All these operations can optionally be masked with another grid that
+/// acts as an alpha-mask.
+///
+/// @note Works with level set grids of floating point type (float/double).
+
+#include <houdini_utils/OP_NodeChain.h> // for getNodeChain(), OP_EvalScope
+#include <houdini_utils/ParmFactory.h>
+
+#include <openvdb_houdini/Utils.h>
+#include <openvdb_houdini/SOP_NodeVDB.h>
+#include <openvdb/tools/LevelSetFilter.h>
+
+#include <OP/OP_AutoLockInputs.h>
+#include <UT/UT_Interrupt.h>
+#include <UT/UT_Version.h>
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/algorithm/string/trim.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace hvdb = openvdb_houdini;
+namespace hutil = houdini_utils;
+
+#undef DWA_DEBUG_MODE
+//#define DWA_DEBUG_MODE
+
+
+////////////////////////////////////////
+
+// Utilities
+
+namespace {
+
+// Add new items to the *end* of this list, and update NUM_OPERATOR_TYPES.
+enum OperatorType {
+    OP_TYPE_RENORM = 0,
+    OP_TYPE_RESHAPE,
+    OP_TYPE_SMOOTH,
+    OP_TYPE_RESIZE
+};
+
+enum { NUM_OPERATOR_TYPES = OP_TYPE_RESIZE + 1 };
+
+
+// Add new items to the *end* of this list, and update NUM_FILTER_TYPES.
+enum FilterType {
+    FILTER_TYPE_NONE = -1,
+    FILTER_TYPE_RENORMALIZE = 0,
+    FILTER_TYPE_MEAN_VALUE,
+    FILTER_TYPE_MEDIAN_VALUE,
+    FILTER_TYPE_MEAN_CURVATURE,
+    FILTER_TYPE_LAPLACIAN_FLOW,
+    FILTER_TYPE_DILATE,
+    FILTER_TYPE_ERODE,
+    FILTER_TYPE_OPEN,
+    FILTER_TYPE_CLOSE,
+    FILTER_TYPE_TRACK,
+    FILTER_TYPE_GAUSSIAN,
+    FILTER_TYPE_RESIZE
+};
+
+enum { NUM_FILTER_TYPES = FILTER_TYPE_RESIZE + 1 };
+
+
+std::string
+filterTypeToString(FilterType filter)
+{
+    std::string ret;
+    switch (filter) {
+        case FILTER_TYPE_NONE:           ret = "none";                  break;
+        case FILTER_TYPE_RENORMALIZE:    ret = "renormalize";           break;
+        case FILTER_TYPE_RESIZE:         ret = "resize narrow band";    break;
+        case FILTER_TYPE_GAUSSIAN:       ret = "gaussian";              break;
+        case FILTER_TYPE_DILATE:         ret = "dilate";                break;
+        case FILTER_TYPE_ERODE:          ret = "erode";                 break;
+        case FILTER_TYPE_OPEN:           ret = "open";                  break;
+        case FILTER_TYPE_CLOSE:          ret = "close";                 break;
+        case FILTER_TYPE_TRACK:          ret = "track";                 break;
+#ifndef SESI_OPENVDB
+        case FILTER_TYPE_MEAN_VALUE:     ret = "mean value";            break;
+        case FILTER_TYPE_MEDIAN_VALUE:   ret = "median value";          break;
+        case FILTER_TYPE_MEAN_CURVATURE: ret = "mean curvature";        break;
+        case FILTER_TYPE_LAPLACIAN_FLOW: ret = "laplacian flow";        break;
+#else
+        case FILTER_TYPE_MEAN_VALUE:     ret = "meanvalue";             break;
+        case FILTER_TYPE_MEDIAN_VALUE:   ret = "medianvalue";           break;
+        case FILTER_TYPE_MEAN_CURVATURE: ret = "meancurvature";         break;
+        case FILTER_TYPE_LAPLACIAN_FLOW: ret = "laplacianflow";         break;
+#endif
+    }
+    return ret;
+}
+
+std::string
+filterTypeToMenuName(FilterType filter)
+{
+    std::string ret;
+    switch (filter) {
+        case FILTER_TYPE_NONE: ret           = "None";                  break;
+        case FILTER_TYPE_RENORMALIZE: ret    = "Renormalize";           break;
+        case FILTER_TYPE_RESIZE: ret         = "Resize Narrow Band";    break;
+        case FILTER_TYPE_MEAN_VALUE: ret     = "Mean Value";            break;
+        case FILTER_TYPE_GAUSSIAN: ret       = "Gaussian";              break;
+        case FILTER_TYPE_MEDIAN_VALUE: ret   = "Median Value";          break;
+        case FILTER_TYPE_MEAN_CURVATURE: ret = "Mean Curvature Flow";   break;
+        case FILTER_TYPE_LAPLACIAN_FLOW: ret = "Laplacian Flow";        break;
+        case FILTER_TYPE_DILATE: ret         = "Dilate";                break;
+        case FILTER_TYPE_ERODE: ret          = "Erode";                 break;
+        case FILTER_TYPE_OPEN: ret           = "Open";                  break;
+        case FILTER_TYPE_CLOSE: ret          = "Close";                 break;
+        case FILTER_TYPE_TRACK: ret          = "Track Narrow Band";     break;
+    }
+    return ret;
+}
+
+
+FilterType
+stringToFilterType(const std::string& s)
+{
+    FilterType ret = FILTER_TYPE_NONE;
+
+    std::string str = s;
+    boost::trim(str);
+    boost::to_lower(str);
+
+    if (str == filterTypeToString(FILTER_TYPE_RENORMALIZE)) {
+        ret = FILTER_TYPE_RENORMALIZE;
+    } else if (str == filterTypeToString(FILTER_TYPE_RESIZE)) {
+        ret = FILTER_TYPE_RESIZE;
+    } else if (str == filterTypeToString(FILTER_TYPE_MEAN_VALUE)) {
+        ret = FILTER_TYPE_MEAN_VALUE;
+    } else if (str == filterTypeToString(FILTER_TYPE_GAUSSIAN)) {
+        ret = FILTER_TYPE_GAUSSIAN;
+    } else if (str == filterTypeToString(FILTER_TYPE_MEDIAN_VALUE)) {
+        ret = FILTER_TYPE_MEDIAN_VALUE;
+    } else if (str == filterTypeToString(FILTER_TYPE_MEAN_CURVATURE)) {
+        ret = FILTER_TYPE_MEAN_CURVATURE;
+    } else if (str == filterTypeToString(FILTER_TYPE_LAPLACIAN_FLOW)) {
+        ret = FILTER_TYPE_LAPLACIAN_FLOW;
+    } else if (str == filterTypeToString(FILTER_TYPE_DILATE)) {
+        ret = FILTER_TYPE_DILATE;
+    } else if (str == filterTypeToString(FILTER_TYPE_ERODE)) {
+        ret = FILTER_TYPE_ERODE;
+    } else if (str == filterTypeToString(FILTER_TYPE_OPEN)) {
+        ret = FILTER_TYPE_OPEN;
+    } else if (str == filterTypeToString(FILTER_TYPE_CLOSE)) {
+        ret = FILTER_TYPE_CLOSE;
+    } else if (str == filterTypeToString(FILTER_TYPE_TRACK)) {
+        ret = FILTER_TYPE_TRACK;
+    }
+
+    return ret;
+}
+
+
+// Add new items to the *end* of this list, and update NUM_ACCURACY_TYPES.
+enum Accuracy {
+    ACCURACY_UPWIND_FIRST = 0,
+    ACCURACY_UPWIND_SECOND,
+    ACCURACY_UPWIND_THIRD,
+    ACCURACY_WENO,
+    ACCURACY_HJ_WENO
+};
+
+enum { NUM_ACCURACY_TYPES = ACCURACY_HJ_WENO + 1 };
+
+std::string
+accuracyToString(Accuracy ac)
+{
+    std::string ret;
+    switch (ac) {
+        case ACCURACY_UPWIND_FIRST: ret     = "upwind first";       break;
+        case ACCURACY_UPWIND_SECOND: ret    = "upwind second";      break;
+        case ACCURACY_UPWIND_THIRD: ret     = "upwind third";       break;
+        case ACCURACY_WENO: ret             = "weno";               break;
+        case ACCURACY_HJ_WENO: ret          = "hj weno";            break;
+    }
+    return ret;
+}
+
+std::string
+accuracyToMenuName(Accuracy ac)
+{
+    std::string ret;
+    switch (ac) {
+        case ACCURACY_UPWIND_FIRST: ret     = "First-order upwinding";      break;
+        case ACCURACY_UPWIND_SECOND: ret    = "Second-order upwinding";     break;
+        case ACCURACY_UPWIND_THIRD: ret     = "Third-order upwinding";      break;
+        case ACCURACY_WENO: ret             = "Fifth-order WENO";           break;
+        case ACCURACY_HJ_WENO: ret          = "Fifth-order HJ-WENO";        break;
+    }
+    return ret;
+}
+
+
+Accuracy
+stringToAccuracy(const std::string& s)
+{
+    Accuracy ret = ACCURACY_UPWIND_FIRST;
+
+    std::string str = s;
+    boost::trim(str);
+    boost::to_lower(str);
+
+    if (str == accuracyToString(ACCURACY_UPWIND_SECOND)) {
+        ret = ACCURACY_UPWIND_SECOND;
+    } else if (str == accuracyToString(ACCURACY_UPWIND_THIRD)) {
+        ret = ACCURACY_UPWIND_THIRD;
+    } else if (str == accuracyToString(ACCURACY_WENO)) {
+        ret = ACCURACY_WENO;
+    } else if (str == accuracyToString(ACCURACY_HJ_WENO)) {
+        ret = ACCURACY_HJ_WENO;
+    }
+
+    return ret;
+}
+
+
+void
+buildFilterMenu(std::vector<std::string>& items, OperatorType op)
+{
+    items.clear();
+
+    if (OP_TYPE_SMOOTH == op) {
+
+        items.push_back(filterTypeToString(FILTER_TYPE_MEAN_VALUE));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_MEAN_VALUE));
+
+        items.push_back(filterTypeToString(FILTER_TYPE_GAUSSIAN));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_GAUSSIAN));
+
+        items.push_back(filterTypeToString(FILTER_TYPE_MEDIAN_VALUE));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_MEDIAN_VALUE));
+
+        items.push_back(filterTypeToString(FILTER_TYPE_MEAN_CURVATURE));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_MEAN_CURVATURE));
+
+        items.push_back(filterTypeToString(FILTER_TYPE_LAPLACIAN_FLOW));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_LAPLACIAN_FLOW));
+
+    } else if (OP_TYPE_RESHAPE == op) {
+
+        items.push_back(filterTypeToString(FILTER_TYPE_DILATE));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_DILATE));
+
+        items.push_back(filterTypeToString(FILTER_TYPE_ERODE));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_ERODE));
+
+        items.push_back(filterTypeToString(FILTER_TYPE_OPEN));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_OPEN));
+
+        items.push_back(filterTypeToString(FILTER_TYPE_CLOSE));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_CLOSE));
+
+#ifdef DWA_DEBUG_MODE
+        items.push_back(filterTypeToString(FILTER_TYPE_TRACK));
+        items.push_back(filterTypeToMenuName(FILTER_TYPE_TRACK));
+#endif
+
+    }
+}
+
+struct FilterParms {
+    FilterParms()
+        : mGroup()
+        , mMaskName()
+        , mSecondInputConnected(false)
+        , mFilterType(FILTER_TYPE_NONE)
+        , mIterations(0)
+        , mHalfWidth(3)
+        , mStencilWidth(0)
+        , mVoxelOffset(0.0f)
+        , mHalfWidthWorld(0.1f)
+        , mStencilWidthWorld(0.1f)
+        , mWorldUnits(false)
+        , mMinMask(0)
+        , mMaxMask(1)
+        , mInvertMask(false)
+        , mAccuracy(ACCURACY_UPWIND_FIRST)
+        , mMaskInputNode(nullptr)
+    {
+    }
+
+    std::string mGroup, mMaskName;
+    bool mSecondInputConnected;
+    FilterType mFilterType;
+    int mIterations, mHalfWidth, mStencilWidth;
+    float mVoxelOffset, mHalfWidthWorld, mStencilWidthWorld;
+    bool  mWorldUnits;
+    float mMinMask, mMaxMask;
+    bool  mInvertMask;
+    Accuracy mAccuracy;
+    OP_Node* mMaskInputNode;
+};
+
+} // namespace
+
+
+////////////////////////////////////////
+
+// SOP Declaration
+
+class SOP_OpenVDB_Filter_Level_Set: public hvdb::SOP_NodeVDB
+{
+public:
+    SOP_OpenVDB_Filter_Level_Set(OP_Network*, const char* name, OP_Operator*, OperatorType);
+    ~SOP_OpenVDB_Filter_Level_Set() override {}
+
+    static OP_Node* factoryRenormalize(OP_Network*, const char* name, OP_Operator*);
+    static OP_Node* factorySmooth(OP_Network*, const char* name, OP_Operator*);
+    static OP_Node* factoryReshape(OP_Network*, const char* name, OP_Operator*);
+    static OP_Node* factoryNarrowBand(OP_Network*, const char* name, OP_Operator*);
+
+    int isRefInput(unsigned input) const override { return (input == 1); }
+
+protected:
+    OP_ERROR cookMySop(OP_Context&) override;
+    bool updateParmsFlags() override;
+
+private:
+    using BossT = hvdb::Interrupter;
+    const OperatorType mOpType;
+
+    OP_ERROR evalFilterParms(OP_Context&, FilterParms&);
+
+    template<typename GridT>
+    bool applyFilters(GU_PrimVDB*, std::vector<FilterParms>&, BossT&,
+        OP_Context&, GU_Detail&, bool verbose);
+
+    template<typename FilterT>
+    void filterGrid(OP_Context&, FilterT&, const FilterParms&, BossT&, bool verbose);
+
+    template<typename FilterT>
+    void offset(const FilterParms&, FilterT&, const float offset, bool verbose,
+        const typename FilterT::MaskType* mask = nullptr);
+
+    template<typename FilterT>
+    void mean(const FilterParms&, FilterT&, BossT&, bool verbose,
+        const typename FilterT::MaskType* mask = nullptr);
+
+    template<typename FilterT>
+    void gaussian(const FilterParms&, FilterT&, BossT&, bool verbose,
+        const typename FilterT::MaskType* mask = nullptr);
+
+    template<typename FilterT>
+    void median(const FilterParms&, FilterT&, BossT&, bool verbose,
+        const typename FilterT::MaskType* mask = nullptr);
+
+    template<typename FilterT>
+    void meanCurvature(const FilterParms&, FilterT&, BossT&, bool verbose,
+        const typename FilterT::MaskType* mask = nullptr);
+
+    template<typename FilterT>
+    void laplacian(const FilterParms&, FilterT&, BossT&, bool verbose,
+        const typename FilterT::MaskType* mask = nullptr);
+
+    template<typename FilterT>
+    void renormalize(const FilterParms&, FilterT&, BossT&, bool verbose = false);
+
+    template<typename FilterT>
+    void resizeNarrowBand(const FilterParms&, FilterT&, BossT&, bool verbose = false);
+
+    template<typename FilterT>
+    void track(const FilterParms&, FilterT&, BossT&, bool verbose);
+};//SOP_OpenVDB_Filter_Level_Set
+
+
+////////////////////////////////////////
+
+// Build UI
+
+void
+newSopOperator(OP_OperatorTable* table)
+{
+    if (table == nullptr) return;
+
+    for (int n = 0; n < NUM_OPERATOR_TYPES; ++n) {
+
+        OperatorType op = OperatorType(n);
+
+        hutil::ParmList parms;
+
+        // Define a string-valued group name pattern parameter and add it to the list.
+        parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
+            .setChoiceList(&hutil::PrimGroupMenuInput1)
+            .setTooltip("Specify a subset of the input VDB grids to be processed.")
+            .setDocumentation(
+                "A subset of the input VDBs to be processed"
+                " (see [specifying volumes|/model/volumes#group])"));
+
+        if (OP_TYPE_RENORM != op && OP_TYPE_RESIZE != op) { // Filter menu
+
+            parms.add(hutil::ParmFactory(PRM_TOGGLE, "mask", "")
+                .setDefault(PRMoneDefaults)
+                .setTypeExtended(PRM_TYPE_TOGGLE_JOIN)
+                .setTooltip("Enable / disable the mask."));
+
+            parms.add(hutil::ParmFactory(PRM_STRING, "maskname", "Alpha Mask")
+                .setChoiceList(&hutil::PrimGroupMenuInput2)
+                .setTooltip("Optional VDB used for alpha masking. Assumes values 0->1.")
+                .setDocumentation(
+                    "If enabled, operate on the input VDBs using the given VDB"
+                    " from the second input as an alpha mask.\n\n"
+                    "The mask VDB is assumed to be scalar, with values between zero and one."
+                    " Where the mask is zero, no processing occurs.  Where the mask is one,"
+                    " the operation is applied at full strength.  For intermediate mask values,"
+                    " the strength varies linearly."));
+
+            std::vector<std::string> items;
+
+            buildFilterMenu(items, op);
+
+            parms.add(hutil::ParmFactory(PRM_STRING, "operation", "Operation")
+                .setDefault(items[0])
+                .setChoiceListItems(PRM_CHOICELIST_SINGLE, items)
+                .setTooltip("The operation to be applied"));
+        }
+
+        // Toggle between world- and index-space units for offset
+        parms.add(hutil::ParmFactory(PRM_TOGGLE, "worldSpaceUnits", "Use World Space Units")
+            .setTooltip("If enabled, use world-space units, otherwise use voxels."));
+
+        // Stencil width
+        parms.add(hutil::ParmFactory(PRM_INT_J, "stencilWidth", "Filter Voxel Radius")
+            .setDefault(PRMoneDefaults)
+            .setRange(PRM_RANGE_RESTRICTED, 1, PRM_RANGE_UI, 5)
+            .setDocumentation(nullptr));
+
+        parms.add(hutil::ParmFactory(PRM_FLT_J, "stencilWidthWorld", "Filter Radius")
+            .setDefault(0.1)
+            .setRange(PRM_RANGE_RESTRICTED, 1e-5, PRM_RANGE_UI, 10)
+            .setDocumentation("The desired radius of the filter"));
+
+        // steps
+        parms.add(hutil::ParmFactory(PRM_INT_J, "iterations", "Iterations")
+            .setDefault(PRMfourDefaults)
+            .setRange(PRM_RANGE_RESTRICTED, 0, PRM_RANGE_UI, 10)
+            .setTooltip("The number of times to apply the operation"));
+
+        // Narrow-Band half-width
+        parms.add(hutil::ParmFactory(PRM_INT_J, "halfWidth", "Half-Width")
+            .setDefault(PRMthreeDefaults)
+            .setRange(PRM_RANGE_RESTRICTED, 1, PRM_RANGE_UI, 10)
+            .setTooltip(
+                "Half the width of the narrow band, in voxels\n\n"
+                "(Many level set operations require this to be a minimum of three voxels.)"));
+
+        parms.add(hutil::ParmFactory(PRM_FLT_J, "halfWidthWorld", "Half-Width")
+            .setDefault(0.1)
+            .setRange(PRM_RANGE_RESTRICTED, 1e-5, PRM_RANGE_UI, 10)
+            .setTooltip("Desired narrow band half-width in world units")
+            .setDocumentation(nullptr));
+
+        // Offset
+        parms.add(hutil::ParmFactory(PRM_FLT_J, "voxelOffset", "Offset")
+            .setDefault(PRMoneDefaults)
+            .setRange(PRM_RANGE_RESTRICTED, 0.0, PRM_RANGE_UI, 10.0)
+            .setTooltip(
+                "The distance in voxels by which to offset the level set surface"
+                " along its normals"));
+
+        { // Renormalization accuracy
+
+            std::vector<std::string> items;
+            for (int i = 0; i < NUM_ACCURACY_TYPES; ++i) {
+                Accuracy ac = Accuracy(i);
+
+#ifndef DWA_DEBUG_MODE // Exclude some of the menu options
+                if (ac == ACCURACY_UPWIND_THIRD || ac == ACCURACY_WENO) continue;
+#endif
+
+                items.push_back(accuracyToString(ac)); // token
+                items.push_back(accuracyToMenuName(ac)); // label
+            }
+
+            parms.add(hutil::ParmFactory(PRM_STRING, "accuracy", "Renorm Accuracy")
+                .setDefault(items[0])
+                .setChoiceListItems(PRM_CHOICELIST_SINGLE, items));
+        }
+
+        //Invert mask.
+        parms.add(hutil::ParmFactory(PRM_TOGGLE, "invert", "Invert Alpha Mask")
+            .setTooltip("Invert the optional alpha mask, mapping 0 to 1 and 1 to 0."));
+
+        // Min mask range
+        parms.add(hutil::ParmFactory(PRM_FLT_J, "minMask", "Min Mask Cutoff")
+            .setDefault(PRMzeroDefaults)
+            .setRange(PRM_RANGE_UI, 0.0, PRM_RANGE_UI, 1.0)
+            .setTooltip("Threshold below which voxel values in the mask map to zero"));
+
+        // Max mask range
+        parms.add(hutil::ParmFactory(PRM_FLT_J, "maxMask", "Max Mask Cutoff")
+            .setDefault(PRMoneDefaults)
+            .setRange(PRM_RANGE_UI, 0.0, PRM_RANGE_UI, 1.0)
+            .setTooltip("Threshold above which voxel values in the mask map to one"));
+
+#ifndef SESI_OPENVDB
+        // Verbosity toggle.
+        parms.add(hutil::ParmFactory(PRM_TOGGLE, "verbose", "Verbose")
+            .setTooltip("If enabled, print the sequence of operations to the terminal."));
+#endif
+
+        // Obsolete parameters
+        hutil::ParmList obsoleteParms;
+        obsoleteParms.add(hutil::ParmFactory(PRM_SEPARATOR, "sep1", "Sep"));
+        obsoleteParms.add(hutil::ParmFactory(PRM_SEPARATOR, "sep2", "Sep"));
+
+        // Register operator
+        if (OP_TYPE_RENORM == op) {
+
+            hvdb::OpenVDBOpFactory("OpenVDB Renormalize Level Set",
+                SOP_OpenVDB_Filter_Level_Set::factoryRenormalize, parms, *table)
+                .setObsoleteParms(obsoleteParms)
+                .addInput("Input with VDB grids to process")
+                .setDocumentation("\
+#icon: COMMON/openvdb\n\
+#tags: vdb\n\
+\n\
+\"\"\"Repair level sets represented by VDB volumes.\"\"\"\n\
+\n\
+@overview\n\
+\n\
+Certain operations on a level set volume can cause the signed distances\n\
+to its zero crossing to become invalid.\n\
+This node iteratively adjusts voxel values to restore proper distances.\n\
+\n\
+NOTE:\n\
+    If the level set departs significantly from a proper signed distance field,\n\
+    it might be necessary to rebuild it completely.\n\
+    That can be done with the\
+ [OpenVDB Rebuild Level Set node|Node:sop/DW_OpenVDBRebuildLevelSet],\n\
+    which converts an input level set to polygons and then back to a level set.\n\
+\n\
+@related\n\
+- [OpenVDB Offset Level Set|Node:sop/DW_OpenVDBOffsetLevelSet]\n\
+- [OpenVDB Rebuild Level Set|Node:sop/DW_OpenVDBRebuildLevelSet]\n\
+- [OpenVDB Smooth Level Set|Node:sop/DW_OpenVDBSmoothLevelSet]\n\
+\n\
+@examples\n\
+\n\
+See [openvdb.org|http://www.openvdb.org/download/] for source code\n\
+and usage examples.\n");
+
+        } else if (OP_TYPE_RESHAPE == op) {
+
+            hvdb::OpenVDBOpFactory("OpenVDB Offset Level Set",
+                SOP_OpenVDB_Filter_Level_Set::factoryReshape, parms, *table)
+                .setObsoleteParms(obsoleteParms)
+                .addInput("Input with VDBs to process")
+                .addOptionalInput("Optional VDB Alpha Mask")
+                .setDocumentation("\
+#icon: COMMON/openvdb\n\
+#tags: vdb\n\
+\n\
+\"\"\"Offset level sets represented by VDB volumes.\"\"\"\n\
+\n\
+@overview\n\
+\n\
+This node changes the shape of a level set by moving the surface in or out\n\
+along its normals.\n\
+Unlike just adding an offset to a signed distance field, this node properly\n\
+updates the active voxels to account for the transformation.\n\
+\n\
+@related\n\
+- [OpenVDB Renormalize Level Set|Node:sop/DW_OpenVDBRenormalizeLevelSet]\n\
+- [OpenVDB Smooth Level Set|Node:sop/DW_OpenVDBSmoothLevelSet]\n\
+\n\
+@examples\n\
+\n\
+See [openvdb.org|http://www.openvdb.org/download/] for source code\n\
+and usage examples.\n");
+
+        } else if (OP_TYPE_SMOOTH == op) {
+
+            hvdb::OpenVDBOpFactory("OpenVDB Smooth Level Set",
+                SOP_OpenVDB_Filter_Level_Set::factorySmooth, parms, *table)
+                .setObsoleteParms(obsoleteParms)
+                .addInput("Input with VDBs to process")
+                .addOptionalInput("Optional VDB Alpha Mask")
+                .setDocumentation("\
+#icon: COMMON/openvdb\n\
+#tags: vdb\n\
+\n\
+\"\"\"Smooth the surface of a level set represented by a VDB volume.\"\"\"\n\
+\n\
+@overview\n\
+\n\
+This node applies a simulated flow operation, moving the surface of a\n\
+signed distance field according to some local property.\n\
+\n\
+For example, if you move along the normal by an amount dependent on the curvature,\n\
+you will flatten out dimples and hills and leave flat areas unchanged.\n\
+\n\
+Unlike the [OpenVDB Filter|Node:sop/DW_OpenVDBFilter] node,\n\
+this node ensures that the level set remains a valid signed distance field.\n\
+\n\
+@related\n\
+- [OpenVDB Filter|Node:sop/DW_OpenVDBFilter]\n\
+- [OpenVDB Offset Level Set|Node:sop/DW_OpenVDBOffsetLevelSet]\n\
+- [OpenVDB Renormalize Level Set|Node:sop/DW_OpenVDBRenormalizeLevelSet]\n\
+\n\
+@examples\n\
+\n\
+See [openvdb.org|http://www.openvdb.org/download/] for source code\n\
+and usage examples.\n");
+
+        } else if (OP_TYPE_RESIZE == op) {
+
+            hvdb::OpenVDBOpFactory("OpenVDB Resize Narrow Band",
+                SOP_OpenVDB_Filter_Level_Set::factoryNarrowBand, parms, *table)
+                .setObsoleteParms(obsoleteParms)
+                .addInput("Input with VDBs to process")
+                .setDocumentation("\
+#icon: COMMON/openvdb\n\
+#tags: vdb\n\
+\n\
+\"\"\"Change the width of the narrow band of a VDB signed distance field.\"\"\"\n\
+\n\
+@overview\n\
+\n\
+This node adjusts the width of the narrow band of a signed distance field\n\
+represented by a VDB volume.\n\
+\n\
+@related\n\
+- [OpenVDB Offset Level Set|Node:sop/DW_OpenVDBOffsetLevelSet]\n\
+- [OpenVDB Rebuild Level Set|Node:sop/DW_OpenVDBRebuildLevelSet]\n\
+- [OpenVDB Renormalize Level Set|Node:sop/DW_OpenVDBRenormalizeLevelSet]\n\
+\n\
+@examples\n\
+\n\
+See [openvdb.org|http://www.openvdb.org/download/] for source code\n\
+and usage examples.\n");
+        }
+    }
+ }
+
+////////////////////////////////////////
+
+// Operator registration
+
+OP_Node*
+SOP_OpenVDB_Filter_Level_Set::factoryRenormalize(
+    OP_Network* net, const char* name, OP_Operator* op)
+{
+    return new SOP_OpenVDB_Filter_Level_Set(net, name, op, OP_TYPE_RENORM);
+}
+
+OP_Node*
+SOP_OpenVDB_Filter_Level_Set::factoryReshape(
+    OP_Network* net, const char* name, OP_Operator* op)
+{
+    return new SOP_OpenVDB_Filter_Level_Set(net, name, op, OP_TYPE_RESHAPE);
+}
+
+OP_Node*
+SOP_OpenVDB_Filter_Level_Set::factorySmooth(
+    OP_Network* net, const char* name, OP_Operator* op)
+{
+    return new SOP_OpenVDB_Filter_Level_Set(net, name, op, OP_TYPE_SMOOTH);
+}
+
+OP_Node*
+SOP_OpenVDB_Filter_Level_Set::factoryNarrowBand(
+    OP_Network* net, const char* name, OP_Operator* op)
+{
+    return new SOP_OpenVDB_Filter_Level_Set(net, name, op, OP_TYPE_RESIZE);
+}
+
+SOP_OpenVDB_Filter_Level_Set::SOP_OpenVDB_Filter_Level_Set(
+    OP_Network* net, const char* name, OP_Operator* op, OperatorType opType)
+    : hvdb::SOP_NodeVDB(net, name, op)
+    , mOpType(opType)
+{
+}
+
+////////////////////////////////////////
+
+// Disable UI Parms.
+bool
+SOP_OpenVDB_Filter_Level_Set::updateParmsFlags()
+{
+    bool changed = false, stencil = false;
+    const bool renorm = mOpType == OP_TYPE_RENORM;
+    const bool smooth = mOpType == OP_TYPE_SMOOTH;
+    const bool reshape = mOpType == OP_TYPE_RESHAPE;
+    const bool resize = mOpType == OP_TYPE_RESIZE;
+
+    if (renorm || resize) {
+        changed |= setVisibleState("invert", false);
+        changed |= setVisibleState("minMask",false);
+        changed |= setVisibleState("maxMask",false);
+    } else {
+        UT_String str;
+        evalString(str, "operation", 0, 0);
+        FilterType operation = stringToFilterType(str.toStdString());
+        stencil = operation == FILTER_TYPE_MEAN_VALUE ||
+                  operation == FILTER_TYPE_GAUSSIAN   ||
+                  operation == FILTER_TYPE_MEDIAN_VALUE;
+        const bool hasMask = (this->nInputs() == 2);
+        changed |= enableParm("mask", hasMask);
+        const bool useMask = hasMask && bool(evalInt("mask", 0, 0));
+        changed |= enableParm("invert",   useMask);
+        changed |= enableParm("minMask",  useMask);
+        changed |= enableParm("maxMask",  useMask);
+        changed |= enableParm("maskname", useMask);
+    }
+
+    const bool worldUnits = bool(evalInt("worldSpaceUnits", 0, 0));
+
+    changed |= setVisibleState("halfWidth", resize && !worldUnits);
+    changed |= setVisibleState("halfWidthWorld", resize && worldUnits);
+
+    changed |= enableParm("iterations",  smooth || renorm);
+    changed |= enableParm("stencilWidth", stencil && !worldUnits);
+    changed |= enableParm("stencilWidthWorld", stencil && worldUnits);
+
+    changed |= setVisibleState("stencilWidth", getEnableState("stencilWidth"));
+    changed |= setVisibleState("stencilWidthWorld", getEnableState("stencilWidthWorld"));
+
+    changed |= setVisibleState("iterations",   getEnableState("iterations"));
+
+    changed |= setVisibleState("worldSpaceUnits", !renorm);
+    changed |= setVisibleState("voxelOffset",     reshape);
+
+    return changed;
+}
+
+////////////////////////////////////////
+
+// Cook
+
+OP_ERROR
+SOP_OpenVDB_Filter_Level_Set::cookMySop(OP_Context& context)
+{
+    try {
+        OP_AutoLockInputs lock;
+        std::vector<FilterParms> filterParms;
+        SOP_OpenVDB_Filter_Level_Set* startNode = this;
+
+        {
+            // Find adjacent, upstream nodes of the same type as this node.
+            std::vector<SOP_OpenVDB_Filter_Level_Set*> nodes =
+                hutil::getNodeChain(context, this);
+
+            startNode = nodes[0];
+
+            // Collect filter parameters starting from the topmost node.
+            filterParms.resize(nodes.size());
+            for (size_t n = 0, N = filterParms.size(); n < N; ++n) {
+                if (nodes[n]->evalFilterParms(context, filterParms[n]) >= UT_ERROR_ABORT) {
+                    return error();
+                }
+            }
+        }
+#if (UT_VERSION_INT >= 0x0e0000b0) // 14.0.176 or later
+        lock.setNode(startNode);
+        if (lock.lock(context) >= UT_ERROR_ABORT) return error();
+#else
+        if (lock.lock(*startNode, context) >= UT_ERROR_ABORT) return error();
+#endif
+
+        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
+        if (startNode->duplicateSourceStealable(
+            0, context, &gdp, myGdpHandle, /*clean = */ true) >= UT_ERROR_ABORT)
+        {
+            return error();
+        }
+
+        BossT boss("Processing level sets");
+
+        const fpreal time = context.getTime();
+#ifndef SESI_OPENVDB
+        const bool verbose = bool(evalInt("verbose", 0, time));
+#else
+        const bool verbose = false;
+#endif
+
+        if (verbose) std::cout << "--- " << this->getName() << " ---\n";
+
+        // Filter grids
+        UT_String groupStr;
+        evalString(groupStr, "group", 0, time);
+
+        const GA_PrimitiveGroup *group =
+            matchGroup(const_cast<GU_Detail&>(*gdp), groupStr.toStdString());
+        for (hvdb::VdbPrimIterator it(gdp, group); it; ++it) {
+
+            // Check grid class
+            const openvdb::GridClass gridClass = it->getGrid().getGridClass();
+            if (gridClass != openvdb::GRID_LEVEL_SET) {
+                std::string s = it.getPrimitiveNameOrIndex().toStdString();
+                s = "VDB primitive " + s + " was skipped because it is not a level-set grid.";
+                addWarning(SOP_MESSAGE, s.c_str());
+                continue;
+            }
+
+            // Appply filters
+
+            bool wasFiltered = applyFilters<openvdb::FloatGrid>(
+                *it, filterParms, boss, context, *gdp, verbose);
+
+            if (boss.wasInterrupted()) break;
+
+            if (!wasFiltered) {
+                wasFiltered = applyFilters<openvdb::DoubleGrid>(
+                    *it, filterParms, boss, context, *gdp, verbose);
+            }
+
+            if (boss.wasInterrupted()) break;
+
+            if (!wasFiltered) {
+                std::string msg = "VDB primitive "
+                    + it.getPrimitiveNameOrIndex().toStdString()
+                    + " is not of floating point type.";
+                addWarning(SOP_MESSAGE, msg.c_str());
+                continue;
+            }
+
+            if (boss.wasInterrupted()) break;
+        }
+
+        if (boss.wasInterrupted()) addWarning(SOP_MESSAGE, "processing was interrupted");
+        boss.end();
+
+    } catch (std::exception& e) {
+        addError(SOP_MESSAGE, e.what());
+    }
+    return error();
+}
+
+////////////////////////////////////////
+
+
+OP_ERROR
+SOP_OpenVDB_Filter_Level_Set::evalFilterParms(OP_Context& context,
+    FilterParms& parms)
+{
+    hutil::OP_EvalScope eval_scope(*this, context);
+    fpreal now = context.getTime();
+
+    parms.mIterations   = static_cast<int>(evalInt("iterations", 0, now));
+    parms.mHalfWidth    = static_cast<int>(evalInt("halfWidth", 0, now));
+    parms.mHalfWidthWorld = float(evalFloat("halfWidthWorld", 0, now));
+    parms.mStencilWidth = static_cast<int>(evalInt("stencilWidth", 0, now));
+    parms.mStencilWidthWorld = float(evalFloat("stencilWidthWorld", 0, now));
+    parms.mVoxelOffset  = static_cast<float>(evalFloat("voxelOffset", 0, now));
+    parms.mMinMask      = static_cast<float>(evalFloat("minMask", 0, now));
+    parms.mMaxMask      = static_cast<float>(evalFloat("maxMask", 0, now));
+    parms.mInvertMask   = bool(evalInt("invert", 0, now));
+    parms.mWorldUnits   = bool(evalInt("worldSpaceUnits", 0, now));
+
+    UT_String str;
+
+    if (OP_TYPE_RENORM == mOpType ) {
+        parms.mFilterType = FILTER_TYPE_RENORMALIZE;
+    } else if (OP_TYPE_RESIZE == mOpType) {
+        parms.mFilterType = FILTER_TYPE_RESIZE;
+    } else {
+        evalString(str, "operation", 0, now);
+        parms.mFilterType = stringToFilterType(str.toStdString());
+    }
+
+    evalString(str, "accuracy", 0, now);
+    parms.mAccuracy = stringToAccuracy(str.toStdString());
+
+    evalString(str, "group", 0, now);
+    parms.mGroup = str.toStdString();
+
+    if (OP_TYPE_SMOOTH == mOpType || OP_TYPE_RESHAPE == mOpType) {
+        if (evalInt("mask", 0, now)) {
+            parms.mMaskInputNode = getInput(1, /*mark_used*/true);
+
+            evalString(str, "maskname", 0, now);
+            parms.mMaskName = str.toStdString();
+        }
+    }
+
+    return error();
+}
+
+
+////////////////////////////////////////
+
+// Filter callers
+
+template<typename GridT>
+bool
+SOP_OpenVDB_Filter_Level_Set::applyFilters(
+    GU_PrimVDB* vdbPrim,
+    std::vector<FilterParms>& filterParms,
+    BossT& boss,
+    OP_Context& context,
+    GU_Detail&,
+    bool verbose)
+{
+    vdbPrim->makeGridUnique();
+    typename GridT::Ptr grid = openvdb::gridPtrCast<GridT>(vdbPrim->getGridPtr());
+
+    if (!grid) return false;
+
+    using ValueT = typename GridT::ValueType;
+    using MaskT = openvdb::FloatGrid;
+    using FilterT = openvdb::tools::LevelSetFilter<GridT, MaskT, BossT>;
+
+    const float voxelSize = static_cast<float>(grid->voxelSize()[0]);
+    FilterT filter(*grid, &boss);
+    filter.setTemporalScheme(openvdb::math::TVD_RK1);
+
+    if (grid->background() < ValueT(openvdb::LEVEL_SET_HALF_WIDTH * voxelSize)) {
+        std::string msg = "VDB primitive '"
+            + std::string(vdbPrim->getGridName())
+            + "' has a narrow band width that is less than 3 voxel units. ";
+        addWarning(SOP_MESSAGE, msg.c_str());
+    }
+
+    for (size_t n = 0, N = filterParms.size(); n < N; ++n) {
+
+        const GA_PrimitiveGroup *group = matchGroup(*gdp, filterParms[n].mGroup);
+
+        // Skip this node if it doesn't operate on this primitive
+        if (group && !group->containsOffset(vdbPrim->getMapOffset())) continue;
+
+        filterGrid(context, filter, filterParms[n], boss, verbose);
+
+        if (boss.wasInterrupted()) break;
+    }
+
+    return true;
+}
+
+
+template<typename FilterT>
+void
+SOP_OpenVDB_Filter_Level_Set::filterGrid(OP_Context& context, FilterT& filter,
+    const FilterParms& parms, BossT& boss, bool verbose)
+{
+    // Alpha-masking
+    using MaskT = typename FilterT::MaskType;
+    typename MaskT::ConstPtr maskGrid;
+
+    if (parms.mMaskInputNode) {
+
+        // record second input
+        if (getInput(1) != parms.mMaskInputNode) {
+            addExtraInput(parms.mMaskInputNode, OP_INTEREST_DATA);
+        }
+
+        GU_DetailHandle maskHandle;
+        maskHandle = static_cast<SOP_Node*>(parms.mMaskInputNode)->getCookedGeoHandle(context);
+
+        GU_DetailHandleAutoReadLock maskScope(maskHandle);
+        const GU_Detail *maskGeo = maskScope.getGdp();
+
+        if (maskGeo) {
+#if (UT_MAJOR_VERSION_INT >= 15)
+            const GA_PrimitiveGroup * maskGroup =
+                parsePrimitiveGroups(parms.mMaskName.c_str(), GroupCreator(maskGeo));
+#else
+            const GA_PrimitiveGroup * maskGroup =
+                parsePrimitiveGroups(parms.mMaskName.c_str(), const_cast<GU_Detail*>(maskGeo));
+#endif
+
+            if (!maskGroup && !parms.mMaskName.empty()) {
+                addWarning(SOP_MESSAGE, "Mask not found.");
+            } else {
+                hvdb::VdbPrimCIterator maskIt(maskGeo, maskGroup);
+                if (maskIt) {
+                    if (maskIt->getStorageType() == UT_VDB_FLOAT) {
+                        maskGrid = openvdb::gridConstPtrCast<MaskT>(maskIt->getGridPtr());
+                    } else {
+                        addWarning(SOP_MESSAGE, "The mask grid has to be a FloatGrid.");
+                    }
+                } else {
+                    addWarning(SOP_MESSAGE, "The mask input is empty.");
+                }
+            }
+        }
+        filter.setMaskRange(parms.mMinMask, parms.mMaxMask);
+        filter.invertMask(parms.mInvertMask);
+    }
+
+    switch (parms.mAccuracy) {
+      case ACCURACY_UPWIND_FIRST:  filter.setSpatialScheme(openvdb::math::FIRST_BIAS);   break;
+      case ACCURACY_UPWIND_SECOND: filter.setSpatialScheme(openvdb::math::SECOND_BIAS);  break;
+      case ACCURACY_UPWIND_THIRD:  filter.setSpatialScheme(openvdb::math::THIRD_BIAS);   break;
+      case ACCURACY_WENO:          filter.setSpatialScheme(openvdb::math::WENO5_BIAS);   break;
+      case ACCURACY_HJ_WENO:       filter.setSpatialScheme(openvdb::math::HJWENO5_BIAS); break;
+    }
+
+    const float voxelSize = float(filter.grid().voxelSize()[0]);
+
+    const float ds = (parms.mWorldUnits ? 1.0f : voxelSize) * parms.mVoxelOffset;
+
+    switch (parms.mFilterType) {
+
+        case FILTER_TYPE_NONE:
+            break;
+        case FILTER_TYPE_RENORMALIZE:
+            renormalize(parms, filter, boss, verbose);
+            break;
+        case FILTER_TYPE_RESIZE:
+            resizeNarrowBand(parms, filter, boss, verbose);
+            break;
+        case FILTER_TYPE_MEAN_VALUE:
+            mean(parms, filter, boss, verbose, maskGrid.get());
+            break;
+        case FILTER_TYPE_GAUSSIAN:
+            gaussian(parms, filter, boss, verbose, maskGrid.get());
+            break;
+        case FILTER_TYPE_MEDIAN_VALUE:
+            median(parms, filter, boss, verbose, maskGrid.get());
+            break;
+        case FILTER_TYPE_MEAN_CURVATURE:
+            meanCurvature(parms, filter, boss, verbose, maskGrid.get());
+            break;
+        case FILTER_TYPE_LAPLACIAN_FLOW:
+            laplacian(parms, filter, boss, verbose, maskGrid.get());
+            break;
+        case FILTER_TYPE_TRACK:
+            track(parms, filter, boss, verbose);
+            break;
+        case FILTER_TYPE_DILATE:
+            offset(parms, filter, -ds, verbose, maskGrid.get());
+            break;
+        case FILTER_TYPE_ERODE:
+            offset(parms, filter,  ds, verbose, maskGrid.get());
+            break;
+        case FILTER_TYPE_OPEN:
+            offset(parms, filter,  ds, verbose, maskGrid.get());
+            offset(parms, filter, -ds, verbose, maskGrid.get());
+            break;
+        case FILTER_TYPE_CLOSE:
+            offset(parms, filter, -ds, verbose, maskGrid.get());
+            offset(parms, filter,  ds, verbose, maskGrid.get());
+            break;
+    }
+}
+
+
+////////////////////////////////////////
+
+// Filter operations
+
+template<typename FilterT>
+inline void
+SOP_OpenVDB_Filter_Level_Set::offset(const FilterParms&, FilterT& filter,
+    const float offset, bool verbose, const typename FilterT::MaskType* mask)
+{
+    if (verbose) {
+        std::cout << "Morphological " << (offset>0 ? "erosion" : "dilation")
+            << " by the offset " << offset << std::endl;
+    }
+
+    filter.offset(offset, mask);
+}
+
+template<typename FilterT>
+void
+SOP_OpenVDB_Filter_Level_Set::mean(const FilterParms& parms, FilterT& filter,
+    BossT& boss, bool verbose, const typename FilterT::MaskType* mask)
+{
+    const double voxelScale = 1.0 / filter.grid().voxelSize()[0];
+
+    for (int n = 0, N = parms.mIterations; n < N && !boss.wasInterrupted(); ++n) {
+
+        int radius = parms.mStencilWidth;
+
+        if (parms.mWorldUnits) {
+            double voxelRadius = double(parms.mStencilWidthWorld) * voxelScale;
+            radius = std::max(1, int(voxelRadius));
+        }
+
+        if (verbose) {
+            std::cout << "Mean filter of radius " << radius << std::endl;
+        }
+
+        filter.mean(radius, mask);
+    }
+}
+
+template<typename FilterT>
+void
+SOP_OpenVDB_Filter_Level_Set::gaussian(const FilterParms& parms, FilterT& filter,
+    BossT& boss, bool verbose, const typename FilterT::MaskType* mask)
+{
+    const double voxelScale = 1.0 / filter.grid().voxelSize()[0];
+
+    for (int n = 0, N = parms.mIterations; n < N && !boss.wasInterrupted(); ++n) {
+
+        int radius = parms.mStencilWidth;
+
+        if (parms.mWorldUnits) {
+            double voxelRadius = double(parms.mStencilWidthWorld) * voxelScale;
+            radius = std::max(1, int(voxelRadius));
+        }
+
+        if (verbose) {
+            std::cout << "Gaussian filter of radius " << radius << std::endl;
+        }
+
+        filter.gaussian(radius, mask);
+    }
+}
+
+template<typename FilterT>
+void
+SOP_OpenVDB_Filter_Level_Set::median(const FilterParms& parms, FilterT& filter,
+    BossT& boss, bool verbose, const typename FilterT::MaskType* mask)
+{
+    const double voxelScale = 1.0 / filter.grid().voxelSize()[0];
+
+    for (int n = 0, N = parms.mIterations; n < N && !boss.wasInterrupted(); ++n) {
+
+        int radius = parms.mStencilWidth;
+
+        if (parms.mWorldUnits) {
+            double voxelRadius = double(parms.mStencilWidthWorld) * voxelScale;
+            radius = std::max(1, int(voxelRadius));
+        }
+
+        if (verbose) {
+            std::cout << "Median filter of radius " << radius << std::endl;
+        }
+
+        filter.median(radius, mask);
+    }
+}
+
+template<typename FilterT>
+void
+SOP_OpenVDB_Filter_Level_Set::meanCurvature(const FilterParms& parms, FilterT& filter,
+    BossT& boss, bool verbose, const typename FilterT::MaskType* mask)
+{
+    for (int n = 0, N = parms.mIterations; n < N && !boss.wasInterrupted(); ++n) {
+
+        if (verbose) std::cout << "Mean-curvature flow" << (n+1) << std::endl;
+
+        filter.meanCurvature(mask);
+    }
+}
+
+template<typename FilterT>
+void
+SOP_OpenVDB_Filter_Level_Set::laplacian(const FilterParms& parms, FilterT& filter,
+    BossT& boss, bool verbose, const typename FilterT::MaskType* mask)
+{
+    for (int n = 0, N = parms.mIterations; n < N && !boss.wasInterrupted(); ++n) {
+
+        if (verbose) std::cout << "Laplacian flow" << (n+1) << std::endl;
+
+        filter.laplacian(mask);
+    }
+}
+
+template<typename FilterT>
+inline void
+SOP_OpenVDB_Filter_Level_Set::renormalize(const FilterParms& parms, FilterT& filter,
+    BossT&, bool verbose)
+{
+    // We will restore the old state since it is important to level set tracking
+    const typename FilterT::State s = filter.getState();
+
+    filter.setNormCount(parms.mIterations);
+
+    filter.setTemporalScheme(openvdb::math::TVD_RK3);
+
+    if (verbose) std::cout << "Renormalize #" << parms.mIterations << std::endl;
+
+    filter.normalize();
+
+    filter.prune();
+
+    filter.setState(s);
+}
+
+template<typename FilterT>
+inline void
+SOP_OpenVDB_Filter_Level_Set::resizeNarrowBand(const FilterParms& parms, FilterT& filter,
+    BossT&, bool /*verbose*/)
+{
+    // The filter is a statemachine so we will restore the old
+    // state since it is important to subsequent level set tracking
+    const typename FilterT::State s = filter.getState();
+
+    filter.setNormCount(1); // only one normalization per iteration
+
+    int width = parms.mHalfWidth;
+
+    if (parms.mWorldUnits) {
+        double voxelWidth = double(parms.mHalfWidthWorld) / filter.grid().voxelSize()[0];
+        width = std::max(1, int(voxelWidth));
+    }
+
+    filter.resize(width);
+
+    filter.setState(s);
+}
+
+template<typename FilterT>
+inline void
+SOP_OpenVDB_Filter_Level_Set::track(const FilterParms& parms, FilterT& filter,
+    BossT& boss, bool verbose)
+{
+    for (int n = 0, N = parms.mIterations; n < N && !boss.wasInterrupted(); ++n) {
+
+        if (verbose) std::cout << "Tracking #" << (n+1) << std::endl;
+        filter.track();
+    }
+}
+
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb_houdini/houdini/SOP_OpenVDB_To_Polygons.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_To_Polygons.cc
@@ -79,9 +79,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_integral.hpp>
-#include <boost/type_traits/is_floating_point.hpp>
-#include <boost/math/special_functions/round.hpp>
 #include <string>
 #include <list>
 #include <vector>

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
@@ -689,7 +689,9 @@ SOP_OpenVDB_Vector_Merge::cookMySop(OP_Context& context)
             // Merge the input grids into an output grid.
             // This does not support a partial set so we quit early in that case.
             ScalarGridMerger op(xGrid, yGrid, zGrid, outGridName, copyInactiveValues,
-                std::bind(&SOP_OpenVDB_Vector_Merge::addWarningMessage,this,std::placeholders::_1));
+                                [this](const char* msg){
+                return addWarningMessage(this, msg);
+            });
             UTvdbProcessTypedGridScalar(UTvdbGetGridType(*nonNullGrid), *nonNullGrid, op);
 
             if (hvdb::GridPtr outGrid = op.getGrid()) {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
@@ -35,7 +35,6 @@
 /// @brief Merge groups of up to three scalar grids into vector grids.
 
 #ifdef _WIN32
-#define BOOST_REGEX_NO_LIB
 #endif
 
 #include <houdini_utils/ParmFactory.h>
@@ -45,7 +44,7 @@
 #include <openvdb/tools/Prune.h>
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_String.h>
-#include <boost/regex.hpp>
+#include <regex>
 #include <functional>
 #include <memory>
 #include <set>
@@ -675,8 +674,8 @@ SOP_OpenVDB_Vector_Merge::cookMySop(OP_Context& context)
             std::string outGridName;
             if (mergeName.isstring()) {
                 UT_String s; s.itoa(i);
-                outGridName = boost::regex_replace(
-                    mergeName.toStdString(), boost::regex("#+"), s.toStdString());
+                outGridName = std::regex_replace(
+                    mergeName.toStdString(), std::regex("#+"), s.toStdString());
             }
 
             if (useXName && nonNullVdb) {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Visualize.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Visualize.cc
@@ -57,16 +57,15 @@
 #include <GU/GU_PolyReduce.h>
 #include <PRM/PRM_Parm.h>
 
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_integral.hpp>
-#include <boost/type_traits/is_floating_point.hpp>
-#include <boost/type_traits/is_arithmetic.hpp>
+#include <type_traits>
 
-namespace boost {
-template<> struct is_integral<openvdb::PointIndex32>: public boost::true_type {};
-template<> struct is_integral<openvdb::PointIndex64>: public boost::true_type {};
-template<> struct is_integral<openvdb::PointDataIndex32>: public boost::true_type {};
-template<> struct is_integral<openvdb::PointDataIndex64>: public boost::true_type {};
+#include <boost/utility/enable_if.hpp>
+
+namespace std {
+template<> struct is_integral<openvdb::PointIndex32>: public std::true_type {};
+template<> struct is_integral<openvdb::PointIndex64>: public std::true_type {};
+template<> struct is_integral<openvdb::PointDataIndex32>: public std::true_type {};
+template<> struct is_integral<openvdb::PointDataIndex64>: public std::true_type {};
 }
 
 namespace hvdb = openvdb_houdini;
@@ -668,15 +667,15 @@ private:
     GA_Offset createPoint(const openvdb::CoordBBox&, const UT_Vector3& color);
 
     template<typename ValType>
-    typename boost::enable_if<boost::is_integral<ValType>, void>::type
+    typename boost::enable_if<std::is_integral<ValType>, void>::type
     addPoint(const openvdb::CoordBBox&, const UT_Vector3& color, ValType s, bool);
 
     template<typename ValType>
-    typename boost::enable_if<boost::is_floating_point<ValType>, void>::type
+    typename boost::enable_if<std::is_floating_point<ValType>, void>::type
     addPoint(const openvdb::CoordBBox&, const UT_Vector3& color, ValType s, bool);
 
     template<typename ValType>
-    typename boost::disable_if<boost::is_arithmetic<ValType>, void>::type
+    typename boost::disable_if<std::is_arithmetic<ValType>, void>::type
     addPoint(const openvdb::CoordBBox&, const UT_Vector3& color, ValType v, bool staggered);
 
     void addPoint(const openvdb::CoordBBox&, const UT_Vector3& color, bool staggered);
@@ -901,7 +900,7 @@ TreeVisualizer::createPoint(const openvdb::CoordBBox& bbox,
 
 
 template<typename ValType>
-typename boost::enable_if<boost::is_integral<ValType>, void>::type
+typename boost::enable_if<std::is_integral<ValType>, void>::type
 TreeVisualizer::addPoint(const openvdb::CoordBBox& bbox,
     const UT_Vector3& color, ValType s, bool)
 {
@@ -910,7 +909,7 @@ TreeVisualizer::addPoint(const openvdb::CoordBBox& bbox,
 
 
 template<typename ValType>
-typename boost::enable_if<boost::is_floating_point<ValType>, void>::type
+typename boost::enable_if<std::is_floating_point<ValType>, void>::type
 TreeVisualizer::addPoint(const openvdb::CoordBBox& bbox,
     const UT_Vector3& color, ValType s, bool)
 {
@@ -919,7 +918,7 @@ TreeVisualizer::addPoint(const openvdb::CoordBBox& bbox,
 
 
 template<typename ValType>
-typename boost::disable_if<boost::is_arithmetic<ValType>, void>::type
+typename boost::disable_if<std::is_arithmetic<ValType>, void>::type
 TreeVisualizer::addPoint(const openvdb::CoordBBox& bbox,
     const UT_Vector3& color, ValType v, bool staggered)
 {


### PR DESCRIPTION
Converted a lot of type_traits into c++11 (std::is_floating_point, std::is_same etc). Was a straight conversion and can then remove some boost headers.

Also changed a lot of boost::bind into std::bind. One issue there was that boost bind has the _1, _2 placeholders in a global namespace so there was ambiguous calling without the std::placeholders to qualify the names.

Another issue with boost bind was that I was getting errors with the bind not matching the overloaded function definition. Not sure if that was an issue with clang on OSX but the only way to get the right function to be bound was to change it's name and therefore making it explicit what function we want called. adding *Impl to the function name seemed an okay idea a the time.

All the tests in vdb_test pass and the SOP nodes seem to be working in houdini from my basic testing. 

I'm open to suggestion if this could be made any nicer (like removing the std::placeholders with namespace aliases?). 

Next step is to go through and change any boost::shared_ptr's to std::shared_ptrs (although there seems to be a comment about abi 3 compatibility which we want to keep for now I'm guessing?