### PR TITLE
Fix for Strict Type builds

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
@@ -448,7 +448,7 @@ public:
             // Translate Houdini points toward the isosurface.
             UTparallelForLightItems(GA_SplittableRange(mRange), [&](const GA_SplittableRange& r) {
                 const auto cptAcc = cpt->getConstAccessor();
-                GA_Offset start = 0, end = 0;
+                GA_Offset start, end;
                 for (GA_Iterator it(r); it.blockAdvance(start, end); ) {
                     if (mBoss && mBoss->wasInterrupted()) break;
                     for (auto offset = start; offset < end; ++offset) {


### PR DESCRIPTION
In strict type builds 0 cannot be assigned to a GA_Offset.  Since the initialization was redundant, it was removed in this case.  If we prefer to always initialize, and explicit cast of (GA_Offset)0 may be used instead.