### PR TITLE
ABI=6 and Fast AttributeArray Copying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,8 @@ cache:
 
 # Setup environment variables for different concurrent builds
 env:
-  # Build and run unit tests for ABI={3,4,5}
+  # Build and run unit tests for ABI={3,4,5,6}
+  - ABI=6 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
   - ABI=5 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
   - ABI=4 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
@@ -60,17 +61,14 @@ env:
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=16.0
 
   # Build and run unit tests for ABI={3,4,5} with Blosc disabled
+  - ABI=6 BLOSC=no RELEASE=yes HOUDINI_MAJOR=none
   - ABI=5 BLOSC=no RELEASE=yes HOUDINI_MAJOR=none
-  - ABI=4 BLOSC=no RELEASE=yes HOUDINI_MAJOR=none
-  - ABI=3 BLOSC=no RELEASE=yes HOUDINI_MAJOR=none
 
   # Build (but don't run) unit tests in debug mode for ABI={3,4,5} with and without Blosc
+  - ABI=6 BLOSC=yes RELEASE=no HOUDINI_MAJOR=none
   - ABI=5 BLOSC=yes RELEASE=no HOUDINI_MAJOR=none
-  - ABI=4 BLOSC=yes RELEASE=no HOUDINI_MAJOR=none
-  - ABI=3 BLOSC=yes RELEASE=no HOUDINI_MAJOR=none
+  - ABI=6 BLOSC=no RELEASE=no HOUDINI_MAJOR=none
   - ABI=5 BLOSC=no RELEASE=no HOUDINI_MAJOR=none
-  - ABI=4 BLOSC=no RELEASE=no HOUDINI_MAJOR=none
-  - ABI=3 BLOSC=no RELEASE=no HOUDINI_MAJOR=none
 
 # Build and install all library dependencies for OpenVDB
 # (build will error if this stage does not succeed)

--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -1,6 +1,17 @@
 OpenVDB Version History
 =======================
 
+Version 6.0.0 - In development
+
+      Some changes in this release (see "ABI changes" below) alter
+      the grid ABI so that it is incompatible with earlier versions
+      of the OpenVDB library, such as the ones built into Houdini
+      up to and including Houdini 16.  To preserve ABI compatibility,
+      when compiling OpenVDB or any dependent code define the macro
+      OPENVDB_ABI_VERSION_NUMBER=N, where, for example, N is 3 for
+      Houdini 15, 15.5 and 16, 4 for Houdini 16.5 and 5 for Houdini 17.0
+
+
 Version 5.2.0 - August 13, 2018
 
     New features:

--- a/openvdb/INSTALL
+++ b/openvdb/INSTALL
@@ -195,8 +195,8 @@ Installation
     A default local build generates the following libraries and executables
     (but see the Makefile for additional targets and build options):
 
-    openvdb/libopenvdb.so.5.2.0         the OpenVDB library
-    openvdb/libopenvdb.so               symlink to libopenvdb.so.5.2.0
+    openvdb/libopenvdb.so.6.0.0         the OpenVDB library
+    openvdb/libopenvdb.so               symlink to libopenvdb.so.6.0.0
     openvdb/pyopenvdb.so                the OpenVDB Python module (if Python
                                         and Boost.Python are available)
     openvdb/vdb_print                   command-line tool that prints info
@@ -242,8 +242,8 @@ Installation
                 version.h
         lib/
             libopenvdb.so
-            libopenvdb.so.5.2
-            libopenvdb.so.5.2.0
+            libopenvdb.so.6.0
+            libopenvdb.so.6.0.0
 
         python/
             include/
@@ -252,7 +252,7 @@ Installation
             lib/
                 python$(PYTHON_VERSION)/
                     pyopenvdb.so
-                    pyopenvdb.so.5.2
+                    pyopenvdb.so.6.0
 
         share/
             doc/

--- a/openvdb/doxygen-config
+++ b/openvdb/doxygen-config
@@ -38,11 +38,11 @@ PROJECT_NAME           = "OpenVDB"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 5.2.0
+PROJECT_NUMBER         = 6.0.0
 
-ALIASES += vdbnamespace="openvdb::v5_2"
-PREDEFINED = OPENVDB_VERSION_NAME=v5_2
-PREDEFINED += OPENVDB_ABI_VERSION_NUMBER=5
+ALIASES += vdbnamespace="openvdb::v6_0"
+PREDEFINED = OPENVDB_VERSION_NAME=v6_0
+PREDEFINED += OPENVDB_ABI_VERSION_NUMBER=6
 
 PREDEFINED += __declspec(x):= __attribute__(x):=
 PREDEFINED += OPENVDB_STATIC_SPECIALIZATION=""

--- a/openvdb/points/AttributeArray.cc
+++ b/openvdb/points/AttributeArray.cc
@@ -193,8 +193,7 @@ AttributeArray::operator==(const AttributeArray& other) const
     this->loadData();
     other.loadData();
 
-    if(this->mCompressedBytes != other.mCompressedBytes ||
-       this->mSerializationFlags != other.mSerializationFlags ||
+    if(this->mSerializationFlags != other.mSerializationFlags ||
        this->mFlags != other.mFlags) return false;
     return this->isEqual(other);
 }

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -148,8 +148,32 @@ public:
     template <typename ValueType, typename CodecType> friend class AttributeHandle;
 
     AttributeArray() = default;
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+    AttributeArray(const AttributeArray& rhs)
+        : mCompressedBytes(rhs.mCompressedBytes)
+        , mFlags(rhs.mFlags)
+        , mSerializationFlags(rhs.mSerializationFlags)
+        , mOutOfCore(rhs.mOutOfCore)
+    {
+        if (rhs.mPageHandle)    mPageHandle = rhs.mPageHandle->copy();
+        else                    mPageHandle = compression::PageHandle::Ptr();
+    }
+    AttributeArray& operator=(const AttributeArray& rhs)
+    {
+        mCompressedBytes = rhs.mCompressedBytes;
+        mFlags = rhs.mFlags;
+        mSerializationFlags = rhs.mSerializationFlags;
+        mOutOfCore = rhs.mOutOfCore;
+        if (rhs.mPageHandle)    mPageHandle = rhs.mPageHandle->copy();
+        else                    mPageHandle = compression::PageHandle::Ptr();
+        return *this;
+    }
+#else
     AttributeArray(const AttributeArray&) = default;
     AttributeArray& operator=(const AttributeArray&) = default;
+#endif
+    AttributeArray(AttributeArray&&) = default;
+    AttributeArray& operator=(AttributeArray&&) = default;
     virtual ~AttributeArray() = default;
 
     /// Return a copy of this attribute.

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -223,7 +223,7 @@ public:
     /// Return @c true if the value type is floating point
     virtual bool valueTypeIsFloatingPoint() const = 0;
 
-    /// Return @c true if the value type is scalar (not vector, quaternion or matrix)
+    /// Return @c true if the value type is a class (ie vector, matrix or quaternion return true)
     virtual bool valueTypeIsClass() const = 0;
 
     /// Return @c true if the value type is a vector
@@ -257,7 +257,7 @@ public:
     bool hasValueType() const { return this->type().first == typeNameAsString<ValueType>(); }
 
     /// Set value at given index @a n from @a sourceIndex of another @a sourceArray
-    /// @note deprecated from ABI=6, use set()/setUnsafe() with source-target index pairs
+    /// @note deprecated from ABI=6, use copyValues() with source-target index pairs
 #if OPENVDB_ABI_VERSION_NUMBER >= 6
     OPENVDB_DEPRECATED
 #endif
@@ -657,7 +657,7 @@ public:
     /// Return @c true if the value type is floating point
     bool valueTypeIsFloatingPoint() const override;
 
-    /// Return @c true if the value type is scalar (not vector, quaternion or matrix)
+    /// Return @c true if the value type is a class (ie vector, matrix or quaternion return true)
     bool valueTypeIsClass() const override;
 
     /// Return @c true if the value type is a vector

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -1314,12 +1314,19 @@ template<typename ValueType_, typename Codec_>
 bool
 TypedAttributeArray<ValueType_, Codec_>::valueTypeIsFloatingPoint() const
 {
-    // std::is_floating_point evaluates to false for half so use std::is_integral
-    // Note that as implemented, this only works as expected for vectors, not matrices
-    // and quaternions. However, because we don't use integer matrices or quaternions,
-    // this still performs correctly for all the types we care about.
     // TODO: Update to use Traits that correctly handle matrices and quaternions.
-    return !std::is_integral<typename VecTraits<ValueType>::ElementType>::value;
+
+    if (std::is_same<ValueType, Quats>::value ||
+        std::is_same<ValueType, Quatd>::value ||
+        std::is_same<ValueType, Mat3s>::value ||
+        std::is_same<ValueType, Mat3d>::value ||
+        std::is_same<ValueType, Mat4s>::value ||
+        std::is_same<ValueType, Mat4d>::value)      return true;
+
+    using ElementT = typename VecTraits<ValueType>::ElementType;
+
+    // half is not defined as float point as expected, so explicitly handle it
+    return std::is_floating_point<ElementT>::value || std::is_same<half, ElementT>::value;
 }
 
 

--- a/openvdb/points/AttributeGroup.cc
+++ b/openvdb/points/AttributeGroup.cc
@@ -53,13 +53,6 @@ GroupHandle::GroupHandle(const GroupAttributeArray& array, const GroupType& offs
     // load data if delay-loaded
 
     mArray.loadData();
-
-    // if array is compressed and preserve compression is true, copy and decompress
-    // into a local copy that is destroyed with handle to maintain thread-safety
-
-    if (mArray.isCompressed()) {
-        const_cast<GroupAttributeArray&>(mArray).decompress();
-    }
 }
 
 
@@ -73,13 +66,6 @@ GroupHandle::GroupHandle(const GroupAttributeArray& array, const GroupType& bitM
     // load data if delay-loaded
 
     mArray.loadData();
-
-    // if array is compressed and preserve compression is true, copy and decompress
-    // into a local copy that is destroyed with handle to maintain thread-safety
-
-    if (mArray.isCompressed()) {
-        const_cast<GroupAttributeArray&>(mArray).decompress();
-    }
 }
 
 

--- a/openvdb/points/PointDelete.h
+++ b/openvdb/points/PointDelete.h
@@ -103,6 +103,22 @@ inline void deleteFromGroup(PointDataTreeT& pointTree,
 namespace point_delete_internal {
 
 
+struct VectorWrapper
+{
+    using T = std::vector<std::pair<Index, Index>>;
+
+    VectorWrapper(const T& _data) : data(_data) { }
+    operator bool() const { return index < data.size(); }
+    VectorWrapper& operator++() { index++; return *this; }
+    Index sourceIndex() const { assert(*this); return data[index].first; }
+    Index targetIndex() const { assert(*this); return data[index].second; }
+
+private:
+    const T& data;
+    T::size_type index = 0;
+}; // struct VectorWrapper
+
+
 template <typename PointDataTreeT, typename FilterT>
 struct DeleteByFilterOp
 {
@@ -167,6 +183,23 @@ struct DeleteByFilterOp
 
             // now construct new attribute arrays which exclude data from deleted points
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+            std::vector<std::pair<Index, Index>> indexMapping;
+            indexMapping.reserve(newSize);
+
+            for (auto voxel = leaf->cbeginValueAll(); voxel; ++voxel) {
+                for (auto iter = leaf->beginIndexVoxel(voxel.getCoord(), mFilter);
+                     iter; ++iter) {
+                    indexMapping.emplace_back(*iter, attributeIndex++);
+                }
+                endOffsets.push_back(static_cast<ValueType>(attributeIndex));
+            }
+
+            for (size_t i = 0; i < attributeSetSize; i++) {
+                VectorWrapper indexMappingWrapper(indexMapping);
+                newAttributeArrays[i]->copyValues(*(existingAttributeArrays[i]), indexMappingWrapper);
+            }
+#else
             for (auto voxel = leaf->cbeginValueAll(); voxel; ++voxel) {
                 for (auto iter = leaf->beginIndexVoxel(voxel.getCoord(), mFilter);
                      iter; ++iter) {
@@ -178,6 +211,7 @@ struct DeleteByFilterOp
                 }
                 endOffsets.push_back(static_cast<ValueType>(attributeIndex));
             }
+#endif
 
             leaf->replaceAttributeSet(newAttributeSet);
             leaf->setOffsets(endOffsets);

--- a/openvdb/points/StreamCompression.cc
+++ b/openvdb/points/StreamCompression.cc
@@ -511,7 +511,12 @@ PagedInputStream::createHandle(std::streamsize n)
         mByteIndex = 0;
     }
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+    // TODO: C++14 introduces std::make_unique
+    PageHandle::Ptr pageHandle(new PageHandle(mPage, mByteIndex, n));
+#else
     PageHandle::Ptr pageHandle = std::make_shared<PageHandle>(mPage, mByteIndex, n);
+#endif
 
     mByteIndex += int(n);
 

--- a/openvdb/points/StreamCompression.h
+++ b/openvdb/points/StreamCompression.h
@@ -209,6 +209,9 @@ public:
     /// @brief Retrieve a reference to the stored page
     Page& page();
 
+    /// @brief Return the size of the buffer
+    int size() const { return mSize; }
+
     /// @brief Read and return the buffer, loading and decompressing
     /// the Page if necessary.
     std::unique_ptr<char[]> read();

--- a/openvdb/points/StreamCompression.h
+++ b/openvdb/points/StreamCompression.h
@@ -189,12 +189,16 @@ private:
 }; // class Page
 
 
-/// @brief A PageHandle holds a shared ptr to a Page and a specific stream
+/// @brief A PageHandle holds a unique ptr to a Page and a specific stream
 /// pointer to a point within the decompressed Page buffer
 class OPENVDB_API PageHandle
 {
 public:
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+    using Ptr = std::unique_ptr<PageHandle>;
+#else
     using Ptr = std::shared_ptr<PageHandle>;
+#endif
 
     /// @brief Create the page handle
     /// @param page a shared ptr to the page that stores the buffer
@@ -208,6 +212,9 @@ public:
     /// @brief Read and return the buffer, loading and decompressing
     /// the Page if necessary.
     std::unique_ptr<char[]> read();
+
+    /// @brief Return a copy of this PageHandle
+    Ptr copy() { return Ptr(new PageHandle(mPage, mIndex, mSize)); }
 
 protected:
     friend class ::TestStreamCompression;

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -404,6 +404,182 @@ TestAttributeArray::testAttributeArray()
         CPPUNIT_ASSERT(attrF->hasValueType<float>());
     }
 
+    { // lots of type checking
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+        Index size(50);
+        {
+            TypedAttributeArray<bool> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("bool"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(1), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(1), attr.storageTypeSize());
+            CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<int16_t> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("int16"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(2), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(2), attr.storageTypeSize());
+            CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<int32_t> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("int32"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(4), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(4), attr.storageTypeSize());
+            CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<int64_t> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("int64"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(8), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(8), attr.storageTypeSize());
+            CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            // half is not registered by default, but for complete-ness
+            TypedAttributeArray<half> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("half"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(2), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(2), attr.storageTypeSize());
+            CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<float> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("float"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(4), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(4), attr.storageTypeSize());
+            CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<double> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("double"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(8), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(8), attr.storageTypeSize());
+            CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<math::Vec3<int32_t>> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("vec3i"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(12), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(12), attr.storageTypeSize());
+            CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<math::Vec3<double>> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("vec3d"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(24), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(24), attr.storageTypeSize());
+            CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<math::Mat3<float>> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("mat3s"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(36), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(36), attr.storageTypeSize());
+            CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<math::Mat4<double>> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("mat4d"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(128), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(128), attr.storageTypeSize());
+            CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<math::Quat<float>> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("quats"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("null"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(16), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(16), attr.storageTypeSize());
+            CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<float, TruncateCodec> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            CPPUNIT_ASSERT_EQUAL(Name("float"), attr.valueType());
+            CPPUNIT_ASSERT_EQUAL(Name("trnc"), attr.codecType());
+            CPPUNIT_ASSERT_EQUAL(Index(4), attr.valueTypeSize());
+            CPPUNIT_ASSERT_EQUAL(Index(2), attr.storageTypeSize());
+            CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
+            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsVector());
+            CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
+            CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
+        }
+#endif
+    }
+
     {
         AttributeArray::Ptr attr(new AttributeArrayC(50));
 
@@ -1226,6 +1402,13 @@ TestAttributeArray::testDelayedLoad()
             CPPUNIT_ASSERT(attrB.isOutOfCore());
             CPPUNIT_ASSERT(attrBcopy.isOutOfCore());
             CPPUNIT_ASSERT(attrBequal.isOutOfCore());
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+            CPPUNIT_ASSERT(!static_cast<AttributeArray&>(attrB).isDataLoaded());
+            CPPUNIT_ASSERT(!static_cast<AttributeArray&>(attrBcopy).isDataLoaded());
+            CPPUNIT_ASSERT(!static_cast<AttributeArray&>(attrBequal).isDataLoaded());
+#endif
+
             attrB.loadData();
             attrBcopy.loadData();
             attrBequal.loadData();
@@ -1233,6 +1416,12 @@ TestAttributeArray::testDelayedLoad()
             CPPUNIT_ASSERT(!attrB.isOutOfCore());
             CPPUNIT_ASSERT(!attrBcopy.isOutOfCore());
             CPPUNIT_ASSERT(!attrBequal.isOutOfCore());
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+            CPPUNIT_ASSERT(static_cast<AttributeArray&>(attrB).isDataLoaded());
+            CPPUNIT_ASSERT(static_cast<AttributeArray&>(attrBcopy).isDataLoaded());
+            CPPUNIT_ASSERT(static_cast<AttributeArray&>(attrBequal).isDataLoaded());
+#endif
 
             CPPUNIT_ASSERT_EQUAL(attrA.memUsage(), attrB.memUsage());
             CPPUNIT_ASSERT_EQUAL(attrA.memUsage(), attrBcopy.memUsage());

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -734,7 +734,11 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(attr.isUniform(), attrB.isUniform());
             CPPUNIT_ASSERT_EQUAL(attr.isTransient(), attrB.isTransient());
             CPPUNIT_ASSERT_EQUAL(attr.isHidden(), attrB.isHidden());
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             CPPUNIT_ASSERT_EQUAL(attr.isCompressed(), attrB.isCompressed());
+#pragma GCC diagnostic pop
 
             for (unsigned i = 0; i < unsigned(count); ++i) {
                 CPPUNIT_ASSERT_EQUAL(attr.get(i), attrB.get(i));
@@ -749,12 +753,19 @@ TestAttributeArray::testAttributeArray()
         attr.set(2, 8);
         attr.set(6, 100);
 
+        // note that in-memory compression has been deprecated, verify all
+        // isCompressed() calls return false
+
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+        CPPUNIT_ASSERT(!attr.isCompressed());
+
         { // test compressed copy construction
             attr.compress();
 
-#ifdef OPENVDB_USE_BLOSC
-            CPPUNIT_ASSERT(attr.isCompressed());
-#endif
+            CPPUNIT_ASSERT(!attr.isCompressed());
 
             AttributeArray::Ptr attrCopy = attr.copy();
             AttributeArrayI& attrB(AttributeArrayI::cast(*attrCopy));
@@ -777,9 +788,7 @@ TestAttributeArray::testAttributeArray()
         { // test compressed copy construction (uncompress on copy)
             attr.compress();
 
-#ifdef OPENVDB_USE_BLOSC
-            CPPUNIT_ASSERT(attr.isCompressed());
-#endif
+            CPPUNIT_ASSERT(!attr.isCompressed());
 
             AttributeArray::Ptr attrCopy = attr.copyUncompressed();
             AttributeArrayI& attrB(AttributeArrayI::cast(*attrCopy));
@@ -803,6 +812,8 @@ TestAttributeArray::testAttributeArray()
             }
         }
     }
+
+#pragma GCC diagnostic pop
 
     { // Fixed codec (position range)
         AttributeArray::Ptr attr1(new AttributeArrayC(50));
@@ -917,7 +928,11 @@ TestAttributeArray::testAttributeArray()
         CPPUNIT_ASSERT_EQUAL(attrA.isUniform(), attrB.isUniform());
         CPPUNIT_ASSERT_EQUAL(attrA.isTransient(), attrB.isTransient());
         CPPUNIT_ASSERT_EQUAL(attrA.isHidden(), attrB.isHidden());
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         CPPUNIT_ASSERT_EQUAL(attrA.isCompressed(), attrB.isCompressed());
+#pragma GCC diagnostic pop
         CPPUNIT_ASSERT_EQUAL(attrA.memUsage(), attrB.memUsage());
 
         for (unsigned i = 0; i < unsigned(count); ++i) {
@@ -1132,6 +1147,10 @@ TestAttributeArray::testAttributeHandle()
         CPPUNIT_ASSERT_EQUAL(Vec3f(10), handle.get(5));
     }
 
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
     {
         AttributeArray* array = attrSet.get(1);
 
@@ -1145,22 +1164,21 @@ TestAttributeArray::testAttributeHandle()
 
         CPPUNIT_ASSERT(!array->isCompressed());
 
-#ifdef OPENVDB_USE_BLOSC
         array->compress();
 
-        CPPUNIT_ASSERT(array->isCompressed());
+        CPPUNIT_ASSERT(!array->isCompressed());
 
         {
             AttributeHandle<float> handleRO(*array);
 
-            CPPUNIT_ASSERT(array->isCompressed());
+            CPPUNIT_ASSERT(!array->isCompressed());
 
             CPPUNIT_ASSERT_EQUAL(float(11), handleRO.get(6));
 
-            CPPUNIT_ASSERT(array->isCompressed());
+            CPPUNIT_ASSERT(!array->isCompressed());
         }
 
-        CPPUNIT_ASSERT(array->isCompressed());
+        CPPUNIT_ASSERT(!array->isCompressed());
 
         {
             AttributeHandle<float> handleRO(*array, /*preserveCompression=*/false);
@@ -1175,8 +1193,9 @@ TestAttributeArray::testAttributeHandle()
         }
 
         CPPUNIT_ASSERT(!array->isCompressed());
-#endif
     }
+
+#pragma GCC diagnostic pop
 
     // check values have been correctly set without using handles
 
@@ -1394,7 +1413,11 @@ TestAttributeArray::testDelayedLoad()
             CPPUNIT_ASSERT_EQUAL(attrA.isUniform(), attrB.isUniform());
             CPPUNIT_ASSERT_EQUAL(attrA.isTransient(), attrB.isTransient());
             CPPUNIT_ASSERT_EQUAL(attrA.isHidden(), attrB.isHidden());
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             CPPUNIT_ASSERT_EQUAL(attrA.isCompressed(), attrB.isCompressed());
+#pragma GCC diagnostic pop
 
             AttributeArrayI attrBcopy(attrB);
             AttributeArrayI attrBequal = attrB;
@@ -1445,7 +1468,11 @@ TestAttributeArray::testDelayedLoad()
             CPPUNIT_ASSERT_EQUAL(attrA2.isUniform(), attrB2.isUniform());
             CPPUNIT_ASSERT_EQUAL(attrA2.isTransient(), attrB2.isTransient());
             CPPUNIT_ASSERT_EQUAL(attrA2.isHidden(), attrB2.isHidden());
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             CPPUNIT_ASSERT_EQUAL(attrA2.isCompressed(), attrB2.isCompressed());
+#pragma GCC diagnostic pop
 
             AttributeArrayF attrB2copy(attrB2);
             AttributeArrayF attrB2equal = attrB2;
@@ -1601,17 +1628,16 @@ TestAttributeArray::testDelayedLoad()
 
             CPPUNIT_ASSERT(attrB.isOutOfCore());
 
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             CPPUNIT_ASSERT(!attrB.isCompressed());
 
             attrB.compress();
 
-#ifdef OPENVDB_USE_BLOSC
-            CPPUNIT_ASSERT(!attrB.isOutOfCore());
-            CPPUNIT_ASSERT(attrB.isCompressed());
-#else
             CPPUNIT_ASSERT(attrB.isOutOfCore());
             CPPUNIT_ASSERT(!attrB.isCompressed());
-#endif
+#pragma GCC diagnostic pop
         }
 
         // read in using delayed load and check copy and assignment constructors
@@ -1879,7 +1905,11 @@ TestAttributeArray::testDelayedLoad()
             io::setStreamMetadataPtr(fileout, streamMetadata);
             io::setDataCompression(fileout, io::COMPRESS_BLOSC);
 
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             attrA.compress();
+#pragma GCC diagnostic pop
             attrA.writeMetadata(fileout, false, /*paged=*/true);
 
             compression::PagedOutputStream outputStreamSize(fileout);
@@ -1914,17 +1944,17 @@ TestAttributeArray::testDelayedLoad()
             inputStream.setSizeOnly(false);
             attrB.readPagedBuffers(inputStream);
 
-#ifdef OPENVDB_USE_BLOSC
-            CPPUNIT_ASSERT(attrB.isCompressed());
-#endif
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            CPPUNIT_ASSERT(!attrB.isCompressed());
 
             CPPUNIT_ASSERT(attrB.isOutOfCore());
             attrB.loadData();
             CPPUNIT_ASSERT(!attrB.isOutOfCore());
 
-#ifdef OPENVDB_USE_BLOSC
-            CPPUNIT_ASSERT(attrB.isCompressed());
-#endif
+            CPPUNIT_ASSERT(!attrB.isCompressed());
+#pragma GCC diagnostic pop
 
             CPPUNIT_ASSERT_EQUAL(attrA.memUsage(), attrB.memUsage());
 
@@ -1975,13 +2005,19 @@ TestAttributeArray::testDelayedLoad()
             inputStream.setSizeOnly(false);
             attrB.readPagedBuffers(inputStream);
 
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
             CPPUNIT_ASSERT(attrB.isOutOfCore());
-            CPPUNIT_ASSERT(attrB.isCompressed());
+            CPPUNIT_ASSERT(!attrB.isCompressed());
 
             attrB.compress();
 
             CPPUNIT_ASSERT(attrB.isOutOfCore());
-            CPPUNIT_ASSERT(attrB.isCompressed());
+            CPPUNIT_ASSERT(!attrB.isCompressed());
+
+#pragma GCC diagnostic pop
         }
 
         // read in using delayed load and check copy and assignment constructors
@@ -2040,12 +2076,15 @@ TestAttributeArray::testDelayedLoad()
 
             CPPUNIT_ASSERT(attrB.isOutOfCore());
 
-            CPPUNIT_ASSERT(attrB.isCompressed());
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            CPPUNIT_ASSERT(!attrB.isCompressed());
 
             AttributeHandle<int> handle(attrB);
 
             CPPUNIT_ASSERT(!attrB.isOutOfCore());
-            CPPUNIT_ASSERT(attrB.isCompressed());
+            CPPUNIT_ASSERT(!attrB.isCompressed());
 
             for (unsigned i = 0; i < unsigned(count); ++i) {
                 CPPUNIT_ASSERT_EQUAL(attrA.get(i), handle.get(i));
@@ -2053,6 +2092,7 @@ TestAttributeArray::testDelayedLoad()
 
             AttributeHandle<int> handle2(attrB, /*preserveCompression=*/false);
             CPPUNIT_ASSERT(!attrB.isCompressed());
+#pragma GCC diagnostic pop
         }
 #endif
 

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -417,7 +417,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(1), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(1), attr.storageTypeSize());
             CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -430,7 +430,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(2), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(2), attr.storageTypeSize());
             CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -443,7 +443,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(4), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(4), attr.storageTypeSize());
             CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -456,7 +456,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(8), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(8), attr.storageTypeSize());
             CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -470,7 +470,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(2), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(2), attr.storageTypeSize());
             CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -483,7 +483,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(4), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(4), attr.storageTypeSize());
             CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -496,7 +496,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(8), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(8), attr.storageTypeSize());
             CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -509,7 +509,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(12), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(12), attr.storageTypeSize());
             CPPUNIT_ASSERT(!attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(attr.valueTypeIsClass());
             CPPUNIT_ASSERT(attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -522,7 +522,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(24), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(24), attr.storageTypeSize());
             CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(attr.valueTypeIsClass());
             CPPUNIT_ASSERT(attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -535,7 +535,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(36), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(36), attr.storageTypeSize());
             CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(attr.valueTypeIsMatrix());
@@ -548,7 +548,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(128), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(128), attr.storageTypeSize());
             CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(attr.valueTypeIsMatrix());
@@ -561,7 +561,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(16), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(16), attr.storageTypeSize());
             CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(!attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -574,7 +574,7 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(Index(4), attr.valueTypeSize());
             CPPUNIT_ASSERT_EQUAL(Index(2), attr.storageTypeSize());
             CPPUNIT_ASSERT(attr.valueTypeIsFloatingPoint());
-            CPPUNIT_ASSERT(attr.valueTypeIsScalar());
+            CPPUNIT_ASSERT(!attr.valueTypeIsClass());
             CPPUNIT_ASSERT(!attr.valueTypeIsVector());
             CPPUNIT_ASSERT(!attr.valueTypeIsQuaternion());
             CPPUNIT_ASSERT(!attr.valueTypeIsMatrix());
@@ -1107,12 +1107,6 @@ TestAttributeArray::testAttributeArrayCopy()
         rangeIndexPairs[10].second = size+1;
 
         CPPUNIT_ASSERT_THROW(attr.copyValues(sourceAttr, rangeWrapper), IndexError);
-        CPPUNIT_ASSERT_THROW(attr.copyValuesUnsafe(sourceAttr, rangeWrapper,
-            /*range-checking=*/true), IndexError);
-
-        // TODO: find a good way of testing the following without reading invalid memory
-        // CPPUNIT_ASSERT_THROW(attr.copyValuesUnsafe(sourceAttr, rangeWrapper,
-        //     /*range-checking=*/false), IndexError);
     }
 
     { // source attribute array is uniform
@@ -1177,8 +1171,7 @@ TestAttributeArray::testAttributeArrayCopy()
         uniformIndexPairs.push_back(std::make_pair(5, 0));
         VectorWrapper uniformWrapper(uniformIndexPairs);
 
-        CPPUNIT_ASSERT_THROW(uniformAttr.copyValuesUnsafe(attr, uniformWrapper,
-            /*rangeChecking=*/true), IndexError);
+        // note that calling copyValues() will implicitly expand the uniform target
 
         CPPUNIT_ASSERT_NO_THROW(uniformAttr.copyValuesUnsafe(attr, uniformWrapper));
 

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -1155,6 +1155,36 @@ TestAttributeArray::testAttributeArrayCopy()
 
         CPPUNIT_ASSERT(!attr.isUniform());
     }
+
+    { // target attribute array is uniform
+        AttributeArrayD uniformTypedAttr(size);
+        AttributeArray& uniformAttr(uniformTypedAttr);
+
+        uniformTypedAttr.collapse(5.3);
+
+        CPPUNIT_ASSERT(uniformAttr.isUniform());
+
+        AttributeArrayD typedAttr(size);
+        AttributeArray& attr(typedAttr);
+
+        typedAttr.set(5, 1.2);
+        typedAttr.set(10, 3.1);
+
+        CPPUNIT_ASSERT(!attr.isUniform());
+
+        std::vector<std::pair<Index, Index>> uniformIndexPairs;
+        uniformIndexPairs.push_back(std::make_pair(10, 0));
+        uniformIndexPairs.push_back(std::make_pair(5, 0));
+        VectorWrapper uniformWrapper(uniformIndexPairs);
+
+        CPPUNIT_ASSERT_THROW(uniformAttr.copyValuesUnsafe(attr, uniformWrapper,
+            /*rangeChecking=*/true), IndexError);
+
+        CPPUNIT_ASSERT_NO_THROW(uniformAttr.copyValuesUnsafe(attr, uniformWrapper));
+
+        CPPUNIT_ASSERT(uniformAttr.isUniform());
+        CPPUNIT_ASSERT(uniformTypedAttr.get(0) == typedAttr.get(5));
+    }
 #endif
 }
 

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -1288,12 +1288,12 @@ TestAttributeArray::testStrided()
         CPPUNIT_ASSERT_EQUAL(Index(3), handle.stride());
         CPPUNIT_ASSERT_EQUAL(Index(2), handle.size());
 
+// as of ABI=6, the base memory requirements of an AttributeArray have been lowered
 #if OPENVDB_ABI_VERSION_NUMBER >= 6
-        size_t arrayMem = 56;
+        size_t arrayMem = 40;
 #else
         size_t arrayMem = 64;
 #endif
-
         CPPUNIT_ASSERT_EQUAL(sizeof(int) * /*size*/3 * /*stride*/2 + arrayMem, array->memUsage());
     }
 

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -1288,7 +1288,11 @@ TestAttributeArray::testStrided()
         CPPUNIT_ASSERT_EQUAL(Index(3), handle.stride());
         CPPUNIT_ASSERT_EQUAL(Index(2), handle.size());
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+        size_t arrayMem = 56;
+#else
         size_t arrayMem = 64;
+#endif
 
         CPPUNIT_ASSERT_EQUAL(sizeof(int) * /*size*/3 * /*stride*/2 + arrayMem, array->memUsage());
     }

--- a/openvdb/unittest/TestAttributeArrayString.cc
+++ b/openvdb/unittest/TestAttributeArrayString.cc
@@ -219,6 +219,15 @@ TestAttributeArrayString::testStringAttribute()
         CPPUNIT_ASSERT_EQUAL(attr.isTransient(), attrB.isTransient());
         CPPUNIT_ASSERT_EQUAL(attr.isHidden(), attrB.isHidden());
         CPPUNIT_ASSERT_EQUAL(isString(attr), isString(attrB));
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+        AttributeArray& baseAttr(attr);
+        CPPUNIT_ASSERT_EQUAL(Name(typeNameAsString<StringIndexType>()), baseAttr.valueType());
+        CPPUNIT_ASSERT_EQUAL(Name("str"), baseAttr.codecType());
+        CPPUNIT_ASSERT_EQUAL(Index(4), baseAttr.valueTypeSize());
+        CPPUNIT_ASSERT_EQUAL(Index(4), baseAttr.storageTypeSize());
+        CPPUNIT_ASSERT(!baseAttr.valueTypeIsFloatingPoint());
+#endif
     }
 
     { // IO

--- a/openvdb/unittest/TestAttributeGroup.cc
+++ b/openvdb/unittest/TestAttributeGroup.cc
@@ -120,6 +120,15 @@ TestAttributeGroup::testAttributeGroup()
         CPPUNIT_ASSERT_EQUAL(attr.isTransient(), attrB.isTransient());
         CPPUNIT_ASSERT_EQUAL(attr.isHidden(), attrB.isHidden());
         CPPUNIT_ASSERT_EQUAL(isGroup(attr), isGroup(attrB));
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+        AttributeArray& baseAttr(attr);
+        CPPUNIT_ASSERT_EQUAL(Name(typeNameAsString<GroupType>()), baseAttr.valueType());
+        CPPUNIT_ASSERT_EQUAL(Name("grp"), baseAttr.codecType());
+        CPPUNIT_ASSERT_EQUAL(Index(1), baseAttr.valueTypeSize());
+        CPPUNIT_ASSERT_EQUAL(Index(1), baseAttr.storageTypeSize());
+        CPPUNIT_ASSERT(!baseAttr.valueTypeIsFloatingPoint());
+#endif
     }
 
     { // casting

--- a/openvdb/unittest/TestAttributeSet.cc
+++ b/openvdb/unittest/TestAttributeSet.cc
@@ -82,7 +82,11 @@ matchingAttributeSets(const AttributeSet& lhs,
 
         if (a->size() != b->size()) return false;
         if (a->isUniform() != b->isUniform()) return false;
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         if (a->isCompressed() != b->isCompressed()) return false;
+#pragma GCC diagnostic pop
         if (a->isHidden() != b->isHidden()) return false;
         if (a->type() != b->type()) return false;
     }

--- a/openvdb/unittest/TestPointAttribute.cc
+++ b/openvdb/unittest/TestPointAttribute.cc
@@ -458,17 +458,20 @@ TestPointAttribute::testBloscCompress()
     CPPUNIT_ASSERT(leafIter->attributeArray("compact").isUniform());
     CPPUNIT_ASSERT(leafIter2->attributeArray("compact").isUniform());
 
+// disable deprecated warnings for in-memory compression
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
     bloscCompressAttribute(tree, "id");
 
 #ifdef OPENVDB_USE_BLOSC
-    CPPUNIT_ASSERT(leafIter->attributeArray("id").isCompressed());
+    CPPUNIT_ASSERT(!leafIter->attributeArray("id").isCompressed());
     CPPUNIT_ASSERT(!leafIter->attributeArray("id2").isCompressed());
-    CPPUNIT_ASSERT(leafIter2->attributeArray("id").isCompressed());
+    CPPUNIT_ASSERT(!leafIter2->attributeArray("id").isCompressed());
     CPPUNIT_ASSERT(!leafIter2->attributeArray("id2").isCompressed());
-
-    CPPUNIT_ASSERT(
-        leafIter->attributeArray("id").memUsage() < leafIter->attributeArray("id2").memUsage());
 #endif
+
+#pragma GCC diagnostic pop
 }
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC

--- a/openvdb/version.h
+++ b/openvdb/version.h
@@ -92,8 +92,8 @@
 
 
 // Library major, minor and patch version numbers
-#define OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER 5
-#define OPENVDB_LIBRARY_MINOR_VERSION_NUMBER 2
+#define OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER 6
+#define OPENVDB_LIBRARY_MINOR_VERSION_NUMBER 0
 #define OPENVDB_LIBRARY_PATCH_VERSION_NUMBER 0
 
 // If OPENVDB_ABI_VERSION_NUMBER is already defined (e.g., via -DOPENVDB_ABI_VERSION_NUMBER=N)
@@ -174,7 +174,7 @@
 
 /// By default, the @b OPENVDB_REQUIRE_VERSION_NAME macro is undefined, and
 /// symbols from the version namespace are promoted to the top-level namespace
-/// so that, for example, @b openvdb::v5_0::io::File can be referred to
+/// so that, for example, @b openvdb::v6_0::io::File can be referred to
 /// simply as @b openvdb::io::File.
 ///
 /// When @b OPENVDB_REQUIRE_VERSION_NAME is defined, symbols must be

--- a/openvdb_houdini/houdini/ParmFactory.cc
+++ b/openvdb_houdini/houdini/ParmFactory.cc
@@ -695,7 +695,7 @@ ParmFactory&
 ParmFactory::setVectorSize(int n) { mImpl->vectorSize = n; return *this; }
 
 ParmFactory&
-ParmFactory::setInvisible(bool invisible) { mImpl->invisible = invisible; return *this; }
+ParmFactory::setInvisible() { mImpl->invisible = true; return *this; }
 
 PRM_Template
 ParmFactory::get() const

--- a/openvdb_houdini/houdini/ParmFactory.cc
+++ b/openvdb_houdini/houdini/ParmFactory.cc
@@ -272,7 +272,8 @@ struct ParmFactory::Impl
         spareData(nullptr),
         multiparms(nullptr),
         typeExtended(PRM_TYPE_NONE),
-        vectorSize(1)
+        vectorSize(1),
+        invisible(false)
     {
         const_cast<PRM_Name*>(name)->harden();
     }
@@ -295,6 +296,7 @@ struct ParmFactory::Impl
     PRM_Type                   type;
     PRM_TypeExtended           typeExtended;
     int                        vectorSize;
+    bool                       invisible;
 
     static PRM_SpareData* const sSOPInputSpareData[4];
 };
@@ -692,6 +694,9 @@ ParmFactory::setTypeExtended(PRM_TypeExtended t) { mImpl->typeExtended = t; retu
 ParmFactory&
 ParmFactory::setVectorSize(int n) { mImpl->vectorSize = n; return *this; }
 
+ParmFactory&
+ParmFactory::setInvisible(bool invisible) { mImpl->invisible = invisible; return *this; }
+
 PRM_Template
 ParmFactory::get() const
 {
@@ -701,21 +706,26 @@ ParmFactory::get() const
 #else
     const char *tooltip = mImpl->tooltip.c_str();
 #endif
+
+    PRM_Template parm;
     if (mImpl->multiType != PRM_MULTITYPE_NONE) {
-        return PRM_Template(
+        parm.initMulti(
             mImpl->multiType,
             const_cast<PRM_Template*>(mImpl->multiparms),
+            PRM_Template::PRM_EXPORT_MIN,
             fpreal(mImpl->vectorSize),
             const_cast<PRM_Name*>(mImpl->name),
             const_cast<PRM_Default*>(mImpl->defaults),
             const_cast<PRM_Range*>(mImpl->range),
+            0, // no callback
             mImpl->spareData,
             tooltip ? ::strdup(tooltip) : nullptr,
             const_cast<PRM_ConditionalBase*>(mImpl->conditional));
     } else {
-        return PRM_Template(
+        parm.initialize(
             mImpl->type,
             mImpl->typeExtended,
+            PRM_Template::PRM_EXPORT_MIN,
             mImpl->vectorSize,
             const_cast<PRM_Name*>(mImpl->name),
             const_cast<PRM_Default*>(mImpl->defaults),
@@ -727,6 +737,10 @@ ParmFactory::get() const
             tooltip ? ::strdup(tooltip) : nullptr,
             const_cast<PRM_ConditionalBase*>(mImpl->conditional));
     }
+    if (mImpl->invisible) {
+        parm.setInvisible(true);
+    }
+    return parm;
 }
 
 
@@ -754,7 +768,7 @@ documentParms(std::ostream& os, PRM_Template const * const parmList, int level =
         ++parmIdx, ++parm)
     {
         const auto parmType = parm->getType();
-        if (parmType == PRM_LABEL) continue;
+        if (parmType == PRM_LABEL || parm->getInvisible()) continue;
 
         const auto parmLabel = [parm]() {
             UT_String lbl = parm->getLabel();

--- a/openvdb_houdini/houdini/ParmFactory.h
+++ b/openvdb_houdini/houdini/ParmFactory.h
@@ -342,7 +342,7 @@ public:
     /// @note Marking parameters as obsolete is preferable to making them invisible as changing
     /// invisible parameter values will still trigger a re-cook, however this is not possible
     /// when using multi-parms.
-    ParmFactory& setInvisible(bool);
+    ParmFactory& setInvisible();
 
     /// Construct and return the parameter template.
     PRM_Template get() const;

--- a/openvdb_houdini/houdini/ParmFactory.h
+++ b/openvdb_houdini/houdini/ParmFactory.h
@@ -338,6 +338,12 @@ public:
     /// @details (The default vector size is one element.)
     ParmFactory& setVectorSize(int);
 
+    /// @brief Mark this parameter as hidden from the UI.
+    /// @note Marking parameters as obsolete is preferable to making them invisible as changing
+    /// invisible parameter values will still trigger a re-cook, however this is not possible
+    /// when using multi-parms.
+    ParmFactory& setInvisible(bool);
+
     /// Construct and return the parameter template.
     PRM_Template get() const;
 

--- a/openvdb_houdini/houdini/PointUtils.cc
+++ b/openvdb_houdini/houdini/PointUtils.cc
@@ -1076,15 +1076,6 @@ convertHoudiniToPointDataGrid(const GU_Detail& ptGeo,
 
     compactAttributes(tree);
 
-    // Apply blosc compression to attributes
-
-    for (const auto& attrInfo : attributes)
-    {
-        if (!attrInfo.second.second)  continue;
-
-        bloscCompressAttribute(tree, attrInfo.first);
-    }
-
     return pointDataGrid;
 }
 

--- a/openvdb_houdini/houdini/PointUtils.h
+++ b/openvdb_houdini/houdini/PointUtils.h
@@ -69,6 +69,7 @@ using OffsetPair = std::pair<GA_Offset, GA_Offset>;
 using OffsetPairList = std::vector<OffsetPair>;
 using OffsetPairListPtr = std::shared_ptr<OffsetPairList>;
 
+// note that the bool parameter here for toggling in-memory compression is now deprecated
 using AttributeInfoMap = std::map<openvdb::Name, std::pair<int, bool>>;
 
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
@@ -418,7 +418,7 @@ Unit Vector:\n\
     }
 
     attrParms.add(hutil::ParmFactory(PRM_TOGGLE, "blosccompression#", "Blosc Compression")
-        .setInvisible(true) // this parm is now a no-op as in-memory blosc compression is deprecated
+        .setInvisible() // this parm is now a no-op as in-memory blosc compression is deprecated
         .setDefault(PRMzeroDefaults));
 
     // Add multi parm

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
@@ -418,11 +418,8 @@ Unit Vector:\n\
     }
 
     attrParms.add(hutil::ParmFactory(PRM_TOGGLE, "blosccompression#", "Blosc Compression")
-        .setDefault(PRMzeroDefaults)
-        .setTooltip(
-            "Enable Blosc compression\n\n"
-            "Blosc is a lossless compression codec that is effective with"
-            " floating-point data and is very fast to compress and decompress."));
+        .setInvisible(true) // this parm is now a no-op as in-memory blosc compression is deprecated
+        .setDefault(PRMzeroDefaults));
 
     // Add multi parm
     parms.add(hutil::ParmFactory(PRM_MULTITYPE_LIST, "attrList", "Point Attributes")
@@ -949,7 +946,6 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Convert)::cookVDBSop(OP
                     const bool isQuaternion = width == 4 && (typeInfo == GA_TYPE_QUATERNION);
                     const bool isMatrix = width == 16 && (typeInfo == GA_TYPE_TRANSFORM);
 
-                    const bool bloscCompression = evalIntInst("blosccompression#", &i, 0, 0);
                     int valueCompression = static_cast<int>(
                         evalIntInst("valuecompression#", &i, 0, 0));
 
@@ -1003,8 +999,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Convert)::cookVDBSop(OP
                         }
                     }
 
-                    attributes[attributeName] =
-                        std::pair<int, bool>(valueCompression, bloscCompression);
+                    attributes[attributeName] = std::pair<int, bool>(valueCompression, false);
                 }
             }
         } else {
@@ -1068,7 +1063,6 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Convert)::cookVDBSop(OP
                         }
                     }
 
-                    // when converting all attributes apply no compression
                     attributes[attributeName] = std::pair<int, bool>(valueCompression, false);
                 }
             }


### PR DESCRIPTION
* Added ABI=6, bumped Travis to build for ABI=6 and deprecated some older ABI builds
* Add various new methods to AttributeArray for querying value and storage type and size metadata
* In-memory compression for AttributeArray has now been deprecated
* AttributeArray member variables have been unioned, cleaned up and packed to reduce memory from 64 bytes to 40 bytes (for an empty array)
* New AttributeArray copyValues() method that can copy batches of attributes using a custom iterator to avoid the cost of doing a virtual function call per-point
* Add copyValues() implementation to deletion of points to accelerate this method for ABI=6
* Add extra AttributeArray read checks to error if attempting to access or write partially-read arrays