### PR TITLE
OVDB-40: Add support for Vec4 metadata

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -6,6 +6,7 @@ Version 6.0.1 - In development
     New features:
     - Added new QuatTraits, MatTraits and ValueTraits type traits to complement
       VecTraits and added an IsSpecializationOf helper metafunction.
+    - Added support for Vec4s, Vec4d and Vec4i metadata.
 
     Improvements:
     - Significantly improved the performance of point data grid string

--- a/openvdb/Metadata.h
+++ b/openvdb/Metadata.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -417,6 +417,9 @@ using Vec2SMetadata  = TypedMetadata<Vec2s>;
 using Vec3DMetadata  = TypedMetadata<Vec3d>;
 using Vec3IMetadata  = TypedMetadata<Vec3i>;
 using Vec3SMetadata  = TypedMetadata<Vec3s>;
+using Vec4DMetadata  = TypedMetadata<Vec4d>;
+using Vec4IMetadata  = TypedMetadata<Vec4i>;
+using Vec4SMetadata  = TypedMetadata<Vec4s>;
 using Mat4SMetadata  = TypedMetadata<Mat4s>;
 using Mat4DMetadata  = TypedMetadata<Mat4d>;
 
@@ -460,6 +463,6 @@ StringMetadata::writeValue(std::ostream& os) const
 
 #endif // OPENVDB_METADATA_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/Types.h
+++ b/openvdb/Types.h
@@ -422,6 +422,9 @@ template<> inline const char* typeNameAsString<Vec3U16>()           { return "ve
 template<> inline const char* typeNameAsString<Vec3i>()             { return "vec3i"; }
 template<> inline const char* typeNameAsString<Vec3f>()             { return "vec3s"; }
 template<> inline const char* typeNameAsString<Vec3d>()             { return "vec3d"; }
+template<> inline const char* typeNameAsString<Vec4i>()             { return "vec4i"; }
+template<> inline const char* typeNameAsString<Vec4f>()             { return "vec4s"; }
+template<> inline const char* typeNameAsString<Vec4d>()             { return "vec4d"; }
 template<> inline const char* typeNameAsString<std::string>()       { return "string"; }
 template<> inline const char* typeNameAsString<Mat3s>()             { return "mat3s"; }
 template<> inline const char* typeNameAsString<Mat3d>()             { return "mat3d"; }

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -14,6 +14,9 @@ New features:
   @vdblink::VecTraits VecTraits@endlink and added an
   @vdblink::IsSpecializationOf IsSpecializationOf@endlink
   helper metafunction.
+- Added support for @vdblink::Vec4SMetadata Vec4s@endlink,
+  @vdblink::Vec4DMetadata Vec4d@endlink
+  and @vdblink::Vec4IMetadata Vec4i@endlink metadata.
 
 @par
 Improvements:

--- a/openvdb/openvdb.cc
+++ b/openvdb/openvdb.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -74,6 +74,9 @@ initialize()
     Vec3IMetadata::registerType();
     Vec3SMetadata::registerType();
     Vec3DMetadata::registerType();
+    Vec4IMetadata::registerType();
+    Vec4SMetadata::registerType();
+    Vec4DMetadata::registerType();
     Mat4SMetadata::registerType();
     Mat4DMetadata::registerType();
 
@@ -168,6 +171,6 @@ __pragma(warning(default:1711))
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/python/pyOpenVDBModule.cc
+++ b/openvdb/python/pyOpenVDBModule.cc
@@ -311,6 +311,15 @@ struct MetaMapConverter
                 } else if (typeName == Vec3SMetadata::staticTypeName()) {
                     const Vec3s v = static_cast<Vec3SMetadata&>(*meta).value();
                     obj = py::make_tuple(v[0], v[1], v[2]);
+                } else if (typeName == Vec4DMetadata::staticTypeName()) {
+                    const Vec4d v = static_cast<Vec4DMetadata&>(*meta).value();
+                    obj = py::make_tuple(v[0], v[1], v[2], v[3]);
+                } else if (typeName == Vec4IMetadata::staticTypeName()) {
+                    const Vec4i v = static_cast<Vec4IMetadata&>(*meta).value();
+                    obj = py::make_tuple(v[0], v[1], v[2], v[3]);
+                } else if (typeName == Vec4SMetadata::staticTypeName()) {
+                    const Vec4s v = static_cast<Vec4SMetadata&>(*meta).value();
+                    obj = py::make_tuple(v[0], v[1], v[2], v[3]);
                 }
                 ret[it->first] = obj;
             }
@@ -385,6 +394,12 @@ struct MetaMapConverter
                 value.reset(new Vec3DMetadata(py::extract<Vec3d>(val)));
             } else if (py::extract<Vec3s>(val).check()) {
                 value.reset(new Vec3SMetadata(py::extract<Vec3s>(val)));
+            } else if (py::extract<Vec4i>(val).check()) {
+                value.reset(new Vec4IMetadata(py::extract<Vec4i>(val)));
+            } else if (py::extract<Vec4d>(val).check()) {
+                value.reset(new Vec4DMetadata(py::extract<Vec4d>(val)));
+            } else if (py::extract<Vec4s>(val).check()) {
+                value.reset(new Vec4SMetadata(py::extract<Vec4s>(val)));
             } else if (py::extract<Metadata::Ptr>(val).check()) {
                 value = py::extract<Metadata::Ptr>(val);
             } else {

--- a/openvdb/python/test/TestOpenVDB.py
+++ b/openvdb/python/test/TestOpenVDB.py
@@ -162,7 +162,8 @@ class TestOpenVDB(unittest.TestCase):
 
         self.assertEqual(grid.metadata, {})
 
-        meta = dict(name='test', saveFloatAsHalf=True, xyz=(-1, 0, 1), intval=42, floatval=1.25)
+        meta = dict(name='test', saveFloatAsHalf=True,
+            xyz=(-1, 0, 1), xyzw=(1.0, 2.25, 3.5, 4.0), intval=42, floatval=1.25)
         grid.metadata = meta
         self.assertEqual(grid.metadata, meta)
 

--- a/openvdb/unittest/TestMetadata.cc
+++ b/openvdb/unittest/TestMetadata.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -31,6 +31,7 @@
 #include <cppunit/extensions/HelperMacros.h>
 #include <openvdb/Exceptions.h>
 #include <openvdb/Metadata.h>
+#include <sstream>
 
 
 class TestMetadata: public CppUnit::TestCase
@@ -121,6 +122,12 @@ TestMetadata::testMetadataAsBool()
         meta.setValue(Vec3s(-1.0, 0.0, 1.0));
         CPPUNIT_ASSERT(meta.asBool());
     }
+    {
+        Vec4DMetadata meta(Vec4d(0.0));
+        CPPUNIT_ASSERT(!meta.asBool());
+        meta.setValue(Vec4d(1.0));
+        CPPUNIT_ASSERT(meta.asBool());
+    }
 }
 
 
@@ -182,6 +189,6 @@ TestMetadata::testCustomMetadata()
     }
 }
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )


### PR DESCRIPTION
- Added `Vec4i`, `Vec4s` and `Vec4d` metadata types.
- Added `typeNameAsString` specializations for Vec4 types.
- Added Vec4 metadata support to pyopenvdb.
- Refactored metadata unit tests and added Vec4 tests.

Signed-off-by: Peter Cucka <peter.cucka@dreamworks.com>