### PR TITLE
Fix seg-fault when attempting to compare AttributeArrays of an unregistered type

### DIFF
--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -1799,7 +1799,7 @@ TypedAttributeArray<ValueType_, Codec_>::isEqual(const AttributeArray& other) co
     if(this->mSize != otherT->mSize ||
        this->mStrideOrTotalSize != otherT->mStrideOrTotalSize ||
        this->mIsUniform != otherT->mIsUniform ||
-       *this->sTypeName != *otherT->sTypeName) return false;
+       this->attributeType() != this->attributeType()) return false;
 
     this->doLoad();
     otherT->doLoad();

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -567,6 +567,13 @@ TestAttributeArray::testAttributeArray()
             }
         }
 
+        { // Equality using an unregistered attribute type
+            TypedAttributeArray<half> attr1(50);
+            TypedAttributeArray<half> attr2(50);
+
+            CPPUNIT_ASSERT(attr1 == attr2);
+        }
+
         // attribute array must not be uniform for compression
 
         attr.set(1, 7);


### PR DESCRIPTION
Creating two AttributeArrays of a type that has yet to be initialized and attempting to compare them would cause a seg-fault as the equality method was previously comparing uninitialized static memory that was only lazy-initialized by calling attributeType().