### PR TITLE
Fix memory leaks in static variable pointers.

### DIFF
--- a/openvdb/Grid.cc
+++ b/openvdb/Grid.cc
@@ -74,35 +74,13 @@ struct LockedGridRegistry {
     GridFactoryMap mMap;
 };
 
-// Declare this at file scope to ensure thread-safe initialization.
-Mutex sInitGridRegistryMutex;
-
 
 // Global function for accessing the registry
 LockedGridRegistry*
 getGridRegistry()
 {
-    Lock lock(sInitGridRegistryMutex);
-
-    static LockedGridRegistry* registry = nullptr;
-
-    if (registry == nullptr) {
-
-#ifdef __ICC
-// Disable ICC "assignment to statically allocated variable" warning.
-// This assignment is mutex-protected and therefore thread-safe.
-__pragma(warning(disable:1711))
-#endif
-
-        registry = new LockedGridRegistry();
-
-#ifdef __ICC
-__pragma(warning(default:1711))
-#endif
-
-    }
-
-    return registry;
+    static LockedGridRegistry registry;
+    return &registry;
 }
 
 } // unnamed namespace

--- a/openvdb/Metadata.cc
+++ b/openvdb/Metadata.cc
@@ -55,28 +55,12 @@ struct LockedMetadataTypeRegistry {
     MetadataFactoryMap mMap;
 };
 
-// Declare this at file scope to ensure thread-safe initialization
-static Mutex theInitMetadataTypeRegistryMutex;
-
 // Global function for accessing the regsitry
 static LockedMetadataTypeRegistry*
 getMetadataTypeRegistry()
 {
-    Lock lock(theInitMetadataTypeRegistryMutex);
-
-    static LockedMetadataTypeRegistry *registry = nullptr;
-
-    if (registry == nullptr) {
-#if defined(__ICC)
-__pragma(warning(disable:1711)) // disable ICC "assignment to static variable" warnings
-#endif
-        registry = new LockedMetadataTypeRegistry();
-#if defined(__ICC)
-__pragma(warning(default:1711))
-#endif
-    }
-
-    return registry;
+    static LockedMetadataTypeRegistry registry;
+    return &registry;
 }
 
 bool

--- a/openvdb/math/Maps.cc
+++ b/openvdb/math/Maps.cc
@@ -52,20 +52,12 @@ Mutex sInitMapRegistryMutex;
 ////////////////////////////////////////
 
 
-MapRegistry* MapRegistry::mInstance = nullptr;
-
-
 // Caller is responsible for calling this function serially.
 MapRegistry*
 MapRegistry::staticInstance()
 {
-    if (mInstance == nullptr) {
-        OPENVDB_START_THREADSAFE_STATIC_WRITE
-            mInstance = new MapRegistry();
-        OPENVDB_FINISH_THREADSAFE_STATIC_WRITE
-            return mInstance;
-    }
-    return mInstance;
+    static MapRegistry registry;
+    return &registry;
 }
 
 

--- a/openvdb/math/Maps.h
+++ b/openvdb/math/Maps.h
@@ -313,8 +313,6 @@ private:
 
     static MapRegistry* staticInstance();
 
-    static MapRegistry* mInstance;
-
     MapDictionary mMap;
 };
 


### PR DESCRIPTION
Hi,

over at Autodesk we run OpenVDB under Valgrind, and we discovered that OpenVDB leaks a number of singletons in static variable pointers. This patch fixes these memory leaks.

Notice, we have used Meyers singleton pattern makes sure that the singletons are only allocated once the static function they reside in is called. This is also thread-safe in C++11 and above.

In AttributeArray,h it was not as straight-forward to use this pattern since the singleton's constructor depending on some code outside the class. In that case (and in Tree.h) we instead used std::call_once which is also thread-safe and serves the same purpose.
