### PR TITLE
OVDB-1: Fixed metadata handling in the Clip tool.

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -3,6 +3,10 @@ OpenVDB Version History
 
 Version 6.1.0 - In development
 
+    Bug fixes:
+    - Fixed a bug in tools::clip() that caused some grid metadata
+      to be discarded.
+
 
 Version 6.0.0 - December 18, 2018
 

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -6,6 +6,11 @@
 @par
 <B>Version 6.1.0</B> - <I>In development</I>
 
+@par
+Bug fixes:
+- Fixed a bug in the @link tools/Clip.h clip@endlink tool that caused
+  some grid metadata to be discarded.
+
 
 @htmlonly <a name="v6_0_0_changes"></a>@endhtmlonly
 @par

--- a/openvdb/tools/Clip.h
+++ b/openvdb/tools/Clip.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -329,13 +329,17 @@ doClip(
         gridMask.topologyDifference(clipMask.constTree());
     }
 
-    typename GridType::Ptr outGrid;
+#if OPENVDB_ABI_VERSION_NUMBER <= 3
+    auto outGrid = grid.copy(CP_NEW);
+#else
+    auto outGrid = grid.copyWithNewTree();
+#endif
     {
         // Copy voxel values and states.
         tree::LeafManager<const MaskTreeT> leafNodes(gridMask);
         CopyLeafNodes<TreeT> maskOp(tree, leafNodes);
         maskOp.run();
-        outGrid = GridType::create(maskOp.tree());
+        outGrid->setTree(maskOp.tree());
     }
     {
         // Copy tile values and states.
@@ -597,6 +601,6 @@ clip(const GridType& inGrid, const math::NonlinearFrustumMap& frustumMap, bool k
 
 #endif // OPENVDB_TOOLS_CLIP_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )


### PR DESCRIPTION
[OVDB-1](https://jira.aswf.io/browse/OVDB-1)
Except when clipping against a camera frustum, the Clip tool didn't properly
copy metadata from the input grid to the output grid.

Signed-off-by: Peter Cucka <peter.cucka@dreamworks.com>