### PR TITLE
OVDB-27: MeshToVolume uses infinite memory when given NANs

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -16,6 +16,7 @@ Version 6.0.1 - In development
       to be discarded.
     - Added a check to points::setGroup to compare the maximum index of the
       provided PointIndexTree to the size of the membership vector.
+    - Fix bug with MeshToVoxel consuming infinite memory when giving NaNs.
 
     Houdini:
     - The Points Convert SOP now reports NaN Positions as warnings when

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -28,6 +28,7 @@ Bug fixes:
   to compare the maximum index of the provided
   @vdblink::tools::PointIndexTree PointIndexTree@endlink
   to the size of the membership vector.
+- Fix bug with MeshToVoxel consuming infinite memory when giving NaNs.
 
 @par
 Houdini:

--- a/openvdb/tools/MeshToVolume.h
+++ b/openvdb/tools/MeshToVolume.h
@@ -2144,7 +2144,10 @@ private:
         ijk = Coord::floor(prim.a);
         coordList.push_back(ijk);
 
-        computeDistance(ijk, prim, data);
+        // The first point may not be quite in bounds, and rely
+        // on one of the neighbours to have the first valid seed,
+        // so we cannot early-exit here.
+        updateDistance(ijk, prim, data);
 
         unsigned char primId = data.getNewPrimId();
         data.primIdAcc.setValueOnly(ijk, primId);
@@ -2157,13 +2160,13 @@ private:
                 nijk = ijk + util::COORD_OFFSETS[i];
                 if (primId != data.primIdAcc.getValue(nijk)) {
                     data.primIdAcc.setValueOnly(nijk, primId);
-                    if(computeDistance(nijk, prim, data)) coordList.push_back(nijk);
+                    if(updateDistance(nijk, prim, data)) coordList.push_back(nijk);
                 }
             }
         }
     }
 
-    static bool computeDistance(const Coord& ijk, const Triangle& prim, VoxelizationDataType& data)
+    static bool updateDistance(const Coord& ijk, const Triangle& prim, VoxelizationDataType& data)
     {
         Vec3d uvw, voxelCenter(ijk[0], ijk[1], ijk[2]);
 
@@ -2171,6 +2174,11 @@ private:
 
         const ValueType dist = ValueType((voxelCenter -
             closestPointOnTriangleToPoint(prim.a, prim.c, prim.b, voxelCenter, uvw)).lengthSqr());
+
+        // Either the points may be NAN, or they could be far enough from
+        // the origin that computing distance fails.
+        if (std::isnan(dist))
+            return false;
 
         const ValueType oldDist = data.distAcc.getValue(ijk);
 


### PR DESCRIPTION
 Check for NANs when computing distances to avoid infinite loops
with bad input geometry.

Rename the computeDistance to updateDistance to better reflect
its behaviour.