### PR TITLE
Replace direct .timeDep with setTimeDep, required in 17.5.

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Rasterize_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Rasterize_Points.cc
@@ -3425,7 +3425,7 @@ SOP_OpenVDB_Rasterize_Points::cookVDBSop(OP_Context& context)
             rasterize(settings, outputGrids);
 
             if (vexContextPtr && vexContextPtr->isTimeDependant()) {
-                OP_Node::flags().timeDep = true;
+                OP_Node::flags().setTimeDep(true);
             }
 
             for (size_t n = 0, N = outputGrids.size(); n < N && !boss.wasInterrupted(); ++n) {


### PR DESCRIPTION
Direct access to .timeDep has been deprecated for a long time, but
will actually be gone in 17.5; so replace with the long-standing
setTimeDep.