### PR TITLE
Pre-defined compiler warnings for gcc and clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,23 +84,10 @@ IF ( OPENVDB_CXX_WARNINGS )
     IF ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
         MESSAGE ( STATUS "Configuring Clang CXX warnings" )
         ADD_DEFINITIONS (
-            -Qunused-arguments
-            -Wall \
-            -Wextra \
-            -Wconversion \
-            -Wc++0x-compat
-            -Wno-c++98-compat-pedantic
-            -Wno-covered-switch-default
-            -Wno-documentation
-            -Wno-documentation-deprecated-sync
-            -Wno-documentation-unknown-command
-            -Wno-double-promotion
-            -Wno-exit-time-destructors
-            -Wno-global-constructors
-            -Wno-mismatched-tags
-            -Wno-padded
+            -Wall
+            -Wextra
+            -Wconversion
             -Wno-sign-conversion
-            -Wno-weak-vtables
         )
     ELSEIF ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
         MESSAGE ( STATUS "Configuring GCC CXX warnings" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ OPTION ( OPENVDB_BUILD_CORE "Build the OpenVDB core" ON )
 OPTION ( OPENVDB_ENABLE_RPATH "Build with RPATH information" ON )
 OPTION ( OPENVDB_ENABLE_3_ABI_COMPATIBLE "Build with OpenVDB v3 ABI" ON )
 OPTION ( OPENVDB_DISABLE_BOOST_IMPLICIT_LINKING "Disable the implicit linking of Boost libraries on Windows" ON )
-OPTION ( OPENVDB_CXX_WARNINGS "Enable or disable a set of pre-defined compiler warnings for clang and gcc" OFF )
+OPTION ( OPENVDB_CXX_STRICT "Enable or disable a set of pre-defined compiler warnings for clang and gcc" OFF )
 
 SET ( OPENVDB_ABI_VERSION_NUMBER "" CACHE STRING "build for compatibility
 with version N of the OpenVDB Grid ABI, where N is 2, 3, 4, etc.
@@ -79,7 +79,7 @@ ELSEIF ( OPENVDB_ENABLE_3_ABI_COMPATIBLE )
   ADD_DEFINITIONS ( -DOPENVDB_3_ABI_COMPATIBLE )
 ENDIF ()
 
-IF ( OPENVDB_CXX_WARNINGS )
+IF ( OPENVDB_CXX_STRICT )
     # Add definitions for a number of compiler warnings for GCC and Clang for all sub projects
     IF ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
         MESSAGE ( STATUS "Configuring Clang CXX warnings" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,10 @@ OPTION ( OPENVDB_BUILD_CORE "Build the OpenVDB core" ON )
 OPTION ( OPENVDB_ENABLE_RPATH "Build with RPATH information" ON )
 OPTION ( OPENVDB_ENABLE_3_ABI_COMPATIBLE "Build with OpenVDB v3 ABI" ON )
 OPTION ( OPENVDB_DISABLE_BOOST_IMPLICIT_LINKING "Disable the implicit linking of Boost libraries on Windows" ON )
+OPTION ( OPENVDB_CXX_WARNINGS "Enable or disable a set of pre-defined compiler warnings for clang and gcc" OFF )
 
 SET ( OPENVDB_ABI_VERSION_NUMBER "" CACHE STRING "build for compatibility
-with version N of the OpenVDB Grid ABI, where N is 2, 3, 4, etc. 
+with version N of the OpenVDB Grid ABI, where N is 2, 3, 4, etc.
 (some newer features will be disabled)")
 
 IF (OPENVDB_BUILD_HOUDINI_SOPS)
@@ -69,13 +70,51 @@ SET ( OPENVDB_TOP_LEVEL_DIR ${PROJECT_SOURCE_DIR} CACHE PATH "OpenVDB Top Level 
 INCLUDE_DIRECTORIES ( ${OPENVDB_TOP_LEVEL_DIR} ) # To make sure we pick up headers from this version of OpenVDB we are building
 IF ( ${OPENVDB_ABI_VERSION_NUMBER} )
   MESSAGE( STATUS "Using openvdb abi version ${OPENVDB_ABI_VERSION_NUMBER}")
-  
+
   ADD_DEFINITIONS (-DOPENVDB_ABI_VERSION_NUMBER=${OPENVDB_ABI_VERSION_NUMBER} )
 ELSEIF ( OPENVDB_ENABLE_3_ABI_COMPATIBLE )
 
   MESSAGE( DEPRECATION "OPENVDB_ENABLE_3_ABI_COMPATIBLE is deprecated. Instead use OPENVDB_ABI_VERSION_NUMBER=N, where N is the abi version.")
 
   ADD_DEFINITIONS ( -DOPENVDB_3_ABI_COMPATIBLE )
+ENDIF ()
+
+IF ( OPENVDB_CXX_WARNINGS )
+    # Add definitions for a number of compiler warnings for GCC and Clang for all sub projects
+    IF ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
+        MESSAGE ( STATUS "Configuring Clang CXX warnings" )
+        ADD_DEFINITIONS (
+            -Qunused-arguments
+            -Weverything
+            -Wc++0x-compat
+            -Wno-c++98-compat-pedantic
+            -Wno-covered-switch-default
+            -Wno-documentation
+            -Wno-documentation-deprecated-sync
+            -Wno-documentation-unknown-command
+            -Wno-double-promotion
+            -Wno-exit-time-destructors
+            -Wno-global-constructors
+            -Wno-mismatched-tags
+            -Wno-padded
+            -Wno-sign-conversion
+            -Wno-weak-vtables
+        )
+    ELSEIF ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
+        MESSAGE ( STATUS "Configuring GCC CXX warnings" )
+        ADD_DEFINITIONS (
+            -Wall
+            -Wextra
+            -pedantic
+            -Wcast-align
+            -Wcast-qual
+            -Wconversion
+            -Wdisabled-optimization
+            -Woverloaded-virtual
+        )
+    ELSE ()
+        MESSAGE ( WARNING "No available CXX warnings for compiler "${CMAKE_CXX_COMPILER_ID} )
+    ENDIF ()
 ENDIF ()
 
 IF ( OPENVDB_BUILD_CORE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,9 @@ IF ( OPENVDB_CXX_WARNINGS )
         MESSAGE ( STATUS "Configuring Clang CXX warnings" )
         ADD_DEFINITIONS (
             -Qunused-arguments
-            -Weverything
+            -Wall \
+            -Wextra \
+            -Wconversion \
             -Wc++0x-compat
             -Wno-c++98-compat-pedantic
             -Wno-covered-switch-default

--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -290,7 +290,9 @@ ifeq (yes,$(strip $(warnings)))
     ifneq (,$(USING_CLANG))
         CXXFLAGS += \
             -Qunused-arguments \
-            -Weverything \
+            -Wall \
+            -Wextra \
+            -Wconversion \
             -Wc++0x-compat \
             -Wno-c++98-compat-pedantic \
             -Wno-covered-switch-default \

--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -62,6 +62,8 @@
 #                       (default: link against shared libraries)
 #   debug=yes           build with debugging symbols and without optimization
 #   verbose=yes         run commands (e.g., doxygen) in verbose mode
+#   warnings=yes        Enable a collection of pre defined compiler warnings
+#                       for GCC and clang
 
 
 #
@@ -280,6 +282,41 @@ ifneq (,$(abi))
 endif
 ifneq (2,$(strip $(GLFW_MAJOR_VERSION)))
     CXXFLAGS += -DOPENVDB_USE_GLFW_3
+endif
+
+ifeq (yes,$(strip $(warnings)))
+    USING_CLANG=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __clang__)
+    USING_GCC=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __GNUC__)
+    ifneq (,$(USING_CLANG))
+        CXXFLAGS += \
+            -Qunused-arguments \
+            -Weverything \
+            -Wc++0x-compat \
+            -Wno-c++98-compat-pedantic \
+            -Wno-covered-switch-default \
+            -Wno-documentation \
+            -Wno-documentation-deprecated-sync \
+            -Wno-documentation-unknown-command \
+            -Wno-double-promotion \
+            -Wno-exit-time-destructors \
+            -Wno-global-constructors \
+            -Wno-mismatched-tags \
+            -Wno-padded \
+            -Wno-sign-conversion \
+            -Wno-weak-vtables \
+        #
+    else ifneq (,$(USING_GCC))
+        CXXFLAGS += \
+            -Wall \
+            -Wextra \
+            -pedantic \
+            -Wcast-align \
+            -Wcast-qual \
+            -Wconversion \
+            -Wdisabled-optimization \
+            -Woverloaded-virtual \
+        #
+    endif
 endif
 
 LIBS := \

--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -285,8 +285,8 @@ ifneq (2,$(strip $(GLFW_MAJOR_VERSION)))
 endif
 
 ifeq (yes,$(strip $(strict)))
-    USING_CLANG=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __clang__)
-    USING_GCC=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __GNUC__)
+    USING_CLANG=$(shell ${CXX} --version | grep clang)
+    USING_GCC=$(shell ${CXX} --version | grep GCC)
     ifneq (,$(USING_CLANG))
         CXXFLAGS += \
             -Qunused-arguments \

--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -62,7 +62,7 @@
 #                       (default: link against shared libraries)
 #   debug=yes           build with debugging symbols and without optimization
 #   verbose=yes         run commands (e.g., doxygen) in verbose mode
-#   warnings=yes        Enable a collection of pre defined compiler warnings
+#   strict=yes          Enable a collection of pre defined compiler warnings
 #                       for GCC and clang
 
 
@@ -284,7 +284,7 @@ ifneq (2,$(strip $(GLFW_MAJOR_VERSION)))
     CXXFLAGS += -DOPENVDB_USE_GLFW_3
 endif
 
-ifeq (yes,$(strip $(warnings)))
+ifeq (yes,$(strip $(strict)))
     USING_CLANG=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __clang__)
     USING_GCC=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __GNUC__)
     ifneq (,$(USING_CLANG))

--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -289,23 +289,10 @@ ifeq (yes,$(strip $(strict)))
     USING_GCC=$(shell ${CXX} --version | grep GCC)
     ifneq (,$(USING_CLANG))
         CXXFLAGS += \
-            -Qunused-arguments \
             -Wall \
             -Wextra \
             -Wconversion \
-            -Wc++0x-compat \
-            -Wno-c++98-compat-pedantic \
-            -Wno-covered-switch-default \
-            -Wno-documentation \
-            -Wno-documentation-deprecated-sync \
-            -Wno-documentation-unknown-command \
-            -Wno-double-promotion \
-            -Wno-exit-time-destructors \
-            -Wno-global-constructors \
-            -Wno-mismatched-tags \
-            -Wno-padded \
             -Wno-sign-conversion \
-            -Wno-weak-vtables \
         #
     else ifneq (,$(USING_GCC))
         CXXFLAGS += \

--- a/openvdb_houdini/Makefile
+++ b/openvdb_houdini/Makefile
@@ -207,8 +207,8 @@ ifdef MBSD
 endif
 
 ifeq (yes,$(strip $(strict)))
-    USING_CLANG=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __clang__)
-    USING_GCC=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __GNUC__)
+    USING_CLANG=$(shell ${CXX} --version | grep clang)
+    USING_GCC=$(shell ${CXX} --version | grep GCC)
     ifneq (,$(USING_CLANG))
         WARNING_FLAGS += \
             -Qunused-arguments \

--- a/openvdb_houdini/Makefile
+++ b/openvdb_houdini/Makefile
@@ -212,7 +212,9 @@ ifeq (yes,$(strip $(warnings)))
     ifneq (,$(USING_CLANG))
         WARNING_FLAGS += \
             -Qunused-arguments \
-            -Weverything \
+            -Wall \
+            -Wextra \
+            -Wconversion \
             -Wc++0x-compat \
             -Wno-c++98-compat-pedantic \
             -Wno-covered-switch-default \

--- a/openvdb_houdini/Makefile
+++ b/openvdb_houdini/Makefile
@@ -53,6 +53,8 @@
 #   debug=yes           build with debugging symbols and without optimization
 #   verbose=yes         run commands (in particular, hcustom and doxygen)
 #                       in verbose mode
+#   warnings=yes        Enable a collection of pre defined compiler warnings
+#                       for GCC and clang
 
 
 #
@@ -202,6 +204,43 @@ ifdef MBSD
     # Darwin ld treats undefined symbols as errors by default;
     # change to runtime resolution, like Linux.
     CXXFLAGS += -undefined dynamic_lookup
+endif
+
+ifeq (yes,$(strip $(warnings)))
+    USING_CLANG=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __clang__)
+    USING_GCC=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __GNUC__)
+    ifneq (,$(USING_CLANG))
+        WARNING_FLAGS += \
+            -Qunused-arguments \
+            -Weverything \
+            -Wc++0x-compat \
+            -Wno-c++98-compat-pedantic \
+            -Wno-covered-switch-default \
+            -Wno-documentation \
+            -Wno-documentation-deprecated-sync \
+            -Wno-documentation-unknown-command \
+            -Wno-double-promotion \
+            -Wno-exit-time-destructors \
+            -Wno-global-constructors \
+            -Wno-mismatched-tags \
+            -Wno-padded \
+            -Wno-sign-conversion \
+            -Wno-weak-vtables \
+        #
+    else ifneq (,$(USING_GCC))
+        WARNING_FLAGS += \
+            -Wall \
+            -Wextra \
+            -pedantic \
+            -Wcast-align \
+            -Wcast-qual \
+            -Wconversion \
+            -Wdisabled-optimization \
+            -Woverloaded-virtual \
+        #
+    endif
+    CXXFLAGS += $(WARNING_FLAGS)
+    HCUSTOM_EXTRA_CFLAGS += $(WARNING_FLAGS)
 endif
 
 ifneq (,$(strip $(wildcard $(HOUDINI_INCL_DIR))))

--- a/openvdb_houdini/Makefile
+++ b/openvdb_houdini/Makefile
@@ -211,23 +211,10 @@ ifeq (yes,$(strip $(strict)))
     USING_GCC=$(shell ${CXX} --version | grep GCC)
     ifneq (,$(USING_CLANG))
         WARNING_FLAGS += \
-            -Qunused-arguments \
             -Wall \
             -Wextra \
             -Wconversion \
-            -Wc++0x-compat \
-            -Wno-c++98-compat-pedantic \
-            -Wno-covered-switch-default \
-            -Wno-documentation \
-            -Wno-documentation-deprecated-sync \
-            -Wno-documentation-unknown-command \
-            -Wno-double-promotion \
-            -Wno-exit-time-destructors \
-            -Wno-global-constructors \
-            -Wno-mismatched-tags \
-            -Wno-padded \
             -Wno-sign-conversion \
-            -Wno-weak-vtables \
         #
     else ifneq (,$(USING_GCC))
         WARNING_FLAGS += \

--- a/openvdb_houdini/Makefile
+++ b/openvdb_houdini/Makefile
@@ -53,7 +53,7 @@
 #   debug=yes           build with debugging symbols and without optimization
 #   verbose=yes         run commands (in particular, hcustom and doxygen)
 #                       in verbose mode
-#   warnings=yes        Enable a collection of pre defined compiler warnings
+#   strict=yes          Enable a collection of pre defined compiler warnings
 #                       for GCC and clang
 
 
@@ -206,7 +206,7 @@ ifdef MBSD
     CXXFLAGS += -undefined dynamic_lookup
 endif
 
-ifeq (yes,$(strip $(warnings)))
+ifeq (yes,$(strip $(strict)))
     USING_CLANG=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __clang__)
     USING_GCC=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __GNUC__)
     ifneq (,$(USING_CLANG))

--- a/openvdb_maya/Makefile
+++ b/openvdb_maya/Makefile
@@ -41,6 +41,8 @@
 #   bits=32|64          build for 32-bit or 64-bit environments (default: 64)
 #   debug=yes           build with debugging symbols and without optimization
 #   verbose=yes         run commands in verbose mode
+#   warnings=yes        Enable a collection of pre defined compiler warnings
+#                       for GCC and clang
 
 
 #
@@ -185,6 +187,41 @@ ifdef MBSD
     # Darwin ld treats undefined symbols as errors by default;
     # change to runtime resolution, like Linux.
     CXXFLAGS += -undefined dynamic_lookup
+endif
+
+ifeq (yes,$(strip $(warnings)))
+    USING_CLANG=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __clang__)
+    USING_GCC=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __GNUC__)
+    ifneq (,$(USING_CLANG))
+        CXXFLAGS += \
+            -Qunused-arguments \
+            -Weverything \
+            -Wc++0x-compat \
+            -Wno-c++98-compat-pedantic \
+            -Wno-covered-switch-default \
+            -Wno-documentation \
+            -Wno-documentation-deprecated-sync \
+            -Wno-documentation-unknown-command \
+            -Wno-double-promotion \
+            -Wno-exit-time-destructors \
+            -Wno-global-constructors \
+            -Wno-mismatched-tags \
+            -Wno-padded \
+            -Wno-sign-conversion \
+            -Wno-weak-vtables \
+        #
+    else ifneq (,$(USING_GCC))
+        CXXFLAGS += \
+            -Wall \
+            -Wextra \
+            -pedantic \
+            -Wcast-align \
+            -Wcast-qual \
+            -Wconversion \
+            -Wdisabled-optimization \
+            -Woverloaded-virtual \
+        #
+    endif
 endif
 
 MAYA_LIBS := \

--- a/openvdb_maya/Makefile
+++ b/openvdb_maya/Makefile
@@ -41,7 +41,7 @@
 #   bits=32|64          build for 32-bit or 64-bit environments (default: 64)
 #   debug=yes           build with debugging symbols and without optimization
 #   verbose=yes         run commands in verbose mode
-#   warnings=yes        Enable a collection of pre defined compiler warnings
+#   strict=yes          Enable a collection of pre defined compiler warnings
 #                       for GCC and clang
 
 
@@ -189,7 +189,7 @@ ifdef MBSD
     CXXFLAGS += -undefined dynamic_lookup
 endif
 
-ifeq (yes,$(strip $(warnings)))
+ifeq (yes,$(strip $(strict)))
     USING_CLANG=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __clang__)
     USING_GCC=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __GNUC__)
     ifneq (,$(USING_CLANG))

--- a/openvdb_maya/Makefile
+++ b/openvdb_maya/Makefile
@@ -190,8 +190,8 @@ ifdef MBSD
 endif
 
 ifeq (yes,$(strip $(strict)))
-    USING_CLANG=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __clang__)
-    USING_GCC=$(shell ${CXX} -dM -E -x c++ - < /dev/null | grep __GNUC__)
+    USING_CLANG=$(shell ${CXX} --version | grep clang)
+    USING_GCC=$(shell ${CXX} --version | grep GCC)
     ifneq (,$(USING_CLANG))
         CXXFLAGS += \
             -Qunused-arguments \

--- a/openvdb_maya/Makefile
+++ b/openvdb_maya/Makefile
@@ -194,23 +194,10 @@ ifeq (yes,$(strip $(strict)))
     USING_GCC=$(shell ${CXX} --version | grep GCC)
     ifneq (,$(USING_CLANG))
         CXXFLAGS += \
-            -Qunused-arguments \
             -Wall \
             -Wextra \
             -Wconversion \
-            -Wc++0x-compat \
-            -Wno-c++98-compat-pedantic \
-            -Wno-covered-switch-default \
-            -Wno-documentation \
-            -Wno-documentation-deprecated-sync \
-            -Wno-documentation-unknown-command \
-            -Wno-double-promotion \
-            -Wno-exit-time-destructors \
-            -Wno-global-constructors \
-            -Wno-mismatched-tags \
-            -Wno-padded \
             -Wno-sign-conversion \
-            -Wno-weak-vtables \
         #
     else ifneq (,$(USING_GCC))
         CXXFLAGS += \

--- a/openvdb_maya/Makefile
+++ b/openvdb_maya/Makefile
@@ -195,7 +195,9 @@ ifeq (yes,$(strip $(warnings)))
     ifneq (,$(USING_CLANG))
         CXXFLAGS += \
             -Qunused-arguments \
-            -Weverything \
+            -Wall \
+            -Wextra \
+            -Wconversion \
             -Wc++0x-compat \
             -Wno-c++98-compat-pedantic \
             -Wno-covered-switch-default \

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -187,31 +187,31 @@ elif [ "$TASK" = "script" ]; then
                 # build OpenVDB core library, OpenVDB Python module and all binaries
                 if [ "$COMPILER" = "gcc" ]; then
                     # for GCC, pre-build vdb_view and python using fewer threads in order to reduce memory consumption
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install_lib abi="$ABI" warnings=yes -j4
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS vdb_view abi="$ABI" warnings=yes -j2
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS python abi="$ABI" warnings=yes -j2
+                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install_lib abi="$ABI" strict=yes -j4
+                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS vdb_view abi="$ABI" strict=yes -j2
+                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS python abi="$ABI" strict=yes -j2
                 fi
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" warnings=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" strict=yes -j4
                 # run C++ and Python unit tests
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi="$ABI" warnings=yes -j4
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS pytest abi="$ABI" warnings=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi="$ABI" strict=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS pytest abi="$ABI" strict=yes -j4
             elif [ "$MODE" = "header" ]; then
                 # check for any indirect includes
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS header_test abi="$ABI" warnings=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS header_test abi="$ABI" strict=yes -j4
             else
                 # build OpenVDB core library, OpenVDB Python module and all binaries
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" warnings=yes debug=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" strict=yes debug=yes -j4
             fi
         else
             if [ "$MODE" = "release" ]; then
                 # build OpenVDB core library, OpenVDB Python module and all binaries
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" warnings=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" strict=yes -j4
                 # run C++ and Python unit tests
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test abi="$ABI" warnings=yes -j4
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS pytest abi="$ABI" warnings=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test abi="$ABI" strict=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS pytest abi="$ABI" strict=yes -j4
             else
                 # build OpenVDB core library, OpenVDB Python module and all binaries
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" warnings=yes debug=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" strict=yes debug=yes -j4
             fi
         fi
     else
@@ -223,8 +223,8 @@ elif [ "$TASK" = "script" ]; then
         # note that this means the DSO can no longer be loaded in Houdini
         sed -i.bak 's/\/hcustom/\/hcustom -t/g' openvdb_houdini/Makefile
         # build OpenVDB core library and OpenVDB houdini library
-        make -C openvdb $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install_lib abi="$ABI" warnings=yes -j4
-        make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS houdinilib abi="$ABI" warnings=yes -j4
+        make -C openvdb $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install_lib abi="$ABI" strict=yes -j4
+        make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS houdinilib abi="$ABI" strict=yes -j4
         # manually install OpenVDB houdini headers and lib
         mkdir houdini_utils
         cp openvdb_houdini/houdini/*.h openvdb_houdini
@@ -232,10 +232,10 @@ elif [ "$TASK" = "script" ]; then
         cp openvdb_houdini/libopenvdb_houdini* /tmp/OpenVDB/lib
         if [ "$MODE" = "header" ]; then
             # check for any indirect includes
-            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS header_test abi="$ABI" warnings=yes -j4
+            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS header_test abi="$ABI" strict=yes -j4
         else
             # build OpenVDB Houdini SOPs
-            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install abi="$ABI" warnings=yes -j4
+            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install abi="$ABI" strict=yes -j4
         fi
     fi
 fi

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -56,7 +56,7 @@ MODE="$4"
 HOUDINI_MAJOR="$5"
 COMPILER="$6"
 
-COMMON_ARGS="CXX=$HOME/ccache_compiler DESTDIR=/tmp/OpenVDB"
+COMMON_ARGS="CXX=$HOME/ccache_compiler DESTDIR=/tmp/OpenVDB strict=yes"
 
 # Location of third-party dependencies for standalone and houdini builds
 STANDALONE_ARGS="   BOOST_LIB_DIR=/usr/lib/x86_64-linux-gnu\
@@ -187,31 +187,31 @@ elif [ "$TASK" = "script" ]; then
                 # build OpenVDB core library, OpenVDB Python module and all binaries
                 if [ "$COMPILER" = "gcc" ]; then
                     # for GCC, pre-build vdb_view and python using fewer threads in order to reduce memory consumption
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install_lib abi="$ABI" strict=yes -j4
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS vdb_view abi="$ABI" strict=yes -j2
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS python abi="$ABI" strict=yes -j2
+                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install_lib abi="$ABI" -j4
+                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS vdb_view abi="$ABI" -j2
+                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS python abi="$ABI" -j2
                 fi
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" strict=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" -j4
                 # run C++ and Python unit tests
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi="$ABI" strict=yes -j4
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS pytest abi="$ABI" strict=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi="$ABI" -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS pytest abi="$ABI" -j4
             elif [ "$MODE" = "header" ]; then
                 # check for any indirect includes
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS header_test abi="$ABI" strict=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS header_test abi="$ABI" -j4
             else
                 # build OpenVDB core library, OpenVDB Python module and all binaries
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" strict=yes debug=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" debug=yes -j4
             fi
         else
             if [ "$MODE" = "release" ]; then
                 # build OpenVDB core library, OpenVDB Python module and all binaries
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" strict=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" -j4
                 # run C++ and Python unit tests
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test abi="$ABI" strict=yes -j4
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS pytest abi="$ABI" strict=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test abi="$ABI" -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS pytest abi="$ABI" -j4
             else
                 # build OpenVDB core library, OpenVDB Python module and all binaries
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" strict=yes debug=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" debug=yes -j4
             fi
         fi
     else
@@ -223,8 +223,8 @@ elif [ "$TASK" = "script" ]; then
         # note that this means the DSO can no longer be loaded in Houdini
         sed -i.bak 's/\/hcustom/\/hcustom -t/g' openvdb_houdini/Makefile
         # build OpenVDB core library and OpenVDB houdini library
-        make -C openvdb $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install_lib abi="$ABI" strict=yes -j4
-        make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS houdinilib abi="$ABI" strict=yes -j4
+        make -C openvdb $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install_lib abi="$ABI" -j4
+        make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS houdinilib abi="$ABI" -j4
         # manually install OpenVDB houdini headers and lib
         mkdir houdini_utils
         cp openvdb_houdini/houdini/*.h openvdb_houdini
@@ -232,10 +232,10 @@ elif [ "$TASK" = "script" ]; then
         cp openvdb_houdini/libopenvdb_houdini* /tmp/OpenVDB/lib
         if [ "$MODE" = "header" ]; then
             # check for any indirect includes
-            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS header_test abi="$ABI" strict=yes -j4
+            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS header_test abi="$ABI" -j4
         else
             # build OpenVDB Houdini SOPs
-            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install abi="$ABI" strict=yes -j4
+            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install abi="$ABI" -j4
         fi
     fi
 fi

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -98,31 +98,6 @@ NO_BLOSC_ARGS="         BLOSC_INCL_DIR=\
 
 HOUDINI_HAS_BOOST=$(echo "$HOUDINI_MAJOR < 16.5" | bc -l)
 
-CLANG_WARNINGS="    -Qunused-arguments\
-                    -Weverything\
-                    -Wc++0x-compat\
-                    -Wno-c++98-compat-pedantic\
-                    -Wno-covered-switch-default\
-                    -Wno-documentation\
-                    -Wno-documentation-deprecated-sync\
-                    -Wno-documentation-unknown-command\
-                    -Wno-double-promotion\
-                    -Wno-exit-time-destructors\
-                    -Wno-global-constructors\
-                    -Wno-mismatched-tags\
-                    -Wno-padded\
-                    -Wno-sign-conversion\
-                    -Wno-weak-vtables"
-
-GCC_WARNINGS="      -Wall
-                    -Wextra\
-                    -pedantic
-                    -Wcast-align\
-                    -Wcast-qual\
-                    -Wconversion\
-                    -Wdisabled-optimization\
-                    -Woverloaded-virtual"
-
 # zero ccache stats
 ccache -z
 
@@ -132,9 +107,9 @@ if [ "$TASK" = "install" ]; then
     echo '#!/bin/bash' > $HOME/ccache_compiler
     echo 'export CCACHE_MAXSIZE=20G' >> $HOME/ccache_compiler
     if [ "$COMPILER" = "clang" ]; then
-        echo 'ccache clang++' "$CLANG_WARNINGS" '$*' | xargs echo -n >> $HOME/ccache_compiler
+        echo 'ccache clang++ $*' >> $HOME/ccache_compiler
     elif [ "$COMPILER" = "gcc" ]; then
-        echo 'ccache g++' "$GCC_WARNINGS" '$*' | xargs echo -n >> $HOME/ccache_compiler
+        echo 'ccache g++ $*' >> $HOME/ccache_compiler
     fi
     chmod 755 $HOME/ccache_compiler
     # update OS
@@ -212,31 +187,31 @@ elif [ "$TASK" = "script" ]; then
                 # build OpenVDB core library, OpenVDB Python module and all binaries
                 if [ "$COMPILER" = "gcc" ]; then
                     # for GCC, pre-build vdb_view and python using fewer threads in order to reduce memory consumption
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install_lib abi="$ABI" -j4
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS vdb_view abi="$ABI" -j2
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS python abi="$ABI" -j2
+                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install_lib abi="$ABI" warnings=yes -j4
+                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS vdb_view abi="$ABI" warnings=yes -j2
+                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS python abi="$ABI" warnings=yes -j2
                 fi
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" warnings=yes -j4
                 # run C++ and Python unit tests
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi="$ABI" -j4
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS pytest abi="$ABI" -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi="$ABI" warnings=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS pytest abi="$ABI" warnings=yes -j4
             elif [ "$MODE" = "header" ]; then
                 # check for any indirect includes
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS header_test abi="$ABI" -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS header_test abi="$ABI" warnings=yes -j4
             else
                 # build OpenVDB core library, OpenVDB Python module and all binaries
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" debug=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" warnings=yes debug=yes -j4
             fi
         else
             if [ "$MODE" = "release" ]; then
                 # build OpenVDB core library, OpenVDB Python module and all binaries
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" warnings=yes -j4
                 # run C++ and Python unit tests
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test abi="$ABI" -j4
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS pytest abi="$ABI" -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test abi="$ABI" warnings=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS pytest abi="$ABI" warnings=yes -j4
             else
                 # build OpenVDB core library, OpenVDB Python module and all binaries
-                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" debug=yes -j4
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" warnings=yes debug=yes -j4
             fi
         fi
     else
@@ -248,8 +223,8 @@ elif [ "$TASK" = "script" ]; then
         # note that this means the DSO can no longer be loaded in Houdini
         sed -i.bak 's/\/hcustom/\/hcustom -t/g' openvdb_houdini/Makefile
         # build OpenVDB core library and OpenVDB houdini library
-        make -C openvdb $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install_lib abi="$ABI" -j4
-        make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS houdinilib abi="$ABI" -j4
+        make -C openvdb $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install_lib abi="$ABI" warnings=yes -j4
+        make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS houdinilib abi="$ABI" warnings=yes -j4
         # manually install OpenVDB houdini headers and lib
         mkdir houdini_utils
         cp openvdb_houdini/houdini/*.h openvdb_houdini
@@ -257,10 +232,10 @@ elif [ "$TASK" = "script" ]; then
         cp openvdb_houdini/libopenvdb_houdini* /tmp/OpenVDB/lib
         if [ "$MODE" = "header" ]; then
             # check for any indirect includes
-            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS header_test abi="$ABI" -j4
+            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS header_test abi="$ABI" warnings=yes -j4
         else
             # build OpenVDB Houdini SOPs
-            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install abi="$ABI" -j4
+            make -C openvdb_houdini $COMMON_ARGS $HOUDINI_ARGS $HOUDINI_BLOSC_ARGS install abi="$ABI" warnings=yes -j4
         fi
     fi
 fi


### PR DESCRIPTION
 - Introduced a set of pre-defined compiler warnings for gcc and clang for all projects. 
 - Updated travis to use warnings flag

Signed-off-by: Nick Avramoussis <nna@dneg.com>