### PR TITLE
Reference Implementation for Proposed Migration to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,217 @@
+version: 2
+jobs:
+  # ABI=6 (VFX Reference Platform 2019) built with Clang 3.8
+  # core library, Python module, binaries, unit tests and header checks
+  testabi6:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh none clang++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 6 yes release none clang++
+      - run:
+          name: Extras
+          command: bash ci/run.sh extras 6 yes release none clang++
+      - run:
+          name: Header
+          command: bash ci/run.sh core 6 yes header none clang++
+      - run:
+          name: Unit
+          command: bash ci/run.sh test 6 yes release none clang++
+      - run:
+          name: Test
+          command: bash ci/run.sh run 6 yes release none clang++
+
+  # ABI=6 with Blosc disabled
+  testabi6noblosc:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh none clang++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 6 no release none clang++
+      - run:
+          name: Unit
+          command: bash ci/run.sh test 6 no release none clang++
+      - run:
+          name: Test
+          command: bash ci/run.sh run 6 no release none clang++
+
+  # ABI=6 in debug mode (unit tests built but not run)
+  testabi6debug:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh none clang++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 6 yes debug none clang++
+      - run:
+          name: Extras
+          command: bash ci/run.sh extras 6 yes debug none clang++
+      - run:
+          name: Unit
+          command: bash ci/run.sh test 6 yes debug none clang++
+
+  # ABI=6 build with GCC 6.3.1
+  testabi6gcc:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh none g++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 6 yes release none g++
+      - run:
+          name: Extras
+          command: bash ci/run.sh extras 6 yes release none g++
+      - run:
+          name: Unit
+          command: bash ci/run.sh test 6 yes release none g++
+      - run:
+          name: Test
+          command: bash ci/run.sh run 6 yes release none g++
+
+  # ABI=5 (VFX Reference Platform 2018)
+  # core library and unit tests
+  testabi5:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh none clang++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 5 yes release none clang++
+      - run:
+          name: Unit
+          command: bash ci/run.sh test 5 yes release none clang++
+      - run:
+          name: Test
+          command: bash ci/run.sh run 5 yes release none clang++
+
+  # ABI=5 with Blosc disabled
+  testabi5noblosc:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh none clang++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 5 no release none clang++
+      - run:
+          name: Unit
+          command: bash ci/run.sh test 5 no release none clang++
+      - run:
+          name: Test
+          command: bash ci/run.sh run 5 no release none clang++
+
+  # ABI=5 in debug mode (unit tests built but not run)
+  testabi5debug:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh none clang++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 5 yes debug none clang++
+      - run:
+          name: Extras
+          command: bash ci/run.sh extras 5 yes debug none clang++
+      - run:
+          name: Unit
+          command: bash ci/run.sh test 5 yes debug none clang++
+
+  # ABI=4 (VFX Reference Platform 2017)
+  # core library and unit tests
+  testabi4:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh none clang++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 4 yes release none clang++
+      - run:
+          name: Unit
+          command: bash ci/run.sh test 4 yes release none clang++
+      - run:
+          name: Test
+          command: bash ci/run.sh run 4 yes release none clang++
+
+  # Houdini 17.0 latest production release (ABI=5)
+  # core library, Houdini library and plugins and header checks
+  houdini17.0:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh 17.0 clang++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 5 yes release 17.0 clang++
+      - run:
+          name: Houdini
+          command: bash ci/run.sh houdini 5 yes release 17.0 clang++
+      - run:
+          name: Header
+          command: bash ci/run.sh houdini 5 yes header 17.0 clang++
+
+  # Houdini 16.5 latest production release (ABI=4)
+  # core library, Houdini library and plugins
+  houdini16.5:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: bash ci/install.sh 16.5 clang++
+      - run:
+          name: Core
+          command: bash ci/run.sh core 4 yes release 16.5 clang++
+      - run:
+          name: Houdini
+          command: bash ci/run.sh houdini 4 yes release 16.5 clang++
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - testabi6
+      - testabi5
+      - testabi4
+      - houdini17.0
+      - houdini16.5
+      - testabi6noblosc
+      - testabi6debug
+      - testabi6gcc
+      - testabi5noblosc
+      - testabi5debug

--- a/ci/download_houdini.py
+++ b/ci/download_houdini.py
@@ -1,0 +1,54 @@
+# Python script to download the latest Houdini production builds
+#
+# Note that this can now be replaced with this API:
+# https://www.sidefx.com/docs/api/download/index.html
+#
+# Author: Dan Bailey
+
+import mechanize
+import sys
+import re
+import exceptions
+
+# this argument is for the major.minor version of Houdini to download (such as 15.0, 15.5, 16.0)
+version = sys.argv[1]
+
+if not re.match('[0-9][0-9]\.[0-9]$', version):
+    raise IOError('Invalid Houdini Version "%s", expecting in the form "major.minor" such as "16.0"' % version)
+
+br = mechanize.Browser()
+br.set_handle_robots(False)
+
+# login to sidefx.com as openvdb
+br.open('https://www.sidefx.com/login/?next=/download/daily-builds')
+br.select_form(nr=0)
+br.form['username'] = 'openvdb'
+br.form['password'] = 'L3_M2f2W'
+br.submit()
+
+# retrieve download id
+br.open('https://www.sidefx.com/download/daily-builds/')
+
+houid = -1
+
+for link in br.links():
+    if '/download/download-houdini' not in link.url:
+        continue
+    if link.text.startswith('houdini-%s' % version) and 'linux_x86_64' in link.text:
+        response = br.follow_link(text=link.text, nr=0)
+        url = response.geturl()
+        houid = url.split('/download-houdini/')[-1]
+        break
+
+# download houdini tarball in 50MB chunks
+url = 'https://www.sidefx.com/download/download-houdini/%sget/' % houid
+response = br.open(url)
+mb = 1024*1024
+chunk = 50
+size = 0
+file = open('hou.tar.gz', 'wb')
+for bytes in iter((lambda: response.read(chunk*mb)), ''):
+    size += 50
+    print 'Read: %sMB' % size
+    file.write(bytes)
+file.close()

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# CircleCI install script for OpenVDB
+#
+# HOUDINI_MAJOR (16.0/16.5/17.0) - the major version of Houdini
+# COMPILER (g++/clang++) - build with GCC or Clang
+#
+# Author: Dan Bailey
+
+set -ex
+
+HOUDINI_MAJOR="$1"
+COMPILER="$2"
+
+apt-get update
+
+apt-get install -y zlib1g-dev
+apt-get install -y wget
+apt-get install -y unzip
+apt-get install -y curl
+apt-get install -y cmake
+apt-get install -y g++
+apt-get install -y clang
+apt-get install -y llvm
+apt-get install -y libglu1-mesa-dev
+apt-get install -y libgl1-mesa-dev
+
+if [ "$HOUDINI_MAJOR" = "none" ]; then
+    apt-get install -y libboost-iostreams-dev
+    apt-get install -y libboost-system-dev
+    apt-get install -y libboost-thread-dev
+    apt-get install -y libtbb-dev
+    apt-get install -y libilmbase-dev
+    apt-get install -y libopenexr-dev
+    apt-get install -y libcppunit-dev
+    apt-get install -y liblog4cplus-dev
+    apt-get install -y libglfw3-dev
+    apt-get install -y python-dev
+    apt-get install -y libboost-python-dev
+    apt-get install -y python-numpy
+    apt-get install -y python-epydoc
+    apt-get install -y doxygen
+    # download and build Blosc 1.5.0
+    if [ ! -d $HOME/blosc/lib ]; then
+        wget https://github.com/Blosc/c-blosc/archive/v1.5.0.zip
+        unzip v1.5.0.zip
+        cd c-blosc-1.5.0
+        mkdir build
+        cd build
+        cmake -DCMAKE_CXX_COMPILER=$COMPILER ../.
+        make
+        make install
+        cd -
+    fi
+else
+    # install houdini pre-requisites
+    apt-get install -y libxi-dev
+    apt-get install -y csh
+    apt-get install -y default-jre
+    apt-get install -y python-dev
+    # boost no longer shipped with Houdini from 16.5 onwards
+    apt-get install -y bc
+    HOUDINI_HAS_BOOST=$(echo "$HOUDINI_MAJOR < 16.5" | bc -l)
+    if [ $HOUDINI_HAS_BOOST -eq 0 ]; then
+        apt-get install -y libboost-iostreams-dev
+        apt-get install -y libboost-system-dev
+    fi
+    apt-get install -y python-mechanize
+    export PYTHONPATH=${PYTHONPATH}:/usr/lib/python2.7/dist-packages
+    # download and unpack latest houdini headers and libraries from daily-builds
+    python ci/download_houdini.py $HOUDINI_MAJOR
+    tar -xzf hou.tar.gz
+    ln -s houdini* hou
+    cd hou
+    tar -xzf houdini.tar.gz
+    cd -
+fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# CircleCI build script for OpenVDB
+#
+# TASK (core/extras/test/run/houdini):
+#        * core - compiling core library
+#        * extras - compiling python module, tests and binaries
+#        * test - compiling unit tests
+#        * run - executing unit tests
+#        * houdini - compiling houdini library and plugins
+# ABI (3/4/5/6) - the ABI version of OpenVDB
+# BLOSC (yes/no) - to build with Blosc support
+# MODE (release/debug/header) - optimized build, debug build or header checks
+# HOUDINI_MAJOR (16.0/16.5/17.0) - the major version of Houdini
+# COMPILER (g++/clang++) - build with GCC or Clang
+#
+# Note that builds use two threads to ensure they stay within 4GB of memory
+#
+# Author: Dan Bailey
+
+set -ex
+
+TASK="$1"
+ABI="$2"
+BLOSC="$3"
+MODE="$4"
+HOUDINI_MAJOR="$5"
+COMPILER="$6"
+
+PARAMS="CXX=$COMPILER DESTDIR=/tmp/OpenVDB abi=$ABI strict=yes"
+
+if [ "$MODE" = "debug" ]; then
+    PARAMS+=" debug=yes"
+fi
+
+# Location of third-party dependencies for standalone and houdini builds
+if [ "$HOUDINI_MAJOR" = "none" ]; then
+    PARAMS+="       BOOST_LIB_DIR=/usr/lib/x86_64-linux-gnu\
+                    EXR_INCL_DIR=/usr/include/OpenEXR\
+                    EXR_LIB_DIR=/usr/local/lib\
+                    TBB_LIB_DIR=/usr/lib\
+                    CONCURRENT_MALLOC_LIB=\
+                    CPPUNIT_INCL_DIR=$HOME/cppunit/include\
+                    CPPUNIT_LIB_DIR=$HOME/cppunit/lib\
+                    LOG4CPLUS_INCL_DIR=/usr/include\
+                    LOG4CPLUS_LIB_DIR=/usr/lib/x86_64-linux-gnu\
+                    GLFW_INCL_DIR=/usr/include/GL\
+                    GLFW_LIB_DIR=/usr/lib/x86_64-linux-gnu\
+                    PYTHON_INCL_DIR=/usr/include/python2.7\
+                    PYTHON_LIB_DIR=/usr/lib/x86_64-linux-gnu\
+                    BOOST_PYTHON_LIB_DIR=/usr/lib/x86_64-linux-gnu\
+                    BOOST_PYTHON_LIB=-lboost_python\
+                    NUMPY_INCL_DIR=/usr/lib/python2.7/dist-packages/numpy/core/include/numpy\
+                    PYTHON_WRAP_ALL_GRID_TYPES=yes\
+                    EPYDOC=/usr/bin/epydoc\
+                    DOXYGEN=/usr/bin/doxygen"
+    if [ "$BLOSC" = "yes" ]; then
+        PARAMS+="   BLOSC_INCL_DIR=$HOME/blosc/include\
+                    BLOSC_LIB_DIR=$HOME/blosc/lib"
+    else
+        PARAMS+="   BLOSC_INCL_DIR=\
+                    BLOSC_LIB_DIR="
+    fi
+else
+    # source houdini_setup
+    cd hou
+    source houdini_setup
+    cd -
+    PARAMS+="       BOOST_INCL_DIR=/root/project/hou/toolkit/include\
+                    BOOST_LIB_DIR=/root/project/hou/dsolib\
+                    TBB_LIB_DIR=/root/project/hou/dsolib\
+                    EXR_INCL_DIR=/root/project/hou/toolkit/include\
+                    EXR_LIB_DIR=/root/project/hou/dsolib\
+                    LOG4CPLUS_INCL_DIR=\
+                    GLFW_INCL_DIR=\
+                    PYTHON_INCL_DIR=\
+                    DOXYGEN="
+    if [ "$BLOSC" = "yes" ]; then
+        PARAMS+="   BLOSC_INCL_DIR=/root/project/hou/toolkit/include\
+                    BLOSC_LIB_DIR=/root/project/hou/dsolib"
+    else
+        PARAMS+="   BLOSC_INCL_DIR=\
+                    BLOSC_LIB_DIR="
+    fi
+fi
+
+# fix to issue with -isystem includes using GCC 6.3.0
+sed -E -i.bak "s/-isystem/-I/g" openvdb/Makefile
+
+# fix to issue with using Clang 3.8 with hcustom
+sed -E -i.bak "s/hcustom -c/hcustom -c | sed 's\/-fno-exceptions\/-DGCC4 -DGCC3 -Wno-deprecated\/g'/g" openvdb_houdini/Makefile
+
+# fix to disable hcustom tagging to remove timestamps in Houdini DSOs
+# note that this means the DSO can no longer be loaded in Houdini
+sed -E -i.bak 's/\/hcustom/\/hcustom -t/g' openvdb_houdini/Makefile
+
+if [ "$TASK" = "core" ]; then
+    if [ "$MODE" = "header" ]; then
+        # check for any indirect includes
+        make -C openvdb $PARAMS header_test -j2
+    else
+        # build OpenVDB core library and OpenVDB houdini library
+        make -C openvdb $PARAMS install_lib -j2
+    fi
+elif [ "$TASK" = "extras" ]; then
+    # build OpenVDB core library, OpenVDB Python module and all binaries
+    if [ "$COMPILER" = "g++" ]; then
+        # Use just one thread for GCC as 2GB per core is insufficient for Boost Python
+        make -C openvdb $PARAMS install
+    else
+        make -C openvdb $PARAMS install -j2
+    fi
+elif [ "$TASK" = "test" ]; then
+    make -C openvdb $PARAMS vdb_test -j2
+elif [ "$TASK" = "houdini" ]; then
+    if [ "$MODE" = "header" ]; then
+        # check for any indirect includes
+        make -C openvdb_houdini $PARAMS header_test -j2
+    else
+        # build OpenVDB Houdini library and plugins
+        make -C openvdb_houdini $PARAMS install -j2
+    fi
+elif [ "$TASK" = "run" ]; then
+    # run unit tests
+    make -C openvdb $PARAMS test verbose=yes
+fi


### PR DESCRIPTION
Note that this is a **draft** pull request, so it cannot be merged. 

This is a reference implementation for migrating from Travis CI to Circle CI as discussed in the CI working group for the TAC today, so I thought I'd share with everyone for transparency. (@lgritz @zxiiro @dheckenberg)

@Idclip, you'll notice I've pulled a few of your refactoring changes across to this branch (thanks for that), otherwise there's not too much that has changed from the Travis configuration. For now, I've put the build scripts into an openvdb/ci sub-directory as I expect there'll be some overlap in using Travis and Circle together during migration. Ultimately the aim should be to deprecate the Travis scripts.

Aside from the ASWF/LF decision to migrate to Circle CI, there are still some outstanding issues to resolve before considering a full PR:
* GCC 6.3.1 issue - the use of -isystem and #include_next is causing some compilation issues, probably a search path issue, but for now I've simply swapped -isystem for -I (I think CMake doesn't encounter this problem)
* Clang 3.8 issue - haven't dug into this in too much detail, but hcustom seems to have an issue with thinking Clang 3.8 is GCC 3.8 with some odd consequences, I've simply swapped the compile flags for the correct ones for now
* The yaml is a bit verbose right now, it would be good to play with some of the code re-use techniques in that language

All builds complete successfully on CircleCI using this configuration.

Note that adopting the new SideFX download API is treated as orthogonal to this migration [OVDB-34](https://jira.aswf.io/browse/OVDB-34)