### PR TITLE
Doxygen Validation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,3 +19,15 @@ spaces_not_tabs_task:
     - set +e
     - git grep -n "	" -- '*.cc' '*.h'
     - test $? -eq 1
+
+# Install Doxygen and build core library documentation, erroring on warning
+# (note - this excludes util/Formats.h due to a bug in Doxygen)
+doxygen_task:
+  test_script:
+    - set +e
+    - apt-get update
+    - apt-get install doxygen -y
+    - cd openvdb
+    - make doc 2>&1 | tee ./doxygen.log
+    - grep "warning:" ./doxygen.log | grep -v "util/Formats.h"
+    - test $? -eq 1


### PR DESCRIPTION
Adds a Cirrus CI validation check for Doxygen. This builds and validates the Doxygen for the core library in under a minute from the PR being submitted.

(Note that I ran into a bug in this version of Doxygen when using a newline character in a default value so this check is currently ignored for util/Formats.h)