### PR TITLE
OVDB-13: Optimize Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,33 +45,37 @@ cache:
 # Setup environment variables for different concurrent builds
 env:
   # Build and run unit tests for ABI={3,4,5,6}
-  - ABI=6 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none COMPILER=clang
-  - ABI=5 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none COMPILER=clang
-  - ABI=4 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none COMPILER=clang
-  - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none COMPILER=clang
+  - ABI=6 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
+  - ABI=5 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
+  - ABI=4 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
+  - ABI=3 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
 
   # Build Houdini plug-ins for H17.0, H16.0, H16.5
-  - ABI=5 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=17.0 COMPILER=clang
-  - ABI=4 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=16.5 COMPILER=clang
-  - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=16.0 COMPILER=clang
+  - ABI=5 BLOSC=yes MODE=release HOUDINI_MAJOR=17.0 COMPILER=clang
+  - ABI=4 BLOSC=yes MODE=release HOUDINI_MAJOR=16.5 COMPILER=clang
+  - ABI=3 BLOSC=yes MODE=release HOUDINI_MAJOR=16.0 COMPILER=clang
 
   # Build and run unit tests using other compilers
-  - ABI=6 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none COMPILER=gcc
+  - ABI=6 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=gcc
 
-  # Build and run unit tests for ABI={3,4,5} with Blosc disabled
-  - ABI=6 BLOSC=no RELEASE=yes HOUDINI_MAJOR=none COMPILER=clang
-  - ABI=5 BLOSC=no RELEASE=yes HOUDINI_MAJOR=none COMPILER=clang
+  # Build and run unit tests for ABI={5,6} with Blosc disabled
+  - ABI=6 BLOSC=no MODE=release HOUDINI_MAJOR=none COMPILER=clang
+  - ABI=5 BLOSC=no MODE=release HOUDINI_MAJOR=none COMPILER=clang
 
-  # Build (but don't run) unit tests in debug mode for ABI={3,4,5} with and without Blosc
-  - ABI=6 BLOSC=yes RELEASE=no HOUDINI_MAJOR=none COMPILER=clang
-  - ABI=5 BLOSC=yes RELEASE=no HOUDINI_MAJOR=none COMPILER=clang
-  - ABI=6 BLOSC=no RELEASE=no HOUDINI_MAJOR=none COMPILER=clang
-  - ABI=5 BLOSC=no RELEASE=no HOUDINI_MAJOR=none COMPILER=clang
+  # Check for indirect header includes (ABI=6 and H17.0)
+  - ABI=6 BLOSC=yes MODE=header HOUDINI_MAJOR=none COMPILER=clang
+  - ABI=5 BLOSC=yes MODE=header HOUDINI_MAJOR=17.0 COMPILER=clang
+
+  # Build (but don't run) unit tests in debug mode for ABI={5,6} with and without Blosc
+  - ABI=6 BLOSC=yes MODE=debug HOUDINI_MAJOR=none COMPILER=clang
+  - ABI=5 BLOSC=yes MODE=debug HOUDINI_MAJOR=none COMPILER=clang
+  - ABI=6 BLOSC=no MODE=debug HOUDINI_MAJOR=none COMPILER=clang
+  - ABI=5 BLOSC=no MODE=debug HOUDINI_MAJOR=none COMPILER=clang
 
 # Build and install all library dependencies for OpenVDB
 # (build will error if this stage does not succeed)
-install: bash travis/travis.run install $ABI $BLOSC $RELEASE $HOUDINI_MAJOR $COMPILER
+install: bash travis/travis.run install $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
 
 # Build OpenVDB and OpenVDB Houdini and run unit tests
 # (build will fail if this stage does not succeed)
-script: bash travis/travis.run script $ABI $BLOSC $RELEASE $HOUDINI_MAJOR $COMPILER
+script: bash travis/travis.run script $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -36,7 +36,11 @@
 #        * script (building OpenVDB and executing unit tests)
 # ABI (3/4/5) - the ABI version of OpenVDB
 # BLOSC (yes/no) - to build with Blosc support
-# RELEASE (yes/no) - to build in release or debug mode
+# MODE (release/debug/header):
+#        * release (standalone - builds all core library components and runs all tests)
+#        * release (houdini - builds core library and Houdini plugins)
+#        * debug (builds all core library components in debug mode)
+#        * header (checks for indirect includes)
 # HOUDINI_MAJOR (16.0/16.5) - the major version of Houdini
 #
 # (Note Travis instances allow only 7.5GB of memory per VM, so limit concurrent builds to 4)
@@ -48,7 +52,7 @@ set -ex
 TASK="$1"
 ABI="$2"
 BLOSC="$3"
-RELEASE="$4"
+MODE="$4"
 HOUDINI_MAJOR="$5"
 COMPILER="$6"
 
@@ -180,18 +184,28 @@ elif [ "$TASK" = "script" ]; then
         # release mode - build and run OpenVDB unit tests
         # debug mode - build OpenVDB unit tests
         if [ "$BLOSC" = "yes" ]; then
-            if [ "$RELEASE" = "yes" ]; then
+            if [ "$MODE" = "release" ]; then
+                # build OpenVDB core library, OpenVDB Python module and all binaries
                 make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" -j4
+                # run C++ and Python unit tests
                 make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi="$ABI" -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS pytest abi="$ABI" -j4
+            elif [ "$MODE" = "header" ]; then
                 # check for any indirect includes
                 make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS header_test abi="$ABI" -j4
             else
+                # build OpenVDB core library, OpenVDB Python module and all binaries
                 make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" debug=yes -j4
             fi
         else
-            if [ "$RELEASE" = "yes" ]; then
+            if [ "$MODE" = "release" ]; then
+                # build OpenVDB core library, OpenVDB Python module and all binaries
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" -j4
+                # run C++ and Python unit tests
                 make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test abi="$ABI" -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS pytest abi="$ABI" -j4
             else
+                # build OpenVDB core library, OpenVDB Python module and all binaries
                 make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" debug=yes -j4
             fi
         fi
@@ -204,17 +218,20 @@ elif [ "$TASK" = "script" ]; then
         # note that this means the DSO can no longer be loaded in Houdini
         sed -i.bak 's/\/hcustom/\/hcustom -t/g' openvdb_houdini/Makefile
         # build OpenVDB core library and OpenVDB houdini library
-        make -C openvdb $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install abi="$ABI" -j4
+        make -C openvdb $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install_lib abi="$ABI" -j4
         make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS houdinilib abi="$ABI" -j4
         # manually install OpenVDB houdini headers and lib
         mkdir houdini_utils
         cp openvdb_houdini/houdini/*.h openvdb_houdini
         cp openvdb_houdini/houdini/*.h houdini_utils
         cp openvdb_houdini/libopenvdb_houdini* /tmp/OpenVDB/lib
-        # build OpenVDB Houdini SOPs
-        make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install abi="$ABI" -j4
-        # check for any indirect includes
-        make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS header_test abi="$ABI" -j4
+        if [ "$MODE" = "header" ]; then
+            # check for any indirect includes
+            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS header_test abi="$ABI" -j4
+        else
+            # build OpenVDB Houdini SOPs
+            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install abi="$ABI" -j4
+        fi
     fi
 fi
 


### PR DESCRIPTION
* Split out header tests into a separate concurrent job
* Removing the building of Python module and binaries from Houdini builds

Results in ~44m being the longest build when caching is not being used.