### PR TITLE
Travis CI Update and H17 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ env:
   - ABI=4 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
 
-  # Build Houdini plug-ins for H16.0, H16.5
+  # Build Houdini plug-ins for H17.0, H16.0, H16.5
+  - ABI=5 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=17.0
   - ABI=4 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=16.5
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=16.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,8 @@
 #
 # Author: Dan Bailey
 
-# OpenVDB requires Ubuntu Trusty 14.04 or later which Travis does not yet
-# support using the faster Container-based infrastructure
-# (https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments)
-sudo: required
-dist: trusty
+# OpenVDB now uses Ubuntu Xenial 16.04 (so as to be able to build for H17+)
+dist: xenial
 
 language: cpp
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![OpenVDB](http://www.openvdb.org/images/openvdb_logo.png)
 
+[![Build Status](https://travis-ci.org/AcademySoftwareFoundation/openvdb.svg?branch=master)](https://travis-ci.org/AcademySoftwareFoundation/openvdb)
+
 [Website](http://www.openvdb.org) |
 [Discussion Forum](http://www.openvdb.org/forum) |
 [Documentation](http://www.openvdb.org/documentation/)

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -109,7 +109,9 @@ if [ "$TASK" = "install" ]; then
     cd /test
     # install OpenVDB pre-requisites when built without Houdini (in order of Makefile)
     if [ "$HOUDINI_MAJOR" = "none" ]; then
-        sudo apt-get install -y libboost-all-dev
+        sudo apt-get install -y libboost-iostreams-dev
+        sudo apt-get install -y libboost-system-dev
+        sudo apt-get install -y libboost-thread-dev
         sudo apt-get install -y libtbb-dev
         # download and build Blosc 1.5.0  if required
         if [ "$BLOSC" = "yes" ]; then
@@ -159,7 +161,8 @@ if [ "$TASK" = "install" ]; then
         sudo ln -s /test/hou/dsolib/libGL.so.1 /test/hou/dsolib/libGL.so
         # boost no longer shipped with Houdini from 16.5 onwards
         if [ $HOUDINI_HAS_BOOST -eq 0 ]; then
-            sudo apt-get install -y libboost-all-dev
+            sudo apt-get install -y libboost-iostreams-dev
+            sudo apt-get install -y libboost-system-dev
             cp -r /usr/include/boost /test/hou/toolkit/include
             cp /usr/lib/x86_64-linux-gnu/libboost_iostreams.so* /test/hou/dsolib
             cp /usr/lib/x86_64-linux-gnu/libboost_system.so* /test/hou/dsolib

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -64,7 +64,9 @@ COMMON_ARGS="   CXX=$HOME/ccache_clang++\
 STANDALONE_ARGS="   BOOST_LIB_DIR=/usr/lib/x86_64-linux-gnu\
                     EXR_INCL_DIR=/usr/include/OpenEXR\
                     EXR_LIB_DIR=/usr/local/lib\
-                    TBB_LIB_DIR=/usr/lib"
+                    TBB_LIB_DIR=/usr/lib\
+                    CPPUNIT_INCL_DIR=/test/cppunit/include\
+                    CPPUNIT_LIB_DIR=/test/cppunit/lib"
 HOUDINI_ARGS="      BOOST_INCL_DIR=/test/hou/toolkit/include\
                     BOOST_LIB_DIR=/test/hou/dsolib\
                     TBB_LIB_DIR=/test/hou/dsolib\
@@ -101,7 +103,6 @@ if [ "$TASK" = "install" ]; then
     if [ "$HOUDINI_MAJOR" = "none" ]; then
         sudo apt-get install -y libboost-all-dev
         sudo apt-get install -y libtbb-dev
-        sudo apt-get install -y libcppunit-dev
         # download and build Blosc 1.5.0  if required
         if [ "$BLOSC" = "yes" ]; then
             wget https://github.com/Blosc/c-blosc/archive/v1.5.0.zip
@@ -113,6 +114,15 @@ if [ "$TASK" = "install" ]; then
             make install
             cd -
         fi
+        # compile and install cppunit
+        wget http://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz
+        tar -xvzf cppunit-1.13.2.tar.gz
+        cd cppunit-1.13.2
+        mkdir -p /test/cppunit
+        ./configure --prefix=/test/cppunit
+        make
+        make install
+        cd -
     else
         # install houdini pre-requisites
         sudo apt-get install -y libxi-dev

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -126,6 +126,12 @@ if [ "$TASK" = "install" ]; then
         cd hou
         tar -xzf houdini.tar.gz
         cd -
+        # copy libGL and libGLU and setup sym-links
+        sudo apt-get install libglu1-mesa
+        cp /usr/lib/x86_64-linux-gnu/libGLU.so* /test/hou/dsolib
+        cp /usr/lib/x86_64-linux-gnu/mesa/libGL.so* /test/hou/dsolib
+        sudo ln -s /test/hou/dsolib/libGLU.so.1 /test/hou/dsolib/libGLU.so
+        sudo ln -s /test/hou/dsolib/libGL.so.1 /test/hou/dsolib/libGL.so
         # boost no longer shipped with Houdini from 16.5 onwards
         if [ $HOUDINI_HAS_BOOST -eq 0 ]; then
             sudo apt-get install -y libboost-all-dev

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -51,27 +51,36 @@ BLOSC="$3"
 RELEASE="$4"
 HOUDINI_MAJOR="$5"
 
-# Disable Doxygen, Log4CPlus, Python and GLFW for now
-COMMON_ARGS="   CXX=$HOME/ccache_clang++\
-                DESTDIR=/tmp/OpenVDB\
-                CONCURRENT_MALLOC_LIB=\
-                DOXYGEN=\
-                LOG4CPLUS_INCL_DIR=\
-                PYTHON_INCL_DIR=\
-                GLFW_INCL_DIR="
+COMMON_ARGS="CXX=$HOME/ccache_compiler DESTDIR=/tmp/OpenVDB"
 
-# Boost, OpenEXR and TBB
+# Location of third-party dependencies for standalone and houdini builds
 STANDALONE_ARGS="   BOOST_LIB_DIR=/usr/lib/x86_64-linux-gnu\
                     EXR_INCL_DIR=/usr/include/OpenEXR\
                     EXR_LIB_DIR=/usr/local/lib\
                     TBB_LIB_DIR=/usr/lib\
+                    CONCURRENT_MALLOC_LIB=\
                     CPPUNIT_INCL_DIR=/test/cppunit/include\
-                    CPPUNIT_LIB_DIR=/test/cppunit/lib"
+                    CPPUNIT_LIB_DIR=/test/cppunit/lib\
+                    LOG4CPLUS_INCL_DIR=/usr/include\
+                    LOG4CPLUS_LIB_DIR=/usr/lib/x86_64-linux-gnu\
+                    GLFW_INCL_DIR=/usr/include/GL\
+                    GLFW_LIB_DIR=/usr/lib/x86_64-linux-gnu\
+                    PYTHON_INCL_DIR=/usr/include/python2.7\
+                    PYTHON_LIB_DIR=/usr/lib/x86_64-linux-gnu\
+                    BOOST_PYTHON_LIB_DIR=/usr/lib/x86_64-linux-gnu\
+                    BOOST_PYTHON_LIB=-lboost_python\
+                    NUMPY_INCL_DIR=/usr/lib/python2.7/dist-packages/numpy/core/include/numpy\
+                    EPYDOC=/usr/bin/epydoc\
+                    DOXYGEN=/usr/bin/doxygen"
 HOUDINI_ARGS="      BOOST_INCL_DIR=/test/hou/toolkit/include\
                     BOOST_LIB_DIR=/test/hou/dsolib\
                     TBB_LIB_DIR=/test/hou/dsolib\
                     EXR_INCL_DIR=/test/hou/toolkit/include\
-                    EXR_LIB_DIR=/test/hou/dsolib"
+                    EXR_LIB_DIR=/test/hou/dsolib\
+                    LOG4CPLUS_INCL_DIR=\
+                    GLFW_INCL_DIR=\
+                    PYTHON_INCL_DIR=\
+                    DOXYGEN="
 
 # Blosc
 STANDALONE_BLOSC_ARGS=" BLOSC_INCL_DIR=/test/blosc/include\
@@ -83,23 +92,22 @@ NO_BLOSC_ARGS="         BLOSC_INCL_DIR=\
 
 HOUDINI_HAS_BOOST=$(echo "$HOUDINI_MAJOR < 16.5" | bc -l)
 
-# introduce wrapper to clang++ that uses ccache, this is mainly
-# for use in hcustom where changing the compiler is hard
-echo '#!/bin/bash' > $HOME/ccache_clang++
-echo 'export CCACHE_MAXSIZE=20G' >> $HOME/ccache_clang++
-echo 'ccache clang++ -Qunused-arguments $*' >> $HOME/ccache_clang++
-chmod 755 $HOME/ccache_clang++
-
 # zero ccache stats
 ccache -z
 
 if [ "$TASK" = "install" ]; then
+    # introduce wrapper to compiler that uses ccache, this is mainly
+    # for use in hcustom where changing the compiler is hard
+    echo '#!/bin/bash' > $HOME/ccache_compiler
+    echo 'export CCACHE_MAXSIZE=20G' >> $HOME/ccache_compiler
+    echo 'ccache clang++ -Qunused-arguments $*' >> $HOME/ccache_compiler
+    chmod 755 $HOME/ccache_compiler
     # update OS
     sudo apt-get update
     # sym-link to reduce command word lengths
     sudo ln -s $PWD /test
     cd /test
-    # install OpenVDB pre-requisites when built without Houdini
+    # install OpenVDB pre-requisites when built without Houdini (in order of Makefile)
     if [ "$HOUDINI_MAJOR" = "none" ]; then
         sudo apt-get install -y libboost-all-dev
         sudo apt-get install -y libtbb-dev
@@ -123,6 +131,13 @@ if [ "$TASK" = "install" ]; then
         make
         make install
         cd -
+        sudo apt-get install -y liblog4cplus-dev
+        sudo apt-get install -y libglfw3-dev
+        sudo apt-get install -y python-dev
+        sudo apt-get install -y libboost-python-dev
+        sudo apt-get install -y python-numpy
+        sudo apt-get install -y python-epydoc
+        sudo apt-get install -y doxygen
     else
         # install houdini pre-requisites
         sudo apt-get install -y libxi-dev

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -171,6 +171,7 @@ elif [ "$TASK" = "script" ]; then
         # debug mode - build OpenVDB unit tests
         if [ "$BLOSC" = "yes" ]; then
             if [ "$RELEASE" = "yes" ]; then
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" -j4
                 make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi="$ABI" -j4
                 # check for any indirect includes
                 make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS header_test abi="$ABI" -j4


### PR DESCRIPTION
* Updated our Travis CI build to use Ubuntu 16.04 (Xenial) from 14.04 (Trusty)
* Added support for building Houdini 17.0 DSOs (relatively easy when using Xenial)
* Various other minor changes to resolve issues in bumping major version of Ubuntu
* Increased CI to also now build python bindings, VDB binaries, C++ and Python documentation
* Add a Travis CI badge to GitHub repo landing page to highlight pass/fail state of master branch