### PR TITLE
Non constant stride value fix on OpenVDB Points Attribute Handles

### DIFF
--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -2101,7 +2101,7 @@ AttributeHandle<ValueType, CodecType>::create(const AttributeArray& array, const
 template <typename ValueType, typename CodecType>
 AttributeHandle<ValueType, CodecType>::AttributeHandle(const AttributeArray& array, const bool collapseOnDestruction)
     : mArray(&array)
-    , mStrideOrTotalSize(array.hasConstantStride() ? array.stride() : 1)
+    , mStrideOrTotalSize(array.stride())
     , mSize(array.hasConstantStride() ? array.size() : array.dataSize())
     , mCollapseOnDestruction(collapseOnDestruction && array.isStreaming())
 {

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -1413,10 +1413,10 @@ TestAttributeArray::testStrided()
         CPPUNIT_ASSERT_NO_THROW(StridedHandle::create(*array));
         CPPUNIT_ASSERT_NO_THROW(StridedWriteHandle::create(*array));
 
-        // handle is bound as if a linear array with stride 1
+        // handle is bound as if a linear array with stride 0
         StridedHandle handle(*array);
         CPPUNIT_ASSERT(!handle.hasConstantStride());
-        CPPUNIT_ASSERT_EQUAL(Index(1), handle.stride());
+        CPPUNIT_ASSERT_EQUAL(Index(0), handle.stride());
         CPPUNIT_ASSERT_EQUAL(array->dataSize(), handle.size());
     }
 }


### PR DESCRIPTION
Required for #341

@danrbailey This caught me out whilst writing new unit tests for the string array/handle improvements. Non constant strides should return 0, not 1

Signed-off-by: Nick Avramoussis <nna@dneg.com>