### PR TITLE
Add methods to StringAttributeArray and StringAttributeWriteHandle

### DIFF
--- a/openvdb/points/AttributeArrayString.cc
+++ b/openvdb/points/AttributeArrayString.cc
@@ -201,6 +201,12 @@ void StringAttributeHandle::get(Name& name, Index n, Index m) const
 }
 
 
+const AttributeArray& StringAttributeHandle::array() const
+{
+    return mHandle.array();
+}
+
+
 ////////////////////////////////////////
 
 // StringAttributeWriteHandle implementation
@@ -292,6 +298,20 @@ void StringAttributeWriteHandle::resetCache()
         // add to the cache
         mCache[stringMeta->value()] = index;
     }
+}
+
+
+bool StringAttributeWriteHandle::hasIndex(const Name& name) const
+{
+    // empty strings always have an index at index zero
+    if (name.empty())   return true;
+    return mCache.find(name) != mCache.end();
+}
+
+
+AttributeArray& StringAttributeWriteHandle::array()
+{
+    return mWriteHandle.array();
 }
 
 

--- a/openvdb/points/AttributeArrayString.cc
+++ b/openvdb/points/AttributeArrayString.cc
@@ -301,7 +301,7 @@ void StringAttributeWriteHandle::resetCache()
 }
 
 
-bool StringAttributeWriteHandle::hasIndex(const Name& name) const
+bool StringAttributeWriteHandle::contains(const Name& name) const
 {
     // empty strings always have an index at index zero
     if (name.empty())   return true;

--- a/openvdb/points/AttributeArrayString.cc
+++ b/openvdb/points/AttributeArrayString.cc
@@ -301,17 +301,17 @@ void StringAttributeWriteHandle::resetCache()
 }
 
 
+AttributeArray& StringAttributeWriteHandle::array()
+{
+    return mWriteHandle.array();
+}
+
+
 bool StringAttributeWriteHandle::contains(const Name& name) const
 {
     // empty strings always have an index at index zero
     if (name.empty())   return true;
     return mCache.find(name) != mCache.end();
-}
-
-
-AttributeArray& StringAttributeWriteHandle::array()
-{
-    return mWriteHandle.array();
 }
 
 

--- a/openvdb/points/AttributeArrayString.h
+++ b/openvdb/points/AttributeArrayString.h
@@ -148,6 +148,8 @@ public:
     Name get(Index n, Index m = 0) const;
     void get(Name& name, Index n, Index m = 0) const;
 
+    const AttributeArray& array() const;
+
 protected:
     AttributeHandle<StringIndexType, StringCodec<false>>    mHandle;
     const MetaMap&                                          mMetadata;
@@ -191,6 +193,10 @@ public:
 
     /// Reset the value cache from the metadata
     void resetCache();
+
+    AttributeArray& array();
+
+    bool hasIndex(const Name& name) const;
 
 private:
     /// Retrieve the index of this string value from the cache

--- a/openvdb/points/AttributeArrayString.h
+++ b/openvdb/points/AttributeArrayString.h
@@ -148,6 +148,7 @@ public:
     Name get(Index n, Index m = 0) const;
     void get(Name& name, Index n, Index m = 0) const;
 
+    /// @brief Returns a reference to the array held in the Handle.
     const AttributeArray& array() const;
 
 protected:
@@ -194,8 +195,11 @@ public:
     /// Reset the value cache from the metadata
     void resetCache();
 
+    /// @brief Returns a reference to the array held in the Write Handle.
     AttributeArray& array();
 
+    /// @brief  Returns whether or not the metadata cache contains a given value.
+    /// @param  name Name of the String.
     bool contains(const Name& name) const;
 
 private:

--- a/openvdb/points/AttributeArrayString.h
+++ b/openvdb/points/AttributeArrayString.h
@@ -196,7 +196,7 @@ public:
 
     AttributeArray& array();
 
-    bool hasIndex(const Name& name) const;
+    bool contains(const Name& name) const;
 
 private:
     /// Retrieve the index of this string value from the cache

--- a/openvdb/unittest/TestAttributeArrayString.cc
+++ b/openvdb/unittest/TestAttributeArrayString.cc
@@ -363,9 +363,27 @@ TestAttributeArrayString::testStringAttributeWriteHandle()
         CPPUNIT_ASSERT_THROW(handle.set(1, "testB"), LookupError);
     }
 
+    { // empty string always has index 0
+        CPPUNIT_ASSERT(handle.hasIndex(""));
+    }
+
+    { // cache won't contain metadata until it has been reset
+        CPPUNIT_ASSERT(!handle.hasIndex("testA"));
+        CPPUNIT_ASSERT(!handle.hasIndex("testB"));
+        CPPUNIT_ASSERT(!handle.hasIndex("testC"));
+    }
+
     handle.resetCache();
 
+    { // empty string always has index 0 regardless of cache reset
+        CPPUNIT_ASSERT(handle.hasIndex(""));
+    }
+
     { // cache now reset
+        CPPUNIT_ASSERT(handle.hasIndex("testA"));
+        CPPUNIT_ASSERT(handle.hasIndex("testB"));
+        CPPUNIT_ASSERT(handle.hasIndex("testC"));
+
         CPPUNIT_ASSERT_NO_THROW(handle.set(1, "testB"));
 
         CPPUNIT_ASSERT_EQUAL(handle.get(0), Name(""));

--- a/openvdb/unittest/TestAttributeArrayString.cc
+++ b/openvdb/unittest/TestAttributeArrayString.cc
@@ -364,25 +364,25 @@ TestAttributeArrayString::testStringAttributeWriteHandle()
     }
 
     { // empty string always has index 0
-        CPPUNIT_ASSERT(handle.hasIndex(""));
+        CPPUNIT_ASSERT(handle.contains(""));
     }
 
     { // cache won't contain metadata until it has been reset
-        CPPUNIT_ASSERT(!handle.hasIndex("testA"));
-        CPPUNIT_ASSERT(!handle.hasIndex("testB"));
-        CPPUNIT_ASSERT(!handle.hasIndex("testC"));
+        CPPUNIT_ASSERT(!handle.contains("testA"));
+        CPPUNIT_ASSERT(!handle.contains("testB"));
+        CPPUNIT_ASSERT(!handle.contains("testC"));
     }
 
     handle.resetCache();
 
     { // empty string always has index 0 regardless of cache reset
-        CPPUNIT_ASSERT(handle.hasIndex(""));
+        CPPUNIT_ASSERT(handle.contains(""));
     }
 
     { // cache now reset
-        CPPUNIT_ASSERT(handle.hasIndex("testA"));
-        CPPUNIT_ASSERT(handle.hasIndex("testB"));
-        CPPUNIT_ASSERT(handle.hasIndex("testC"));
+        CPPUNIT_ASSERT(handle.contains("testA"));
+        CPPUNIT_ASSERT(handle.contains("testB"));
+        CPPUNIT_ASSERT(handle.contains("testC"));
 
         CPPUNIT_ASSERT_NO_THROW(handle.set(1, "testB"));
 


### PR DESCRIPTION
Added missing array() method for StringAttributeHandle and StringAttributeWriteHandle. Also added convenience hasIndex() method to StringAttributeWriteHandle for checking if a string exists in the metadata cache already.

Updated StringAttributeWriteHandle unit tests to use hasIndex to verify it is working as intended.