### PR TITLE
Add OPENVDB_NO_DEPRECATION_WARNING_BEGIN/END macros

### DIFF
--- a/openvdb/Platform.h
+++ b/openvdb/Platform.h
@@ -186,6 +186,9 @@
         _Pragma("message(\"NOTE: ignoring deprecation warning\")")
     #define OPENVDB_NO_DEPRECATION_WARNING_END \
         _Pragma("GCC diagnostic pop")
+#else
+    #define OPENVDB_NO_DEPRECATION_WARNING_BEGIN
+    #define OPENVDB_NO_DEPRECATION_WARNING_END
 #endif
 
 

--- a/openvdb/Platform.h
+++ b/openvdb/Platform.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -36,6 +36,26 @@
 #include "PlatformConfig.h"
 
 #define PRAGMA(x) _Pragma(#x)
+
+/// @name Utilities
+/// @{
+/// @cond OPENVDB_VERSION_INTERNAL
+#define OPENVDB_PREPROC_STRINGIFY_(x) #x
+/// @endcond
+/// @brief Return @a x as a string literal.  If @a x is a macro,
+/// return its value as a string literal.
+/// @hideinitializer
+#define OPENVDB_PREPROC_STRINGIFY(x) OPENVDB_PREPROC_STRINGIFY_(x)
+
+/// @cond OPENVDB_VERSION_INTERNAL
+#define OPENVDB_PREPROC_CONCAT_(x, y) x ## y
+/// @endcond
+/// @brief Form a new token by concatenating two existing tokens.
+/// If either token is a macro, concatenate its value.
+/// @hideinitializer
+#define OPENVDB_PREPROC_CONCAT(x, y) OPENVDB_PREPROC_CONCAT_(x, y)
+/// @}
+
 
 /// Use OPENVDB_DEPRECATED to mark functions as deprecated.
 /// It should be placed right before the signature of the function,
@@ -131,6 +151,44 @@
 #endif
 
 
+/// @brief Bracket code with OPENVDB_NO_DEPRECATION_WARNING_BEGIN/_END,
+/// to inhibit warnings about deprecated code.
+/// @note Use this sparingly.  Remove references to deprecated code if at all possible.
+/// @details Example:
+/// @code
+/// OPENVDB_DEPRECATED void myDeprecatedFunction() {}
+///
+/// {
+///     OPENVDB_NO_DEPRECATION_WARNING_BEGIN
+///     myDeprecatedFunction();
+///     OPENVDB_NO_DEPRECATION_WARNING_END
+/// }
+/// @endcode
+#if defined __INTEL_COMPILER
+    #define OPENVDB_NO_DEPRECATION_WARNING_BEGIN \
+        _Pragma("warning (push)") \
+        _Pragma("warning (disable:1478)") \
+        PRAGMA(message("NOTE: ignoring deprecation warning at " __FILE__  \
+            ":" OPENVDB_PREPROC_STRINGIFY(__LINE__)))
+    #define OPENVDB_NO_DEPRECATION_WARNING_END \
+        _Pragma("warning (pop)")
+#elif defined __clang__
+    #define OPENVDB_NO_DEPRECATION_WARNING_BEGIN \
+        _Pragma("clang diagnostic push") \
+        _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+        // note: no #pragma message, since Clang treats them as warnings
+    #define OPENVDB_NO_DEPRECATION_WARNING_END \
+        _Pragma("clang diagnostic pop")
+#elif defined __GNUC__
+    #define OPENVDB_NO_DEPRECATION_WARNING_BEGIN \
+        _Pragma("GCC diagnostic push") \
+        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"") \
+        _Pragma("message(\"NOTE: ignoring deprecation warning\")")
+    #define OPENVDB_NO_DEPRECATION_WARNING_END \
+        _Pragma("GCC diagnostic pop")
+#endif
+
+
 #ifdef _MSC_VER
     /// Visual C++ does not have constants like M_PI unless this is defined.
     /// @note This is needed even though the core library is built with this but
@@ -204,6 +262,6 @@ using boost::uint64_t;
 
 #endif // OPENVDB_PLATFORM_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/points/PointMove.h
+++ b/openvdb/points/PointMove.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -513,7 +513,9 @@ struct GlobalMovePointsOp
         for (const auto& it : indices) {
             const auto& sourceArray = mSourceHandles.getConstArray(std::get<0>(it));
             const Index tgtOffset = indexOffsetFromVoxel(std::get<1>(it), targetLeaf, offsets);
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
             targetArray.set(tgtOffset, sourceArray, std::get<2>(it));
+            OPENVDB_NO_DEPRECATION_WARNING_END
         }
     }
 
@@ -629,7 +631,9 @@ struct LocalMovePointsOp
 
         for (const auto& it : indices) {
             const Index tgtOffset = indexOffsetFromVoxel(it.first, targetLeaf, offsets);
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
             targetArray.set(tgtOffset, sourceArray, it.second);
+            OPENVDB_NO_DEPRECATION_WARNING_END
         }
     }
 
@@ -995,6 +999,6 @@ void CachedDeformer<T>::apply(Vec3d& position, const IndexIterT& iter) const
 
 #endif // OPENVDB_POINTS_POINT_MOVE_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -736,11 +736,9 @@ TestAttributeArray::testAttributeArray()
             CPPUNIT_ASSERT_EQUAL(attr.isUniform(), attrB.isUniform());
             CPPUNIT_ASSERT_EQUAL(attr.isTransient(), attrB.isTransient());
             CPPUNIT_ASSERT_EQUAL(attr.isHidden(), attrB.isHidden());
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
             CPPUNIT_ASSERT_EQUAL(attr.isCompressed(), attrB.isCompressed());
-#pragma GCC diagnostic pop
+            OPENVDB_NO_DEPRECATION_WARNING_END
 
             for (unsigned i = 0; i < unsigned(count); ++i) {
                 CPPUNIT_ASSERT_EQUAL(attr.get(i), attrB.get(i));
@@ -765,9 +763,7 @@ TestAttributeArray::testAttributeArray()
         // note that in-memory compression has been deprecated, verify all
         // isCompressed() calls return false
 
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        OPENVDB_NO_DEPRECATION_WARNING_BEGIN
 
         CPPUNIT_ASSERT(!attr.isCompressed());
 
@@ -820,9 +816,10 @@ TestAttributeArray::testAttributeArray()
                 CPPUNIT_ASSERT_EQUAL(attr.getUnsafe(i), attrB.getUnsafe(i));
             }
         }
+
+        OPENVDB_NO_DEPRECATION_WARNING_END
     }
 
-#pragma GCC diagnostic pop
 
     { // Fixed codec (position range)
         AttributeArray::Ptr attr1(new AttributeArrayC(50));
@@ -937,11 +934,9 @@ TestAttributeArray::testAttributeArray()
         CPPUNIT_ASSERT_EQUAL(attrA.isUniform(), attrB.isUniform());
         CPPUNIT_ASSERT_EQUAL(attrA.isTransient(), attrB.isTransient());
         CPPUNIT_ASSERT_EQUAL(attrA.isHidden(), attrB.isHidden());
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        OPENVDB_NO_DEPRECATION_WARNING_BEGIN
         CPPUNIT_ASSERT_EQUAL(attrA.isCompressed(), attrB.isCompressed());
-#pragma GCC diagnostic pop
+        OPENVDB_NO_DEPRECATION_WARNING_END
         CPPUNIT_ASSERT_EQUAL(attrA.memUsage(), attrB.memUsage());
 
         for (unsigned i = 0; i < unsigned(count); ++i) {
@@ -1036,13 +1031,11 @@ TestAttributeArray::testAttributeArrayCopy()
         AttributeArrayD typedAttr(size);
         AttributeArray& attr(typedAttr);
 
-// disable deprecated warnings for virtual set() method (from ABI=6 onwards)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        OPENVDB_NO_DEPRECATION_WARNING_BEGIN
         for (const auto& pair : indexPairs) {
             attr.set(pair.second, sourceAttr, pair.first);
         }
-#pragma GCC diagnostic pop
+        OPENVDB_NO_DEPRECATION_WARNING_END
 
         CPPUNIT_ASSERT(targetAttr == attr);
     }
@@ -1365,9 +1358,7 @@ TestAttributeArray::testAttributeHandle()
         CPPUNIT_ASSERT_EQUAL(Vec3f(10), handle.get(5));
     }
 
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    OPENVDB_NO_DEPRECATION_WARNING_BEGIN
 
     {
         AttributeArray* array = attrSet.get(1);
@@ -1413,7 +1404,7 @@ TestAttributeArray::testAttributeHandle()
         CPPUNIT_ASSERT(!array->isCompressed());
     }
 
-#pragma GCC diagnostic pop
+    OPENVDB_NO_DEPRECATION_WARNING_END
 
     // check values have been correctly set without using handles
 
@@ -1635,11 +1626,9 @@ TestAttributeArray::testDelayedLoad()
             CPPUNIT_ASSERT_EQUAL(attrA.isUniform(), attrB.isUniform());
             CPPUNIT_ASSERT_EQUAL(attrA.isTransient(), attrB.isTransient());
             CPPUNIT_ASSERT_EQUAL(attrA.isHidden(), attrB.isHidden());
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
             CPPUNIT_ASSERT_EQUAL(attrA.isCompressed(), attrB.isCompressed());
-#pragma GCC diagnostic pop
+            OPENVDB_NO_DEPRECATION_WARNING_END
 
             AttributeArrayI attrBcopy(attrB);
             AttributeArrayI attrBequal = attrB;
@@ -1690,11 +1679,9 @@ TestAttributeArray::testDelayedLoad()
             CPPUNIT_ASSERT_EQUAL(attrA2.isUniform(), attrB2.isUniform());
             CPPUNIT_ASSERT_EQUAL(attrA2.isTransient(), attrB2.isTransient());
             CPPUNIT_ASSERT_EQUAL(attrA2.isHidden(), attrB2.isHidden());
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
             CPPUNIT_ASSERT_EQUAL(attrA2.isCompressed(), attrB2.isCompressed());
-#pragma GCC diagnostic pop
+            OPENVDB_NO_DEPRECATION_WARNING_END
 
             AttributeArrayF attrB2copy(attrB2);
             AttributeArrayF attrB2equal = attrB2;
@@ -1850,16 +1837,16 @@ TestAttributeArray::testDelayedLoad()
 
             CPPUNIT_ASSERT(attrB.isOutOfCore());
 
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
+
             CPPUNIT_ASSERT(!attrB.isCompressed());
 
             attrB.compress();
 
             CPPUNIT_ASSERT(attrB.isOutOfCore());
             CPPUNIT_ASSERT(!attrB.isCompressed());
-#pragma GCC diagnostic pop
+
+            OPENVDB_NO_DEPRECATION_WARNING_END
         }
 
         // read in using delayed load and check copy and assignment constructors
@@ -2127,11 +2114,9 @@ TestAttributeArray::testDelayedLoad()
             io::setStreamMetadataPtr(fileout, streamMetadata);
             io::setDataCompression(fileout, io::COMPRESS_BLOSC);
 
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
             attrA.compress();
-#pragma GCC diagnostic pop
+            OPENVDB_NO_DEPRECATION_WARNING_END
             attrA.writeMetadata(fileout, false, /*paged=*/true);
 
             compression::PagedOutputStream outputStreamSize(fileout);
@@ -2166,9 +2151,8 @@ TestAttributeArray::testDelayedLoad()
             inputStream.setSizeOnly(false);
             attrB.readPagedBuffers(inputStream);
 
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
+
             CPPUNIT_ASSERT(!attrB.isCompressed());
 
             CPPUNIT_ASSERT(attrB.isOutOfCore());
@@ -2176,7 +2160,8 @@ TestAttributeArray::testDelayedLoad()
             CPPUNIT_ASSERT(!attrB.isOutOfCore());
 
             CPPUNIT_ASSERT(!attrB.isCompressed());
-#pragma GCC diagnostic pop
+
+            OPENVDB_NO_DEPRECATION_WARNING_END
 
             CPPUNIT_ASSERT_EQUAL(attrA.memUsage(), attrB.memUsage());
 
@@ -2285,9 +2270,7 @@ TestAttributeArray::testDelayedLoad()
             inputStream.setSizeOnly(false);
             attrB.readPagedBuffers(inputStream);
 
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
 
             CPPUNIT_ASSERT(attrB.isOutOfCore());
             CPPUNIT_ASSERT(!attrB.isCompressed());
@@ -2297,7 +2280,7 @@ TestAttributeArray::testDelayedLoad()
             CPPUNIT_ASSERT(attrB.isOutOfCore());
             CPPUNIT_ASSERT(!attrB.isCompressed());
 
-#pragma GCC diagnostic pop
+            OPENVDB_NO_DEPRECATION_WARNING_END
         }
 
         // read in using delayed load and check copy and assignment constructors
@@ -2356,9 +2339,8 @@ TestAttributeArray::testDelayedLoad()
 
             CPPUNIT_ASSERT(attrB.isOutOfCore());
 
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            OPENVDB_NO_DEPRECATION_WARNING_BEGIN
+
             CPPUNIT_ASSERT(!attrB.isCompressed());
 
             AttributeHandle<int> handle(attrB);
@@ -2372,7 +2354,8 @@ TestAttributeArray::testDelayedLoad()
 
             AttributeHandle<int> handle2(attrB, /*preserveCompression=*/false);
             CPPUNIT_ASSERT(!attrB.isCompressed());
-#pragma GCC diagnostic pop
+
+            OPENVDB_NO_DEPRECATION_WARNING_END
         }
 #endif
 
@@ -2676,6 +2659,6 @@ TestAttributeArray::testProfile()
     }
 }
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/unittest/TestAttributeSet.cc
+++ b/openvdb/unittest/TestAttributeSet.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -82,11 +82,9 @@ matchingAttributeSets(const AttributeSet& lhs,
 
         if (a->size() != b->size()) return false;
         if (a->isUniform() != b->isUniform()) return false;
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        OPENVDB_NO_DEPRECATION_WARNING_BEGIN
         if (a->isCompressed() != b->isCompressed()) return false;
-#pragma GCC diagnostic pop
+        OPENVDB_NO_DEPRECATION_WARNING_END
         if (a->isHidden() != b->isHidden()) return false;
         if (a->type() != b->type()) return false;
     }
@@ -1076,6 +1074,6 @@ TestAttributeSet::testAttributeSetGroups()
     }
 }
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/unittest/TestPointAttribute.cc
+++ b/openvdb/unittest/TestPointAttribute.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -458,9 +458,7 @@ TestPointAttribute::testBloscCompress()
     CPPUNIT_ASSERT(leafIter->attributeArray("compact").isUniform());
     CPPUNIT_ASSERT(leafIter2->attributeArray("compact").isUniform());
 
-// disable deprecated warnings for in-memory compression
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    OPENVDB_NO_DEPRECATION_WARNING_BEGIN
 
     bloscCompressAttribute(tree, "id");
 
@@ -471,9 +469,9 @@ TestPointAttribute::testBloscCompress()
     CPPUNIT_ASSERT(!leafIter2->attributeArray("id2").isCompressed());
 #endif
 
-#pragma GCC diagnostic pop
+    OPENVDB_NO_DEPRECATION_WARNING_END
 }
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/version.h
+++ b/openvdb/version.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -70,25 +70,6 @@
 #define OPENVDB_VERSION_HAS_BEEN_INCLUDED
 
 #include "Platform.h"
-
-/// @name Utilities
-/// @{
-/// @cond OPENVDB_VERSION_INTERNAL
-#define OPENVDB_PREPROC_STRINGIFY_(x) #x
-/// @endcond
-/// @brief Return @a x as a string literal.  If @a x is a macro,
-/// return its value as a string literal.
-/// @hideinitializer
-#define OPENVDB_PREPROC_STRINGIFY(x) OPENVDB_PREPROC_STRINGIFY_(x)
-
-/// @cond OPENVDB_VERSION_INTERNAL
-#define OPENVDB_PREPROC_CONCAT_(x, y) x ## y
-/// @endcond
-/// @brief Form a new token by concatenating two existing tokens.
-/// If either token is a macro, concatenate its value.
-/// @hideinitializer
-#define OPENVDB_PREPROC_CONCAT(x, y) OPENVDB_PREPROC_CONCAT_(x, y)
-/// @}
 
 
 // Library major, minor and patch version numbers
@@ -252,6 +233,6 @@ struct VersionId {
 
 #endif // OPENVDB_VERSION_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )


### PR DESCRIPTION
These macros disable deprecation warnings from Clang, GCC and ICC.
With GCC and ICC, the macros also output a `#pragma message`, so as to discourage their use long-term.  (With Clang, there doesn't appear to be a way to output a message without generating a warning.)

Reviewers: @kmuseth @danrbailey 