### PR TITLE
OVDB-10: Fixes for various GCC 5.4 and Clang 7 warnings

### DIFF
--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -19,9 +19,6 @@ Bug fixes:
 Houdini:
 - The Points&nbsp;Convert SOP now reports NaN Positions as warnings when
   converting from Houdini Points to VDB Points.
-
-@par
-Houdini:
 - Fixed a bug where the Points&nbsp;Convert&nbsp;SOP was incorrectly ignoring
   point attributes with the same name as an existing point group.
 - The Transform&nbsp;SOP now supports frustum transforms by applying the

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -10,6 +10,15 @@
 Bug fixes:
 - Fixed a bug in the @link tools/Clip.h clip@endlink tool that caused
   some grid metadata to be discarded.
+- Added a check to @vdblink::points::setGroup() points::setGroup@endlink
+  to compare the maximum index of the provided
+  @vdblink::tools::PointIndexTree PointIndexTree@endlink
+  to the size of the membership vector.
+
+@par
+Houdini:
+- The Points&nbsp;Convert SOP now reports NaN Positions as warnings when
+  converting from Houdini Points to VDB Points.
 
 
 @htmlonly <a name="v6_0_0_changes"></a>@endhtmlonly

--- a/openvdb/math/DDA.h
+++ b/openvdb/math/DDA.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -41,8 +41,8 @@
 #include "Math.h"
 #include "Vec3.h"
 #include <openvdb/Types.h>
-#include <iostream>// for std::ostream
-#include <limits>// for std::numeric_limits<Type>::max()
+#include <iostream> // for std::ostream
+#include <limits> // for std::numeric_limits<Type>::max()
 #include <boost/mpl/at.hpp>
 
 namespace openvdb {
@@ -62,10 +62,10 @@ template<typename RayT, Index Log2Dim = 0>
 class DDA
 {
 public:
-    typedef typename RayT::RealType RealType;
-    typedef RealType                RealT;
-    typedef typename RayT::Vec3Type Vec3Type;
-    typedef Vec3Type                Vec3T;
+    using RealType = typename RayT::RealType;
+    using RealT = RealType;
+    using Vec3Type = typename RayT::Vec3Type;
+    using Vec3T = Vec3Type;
 
     /// @brief uninitialized constructor
     DDA() {}
@@ -141,11 +141,11 @@ public:
     /// @brief Print information about this DDA for debugging.
     /// @param os    a stream to which to write textual information.
     void print(std::ostream& os = std::cout) const
-      {
-          os << "Dim=" << (1<<Log2Dim) << " time=" << mT0 << " next()="
-             << this->next() << " voxel=" << mVoxel << " next=" << mNext
-             << " delta=" << mDelta << " step=" << mStep << std::endl;
-      }
+    {
+        os << "Dim=" << (1<<Log2Dim) << " time=" << mT0 << " next()="
+            << this->next() << " voxel=" << mVoxel << " next=" << mNext
+            << " delta=" << mDelta << " step=" << mStep << std::endl;
+    }
 
 private:
     RealT mT0, mT1;
@@ -171,8 +171,8 @@ inline std::ostream& operator<<(std::ostream& os, const DDA<RayT, Log2Dim>& dda)
 template<typename TreeT, int NodeLevel>
 struct LevelSetHDDA
 {
-    typedef typename TreeT::RootNodeType::NodeChainType ChainT;
-    typedef typename boost::mpl::at<ChainT, boost::mpl::int_<NodeLevel> >::type NodeT;
+    using ChainT = typename TreeT::RootNodeType::NodeChainType;
+    using NodeT = typename boost::mpl::at<ChainT, boost::mpl::int_<NodeLevel> >::type;
 
     template <typename TesterT>
     static bool test(TesterT& tester)
@@ -216,9 +216,9 @@ class VolumeHDDA
 {
 public:
 
-    typedef typename TreeT::RootNodeType::NodeChainType ChainT;
-    typedef typename boost::mpl::at<ChainT, boost::mpl::int_<ChildNodeLevel> >::type NodeT;
-    typedef typename RayT::TimeSpan TimeSpanT;
+    using ChainT = typename TreeT::RootNodeType::NodeChainType;
+    using NodeT = typename boost::mpl::at<ChainT, boost::mpl::int_<ChildNodeLevel> >::type;
+    using TimeSpanT = typename RayT::TimeSpan;
 
     VolumeHDDA() {}
 
@@ -252,7 +252,7 @@ private:
     {
         mDDA.init(ray);
         do {
-            if (acc.template probeConstNode<NodeT>(mDDA.voxel()) != NULL) {//child node
+            if (acc.template probeConstNode<NodeT>(mDDA.voxel()) != nullptr) {//child node
                 ray.setTimes(mDDA.time(), mDDA.next());
                 if (mHDDA.march(ray, acc, t)) return true;//terminate
             } else if (acc.isValueOn(mDDA.voxel())) {//hit an active tile
@@ -276,7 +276,7 @@ private:
     {
         mDDA.init(ray);
         do {
-            if (acc.template probeConstNode<NodeT>(mDDA.voxel()) != NULL) {//child node
+            if (acc.template probeConstNode<NodeT>(mDDA.voxel()) != nullptr) {//child node
                 ray.setTimes(mDDA.time(), mDDA.next());
                 mHDDA.hits(ray, acc, times, t);
             } else if (acc.isValueOn(mDDA.voxel())) {//hit an active tile
@@ -301,8 +301,8 @@ class VolumeHDDA<TreeT, RayT, 0>
 {
 public:
 
-    typedef typename TreeT::LeafNodeType LeafT;
-    typedef typename RayT::TimeSpan TimeSpanT;
+    using LeafT = typename TreeT::LeafNodeType;
+    using TimeSpanT = typename RayT::TimeSpan;
 
     VolumeHDDA() {}
 
@@ -370,6 +370,6 @@ private:
 
 #endif // OPENVDB_MATH_DDA_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/math/Mat.h
+++ b/openvdb/math/Mat.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -811,7 +811,7 @@ snapMatBasis(const MatType& source, Axis axis, const Vec3<typename MatType::valu
 /// @brief Write 0s along Mat4's last row and column, and a 1 on its diagonal.
 /// @details Useful initialization when we're initializing just the 3&times;3 block.
 template<class MatType>
-static MatType&
+inline MatType&
 padMat4(MatType& dest)
 {
     dest[0][3] = dest[1][3] = dest[2][3] = 0;
@@ -1045,6 +1045,6 @@ polarDecomposition(const MatType& input, MatType& unitary,
 
 #endif // OPENVDB_MATH_MAT_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/python/pyAccessor.h
+++ b/openvdb/python/pyAccessor.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -46,11 +46,11 @@ using namespace openvdb::OPENVDB_VERSION_NAME;
 template<typename _GridT>
 struct AccessorTraits
 {
-    typedef _GridT                              GridT;
-    typedef GridT                               NonConstGridT;
-    typedef typename NonConstGridT::Ptr         GridPtrT;
-    typedef typename NonConstGridT::Accessor    AccessorT;
-    typedef typename AccessorT::ValueType       ValueT;
+    using GridT = _GridT;
+    using NonConstGridT = GridT;
+    using GridPtrT = typename NonConstGridT::Ptr;
+    using AccessorT = typename NonConstGridT::Accessor;
+    using ValueT = typename AccessorT::ValueType;
 
     static const bool IsConst = false;
 
@@ -76,11 +76,11 @@ struct AccessorTraits
 template<typename _GridT>
 struct AccessorTraits<const _GridT>
 {
-    typedef const _GridT                            GridT;
-    typedef _GridT                                  NonConstGridT;
-    typedef typename NonConstGridT::ConstPtr        GridPtrT;
-    typedef typename NonConstGridT::ConstAccessor   AccessorT;
-    typedef typename AccessorT::ValueType           ValueT;
+    using GridT = const _GridT;
+    using NonConstGridT = _GridT;
+    using GridPtrT = typename NonConstGridT::ConstPtr;
+    using AccessorT = typename NonConstGridT::ConstAccessor;
+    using ValueT = typename AccessorT::ValueType;
 
     static const bool IsConst = true;
 
@@ -124,7 +124,7 @@ extractValueArg(
     py::object obj,
     const char* functionName,
     int argIdx = 0, // args are numbered starting from 1
-    const char* expectedType = NULL)
+    const char* expectedType = nullptr)
 {
     return pyutil::extractArg<typename GridT::ValueType>(
         obj, functionName, AccessorTraits<GridT>::typeName(), argIdx, expectedType);
@@ -156,11 +156,11 @@ template<typename _GridType>
 class AccessorWrap
 {
 public:
-    typedef AccessorTraits<_GridType>       Traits;
-    typedef typename Traits::AccessorT      Accessor;
-    typedef typename Traits::ValueT         ValueType;
-    typedef typename Traits::NonConstGridT  GridType;
-    typedef typename Traits::GridPtrT       GridPtrType;
+    using Traits = AccessorTraits<_GridType>;
+    using Accessor = typename Traits::AccessorT;
+    using ValueType = typename Traits::ValueT;
+    using GridType = typename Traits::NonConstGridT;
+    using GridPtrType = typename Traits::GridPtrT;
 
     AccessorWrap(GridPtrType grid): mGrid(grid), mAccessor(grid->getAccessor()) {}
 
@@ -338,6 +338,6 @@ private:
 
 #endif // OPENVDB_PYACCESSOR_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/python/pyGrid.h
+++ b/openvdb/python/pyGrid.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -1063,6 +1063,12 @@ protected:
         }
     }
 
+#ifdef __clang__
+    // Suppress "enum value not explicitly handled" warnings
+    PRAGMA(clang diagnostic push)
+    PRAGMA(clang diagnostic ignored "-Wswitch-enum")
+#endif
+
     void copyFromArray() const override
     {
         switch (this->mArrayTypeId) {
@@ -1092,6 +1098,11 @@ protected:
         default: throw openvdb::TypeError(); break;
         }
     }
+
+#ifdef __clang__
+    PRAGMA(clang diagnostic pop)
+#endif
+
 }; // class CopyOp
 
 // Specialization for Vec3 grids
@@ -1125,6 +1136,12 @@ protected:
             boost::python::throw_error_already_set();
         }
     }
+
+#ifdef __clang__
+    // Suppress "enum value not explicitly handled" warnings
+    PRAGMA(clang diagnostic push)
+    PRAGMA(clang diagnostic ignored "-Wswitch-enum")
+#endif
 
     void copyFromArray() const override
     {
@@ -1171,6 +1188,11 @@ protected:
         default: throw openvdb::TypeError(); break;
         }
     }
+
+#ifdef __clang__
+    PRAGMA(clang diagnostic pop)
+#endif
+
 }; // class CopyOp
 
 
@@ -2542,6 +2564,6 @@ exportGrid()
 
 #endif // OPENVDB_PYGRID_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/python/pyGrid.h
+++ b/openvdb/python/pyGrid.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -1074,7 +1074,7 @@ protected:
         case DtId::INT64: this->template fromArray<typename NumPyToCpp<DtId::INT64>::type>(); break;
         case DtId::UINT32:this->template fromArray<typename NumPyToCpp<DtId::UINT32>::type>();break;
         case DtId::UINT64:this->template fromArray<typename NumPyToCpp<DtId::UINT64>::type>();break;
-        default: throw openvdb::TypeError(); break;
+        case DtId::NONE: throw openvdb::TypeError(); break;
         }
     }
 
@@ -1089,7 +1089,7 @@ protected:
         case DtId::INT64:  this->template toArray<typename NumPyToCpp<DtId::INT64>::type>(); break;
         case DtId::UINT32: this->template toArray<typename NumPyToCpp<DtId::UINT32>::type>(); break;
         case DtId::UINT64: this->template toArray<typename NumPyToCpp<DtId::UINT64>::type>(); break;
-        default: throw openvdb::TypeError(); break;
+        case DtId::NONE: throw openvdb::TypeError(); break;
         }
     }
 }; // class CopyOp
@@ -1145,7 +1145,7 @@ protected:
             this->template fromArray<math::Vec3<typename NumPyToCpp<DtId::UINT32>::type>>(); break;
         case DtId::UINT64:
             this->template fromArray<math::Vec3<typename NumPyToCpp<DtId::UINT64>::type>>(); break;
-        default: throw openvdb::TypeError(); break;
+        case DtId::NONE: throw openvdb::TypeError(); break;
         }
     }
 
@@ -1168,7 +1168,7 @@ protected:
             this->template toArray<math::Vec3<typename NumPyToCpp<DtId::UINT32>::type>>(); break;
         case DtId::UINT64:
             this->template toArray<math::Vec3<typename NumPyToCpp<DtId::UINT64>::type>>(); break;
-        default: throw openvdb::TypeError(); break;
+        case DtId::NONE: throw openvdb::TypeError(); break;
         }
     }
 }; // class CopyOp
@@ -1285,7 +1285,8 @@ copyVecArray(NumPyArrayType& arrayObj, std::vector<VecT>& vec)
     case DtId::INT64:  CopyVecOp<NumPyToCpp<DtId::INT64>::type, ValueT>()(src, dst, M*N); break;
     case DtId::UINT32: CopyVecOp<NumPyToCpp<DtId::UINT32>::type, ValueT>()(src, dst, M*N); break;
     case DtId::UINT64: CopyVecOp<NumPyToCpp<DtId::UINT64>::type, ValueT>()(src, dst, M*N); break;
-    default: break;
+    case DtId::BOOL: break;
+    case DtId::NONE: break;
     }
 }
 
@@ -1318,7 +1319,7 @@ meshToLevelSet(py::object pointsObj, py::object trianglesObj, py::object quadsOb
                     case DtId::FLOAT: case DtId::DOUBLE: //case DtId::HALF:
                     case DtId::INT16: case DtId::INT32: case DtId::INT64:
                     case DtId::UINT32: case DtId::UINT64: break;
-                    default: wrongArrayType = true; break;
+                    case DtId::BOOL: case DtId::NONE: wrongArrayType = true; break;
                 }
             }
             if (wrongArrayType) {
@@ -2542,6 +2543,6 @@ exportGrid()
 
 #endif // OPENVDB_PYGRID_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/python/pyGrid.h
+++ b/openvdb/python/pyGrid.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2019 DreamWorks Animation LLC
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -1074,7 +1074,7 @@ protected:
         case DtId::INT64: this->template fromArray<typename NumPyToCpp<DtId::INT64>::type>(); break;
         case DtId::UINT32:this->template fromArray<typename NumPyToCpp<DtId::UINT32>::type>();break;
         case DtId::UINT64:this->template fromArray<typename NumPyToCpp<DtId::UINT64>::type>();break;
-        case DtId::NONE: throw openvdb::TypeError(); break;
+        default: throw openvdb::TypeError(); break;
         }
     }
 
@@ -1089,7 +1089,7 @@ protected:
         case DtId::INT64:  this->template toArray<typename NumPyToCpp<DtId::INT64>::type>(); break;
         case DtId::UINT32: this->template toArray<typename NumPyToCpp<DtId::UINT32>::type>(); break;
         case DtId::UINT64: this->template toArray<typename NumPyToCpp<DtId::UINT64>::type>(); break;
-        case DtId::NONE: throw openvdb::TypeError(); break;
+        default: throw openvdb::TypeError(); break;
         }
     }
 }; // class CopyOp
@@ -1145,7 +1145,7 @@ protected:
             this->template fromArray<math::Vec3<typename NumPyToCpp<DtId::UINT32>::type>>(); break;
         case DtId::UINT64:
             this->template fromArray<math::Vec3<typename NumPyToCpp<DtId::UINT64>::type>>(); break;
-        case DtId::NONE: throw openvdb::TypeError(); break;
+        default: throw openvdb::TypeError(); break;
         }
     }
 
@@ -1168,7 +1168,7 @@ protected:
             this->template toArray<math::Vec3<typename NumPyToCpp<DtId::UINT32>::type>>(); break;
         case DtId::UINT64:
             this->template toArray<math::Vec3<typename NumPyToCpp<DtId::UINT64>::type>>(); break;
-        case DtId::NONE: throw openvdb::TypeError(); break;
+        default: throw openvdb::TypeError(); break;
         }
     }
 }; // class CopyOp
@@ -1285,8 +1285,7 @@ copyVecArray(NumPyArrayType& arrayObj, std::vector<VecT>& vec)
     case DtId::INT64:  CopyVecOp<NumPyToCpp<DtId::INT64>::type, ValueT>()(src, dst, M*N); break;
     case DtId::UINT32: CopyVecOp<NumPyToCpp<DtId::UINT32>::type, ValueT>()(src, dst, M*N); break;
     case DtId::UINT64: CopyVecOp<NumPyToCpp<DtId::UINT64>::type, ValueT>()(src, dst, M*N); break;
-    case DtId::BOOL: break;
-    case DtId::NONE: break;
+    default: break;
     }
 }
 
@@ -1319,7 +1318,7 @@ meshToLevelSet(py::object pointsObj, py::object trianglesObj, py::object quadsOb
                     case DtId::FLOAT: case DtId::DOUBLE: //case DtId::HALF:
                     case DtId::INT16: case DtId::INT32: case DtId::INT64:
                     case DtId::UINT32: case DtId::UINT64: break;
-                    case DtId::BOOL: case DtId::NONE: wrongArrayType = true; break;
+                    default: wrongArrayType = true; break;
                 }
             }
             if (wrongArrayType) {
@@ -2543,6 +2542,6 @@ exportGrid()
 
 #endif // OPENVDB_PYGRID_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2019 DreamWorks Animation LLC
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/python/pyutil.h
+++ b/openvdb/python/pyutil.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -226,9 +226,9 @@ inline T
 extractArg(
     boost::python::object obj,
     const char* functionName,
-    const char* className = NULL,
+    const char* className = nullptr,
     int argIdx = 0, // args are numbered starting from 1
-    const char* expectedType = NULL)
+    const char* expectedType = nullptr)
 {
     boost::python::extract<T> val(obj);
     if (!val.check()) {
@@ -279,6 +279,6 @@ className(boost::python::object obj)
 
 #endif // OPENVDB_PYUTIL_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/Composite.h
+++ b/openvdb/tools/Composite.h
@@ -176,13 +176,13 @@ enum CSGOperation { CSG_UNION, CSG_INTERSECTION, CSG_DIFFERENCE };
 template<typename TreeType, CSGOperation Operation>
 struct BuildPrimarySegment
 {
-    typedef typename TreeType::ValueType                                            ValueType;
-    typedef typename TreeType::Ptr                                                  TreePtrType;
-    typedef typename TreeType::LeafNodeType                                         LeafNodeType;
-    typedef typename LeafNodeType::NodeMaskType                                     NodeMaskType;
-    typedef typename TreeType::RootNodeType                                         RootNodeType;
-    typedef typename RootNodeType::NodeChainType                                    NodeChainType;
-    typedef typename boost::mpl::at<NodeChainType, boost::mpl::int_<1> >::type      InternalNodeType;
+    using ValueType = typename TreeType::ValueType;
+    using TreePtrType = typename TreeType::Ptr;
+    using LeafNodeType = typename TreeType::LeafNodeType;
+    using NodeMaskType = typename LeafNodeType::NodeMaskType;
+    using RootNodeType = typename TreeType::RootNodeType;
+    using NodeChainType = typename RootNodeType::NodeChainType;
+    using InternalNodeType = typename boost::mpl::at<NodeChainType, boost::mpl::int_<1> >::type;
 
     BuildPrimarySegment(const TreeType& lhs, const TreeType& rhs)
         : mSegment(new TreeType(lhs.background()))
@@ -213,9 +213,10 @@ private:
 
     struct ProcessInternalNodes {
 
-        ProcessInternalNodes(std::vector<const InternalNodeType*>& lhsNodes, const TreeType& rhsTree,
-            TreeType& outputTree, std::vector<const LeafNodeType*>& outputLeafNodes)
-            : mLhsNodes(lhsNodes.empty() ? NULL : &lhsNodes.front())
+        ProcessInternalNodes(std::vector<const InternalNodeType*>& lhsNodes,
+            const TreeType& rhsTree, TreeType& outputTree,
+            std::vector<const LeafNodeType*>& outputLeafNodes)
+            : mLhsNodes(lhsNodes.empty() ? nullptr : &lhsNodes.front())
             , mRhsTree(&rhsTree)
             , mLocalTree(mRhsTree->background())
             , mOutputTree(&outputTree)
@@ -252,7 +253,8 @@ private:
 
                 const InternalNodeType& lhsNode = *mLhsNodes[n];
                 const Coord& ijk = lhsNode.origin();
-                const InternalNodeType * rhsNode = rhsAcc.template probeConstNode<InternalNodeType>(ijk);
+                const InternalNodeType * rhsNode =
+                    rhsAcc.template probeConstNode<InternalNodeType>(ijk);
 
                 if (rhsNode) {
                     lhsNode.getNodes(*mOutputLeafNodes);
@@ -289,8 +291,9 @@ private:
 
     struct ProcessLeafNodes {
 
-        ProcessLeafNodes(std::vector<const LeafNodeType*>& lhsNodes, const TreeType& rhsTree, TreeType& output)
-            : mLhsNodes(lhsNodes.empty() ? NULL : &lhsNodes.front())
+        ProcessLeafNodes(std::vector<const LeafNodeType*>& lhsNodes,
+            const TreeType& rhsTree, TreeType& output)
+            : mLhsNodes(lhsNodes.empty() ? nullptr : &lhsNodes.front())
             , mRhsTree(&rhsTree)
             , mLocalTree(mRhsTree->background())
             , mOutputTree(&output)
@@ -381,13 +384,13 @@ private:
 template<typename TreeType, CSGOperation Operation>
 struct BuildSecondarySegment
 {
-    typedef typename TreeType::ValueType                                            ValueType;
-    typedef typename TreeType::Ptr                                                  TreePtrType;
-    typedef typename TreeType::LeafNodeType                                         LeafNodeType;
-    typedef typename LeafNodeType::NodeMaskType                                     NodeMaskType;
-    typedef typename TreeType::RootNodeType                                         RootNodeType;
-    typedef typename RootNodeType::NodeChainType                                    NodeChainType;
-    typedef typename boost::mpl::at<NodeChainType, boost::mpl::int_<1> >::type      InternalNodeType;
+    using ValueType = typename TreeType::ValueType;
+    using TreePtrType = typename TreeType::Ptr;
+    using LeafNodeType = typename TreeType::LeafNodeType;
+    using NodeMaskType = typename LeafNodeType::NodeMaskType;
+    using RootNodeType = typename TreeType::RootNodeType;
+    using NodeChainType = typename RootNodeType::NodeChainType;
+    using InternalNodeType = typename boost::mpl::at<NodeChainType, boost::mpl::int_<1> >::type;
 
     BuildSecondarySegment(const TreeType& lhs, const TreeType& rhs)
         : mSegment(new TreeType(lhs.background()))
@@ -418,9 +421,10 @@ private:
 
     struct ProcessInternalNodes {
 
-        ProcessInternalNodes(std::vector<const InternalNodeType*>& rhsNodes, const TreeType& lhsTree,
-            TreeType& outputTree, std::vector<const LeafNodeType*>& outputLeafNodes)
-            : mRhsNodes(rhsNodes.empty() ? NULL : &rhsNodes.front())
+        ProcessInternalNodes(std::vector<const InternalNodeType*>& rhsNodes,
+            const TreeType& lhsTree, TreeType& outputTree,
+            std::vector<const LeafNodeType*>& outputLeafNodes)
+            : mRhsNodes(rhsNodes.empty() ? nullptr : &rhsNodes.front())
             , mLhsTree(&lhsTree)
             , mLocalTree(mLhsTree->background())
             , mOutputTree(&outputTree)
@@ -457,7 +461,8 @@ private:
 
                 const InternalNodeType& rhsNode = *mRhsNodes[n];
                 const Coord& ijk = rhsNode.origin();
-                const InternalNodeType * lhsNode = lhsAcc.template probeConstNode<InternalNodeType>(ijk);
+                const InternalNodeType * lhsNode =
+                    lhsAcc.template probeConstNode<InternalNodeType>(ijk);
 
                 if (lhsNode) {
                    rhsNode.getNodes(*mOutputLeafNodes);
@@ -504,8 +509,9 @@ private:
 
     struct ProcessLeafNodes {
 
-        ProcessLeafNodes(std::vector<const LeafNodeType*>& rhsNodes, const TreeType& lhsTree, TreeType& output)
-            : mRhsNodes(rhsNodes.empty() ? NULL : &rhsNodes.front())
+        ProcessLeafNodes(std::vector<const LeafNodeType*>& rhsNodes,
+            const TreeType& lhsTree, TreeType& output)
+            : mRhsNodes(rhsNodes.empty() ? nullptr : &rhsNodes.front())
             , mLhsTree(&lhsTree)
             , mLocalTree(mLhsTree->background())
             , mOutputTree(&output)
@@ -594,7 +600,7 @@ doCSGCopy(const TreeType& lhs, const TreeType& rhs)
 template<typename TreeType>
 struct GridOrTreeConstructor
 {
-    typedef typename TreeType::Ptr TreeTypePtr;
+    using TreeTypePtr = typename TreeType::Ptr;
     static TreeTypePtr construct(const TreeType&, TreeTypePtr& tree) { return tree; }
 };
 
@@ -602,9 +608,9 @@ struct GridOrTreeConstructor
 template<typename TreeType>
 struct GridOrTreeConstructor<Grid<TreeType> >
 {
-    typedef Grid<TreeType>                  GridType;
-    typedef typename Grid<TreeType>::Ptr    GridTypePtr;
-    typedef typename TreeType::Ptr          TreeTypePtr;
+    using GridType = Grid<TreeType>;
+    using GridTypePtr = typename Grid<TreeType>::Ptr;
+    using TreeTypePtr = typename TreeType::Ptr;
 
     static GridTypePtr construct(const GridType& grid, TreeTypePtr& tree) {
         GridTypePtr maskGrid(GridType::create(tree));
@@ -653,10 +659,11 @@ inline void transferLeafNodes(TreeT &srcTree, TreeT &dstTree,
 /// Template specailization of compActiveLeafVoxels
 template <typename TreeT, typename OpT>
 inline
-typename std::enable_if<!std::is_same<typename TreeT::ValueType, bool>::value &&
-                        !std::is_same<typename TreeT::BuildType, ValueMask>::value &&
-                         std::is_same<typename TreeT::LeafNodeType::Buffer::ValueType,
-                                      typename TreeT::LeafNodeType::Buffer::StorageType>::value>::type
+typename std::enable_if<
+    !std::is_same<typename TreeT::ValueType, bool>::value &&
+    !std::is_same<typename TreeT::BuildType, ValueMask>::value &&
+    std::is_same<typename TreeT::LeafNodeType::Buffer::ValueType,
+    typename TreeT::LeafNodeType::Buffer::StorageType>::value>::type
 doCompActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT op)
 {
     using LeafT  = typename TreeT::LeafNodeType;
@@ -680,8 +687,9 @@ doCompActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT op)
 /// Template specailization of compActiveLeafVoxels
 template <typename TreeT, typename OpT>
 inline
-typename std::enable_if<std::is_same<typename TreeT::BuildType, ValueMask>::value &&
-                        std::is_same<typename TreeT::ValueType, bool>::value>::type
+typename std::enable_if<
+    std::is_same<typename TreeT::BuildType, ValueMask>::value &&
+    std::is_same<typename TreeT::ValueType, bool>::value>::type
 doCompActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT)
 {
     using LeafT  = typename TreeT::LeafNodeType;
@@ -701,8 +709,9 @@ doCompActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT)
 /// Template specailization of compActiveLeafVoxels
 template <typename TreeT, typename OpT>
 inline
-typename std::enable_if<std::is_same<typename TreeT::ValueType, bool>::value &&
-                        !std::is_same<typename TreeT::BuildType, ValueMask>::value>::type
+typename std::enable_if<
+    std::is_same<typename TreeT::ValueType, bool>::value &&
+    !std::is_same<typename TreeT::BuildType, ValueMask>::value>::type
 doCompActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT op)
 {
     using LeafT = typename TreeT::LeafNodeType;
@@ -747,9 +756,9 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline void
 compMax(GridOrTreeT& aTree, GridOrTreeT& bTree)
 {
-    typedef TreeAdapter<GridOrTreeT>    Adapter;
-    typedef typename Adapter::TreeType  TreeT;
-    typedef typename TreeT::ValueType   ValueT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreeT = typename Adapter::TreeType;
+    using ValueT = typename TreeT::ValueType;
     struct Local {
         static inline void op(CombineArgs<ValueT>& args) {
             args.setResult(composite::max(args.a(), args.b()));
@@ -763,9 +772,9 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline void
 compMin(GridOrTreeT& aTree, GridOrTreeT& bTree)
 {
-    typedef TreeAdapter<GridOrTreeT>    Adapter;
-    typedef typename Adapter::TreeType  TreeT;
-    typedef typename TreeT::ValueType   ValueT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreeT = typename Adapter::TreeType;
+    using ValueT = typename TreeT::ValueType;
     struct Local {
         static inline void op(CombineArgs<ValueT>& args) {
             args.setResult(composite::min(args.a(), args.b()));
@@ -779,8 +788,8 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline void
 compSum(GridOrTreeT& aTree, GridOrTreeT& bTree)
 {
-    typedef TreeAdapter<GridOrTreeT> Adapter;
-    typedef typename Adapter::TreeType TreeT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreeT = typename Adapter::TreeType;
     struct Local {
         static inline void op(CombineArgs<typename TreeT::ValueType>& args) {
             args.setResult(args.a() + args.b());
@@ -794,8 +803,8 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline void
 compMul(GridOrTreeT& aTree, GridOrTreeT& bTree)
 {
-    typedef TreeAdapter<GridOrTreeT> Adapter;
-    typedef typename Adapter::TreeType TreeT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreeT = typename Adapter::TreeType;
     struct Local {
         static inline void op(CombineArgs<typename TreeT::ValueType>& args) {
             args.setResult(args.a() * args.b());
@@ -809,8 +818,8 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline void
 compDiv(GridOrTreeT& aTree, GridOrTreeT& bTree)
 {
-    typedef TreeAdapter<GridOrTreeT> Adapter;
-    typedef typename Adapter::TreeType TreeT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreeT = typename Adapter::TreeType;
     struct Local {
         static inline void op(CombineArgs<typename TreeT::ValueType>& args) {
             args.setResult(composite::divide(args.a(), args.b()));
@@ -854,9 +863,9 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline void
 compReplace(GridOrTreeT& aTree, const GridOrTreeT& bTree)
 {
-    typedef TreeAdapter<GridOrTreeT> Adapter;
-    typedef typename Adapter::TreeType TreeT;
-    typedef typename TreeT::ValueOnCIter ValueOnCIterT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreeT = typename Adapter::TreeType;
+    using ValueOnCIterT = typename TreeT::ValueOnCIter;
 
     // Copy active states (but not values) from B to A.
     Adapter::tree(aTree).topologyUnion(Adapter::tree(bTree));
@@ -882,9 +891,9 @@ template<typename TreeType>
 class CsgVisitorBase
 {
 public:
-    typedef TreeType TreeT;
-    typedef typename TreeT::ValueType ValueT;
-    typedef typename TreeT::LeafNodeType::ChildAllIter ChildIterT;
+    using TreeT = TreeType;
+    using ValueT = typename TreeT::ValueType;
+    using ChildIterT = typename TreeT::LeafNodeType::ChildAllIter;
 
     enum { STOP = 3 };
 
@@ -924,9 +933,9 @@ protected:
 template<typename TreeType>
 struct CsgUnionVisitor: public CsgVisitorBase<TreeType>
 {
-    typedef TreeType TreeT;
-    typedef typename TreeT::ValueType ValueT;
-    typedef typename TreeT::LeafNodeType::ChildAllIter ChildIterT;
+    using TreeT = TreeType;
+    using ValueT = typename TreeT::ValueType;
+    using ChildIterT = typename TreeT::LeafNodeType::ChildAllIter;
 
     enum { STOP = CsgVisitorBase<TreeT>::STOP };
 
@@ -997,9 +1006,9 @@ struct CsgUnionVisitor: public CsgVisitorBase<TreeType>
 template<typename TreeType>
 struct CsgIntersectVisitor: public CsgVisitorBase<TreeType>
 {
-    typedef TreeType TreeT;
-    typedef typename TreeT::ValueType ValueT;
-    typedef typename TreeT::LeafNodeType::ChildAllIter ChildIterT;
+    using TreeT = TreeType;
+    using ValueT = typename TreeT::ValueType;
+    using ChildIterT = typename TreeT::LeafNodeType::ChildAllIter;
 
     enum { STOP = CsgVisitorBase<TreeT>::STOP };
 
@@ -1069,9 +1078,9 @@ struct CsgIntersectVisitor: public CsgVisitorBase<TreeType>
 template<typename TreeType>
 struct CsgDiffVisitor: public CsgVisitorBase<TreeType>
 {
-    typedef TreeType TreeT;
-    typedef typename TreeT::ValueType ValueT;
-    typedef typename TreeT::LeafNodeType::ChildAllIter ChildIterT;
+    using TreeT = TreeType;
+    using ValueT = typename TreeT::ValueType;
+    using ChildIterT = typename TreeT::LeafNodeType::ChildAllIter;
 
     enum { STOP = CsgVisitorBase<TreeT>::STOP };
 
@@ -1144,8 +1153,8 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline void
 csgUnion(GridOrTreeT& a, GridOrTreeT& b, bool prune)
 {
-    typedef TreeAdapter<GridOrTreeT> Adapter;
-    typedef typename Adapter::TreeType TreeT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreeT = typename Adapter::TreeType;
     TreeT &aTree = Adapter::tree(a), &bTree = Adapter::tree(b);
     CsgUnionVisitor<TreeT> visitor(aTree, bTree);
     aTree.visit2(bTree, visitor);
@@ -1156,8 +1165,8 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline void
 csgIntersection(GridOrTreeT& a, GridOrTreeT& b, bool prune)
 {
-    typedef TreeAdapter<GridOrTreeT> Adapter;
-    typedef typename Adapter::TreeType TreeT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreeT = typename Adapter::TreeType;
     TreeT &aTree = Adapter::tree(a), &bTree = Adapter::tree(b);
     CsgIntersectVisitor<TreeT> visitor(aTree, bTree);
     aTree.visit2(bTree, visitor);
@@ -1168,8 +1177,8 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline void
 csgDifference(GridOrTreeT& a, GridOrTreeT& b, bool prune)
 {
-    typedef TreeAdapter<GridOrTreeT> Adapter;
-    typedef typename Adapter::TreeType TreeT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreeT = typename Adapter::TreeType;
     TreeT &aTree = Adapter::tree(a), &bTree = Adapter::tree(b);
     CsgDiffVisitor<TreeT> visitor(aTree, bTree);
     aTree.visit2(bTree, visitor);
@@ -1181,8 +1190,8 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline typename GridOrTreeT::Ptr
 csgUnionCopy(const GridOrTreeT& a, const GridOrTreeT& b)
 {
-    typedef TreeAdapter<GridOrTreeT>            Adapter;
-    typedef typename Adapter::TreeType::Ptr     TreePtrT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreePtrT = typename Adapter::TreeType::Ptr;
 
     TreePtrT output = composite::doCSGCopy<composite::CSG_UNION>(
                         Adapter::tree(a), Adapter::tree(b));
@@ -1195,8 +1204,8 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline typename GridOrTreeT::Ptr
 csgIntersectionCopy(const GridOrTreeT& a, const GridOrTreeT& b)
 {
-    typedef TreeAdapter<GridOrTreeT>            Adapter;
-    typedef typename Adapter::TreeType::Ptr     TreePtrT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreePtrT = typename Adapter::TreeType::Ptr;
 
     TreePtrT output = composite::doCSGCopy<composite::CSG_INTERSECTION>(
                         Adapter::tree(a), Adapter::tree(b));
@@ -1209,8 +1218,8 @@ template<typename GridOrTreeT>
 OPENVDB_STATIC_SPECIALIZATION inline typename GridOrTreeT::Ptr
 csgDifferenceCopy(const GridOrTreeT& a, const GridOrTreeT& b)
 {
-    typedef TreeAdapter<GridOrTreeT>            Adapter;
-    typedef typename Adapter::TreeType::Ptr     TreePtrT;
+    using Adapter = TreeAdapter<GridOrTreeT>;
+    using TreePtrT = typename Adapter::TreeType::Ptr;
 
     TreePtrT output = composite::doCSGCopy<composite::CSG_DIFFERENCE>(
                         Adapter::tree(a), Adapter::tree(b));
@@ -1241,8 +1250,9 @@ csgDifferenceCopy(const GridOrTreeT& a, const GridOrTreeT& b)
 ///
 /// @warning This function only operated on leaf node values,
 ///          i.e. tile values are ignored.
-template <typename TreeT, typename OpT = composite::CopyOp<TreeT> >
-inline void compActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT op = composite::CopyOp<TreeT>())
+template<typename TreeT, typename OpT = composite::CopyOp<TreeT> >
+inline void
+compActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT op = composite::CopyOp<TreeT>())
 {
     composite::doCompActiveLeafVoxels<TreeT, OpT>(srcTree, dstTree, op);
 }

--- a/openvdb/tools/Filter.h
+++ b/openvdb/tools/Filter.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -84,7 +84,7 @@ public:
     /// @param interrupt Optional interrupter.
     Filter(GridT& grid, InterruptT* interrupt = nullptr)
         : mGrid(&grid)
-        , mTask(0)
+        , mTask(nullptr)
         , mInterrupter(interrupt)
         , mMask(nullptr)
         , mGrainSize(1)
@@ -457,6 +457,6 @@ Filter<GridT, MaskT, InterruptT>::wasInterrupted()
 
 #endif // OPENVDB_TOOLS_FILTER_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/LevelSetFracture.h
+++ b/openvdb/tools/LevelSetFracture.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -45,8 +45,10 @@
 #include "GridTransformer.h" // for resampleToMatch()
 #include "LevelSetUtil.h" // for sdfSegmentation()
 
+#include <algorithm> // for std::max(), std::min()
 #include <limits>
 #include <list>
+#include <vector>
 
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_reduce.h>
@@ -62,16 +64,16 @@ template<class GridType, class InterruptType = util::NullInterrupter>
 class LevelSetFracture
 {
 public:
-    typedef std::vector<Vec3s> Vec3sList;
-    typedef std::vector<math::Quats> QuatsList;
-    typedef std::list<typename GridType::Ptr> GridPtrList;
-    typedef typename GridPtrList::iterator GridPtrListIter;
+    using Vec3sList = std::vector<Vec3s>;
+    using QuatsList = std::vector<math::Quats>;
+    using GridPtrList = std::list<typename GridType::Ptr>;
+    using GridPtrListIter = typename GridPtrList::iterator;
 
 
     /// @brief Default constructor
     ///
     /// @param interrupter  optional interrupter object
-    explicit LevelSetFracture(InterruptType* interrupter = NULL);
+    explicit LevelSetFracture(InterruptType* interrupter = nullptr);
 
     /// @brief Divide volumes represented by level set grids into multiple,
     /// disjoint pieces by intersecting them with one or more "cutter" volumes,
@@ -92,7 +94,7 @@ public:
     /// @param cutterOverlap  toggle to allow consecutive cutter instances to fracture
     ///                       previously generated fragments
     void fracture(GridPtrList& grids, const GridType& cutter, bool segment = false,
-        const Vec3sList* points = NULL, const QuatsList* rotations = NULL,
+        const Vec3sList* points = nullptr, const QuatsList* rotations = nullptr,
         bool cutterOverlap = true);
 
     /// Return a list of new fragments, not including the residuals from the input grids.
@@ -129,12 +131,12 @@ namespace level_set_fracture_internal {
 template<typename LeafNodeType>
 struct FindMinMaxVoxelValue {
 
-    typedef typename LeafNodeType::ValueType    ValueType;
+    using ValueType = typename LeafNodeType::ValueType;
 
     FindMinMaxVoxelValue(const std::vector<const LeafNodeType*>& nodes)
         : minValue(std::numeric_limits<ValueType>::max())
         , maxValue(-minValue)
-        , mNodes(nodes.empty() ? NULL : &nodes.front())
+        , mNodes(nodes.empty() ? nullptr : &nodes.front())
     {
     }
 
@@ -220,7 +222,7 @@ LevelSetFracture<GridType, InterruptType>::fracture(GridPtrList& grids, const Gr
 
             // Since there is no scaling, use the generic resampler instead of
             // the more expensive level set rebuild tool.
-            if (mInterrupter != NULL) {
+            if (mInterrupter != nullptr) {
 
                 if (hasInstanceRotations) {
                     doResampleToMatch<BoxSampler>(cutterGrid, instCutterGrid, *mInterrupter);
@@ -259,7 +261,7 @@ template<class GridType, class InterruptType>
 bool
 LevelSetFracture<GridType, InterruptType>::isValidFragment(GridType& grid) const
 {
-    typedef typename GridType::TreeType::LeafNodeType LeafNodeType;
+    using LeafNodeType = typename GridType::TreeType::LeafNodeType;
 
     if (grid.tree().leafCount() < 9) {
 
@@ -309,7 +311,7 @@ void
 LevelSetFracture<GridType, InterruptType>::process(
     GridPtrList& grids, const GridType& cutter)
 {
-    typedef typename GridType::Ptr GridPtr;
+    using GridPtr = typename GridType::Ptr;
     GridPtrList newFragments;
 
     for (GridPtrListIter it = grids.begin(); it != grids.end(); ++it) {
@@ -341,6 +343,6 @@ LevelSetFracture<GridType, InterruptType>::process(
 
 #endif // OPENVDB_TOOLS_LEVELSETFRACTURE_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/LevelSetMorph.h
+++ b/openvdb/tools/LevelSetMorph.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -353,7 +353,7 @@ Morph(LevelSetMorphing<GridT, InterruptT>& parent)
     : mParent(&parent)
     , mMinAbsS(ValueType(1e-6))
     , mMap(parent.mTracker.grid().transform().template constMap<MapT>().get())
-    , mTask(0)
+    , mTask(nullptr)
 {
 }
 
@@ -670,6 +670,6 @@ euler(const LeafRange& range, ValueType dt,
 
 #endif // OPENVDB_TOOLS_LEVEL_SET_MORPH_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/LevelSetTracker.h
+++ b/openvdb/tools/LevelSetTracker.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -545,7 +545,7 @@ Normalizer(LevelSetTracker& tracker, const MaskT* mask)
     , mDt(tracker.voxelSize()*(TemporalScheme == math::TVD_RK1 ? 0.3f :
                                TemporalScheme == math::TVD_RK2 ? 0.9f : 1.0f))
     , mInvDx(1.0f/tracker.voxelSize())
-    , mTask(0)
+    , mTask(nullptr)
 {
 }
 
@@ -676,8 +676,6 @@ LevelSetTracker<GridT,InterruptT>::
 Normalizer<SpatialScheme, TemporalScheme, MaskT>::
 euler(const LeafRange& range, Index phiBuffer, Index resultBuffer)
 {
-    using VoxelIterT = typename LeafType::ValueOnCIter;
-
     mTracker.checkInterrupter();
 
     StencilT stencil(mTracker.grid());
@@ -686,7 +684,7 @@ euler(const LeafRange& range, Index phiBuffer, Index resultBuffer)
         const ValueType* phi = leafIter.buffer(phiBuffer).data();
         ValueType* result = leafIter.buffer(resultBuffer).data();
         if (mMask == nullptr) {
-            for (VoxelIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
+            for (auto iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 stencil.moveTo(iter);
                 this->eval<Nominator, Denominator>(stencil, phi, result, iter.pos());
             }//loop over active voxels in the leaf of the level set
@@ -707,6 +705,6 @@ euler(const LeafRange& range, Index phiBuffer, Index resultBuffer)
 
 #endif // OPENVDB_TOOLS_LEVEL_SET_TRACKER_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/Morphology.h
+++ b/openvdb/tools/Morphology.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -58,7 +58,9 @@
 #include <tbb/task_scheduler_init.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
+#include <functional>
 #include <type_traits>
+#include <vector>
 
 
 namespace openvdb {
@@ -231,10 +233,10 @@ inline void deactivate(
 
 /// Mapping from a Log2Dim to a data type of size 2^Log2Dim bits
 template<Index Log2Dim> struct DimToWord {};
-template<> struct DimToWord<3> { typedef uint8_t Type; };
-template<> struct DimToWord<4> { typedef uint16_t Type; };
-template<> struct DimToWord<5> { typedef uint32_t Type; };
-template<> struct DimToWord<6> { typedef uint64_t Type; };
+template<> struct DimToWord<3> { using Type = uint8_t; };
+template<> struct DimToWord<4> { using Type = uint16_t; };
+template<> struct DimToWord<5> { using Type = uint32_t; };
+template<> struct DimToWord<6> { using Type = uint64_t; };
 
 
 ////////////////////////////////////////
@@ -244,7 +246,7 @@ template<typename TreeType>
 class Morphology
 {
 public:
-    typedef tree::LeafManager<TreeType> ManagerType;
+    using ManagerType = tree::LeafManager<TreeType>;
 
     Morphology(TreeType& tree):
         mOwnsManager(true), mManager(new ManagerType(tree)), mAcc(tree), mSteps(1) {}
@@ -276,9 +278,9 @@ protected:
 
     void doErosion(NearestNeighbors nn);
 
-    typedef typename TreeType::LeafNodeType LeafType;
-    typedef typename LeafType::NodeMaskType MaskType;
-    typedef tree::ValueAccessor<TreeType>   AccessorType;
+    using LeafType = typename TreeType::LeafNodeType;
+    using MaskType = typename LeafType::NodeMaskType;
+    using AccessorType = tree::ValueAccessor<TreeType>;
 
     const bool   mOwnsManager;
     ManagerType* mManager;
@@ -287,7 +289,7 @@ protected:
 
     static const int LEAF_DIM     = LeafType::DIM;
     static const int LEAF_LOG2DIM = LeafType::LOG2DIM;
-    typedef typename DimToWord<LEAF_LOG2DIM>::Type Word;
+    using Word = typename DimToWord<LEAF_LOG2DIM>::Type;
 
     struct Neighbor {
         LeafType* leaf;//null if a tile
@@ -389,9 +391,9 @@ protected:
     };// LeafCache
 
     struct ErodeVoxelsOp {
-        typedef tbb::blocked_range<size_t> RangeT;
+        using RangeT = tbb::blocked_range<size_t>;
         ErodeVoxelsOp(std::vector<MaskType>& masks, ManagerType& manager)
-            : mTask(0), mSavedMasks(masks) , mManager(manager) {}
+            : mTask(nullptr), mSavedMasks(masks) , mManager(manager) {}
         void runParallel(NearestNeighbors nn);
         void operator()(const RangeT& r) const {mTask(const_cast<ErodeVoxelsOp*>(this), r);}
         void erode6( const RangeT&) const;
@@ -892,7 +894,7 @@ template<typename TreeType>
 class ActivationOp
 {
 public:
-    typedef typename TreeType::ValueType ValueT;
+    using ValueT = typename TreeType::ValueType;
 
     ActivationOp(bool state, const ValueT& val, const ValueT& tol)
         : mActivate(state)
@@ -916,7 +918,7 @@ public:
 
     void operator()(const typename TreeType::LeafIter& lit) const
     {
-        typedef typename TreeType::LeafNodeType LeafT;
+        using LeafT = typename TreeType::LeafNodeType;
         LeafT& leaf = *lit;
         if (mActivate) {
             for (typename LeafT::ValueOffIter it = leaf.beginValueOff(); it; ++it) {
@@ -946,8 +948,8 @@ inline void
 activate(GridOrTree& gridOrTree, const typename GridOrTree::ValueType& value,
     const typename GridOrTree::ValueType& tolerance)
 {
-    typedef TreeAdapter<GridOrTree> Adapter;
-    typedef typename Adapter::TreeType TreeType;
+    using Adapter = TreeAdapter<GridOrTree>;
+    using TreeType = typename Adapter::TreeType;
 
     TreeType& tree = Adapter::tree(gridOrTree);
 
@@ -969,8 +971,8 @@ inline void
 deactivate(GridOrTree& gridOrTree, const typename GridOrTree::ValueType& value,
     const typename GridOrTree::ValueType& tolerance)
 {
-    typedef TreeAdapter<GridOrTree> Adapter;
-    typedef typename Adapter::TreeType TreeType;
+    using Adapter = TreeAdapter<GridOrTree>;
+    using TreeType = typename Adapter::TreeType;
 
     TreeType& tree = Adapter::tree(gridOrTree);
 
@@ -991,9 +993,9 @@ deactivate(GridOrTree& gridOrTree, const typename GridOrTree::ValueType& value,
 template<typename TreeT>
 class DilationOp
 {
-    typedef typename TreeT::template ValueConverter<ValueMask>::Type MaskT;
-    typedef tbb::enumerable_thread_specific<MaskT>                   PoolT;
-    typedef typename MaskT::LeafNodeType                             LeafT;
+    using MaskT = typename TreeT::template ValueConverter<ValueMask>::Type;
+    using PoolT = tbb::enumerable_thread_specific<MaskT>;
+    using LeafT = typename MaskT::LeafNodeType;
 
     // Very light-weight member data
     const int mIter;// number of iterations
@@ -1018,7 +1020,7 @@ public:
 
         delete [] mLeafs;// no more need for the array of leaf node pointers
 
-        typedef typename PoolT::iterator IterT;
+        using IterT = typename PoolT::iterator;
         for (IterT it=pool.begin(); it!=pool.end(); ++it) mask.merge(*it);// fast stealing
 
         if (mode == PRESERVE_TILES) tools::prune(mask);//multithreaded
@@ -1039,7 +1041,7 @@ private:
 
     // Simple wrapper of a raw double-pointer to mimic a std container
     struct MyArray {
-        typedef LeafT* value_type;//required by Tree::stealNodes
+        using value_type = LeafT*;//required by Tree::stealNodes
         value_type* ptr;
         MyArray(value_type* array) : ptr(array) {}
         void push_back(value_type leaf) { *ptr++ = leaf; }//required by Tree::stealNodes
@@ -1099,6 +1101,6 @@ dilateActiveValues(tree::LeafManager<TreeType>& manager,
 
 #endif // OPENVDB_TOOLS_MORPHOLOGY_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/ParticleAtlas.h
+++ b/openvdb/tools/ParticleAtlas.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -903,7 +903,7 @@ template<typename PointIndexGridType>
 inline void
 ParticleAtlas<PointIndexGridType>::Iterator::updateFromLevel(size_t level)
 {
-    using TreeType = typename PointIndexGridType::TreeType;
+    using TreeT = typename PointIndexGridType::TreeType;
     using LeafNodeType = typename TreeType::LeafNodeType;
 
     this->clear();
@@ -911,8 +911,7 @@ ParticleAtlas<PointIndexGridType>::Iterator::updateFromLevel(size_t level)
     if (mAccessorListSize > 0) {
         const size_t levelIdx = std::min(mAccessorListSize - 1, level);
 
-        const TreeType& tree = mAtlas->pointIndexGrid(levelIdx).tree();
-
+        const TreeT& tree = mAtlas->pointIndexGrid(levelIdx).tree();
 
         std::vector<const LeafNodeType*> nodes;
         tree.getNodes(nodes);
@@ -1060,6 +1059,6 @@ ParticleAtlas<PointIndexGridType>::Iterator::worldSpaceSearchAndUpdate(
 
 #endif // OPENVDB_TOOLS_PARTICLE_ATLAS_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/ParticlesToLevelSet.h
+++ b/openvdb/tools/ParticlesToLevelSet.h
@@ -789,8 +789,15 @@ private:
                 const Real x2y2 = x2 + math::Pow2(c.y() - P[1]);
                 for (c.z() = lo.z(); c.z() <= hi.z(); ++c.z()) {
                     const Real x2y2z2 = x2y2 + math::Pow2(c.z()-P[2]); // squared dist from c to P
+#if defined __INTEL_COMPILER
+    _Pragma("warning (push)")
+    _Pragma("warning (disable:186)") // "pointless comparison of unsigned integer with zero"
+#endif
                     if (x2y2z2 >= max2 || (!acc.probeValue(c, v) && (v < ValueT(0))))
                         continue;//outside narrow band of the particle or inside existing level set
+#if defined __INTEL_COMPILER
+    _Pragma("warning (pop)")
+#endif
                     if (x2y2z2 <= min2) {//inside narrow band of the particle.
                         acc.setValueOff(c, inside);
                         continue;

--- a/openvdb/tools/PointsToMask.h
+++ b/openvdb/tools/PointsToMask.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -245,9 +245,10 @@ struct PointsToMask<GridT, InterrupterT>::ReducePool
         : mOwnsGrid(false)
         , mGrid(grid)
     {
-        if ( grainSize == 0 ) {
-            using IterT = typename PoolType::const_iterator;
-            for (IterT i=pool.begin(); i!=pool.end(); ++i) mGrid->topologyUnion( *i );
+        if (grainSize == 0) {
+            for (typename PoolType::const_iterator i = pool.begin(); i != pool.end(); ++i) {
+                mGrid->topologyUnion(*i);
+            }
         } else {
             VecT grids( pool.size() );
             typename PoolType::iterator i = pool.begin();
@@ -281,6 +282,6 @@ struct PointsToMask<GridT, InterrupterT>::ReducePool
 
 #endif // OPENVDB_TOOLS_POINTSTOMASK_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/RayTracer.h
+++ b/openvdb/tools/RayTracer.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -280,7 +280,7 @@ public:
         RGBA  operator* (ValueT scale)  const { return RGBA(r*scale, g*scale, b*scale);}
         RGBA  operator+ (const RGBA& rhs) const { return RGBA(r+rhs.r, g+rhs.g, b+rhs.b);}
         RGBA  operator* (const RGBA& rhs) const { return RGBA(r*rhs.r, g*rhs.g, b*rhs.b);}
-        RGBA& operator+=(const RGBA& rhs) { r+=rhs.r; g+=rhs.g; b+=rhs.b, a+=rhs.a; return *this;}
+        RGBA& operator+=(const RGBA& rhs) { r+=rhs.r; g+=rhs.g; b+=rhs.b; a+=rhs.a; return *this;}
 
         void over(const RGBA& rhs)
         {
@@ -1120,6 +1120,6 @@ operator()(const tbb::blocked_range<size_t>& range) const
 
 #endif // OPENVDB_TOOLS_RAYTRACER_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/Statistics.h
+++ b/openvdb/tools/Statistics.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -170,13 +170,13 @@ statistics(const IterT& iter, const ValueOp& op, bool threaded);
 /// FloatGrid grid = ...;
 ///
 /// // Assume that we know that the grid has a uniform scale map.
-/// typedef math::UniformScaleMap MapType;
+/// using MapType = math::UniformScaleMap;
 /// // Specify a world-space gradient operator that uses first-order differencing.
-/// typedef math::Gradient<MapType, math::FD_1ST> GradientOp;
+/// using GradientOp = math::Gradient<MapType, math::FD_1ST>;
 /// // Wrap the operator with an adapter that computes the magnitude of the gradient.
-/// typedef math::OpMagnitude<GradientOp, MapType> MagnitudeOp;
+/// using MagnitudeOp = math::OpMagnitude<GradientOp, MapType>;
 /// // Wrap the operator with an adapter that associates a map with it.
-/// typedef math::MapAdapter<MapType, GradientOp, double> CompoundOp;
+/// using CompoundOp = math::MapAdapter<MapType, GradientOp, double>;
 ///
 /// if (MapType::Ptr map = grid.constTransform().constMap<MapType>()) {
 ///     math::Stats stats = tools::opStatistics(grid.cbeginValueOn(), CompoundOp(*map));
@@ -189,11 +189,11 @@ statistics(const IterT& iter, const ValueOp& op, bool threaded);
 /// Vec3SGrid grid = ...;
 ///
 /// // Assume that we know that the grid has a uniform scale map.
-/// typedef math::UniformScaleMap MapType;
+/// using MapType = math::UniformScaleMap;
 /// // Specify a world-space divergence operator that uses first-order differencing.
-/// typedef math::Divergence<MapType, math::FD_1ST> DivergenceOp;
+/// using DivergenceOp = math::Divergence<MapType, math::FD_1ST>;
 /// // Wrap the operator with an adapter that associates a map with it.
-/// typedef math::MapAdapter<MapType, DivergenceOp, double> CompoundOp;
+/// using CompoundOp = math::MapAdapter<MapType, DivergenceOp, double>;
 ///
 /// if (MapType::Ptr map = grid.constTransform().constMap<MapType>()) {
 ///     math::Stats stats = tools::opStatistics(grid.cbeginValueOn(), CompoundOp(*map));
@@ -206,7 +206,7 @@ statistics(const IterT& iter, const ValueOp& op, bool threaded);
 /// Vec3SGrid grid = ...;
 ///
 /// // Specify an index-space divergence operator that uses first-order differencing.
-/// typedef math::ISDivergence<math::FD_1ST> DivergenceOp;
+/// using DivergenceOp = math::ISDivergence<math::FD_1ST>;
 ///
 /// math::Stats stats = tools::opStatistics(grid.cbeginValueOn(), DivergenceOp());
 /// @endcode
@@ -229,12 +229,12 @@ namespace stats_internal {
 /// whereas node-level iterators use the name ValueType.
 template<typename IterT, typename AuxT = void>
 struct IterTraits {
-    typedef typename IterT::ValueType ValueType;
+    using ValueType = typename IterT::ValueType;
 };
 
 template<typename TreeT, typename ValueIterT>
 struct IterTraits<tree::TreeValueIteratorBase<TreeT, ValueIterT> > {
-    typedef typename tree::TreeValueIteratorBase<TreeT, ValueIterT>::ValueT ValueType;
+    using ValueType = typename tree::TreeValueIteratorBase<TreeT, ValueIterT>::ValueT;
 };
 
 
@@ -259,8 +259,8 @@ struct GetValImpl<T, /*IsVector=*/true> {
 template<typename IterT, typename StatsT>
 struct GetVal
 {
-    typedef typename IterTraits<IterT>::ValueType ValueT;
-    typedef GetValImpl<ValueT, VecTraits<ValueT>::IsVec> ImplT;
+    using ValueT = typename IterTraits<IterT>::ValueType;
+    using ImplT = GetValImpl<ValueT, VecTraits<ValueT>::IsVec>;
 
     inline void operator()(const IterT& iter, StatsT& stats) const {
         if (iter.isVoxelValue()) stats.add(ImplT::get(*iter));
@@ -312,9 +312,9 @@ struct HistOp
 template<typename IterT, typename OpT, typename StatsT>
 struct MathOp
 {
-    typedef typename IterT::TreeT                     TreeT;
-    typedef typename TreeT::ValueType                 ValueT;
-    typedef typename tree::ValueAccessor<const TreeT> ConstAccessor;
+    using TreeT = typename IterT::TreeT;
+    using ValueT = typename TreeT::ValueType;
+    using ConstAccessor = typename tree::ValueAccessor<const TreeT>;
 
     // Each thread gets its own accessor and its own copy of the operator.
     ConstAccessor mAcc;
@@ -323,7 +323,7 @@ struct MathOp
 
     template<typename TreeT>
     static inline TreeT* THROW_IF_NULL(TreeT* ptr) {
-        if (ptr == NULL) OPENVDB_THROW(ValueError, "iterator references a null tree");
+        if (ptr == nullptr) OPENVDB_THROW(ValueError, "iterator references a null tree");
         return ptr;
     }
 
@@ -367,7 +367,7 @@ template<typename IterT>
 inline math::Histogram
 histogram(const IterT& iter, double vmin, double vmax, size_t numBins, bool threaded)
 {
-    typedef stats_internal::GetVal<IterT, math::Histogram> ValueOp;
+    using ValueOp = stats_internal::GetVal<IterT, math::Histogram>;
     ValueOp valOp;
     stats_internal::HistOp<IterT, ValueOp> op(valOp, vmin, vmax, numBins);
     tools::accumulate(iter, op, threaded);
@@ -433,6 +433,6 @@ opStatistics(const IterT& iter, const OperatorT& op, bool threaded)
 
 #endif // OPENVDB_TOOLS_STATISTICS_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/ValueTransformer.h
+++ b/openvdb/tools/ValueTransformer.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -331,7 +331,7 @@ template<typename IterT, typename OpT>
 class SharedOpApplier
 {
 public:
-    typedef typename tree::IteratorRange<IterT> IterRange;
+    using IterRange = typename tree::IteratorRange<IterT>;
 
     SharedOpApplier(const IterT& iter, OpT& op): mIter(iter), mOp(op) {}
 
@@ -357,7 +357,7 @@ template<typename IterT, typename OpT>
 class CopyableOpApplier
 {
 public:
-    typedef typename tree::IteratorRange<IterT> IterRange;
+    using IterRange = typename tree::IteratorRange<IterT>;
 
     CopyableOpApplier(const IterT& iter, const OpT& op): mIter(iter), mOp(op), mOrigOp(&op) {}
 
@@ -395,7 +395,7 @@ foreach(const IterT& iter, XformOp& op, bool threaded, bool shared)
         typename valxform::SharedOpApplier<IterT, XformOp> proc(iter, op);
         proc.process(threaded);
     } else {
-        typedef typename valxform::CopyableOpApplier<IterT, XformOp> Processor;
+        using Processor = typename valxform::CopyableOpApplier<IterT, XformOp>;
         Processor proc(iter, op);
         proc.process(threaded);
     }
@@ -420,9 +420,9 @@ template<typename InIterT, typename OutTreeT, typename OpT>
 class SharedOpTransformer
 {
 public:
-    typedef typename InIterT::TreeT InTreeT;
-    typedef typename tree::IteratorRange<InIterT> IterRange;
-    typedef typename OutTreeT::ValueType OutValueT;
+    using InTreeT = typename InIterT::TreeT;
+    using IterRange = typename tree::IteratorRange<InIterT>;
+    using OutValueT = typename OutTreeT::ValueType;
 
     SharedOpTransformer(const InIterT& inIter, OutTreeT& outTree, OpT& op, MergePolicy merge):
         mIsRoot(true),
@@ -454,7 +454,7 @@ public:
         // (the top-level output tree was supplied by the caller).
         if (!mIsRoot) {
             delete mOutputTree;
-            mOutputTree = NULL;
+            mOutputTree = nullptr;
         }
     }
 
@@ -504,9 +504,9 @@ template<typename InIterT, typename OutTreeT, typename OpT>
 class CopyableOpTransformer
 {
 public:
-    typedef typename InIterT::TreeT InTreeT;
-    typedef typename tree::IteratorRange<InIterT> IterRange;
-    typedef typename OutTreeT::ValueType OutValueT;
+    using InTreeT = typename InIterT::TreeT;
+    using IterRange = typename tree::IteratorRange<InIterT>;
+    using OutValueT = typename OutTreeT::ValueType;
 
     CopyableOpTransformer(const InIterT& inIter, OutTreeT& outTree,
         const OpT& op, MergePolicy merge):
@@ -542,7 +542,7 @@ public:
         // (the top-level output tree was supplied by the caller).
         if (!mIsRoot) {
             delete mOutputTree;
-            mOutputTree = NULL;
+            mOutputTree = nullptr;
         }
     }
 
@@ -599,14 +599,14 @@ inline void
 transformValues(const InIterT& inIter, OutGridT& outGrid, XformOp& op,
     bool threaded, bool shared, MergePolicy merge)
 {
-    typedef TreeAdapter<OutGridT> Adapter;
-    typedef typename Adapter::TreeType OutTreeT;
+    using Adapter = TreeAdapter<OutGridT>;
+    using OutTreeT = typename Adapter::TreeType;
     if (shared) {
-        typedef typename valxform::SharedOpTransformer<InIterT, OutTreeT, XformOp> Processor;
+        using Processor = typename valxform::SharedOpTransformer<InIterT, OutTreeT, XformOp>;
         Processor proc(inIter, Adapter::tree(outGrid), op, merge);
         proc.process(threaded);
     } else {
-        typedef typename valxform::CopyableOpTransformer<InIterT, OutTreeT, XformOp> Processor;
+        using Processor = typename valxform::CopyableOpTransformer<InIterT, OutTreeT, XformOp>;
         Processor proc(inIter, Adapter::tree(outGrid), op, merge);
         proc.process(threaded);
     }
@@ -618,10 +618,10 @@ inline void
 transformValues(const InIterT& inIter, OutGridT& outGrid, const XformOp& op,
     bool threaded, bool /*share*/, MergePolicy merge)
 {
-    typedef TreeAdapter<OutGridT> Adapter;
-    typedef typename Adapter::TreeType OutTreeT;
+    using Adapter = TreeAdapter<OutGridT>;
+    using OutTreeT = typename Adapter::TreeType;
     // Const ops are shared across threads, not copied.
-    typedef typename valxform::SharedOpTransformer<InIterT, OutTreeT, const XformOp> Processor;
+    using Processor = typename valxform::SharedOpTransformer<InIterT, OutTreeT, const XformOp>;
     Processor proc(inIter, Adapter::tree(outGrid), op, merge);
     proc.process(threaded);
 }
@@ -637,7 +637,7 @@ template<typename IterT, typename OpT>
 class OpAccumulator
 {
 public:
-    typedef typename tree::IteratorRange<IterT> IterRange;
+    using IterRange = typename tree::IteratorRange<IterT>;
 
     // The root task makes a const copy of the original functor (mOrigOp)
     // and keeps a pointer to the original functor (mOp), which it then modifies.
@@ -702,6 +702,6 @@ accumulate(const IterT& iter, XformOp& op, bool threaded)
 
 #endif // OPENVDB_TOOLS_VALUETRANSFORMER_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/VolumeAdvect.h
+++ b/openvdb/tools/VolumeAdvect.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -396,7 +396,7 @@ struct VolumeAdvection<VelocityGridT, StaggeredVelocity, InterrupterType>::Advec
     using VoxelIterT = typename TreeT::LeafNodeType::ValueOnIter;
 
     Advect(const VolumeGridT& inGrid, const VolumeAdvection& parent)
-        : mTask(0)
+        : mTask(nullptr)
         , mInGrid(&inGrid)
         , mVelocityInt(parent.mVelGrid)
         , mParent(&parent)
@@ -567,6 +567,6 @@ struct VolumeAdvection<VelocityGridT, StaggeredVelocity, InterrupterType>::Advec
 
 #endif // OPENVDB_TOOLS_VOLUME_ADVECT_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tree/LeafManager.h
+++ b/openvdb/tree/LeafManager.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -222,7 +222,7 @@ public:
         , mAuxBuffersPerLeaf(auxBuffersPerLeaf)
         , mLeafs(nullptr)
         , mAuxBuffers(nullptr)
-        , mTask(0)
+        , mTask(nullptr)
         , mIsMaster(true)
     {
         this->rebuild(serial);
@@ -239,7 +239,7 @@ public:
         , mAuxBuffersPerLeaf(auxBuffersPerLeaf)
         , mLeafs(new LeafType*[mLeafCount])
         , mAuxBuffers(nullptr)
-        , mTask(0)
+        , mTask(nullptr)
         , mIsMaster(true)
     {
         size_t n = mLeafCount;
@@ -849,6 +849,6 @@ struct LeafManagerImpl<LeafManager<const TreeT> >
 
 #endif // OPENVDB_TREE_LEAFMANAGER_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/unittest/TestPointConversion.cc
+++ b/openvdb/unittest/TestPointConversion.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -604,7 +604,7 @@ TestPointConversion::testPointConversionNans()
     {
         size_t iOffset = i;
         for (const int& idx : nanIndices) {
-            if (iOffset >= idx) iOffset += 1;
+            if (int(iOffset) >= idx) iOffset += 1;
         }
 
         CPPUNIT_ASSERT_EQUAL(id.buffer()[iOffset], pointData[i].id);
@@ -1126,6 +1126,6 @@ TestPointConversion::testComputeVoxelSize()
     }
 }
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/util/NodeMasks.h
+++ b/openvdb/util/NodeMasks.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -729,12 +729,12 @@ public:
     /// Set the <i>n</i>th  bit on
     void setOn(Index32 n) {
         assert( n  < 8 );
-        mByte = mByte | static_cast<Byte>(0x01U << (n & 7));
+        mByte = static_cast<Byte>(mByte | 0x01U << (n & 7));
     }
     /// Set the <i>n</i>th bit off
     void setOff(Index32 n) {
         assert( n  < 8 );
-        mByte = mByte & static_cast<Byte>(~(0x01U << (n & 7)));
+        mByte = static_cast<Byte>(mByte & ~(0x01U << (n & 7)));
     }
     /// Set the <i>n</i>th bit to the specified state
     void set(Index32 n, bool On) { On ? this->setOn(n) : this->setOff(n); }
@@ -747,7 +747,7 @@ public:
     /// Toggle the state of the <i>n</i>th bit
     void toggle(Index32 n) {
         assert( n  < 8 );
-        mByte = mByte ^ static_cast<Byte>(0x01U << (n & 7));
+        mByte = static_cast<Byte>(mByte ^ 0x01U << (n & 7));
     }
     /// Toggle the state of all bits in the mask
     void toggle() { mByte = static_cast<Byte>(~mByte); }
@@ -1435,6 +1435,6 @@ public:
 
 #endif // OPENVDB_UTIL_NODEMASKS_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/util/NullInterrupter.h
+++ b/openvdb/util/NullInterrupter.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -55,7 +55,7 @@ struct NullInterrupter
     NullInterrupter () {}
     /// Signal the start of an interruptible operation.
     /// @param name  an optional descriptive name for the operation
-    void start(const char* name = NULL) { (void)name; }
+    void start(const char* name = nullptr) { (void)name; }
     /// Signal the end of an interruptible operation.
     void end() {}
     /// Check if an interruptible operation should be aborted.
@@ -85,6 +85,6 @@ inline bool wasInterrupted<util::NullInterrupter>(util::NullInterrupter*, int) {
 
 #endif // OPENVDB_UTIL_NULL_INTERRUPTER_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/viewer/RenderModules.cc
+++ b/openvdb/viewer/RenderModules.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -288,22 +288,22 @@ BufferObject::render() const
 
     glBindBuffer(GL_ARRAY_BUFFER, mVertexBuffer);
     glEnableClientState(GL_VERTEX_ARRAY);
-    glVertexPointer(3, GL_FLOAT, 0, 0);
+    glVertexPointer(3, GL_FLOAT, nullptr, nullptr);
 
     if (usesColorBuffer) {
         glBindBuffer(GL_ARRAY_BUFFER, mColorBuffer);
         glEnableClientState(GL_COLOR_ARRAY);
-        glColorPointer(3, GL_FLOAT, 0, 0);
+        glColorPointer(3, GL_FLOAT, nullptr, nullptr);
     }
 
     if (usesNormalBuffer) {
         glEnableClientState(GL_NORMAL_ARRAY);
         glBindBuffer(GL_ARRAY_BUFFER, mNormalBuffer);
-        glNormalPointer(GL_FLOAT, 0, 0);
+        glNormalPointer(GL_FLOAT, nullptr, nullptr);
     }
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mIndexBuffer);
-    glDrawElements(mPrimType, mPrimNum, GL_UNSIGNED_INT, 0);
+    glDrawElements(mPrimType, mPrimNum, GL_UNSIGNED_INT, nullptr);
 
     // disable client-side capabilities
     if (usesColorBuffer) glDisableClientState(GL_COLOR_ARRAY);
@@ -1691,6 +1691,6 @@ MeshModule::render()
 
 } // namespace openvdb_viewer
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/viewer/RenderModules.cc
+++ b/openvdb/viewer/RenderModules.cc
@@ -288,18 +288,18 @@ BufferObject::render() const
 
     glBindBuffer(GL_ARRAY_BUFFER, mVertexBuffer);
     glEnableClientState(GL_VERTEX_ARRAY);
-    glVertexPointer(3, GL_FLOAT, nullptr, nullptr);
+    glVertexPointer(3, GL_FLOAT, 0, nullptr);
 
     if (usesColorBuffer) {
         glBindBuffer(GL_ARRAY_BUFFER, mColorBuffer);
         glEnableClientState(GL_COLOR_ARRAY);
-        glColorPointer(3, GL_FLOAT, nullptr, nullptr);
+        glColorPointer(3, GL_FLOAT, 0, nullptr);
     }
 
     if (usesNormalBuffer) {
         glEnableClientState(GL_NORMAL_ARRAY);
         glBindBuffer(GL_ARRAY_BUFFER, mNormalBuffer);
-        glNormalPointer(GL_FLOAT, nullptr, nullptr);
+        glNormalPointer(GL_FLOAT, 0, nullptr);
     }
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mIndexBuffer);

--- a/openvdb_houdini/houdini/PointUtils.h
+++ b/openvdb_houdini/houdini/PointUtils.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -117,6 +117,7 @@ computeVoxelSizeFromHoudini(
 /// @param  attributes     a vector of VDB Points attributes to be included
 ///                        (empty vector defaults to all)
 /// @param  transform      transform to use for the new point grid
+/// @param  warnings       list of warnings to be added to the SOP
 OPENVDB_HOUDINI_API
 openvdb::points::PointDataGrid::Ptr
 convertHoudiniToPointDataGrid(
@@ -215,6 +216,6 @@ OPENVDB_HOUDINI_API extern const PRM_ChoiceList VDBPointsGroupMenu;
 
 #endif // OPENVDB_HOUDINI_POINT_UTILS_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )


### PR DESCRIPTION
[OVDB-10](https://jira.aswf.io/browse/OVDB-10): Introduce stricter Clang and GCC warnings for Travis builds

More work to be done, but this should significantly reduce the volume of warnings from GCC 5.4 and Clang 7.

For the Python module and unit test warnings, we'll need to look into why Clang is seemingly not respecting `-isystem`.