### PR TITLE
Point String Attribute Improvements

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -7,6 +7,10 @@ Version 6.0.1 - In development
     - Added new QuatTraits, MatTraits and ValueTraits type traits to complement
       VecTraits and added an IsSpecializationOf helper metafunction.
 
+    Improvements:
+    - Significantly improved the performance of point data grid string attribute
+      generation.
+
     Bug fixes:
     - Fixed a bug in tools::clip() that caused some grid metadata
       to be discarded.

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -16,6 +16,11 @@ New features:
   helper metafunction.
 
 @par
+Improvements:
+- Significantly improved the performance of point data grid string attribute
+  generation.
+
+@par
 Bug fixes:
 - Fixed a bug in the @link tools/Clip.h clip@endlink tool that caused
   some grid metadata to be discarded.

--- a/openvdb/points/AttributeArrayString.cc
+++ b/openvdb/points/AttributeArrayString.cc
@@ -35,7 +35,9 @@
 #include <openvdb/Metadata.h>
 #include <openvdb/MetaMap.h>
 
-#include <sstream>
+#include <tbb/parallel_sort.h>
+
+#include <string>
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
@@ -45,7 +47,7 @@ namespace points {
 
 namespace {
 
-    bool isStringMeta(const Name& key, const Metadata::Ptr& meta)
+    bool isStringMeta(const Name& key, const Metadata::ConstPtr& meta)
     {
         // ensure the metadata is StringMetadata
         if (meta->typeName() != "string")           return false;
@@ -55,23 +57,16 @@ namespace {
         return true;
     }
 
-    Name getStringKey(const StringIndexType index)
+    void getStringKey(const StringIndexType index, Name& key)
     {
-        std::stringstream ss;
-        ss << "string:" << (index - 1);
-        return ss.str();
+        key = "string:" + std::to_string(index - 1);
     }
 
     StringIndexType getStringIndex(const Name& key)
     {
-        Name indexStr = key.substr(7, key.size() - 7);
-
+        const Name indexStr = key.substr(7, key.size() - 7);
         // extract the index as an unsigned integer
-        std::istringstream indexSS(indexStr);
-        Index index;
-        indexSS >> index;
-
-        return (index + 1);
+        return std::stoul(indexStr) + 1;
     }
 
 } // namespace
@@ -80,11 +75,59 @@ namespace {
 ////////////////////////////////////////
 
 
+inline void
+populateStringCache(const MetaMap& metadata,
+                    std::vector<std::pair<Index, Index>>& idBlocks,
+                    std::unordered_set<Name>& values)
+{
+    std::vector<Index> stringIndices;
+
+    for (auto it = metadata.beginMeta(), itEnd = metadata.endMeta(); it != itEnd; ++it) {
+        const Name& key = it->first;
+        const Metadata::ConstPtr meta = it->second;
+
+        // ensure the metadata is StringMetadata and key starts "string:"
+        if (!isStringMeta(key, meta))   continue;
+
+        // extract index
+        stringIndices.emplace_back(getStringIndex(key));
+
+        // extract value from metadata and add to cache
+        const StringMetadata* stringMeta = static_cast<const StringMetadata*>(meta.get());
+        assert(stringMeta);
+        values.insert(stringMeta->value());
+    }
+
+    if (stringIndices.empty()) return;
+
+    tbb::parallel_sort(stringIndices.begin(), stringIndices.end());
+
+    // bucket string indices
+
+    Index key = stringIndices.front();
+    Index size = 0;
+
+    for (const Index id : stringIndices) {
+        if (key + size != id) {
+            assert(size > 0);
+            idBlocks.emplace_back(key, size);
+            size = 0;
+            key = id;
+        }
+        ++size;
+    }
+
+    // add the last block
+    idBlocks.emplace_back(key, size);
+}
+
 // StringMetaInserter implementation
 
 
 StringMetaInserter::StringMetaInserter(MetaMap& metadata)
     : mMetadata(metadata)
+    , mValues()
+    , mIdBlocks()
 {
     // populate the cache
     resetCache();
@@ -93,54 +136,64 @@ StringMetaInserter::StringMetaInserter(MetaMap& metadata)
 
 void StringMetaInserter::insert(const Name& name)
 {
-    // name already exists, so do nothing
+    using IterT = std::vector<std::pair<Index, Index>>::iterator;
 
-    if (std::binary_search(mValues.begin(), mValues.end(), name))  return;
+    // if name already exists, do nothing
 
-    // find first unused index in the cache
+    if (mValues.count(name))  return;
+
+    // look through the id blocks for the next available index
 
     Index index = 1;
-    for (const Index& idx : mIndices) {
-        if (idx != index)   break;
-        ++index;
+    IterT iter = mIdBlocks.begin();
+    for (; iter != mIdBlocks.end(); ++iter) {
+        const Index start = iter->first;
+        const Index end = start + iter->second;
+
+        if (index < start || index >= end) break;
+        index = end;
     }
 
-    // now insert into metadata
+    // index now holds the next valid index. if it's 1 (the beginning
+    // iterator) no initial block exists - add it
 
-    const Name key = getStringKey(index);
+    IterT block;
+    if (iter == mIdBlocks.begin()) {
+        block = mIdBlocks.insert(iter, {1, 1});
+        iter = std::next(block);
+    }
+    else {
+        // accumulate the id block size where the next index is going
+        block = std::prev(iter);
+        block->second += 1;
+    }
+
+    // see if this block and the next block can be compacted
+
+    if (iter != mIdBlocks.end() &&
+        block->second + 1 == iter->first) {
+        block->second += iter->second;
+        mIdBlocks.erase(iter);
+    }
+
+    // insert into metadata
+
+    Name key;
+    getStringKey(index, key);
     mMetadata.insertMeta(key, StringMetadata(name));
 
-    // finally update the caches (insertion sort)
+    // update the cache
 
-    mIndices.insert(std::upper_bound(mIndices.begin(), mIndices.end(), index), index);
-    mValues.insert(std::upper_bound(mValues.begin(), mValues.end(), name), name);
+    mValues.emplace(name);
 }
 
 
 void StringMetaInserter::resetCache()
 {
-    mIndices.clear();
     mValues.clear();
+    mIdBlocks.clear();
 
-    for (auto it = mMetadata.beginMeta(), itEnd = mMetadata.endMeta(); it != itEnd; ++it) {
-        const Name& key = it->first;
-        const Metadata::Ptr meta = it->second;
-
-        // ensure the metadata is StringMetadata and key starts "string:"
-        if (!isStringMeta(key, meta))   continue;
-
-        // extract index and add to cache
-        Index index = getStringIndex(key);
-        mIndices.push_back(index);
-
-        // extract value from metadata and add to cache
-        StringMetadata* stringMeta = static_cast<StringMetadata*>(meta.get());
-        assert(stringMeta);
-        mValues.push_back(stringMeta->value());
-    }
-
-    std::sort(mIndices.begin(), mIndices.end());
-    std::sort(mValues.begin(), mValues.end());
+    populateStringCache(mMetadata, mIdBlocks, mValues);
 }
 
 
@@ -187,7 +240,8 @@ void StringAttributeHandle::get(Name& name, Index n, Index m) const
         return;
     }
 
-    const Name key = getStringKey(index);
+    Name key;
+    getStringKey(index, key);
 
     // key is assumed to exist in metadata
 
@@ -199,7 +253,6 @@ void StringAttributeHandle::get(Name& name, Index n, Index m) const
 
     name = meta->value();
 }
-
 
 const AttributeArray& StringAttributeHandle::array() const
 {
@@ -315,7 +368,7 @@ bool StringAttributeWriteHandle::contains(const Name& name) const
 }
 
 
-Index StringAttributeWriteHandle::getIndex(const Name& name)
+Index StringAttributeWriteHandle::getIndex(const Name& name) const
 {
     // zero used for an empty string
     if (name.empty())   return Index(0);

--- a/openvdb/points/AttributeArrayString.h
+++ b/openvdb/points/AttributeArrayString.h
@@ -39,6 +39,7 @@
 
 #include "AttributeArray.h"
 #include <memory>
+#include <unordered_set>
 
 
 namespace openvdb {
@@ -93,8 +94,8 @@ public:
 
 private:
     MetaMap& mMetadata;
-    std::vector<Index> mIndices;
-    std::vector<Name> mValues;
+    std::vector<std::pair<Index, Index>> mIdBlocks;
+    std::unordered_set<Name> mValues;
 }; // StringMetaInserter
 
 
@@ -206,7 +207,7 @@ public:
 private:
     /// Retrieve the index of this string value from the cache
     /// @note throws if name does not exist in cache
-    Index getIndex(const Name& name);
+    Index getIndex(const Name& name) const;
 
     using ValueMap = std::map<std::string, Index>;
 

--- a/openvdb/points/AttributeArrayString.h
+++ b/openvdb/points/AttributeArrayString.h
@@ -144,9 +144,11 @@ public:
                             const MetaMap& metadata,
                             const bool preserveCompression = true);
 
-    Index stride() const { return 1; }
+    Index stride() const { return mHandle.stride(); }
     Index size() const { return mHandle.size(); }
+
     bool isUniform() const { return mHandle.isUniform(); }
+    bool hasConstantStride() const { return mHandle.hasConstantStride(); }
 
     Name get(Index n, Index m = 0) const;
     void get(Name& name, Index n, Index m = 0) const;

--- a/openvdb/points/AttributeArrayString.h
+++ b/openvdb/points/AttributeArrayString.h
@@ -40,6 +40,7 @@
 #include "AttributeArray.h"
 #include <memory>
 #include <unordered_set>
+#include <unordered_map>
 
 
 namespace openvdb {
@@ -209,7 +210,7 @@ private:
     /// @note throws if name does not exist in cache
     Index getIndex(const Name& name) const;
 
-    using ValueMap = std::map<std::string, Index>;
+    using ValueMap = std::unordered_map<std::string, Index>;
 
     ValueMap                                                    mCache;
     AttributeWriteHandle<StringIndexType, StringCodec<false>>   mWriteHandle;

--- a/openvdb/points/AttributeArrayString.h
+++ b/openvdb/points/AttributeArrayString.h
@@ -142,6 +142,7 @@ public:
                             const MetaMap& metadata,
                             const bool preserveCompression = true);
 
+    Index stride() const { return 1; }
     Index size() const { return mHandle.size(); }
     bool isUniform() const { return mHandle.isUniform(); }
 


### PR DESCRIPTION
Main contributions are the significant improvements to the construction and cache of the StringMetaInserter. This currently only manifests during point conversion as there isn't really anything else that deals with string attributes. However these improvements drastically speed up algorithms in AX and Point Merging (which I'll push up for discussion afterwards). 

Performance statistics here:

https://pastebin.com/TN9jwRQT

I've not included memory statistics but hopefully it's pretty apparent without me needing to provide exact numbers

Note that this does change ABI for the StringMetaInserter:

![abi_smi](https://user-images.githubusercontent.com/4256455/52227096-830f2200-28a6-11e9-813c-ca88cc96e495.jpg)
