### PR TITLE
VDB Vector Merge preserves Metadata

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -53,6 +53,8 @@ Version 6.0.1 - In development
       for tab menus.
     - Added type lists for sets of commonly-used grid types, including
       ScalarGridTypes, Vec3GridTypes, AllGridTypes, etc.
+    - VDB Vector Merge SOP now copies metadata from the representative
+      scalar grid.
 
     Python:
     - Added limited support for point data grids, comprising I/O and

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -73,6 +73,8 @@ Houdini:
   OpPolicy classes to provide their own label naming scheme for tab menus.
 - Added type lists for sets of commonly-used grid types, including
   @b ScalarGridTypes, @b Vec3GridTypes, @b AllGridTypes, etc.
+- VDB Vector Merge SOP now copies metadata from the representative
+  scalar grid.
 
 @par
 Python:

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
@@ -762,7 +762,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Vector_Merge)::cookVDBSop(OP_C
                     addMessage(SOP_MESSAGE, ostr.str().c_str());
                 }
 
-                if (GEO_PrimVDB* outVdb = hvdb::createVdbPrimitive(*gdp, outGrid)) {
+                if (GEO_PrimVDB* outVdb = GU_PrimVDB::buildFromGrid(*gdp, outGrid, nonNullVdb, outGridName.c_str())) {
                     primsToGroup.push_back(outVdb);
                 }
 


### PR DESCRIPTION
VDB Vector Merge will better preserve metadata if it uses buildFromGrid.

Bug: 95536