### PR TITLE
Refactor TestAttributeArray and add a new friend class to io::MappedFile

### DIFF
--- a/openvdb/io/io.h
+++ b/openvdb/io/io.h
@@ -41,6 +41,7 @@
 #include <memory>
 #include <string>
 
+class TestMappedFile;
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
@@ -178,6 +179,7 @@ public:
 
 private:
     friend class File;
+    friend class ::TestMappedFile;
 
     explicit MappedFile(const std::string& filename, bool autoDelete = false);
 


### PR DESCRIPTION
This new friend class is used to expose the constructor of io::MappedFile for use in the unit tests for AttributeArray, which makes them simpler.