### PR TITLE
Downgrade library version to 6.0.1

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -9,7 +9,7 @@ Version 6.0.0 - December 18, 2018
       Some changes in this release (see "ABI changes" below) alter
       the grid ABI so that it is incompatible with earlier versions
       of the OpenVDB library, such as the ones built into Houdini
-      up to and including Houdini 16.  To preserve ABI compatibility,
+      up to and including Houdini 17.  To preserve ABI compatibility,
       when compiling OpenVDB or any dependent code define the macro
       OPENVDB_ABI_VERSION_NUMBER=N, where, for example, N is 3 for
       Houdini 15, 15.5 and 16, 4 for Houdini 16.5 and 5 for Houdini 17.0
@@ -21,7 +21,7 @@ Version 6.0.0 - December 18, 2018
       particlesToMask() and particleTrailsToMask() for common particle
       rasterization use cases.
     - Added batch copying of AttributeArray values that significantly
-      out-performs the older method that relied on a virtual function.
+      outperforms the older method that relied on a virtual function.
 
     Improvements:
     - Improved the responsiveness of the mesh to volume converter to interrupt
@@ -29,22 +29,24 @@ Version 6.0.0 - December 18, 2018
     - Attempts to use a partially deserialized AttributeArray now errors.
     - Updated point deletion to use faster batch copying for ABI=6+.
     - Methods relating to in-memory Blosc compression for AttributeArrays now
-      do nothing and have been marked deprecated resulting in memory savings for
-      ABI=6+.
+      do nothing and have been marked deprecated resulting in memory savings
+      for ABI=6+.
 
     Bug fixes:
-    - Fixed various signed/unsigned casting issues when moving points in point
-      data grids to resolve compiler warnings.
+    - Fixed various signed/unsigned casting issues to resolve compiler warnings
+      when moving points in point data grids.
 
     ABI changes:
     - Added new virtual functions to AttributeArray.
     - Changed the order and size of member variables in AttributeArray
-      and TypedAttributeArray classes.
+      and TypedAttributeArray.
 
     API changes:
     - Removed a number of methods that were deprecated in version 5.0.0 or
       earlier.
     - Removed the experimental ValueAccessor::newSetValue method.
+    - Deprecated AttributeArray methods relating to in-memory
+      Blosc compression.
 
     Houdini:
     - Added an option to the Visualize SOP to display leaf nodes as points.

--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -1,7 +1,7 @@
 OpenVDB Version History
 =======================
 
-Version 6.1.0 - In development
+Version 6.0.1 - In development
 
 
 Version 6.0.0 - December 18, 2018
@@ -52,8 +52,9 @@ Version 6.0.0 - December 18, 2018
       and "voxelmode" parameters to "leafstyle", "internalstyle", etc.
       and converted them from ordinal to string-valued.
     - Made various improvements to viewport rendering of point data grids.
-    - Updated ParmFactory to allow parameters to be marked as hidden, this is
-      useful for multi-parms where it is not possible to mark them as obsolete.
+    - Added a ParmFactory::setInvisible() method to allow parameters
+      to be marked as hidden.  This is useful for multi-parms,
+      whose child parameters cannot be made obsolete.
     - Removed the option to use in-memory Blosc compression from the Points
       Convert SOP as this feature has now been deprecated.
     - Made various small changes for Houdini 17 compatibility.

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -2,9 +2,9 @@
 
 @page changes Release Notes
 
-@htmlonly <a name="v6_1_0_changes"></a>@endhtmlonly
+@htmlonly <a name="v6_0_1_changes"></a>@endhtmlonly
 @par
-<B>Version 6.1.0</B> - <I>In development</I>
+<B>Version 6.0.1</B> - <I>In development</I>
 
 
 @htmlonly <a name="v6_0_0_changes"></a>@endhtmlonly
@@ -69,8 +69,9 @@ Houdini:
   to <TT>leafstyle</TT>, <TT>internalstyle</TT>, etc. and converted them
   from ordinals to strings.
 - Made various improvements to viewport rendering of point data grids.
-- Updated ParmFactory to allow parameters to be marked as hidden, this is
-  useful for multi-parms where it is not possible to mark them as obsolete.
+- Added a <B>ParmFactory::setInvisible</B> method to allow parameters
+  to be marked as hidden.  This is useful for multi-parms,
+  whose child parameters cannot be made obsolete.
 - Removed the option to use in-memory Blosc compression from the
   Points&nbsp;Convert&nbsp;SOP as this feature has now been deprecated.
 - Made various small changes for Houdini&nbsp;17 compatibility.

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -57,9 +57,7 @@ ABI changes:
 API changes:
 - Removed a number of methods that were deprecated in version&nbsp;5.0.0 or
   earlier.
-- Removed the experimental
-  @vdblink::tree::ValueAccessor::newSetValue() ValueAccessor::newSetValue@endlink
-  method.
+- Removed the experimental @b ValueAccessor::newSetValue method.
 
 @par
 Houdini:

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -12,6 +12,18 @@
 <B>Version 6.0.0</B> - <I>December 18, 2018</I>
 
 @par
+<BLOCKQUOTE>
+Some changes in this release (see @ref v6_0_0_ABI_changes "ABI changes" below)
+alter the grid&nbsp;ABI so that it is incompatible with earlier versions of
+the OpenVDB library, such as the ones built into Houdini up to and including
+Houdini&nbsp;17.
+To preserve ABI compatibility, when compiling OpenVDB or any dependent code
+define the macro <TT>OPENVDB_ABI_VERSION_NUMBER=</TT><I>N</I>, where,
+for example, <I>N</I> is 3 for Houdini&nbsp;15, 15.5 and&nbsp;16,
+4 for Houdini&nbsp;16.5 and 5 for Houdini&nbsp;17.0.
+</BLOCKQUOTE>
+
+@par
 New features:
 - Added support to the
   @link ParticlesToLevelSet.h ParticlesToLevelSet@endlink tool
@@ -22,11 +34,12 @@ New features:
   @vdblink::tools::particlesToMask() particlesToMask@endlink
   and @vdblink::tools::particleTrailsToMask() particleTrailsToMask@endlink
   for common particle rasterization use cases.
-- Added batch copying functions
-  @vdblink::points::AttributeArray::copyValues() AttributeArray::copyValues()@endlink
-  @vdblink::points::AttributeArray::copyValuesUnsafe() AttributeArray::copyValuesUnsafe()@endlink
-  that significantly out-performs the older
-  @vdblink::points::AttributeArray::set() AttributeArray@endlink method.
+- Added batch copying functions @vdblink::points::AttributeArray::copyValues()
+  AttributeArray::copyValues@endlink and
+  @vdblink::points::AttributeArray::copyValuesUnsafe()
+  AttributeArray::copyValuesUnsafe@endlink that significantly outperform
+  the older @vdblink::points::AttributeArray::set()
+  AttributeArray::set@endlink method.
 
 @par
 Improvements:
@@ -36,28 +49,31 @@ Improvements:
   @vdblink::points::AttributeArray AttributeArray@endlink now errors.
 - Updated point deletion to use faster batch copying for ABI=6+.
 - Methods relating to in-memory Blosc compression for
-  @vdblink::points::AttributeArray AttributeArray@endlink now do nothing and
-  have been marked deprecated resulting in memory savings for ABI=6+.
+  @vdblink::points::AttributeArray::compress() AttributeArray@endlink
+  now do nothing and have been marked deprecated resulting in memory savings
+  for ABI=6+.
 
 @par
 Bug fixes:
-- Fixed various signed/unsigned casting issues when moving points in point
-  data grids to resolve compiler warnings.
+- Fixed various signed/unsigned casting issues to resolve compiler warnings
+  when moving points in point data grids.
 
+@anchor v6_0_0_ABI_changes
 @par
 ABI changes:
 - Added multiple new virtual functions to
   @vdblink::points::AttributeArray AttributeArray@endlink.
 - Changed the order and size of member variables in
   @vdblink::points::AttributeArray AttributeArray@endlink
-  and @vdblink::points::TypedAttributeArray TypedAttributeArray@endlink
-  classes.
+  and @vdblink::points::TypedAttributeArray TypedAttributeArray@endlink.
 
 @par
 API changes:
 - Removed a number of methods that were deprecated in version&nbsp;5.0.0 or
   earlier.
 - Removed the experimental @b ValueAccessor::newSetValue method.
+- Deprecated @vdblink::points::AttributeArray::compress()
+  AttributeArray@endlink methods relating to in-memory Blosc compression.
 
 @par
 Houdini:

--- a/openvdb/doxygen-config
+++ b/openvdb/doxygen-config
@@ -38,7 +38,7 @@ PROJECT_NAME           = "OpenVDB"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 6.1.0
+PROJECT_NUMBER         = 6.0.1
 
 ALIASES += vdbnamespace="openvdb::v6_0"
 PREDEFINED = OPENVDB_VERSION_NAME=v6_0

--- a/openvdb/version.h
+++ b/openvdb/version.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -93,8 +93,8 @@
 
 // Library major, minor and patch version numbers
 #define OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER 6
-#define OPENVDB_LIBRARY_MINOR_VERSION_NUMBER 1
-#define OPENVDB_LIBRARY_PATCH_VERSION_NUMBER 0
+#define OPENVDB_LIBRARY_MINOR_VERSION_NUMBER 0
+#define OPENVDB_LIBRARY_PATCH_VERSION_NUMBER 1
 
 // If OPENVDB_ABI_VERSION_NUMBER is already defined (e.g., via -DOPENVDB_ABI_VERSION_NUMBER=N)
 // use that ABI version.  Otherwise, use this library version's default ABI.
@@ -174,7 +174,7 @@
 
 /// By default, the @b OPENVDB_REQUIRE_VERSION_NAME macro is undefined, and
 /// symbols from the version namespace are promoted to the top-level namespace
-/// so that, for example, @b openvdb::v6_0::io::File can be referred to
+/// so that, for example, @b openvdb::v5_0::io::File can be referred to
 /// simply as @b openvdb::io::File.
 ///
 /// When @b OPENVDB_REQUIRE_VERSION_NAME is defined, symbols must be
@@ -252,6 +252,6 @@ struct VersionId {
 
 #endif // OPENVDB_VERSION_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )


### PR DESCRIPTION
Downgraded library version to 6.0.1 from 6.1.0 pending any API-breaking changes and removed a broken Doxygen link.

Reviewers: @kmuseth  @danrbailey 
