### PR TITLE
Minor warning fix to LOD binary

### DIFF
--- a/openvdb/cmd/openvdb_lod/main.cc
+++ b/openvdb/cmd/openvdb_lod/main.cc
@@ -169,8 +169,6 @@ mip(const GridType& inGrid, const Options& opts)
         }
     }
 
-    const double msec = timer.delta(); // elapsed time
-
     if (outGrids.size() == 1 && opts.preserve) {
         // If -preserve is in effect and there is only one output grid,
         // give it the same name as the input grid.
@@ -178,7 +176,7 @@ mip(const GridType& inGrid, const Options& opts)
     }
 
     OPENVDB_LOG_INFO("processed grid \"" << inGrid.getName() << "\" in "
-        << std::setprecision(3) << (msec / 1000.0) << " sec");
+        << std::setprecision(3) << (timer.delta() / 1000.0) << " sec");
 
     return outGrids;
 }


### PR DESCRIPTION
Minor warning fix to openvdb_lod/main.cc when building without log4cplus:

```cmd/openvdb_lod/main.cc:172:18: warning: unused variable ‘msec’ [-Wunused-variable]```


Signed-off-by: Nick Avramoussis <nna@dneg.com>