### PR TITLE
Fixes for tbb::atomic errors reported by GCC 6.3

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -10,13 +10,13 @@ Version 6.0.1 - In development
     - Added a generic TypeList class.
     - Added GridBase::apply(), which invokes a functor on a grid
       if the resolved grid type is a member of a given type list.
-    - Added util::printTime that outputs nicely-formatted time information.
-    - Added a template specialization of std::hash with Coord.
-    - Added CoordBBox::moveMin and CoordBBox::moveMax to move a CoordBBox.
+    - Added util::printTime(), which outputs nicely formatted time information.
+    - Added a std::hash<Coord> template specialization.
+    - Added CoordBBox::moveMin() and CoordBBox::moveMax() to move a CoordBBox.
 
     Improvements:
-    - The API of util::CpuTimer has been improved and is now making use of
-      a new util::printTime function for nicer output of time information.
+    - util::CpuTimer now makes use of util::printTime() for nicer output,
+      and its API has been improved.
     - Significantly improved the performance of point data grid string
       attribute generation.
     - AttributeArray::copy() and the copy assignment operator for
@@ -31,8 +31,11 @@ Version 6.0.1 - In development
       provided PointIndexTree to the size of the membership vector.
     - Fixed a race condition when moving points in point data grids for ABI=6+
       due to non-const access of AttributeArrays resulting in a copy-on-write.
-    - Fix bug with MeshToVoxel consuming infinite memory when giving NaNs.
-    - Fix a rounding error bug in point conversion when using floating-point.
+    - Fixed a bug that caused the mesh to volume converter to consume
+      unlimited memory when it encountered NaNs in vertex positions.
+    - Fixed a rounding error bug in point conversion when using
+      single-precision floating-point.
+    - Addressed some type conversion issues and other issues reported by GCC 6.
 
     API changes:
     - Moved the CopyConstness metafunction from TreeIterator.h to Types.h.
@@ -44,10 +47,11 @@ Version 6.0.1 - In development
       point attributes with the same name as an existing point group.
     - The Transform SOP now supports frustum transforms by applying the
       transformation to the internal affine map.
-    - Renamed SOP labels to match native Houdini SOPs - New Names:
-      Renormalize SDF, Reshape SDF, Smooth SDF, Morph SDF, Rebuild SDF,
-      Project Non-Divergent, Segment by Connectivity, Topology to SDF,
-      Visualize Tree
+    - Changed the labels (but not the opnames) of several SOPs to match
+      the corresponding native Houdini SOPs.  The new labels are
+      Morph SDF, Project Non-Divergent, Rebuild SDF, Renormalize SDF,
+      Reshape SDF, Segment by Connectivity, Smooth SDF, Topology to SDF,
+      and Visualize Tree.
     - Added a houdini_utils::OpPolicy::getLabelName() method to allow
       derived OpPolicy classes to provide their own label naming scheme
       for tab menus.

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -21,18 +21,19 @@ New features:
 - Added @vdblink::GridBase::apply() GridBase::apply@endlink,
   which invokes a functor on a grid if the resolved grid type
   is a member of a given type list.
-- Added @vdblink::util::printTime util::printTime@endlink that
-  outputs nicely-formatted time information.
-- Added a template specialization of std::hash with @vdblink::math::Coord Coord@endlink.
-- Added @vdblink::math::CoordBBox::moveMin CoordBBox::moveMin@endlink and
-  @vdblink::math::CoordBBox::moveMax CoordBBox::moveMax@endlink to move a
+- Added @vdblink::util::printTime() printTime@endlink, which outputs
+  nicely formatted time information.
+- Added a @link std::hash<openvdb::math::Coord> std::hash<Coord>@endlink
+  template specialization.
+- Added @vdblink::math::CoordBBox::moveMin moveMin@endlink and
+  @vdblink::math::CoordBBox::moveMax moveMax@endlink methods to
   @vdblink::math::CoordBBox CoordBBox@endlink.
 
 @par
 Improvements:
-- The API of @vdblink::util::CpuTimer util::CpuTimer@endlink has been improved
-  and is now making use of a new @vdblink::util::printTime util::printTime@endlink
-  function for nicer output of time information.
+- @vdblink::util::CpuTimer CpuTimer@endlink now makes use of
+  @vdblink::util::printTime() printTime@endlink for nicer output,
+  and its API has been improved.
 - Significantly improved the performance of point data grid string attribute
   generation.
 - @vdblink::points::AttributeArray::copy() AttributeArray::copy@endlink
@@ -50,8 +51,14 @@ Bug fixes:
   to the size of the membership vector.
 - Fixed a race condition when moving points in point data grids for ABI=6+
   due to non-const access of AttributeArrays resulting in a copy-on-write.
-- Fix bug with MeshToVoxel consuming infinite memory when giving NaNs.
-- Fix a rounding error bug in point conversion when using floating-point.
+- Fixed a bug that caused the @link MeshToVolume.h mesh to volume@endlink
+  converter to consume unlimited memory when it encountered NaNs
+  in vertex positions.
+- Fixed a rounding error bug in
+  @link PointConversion.h point conversion@endlink when using
+  single-precision floating-point.
+- Addressed some type conversion issues and other issues reported by
+  GCC&nbsp;6.
 
 @par
 API changes:
@@ -66,11 +73,14 @@ Houdini:
   point attributes with the same name as an existing point group.
 - The Transform&nbsp;SOP now supports frustum transforms by applying the
   transformation to the internal affine map.
-- Renamed SOP labels to match native Houdini SOPs - New Names:
-  Renormalize SDF, Reshape SDF, Smooth SDF, Morph SDF, Rebuild SDF, Project
-  Non-Divergent, Segment by Connectivity, Topology to SDF, Visualize Tree
-- Added a @b houdini_utils::OpPolicy::getLabelName() method to allow derived
-  OpPolicy classes to provide their own label naming scheme for tab menus.
+- Changed the labels (but not the opnames) of several SOPs to match
+  the corresponding native Houdini SOPs.
+  The new labels are Morph&nbsp;SDF, Project&nbsp;Non-Divergent,
+  Rebuild&nbsp;SDF, Renormalize&nbsp;SDF, Reshape&nbsp;SDF,
+  Segment&nbsp;by&nbsp;Connectivity, Smooth&nbsp;SDF,
+  Topology&nbsp;to&nbsp;SDF, and Visualize&nbsp;Tree.
+- Added an @b OpPolicy::getLabelName method to allow derived @b OpPolicy
+  classes to provide their own label naming scheme for tab menus.
 - Added type lists for sets of commonly-used grid types, including
   @b ScalarGridTypes, @b Vec3GridTypes, @b AllGridTypes, etc.
 

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -148,7 +148,11 @@ public:
 
     template <typename ValueType, typename CodecType> friend class AttributeHandle;
 
-    AttributeArray() : mPageHandle() { }
+#if OPENVDB_ABI_VERSION_NUMBER >= 5
+    AttributeArray(): mPageHandle() { mOutOfCore = 0; }
+#else
+    AttributeArray(): mPageHandle() {}
+#endif
     virtual ~AttributeArray()
     {
         // if this AttributeArray has been partially read, zero the compressed bytes,
@@ -422,7 +426,7 @@ protected:
     uint8_t mFlags = 0;
     uint8_t mSerializationFlags = 0;
 #if OPENVDB_ABI_VERSION_NUMBER >= 5
-    tbb::atomic<Index32> mOutOfCore = 0; // interpreted as bool
+    tbb::atomic<Index32> mOutOfCore; // interpreted as bool
 #endif
     compression::PageHandle::Ptr mPageHandle;
 
@@ -432,7 +436,7 @@ protected:
     mutable tbb::spin_mutex mMutex;
     uint8_t mFlags = 0;
     uint8_t mSerializationFlags = 0;
-    tbb::atomic<Index32> mOutOfCore = 0; // interpreted as bool
+    tbb::atomic<Index32> mOutOfCore; // interpreted as bool
     /// used for out-of-core, paged reading
     union {
         compression::PageHandle::Ptr mPageHandle;
@@ -2321,6 +2325,6 @@ AttributeArray& AttributeWriteHandle<ValueType, CodecType>::array()
 
 #endif // OPENVDB_POINTS_ATTRIBUTE_ARRAY_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tree/LeafBuffer.h
+++ b/openvdb/tree/LeafBuffer.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -133,13 +133,13 @@ public:
     bool empty() const { return (mData == nullptr); }
 #else
     /// Default constructor
-    inline LeafBuffer(): mData(new ValueType[SIZE]), mOutOfCore(0) {}
+    inline LeafBuffer(): mData(new ValueType[SIZE]) { mOutOfCore = 0; }
     /// Construct a buffer populated with the specified value.
     explicit inline LeafBuffer(const ValueType&);
     /// Copy constructor
     inline LeafBuffer(const LeafBuffer&);
     /// Construct a buffer but don't allocate memory for the full array of values.
-    LeafBuffer(PartialCreate, const ValueType&): mData(nullptr), mOutOfCore(0) {}
+    LeafBuffer(PartialCreate, const ValueType&): mData(nullptr) { mOutOfCore = 0; }
     /// Destructor
     inline ~LeafBuffer();
 
@@ -251,8 +251,8 @@ template<typename T, Index Log2Dim>
 inline
 LeafBuffer<T, Log2Dim>::LeafBuffer(const ValueType& val)
     : mData(new ValueType[SIZE])
-    , mOutOfCore(0)
 {
+    mOutOfCore = 0;
     this->fill(val);
 }
 
@@ -584,6 +584,6 @@ template<Index Log2Dim> const bool LeafBuffer<bool, Log2Dim>::sOff = false;
 
 #endif // OPENVDB_TREE_LEAFBUFFER_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/unittest/TestPointMove.cc
+++ b/openvdb/unittest/TestPointMove.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -856,8 +856,9 @@ TestPointMove::testCustomDeformer()
         const int leafCount = points->tree().leafCount();
         const int pointCount = int(positions.size());
 
-        tbb::atomic<int> resetCalls = 0;
-        tbb::atomic<int> applyCalls = 0;
+        tbb::atomic<int> resetCalls, applyCalls;
+        resetCalls = 0;
+        applyCalls = 0;
 
         // this deformer applies an offset and tracks the number of calls
 
@@ -1184,6 +1185,6 @@ TestPointMove::testPointOrder()
     ASSERT_APPROX_EQUAL(positions1, positions3, __LINE__);
 }
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/util/PagedArray.h
+++ b/openvdb/util/PagedArray.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 //
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
@@ -202,7 +202,7 @@ public:
     using ValueType = ValueT;
 
     /// @brief Default constructor
-    PagedArray() = default;
+    PagedArray() { mSize = 0; }
 
     /// @brief Destructor removed all allocated pages
     ~PagedArray() { this->clear(); }
@@ -510,7 +510,7 @@ private:
         }
     }
     PageTableT mPageTable;//holds points to allocated pages
-    tbb::atomic<size_t> mSize{0};// current number of elements in array
+    tbb::atomic<size_t> mSize;// current number of elements in array
     size_t mCapacity = 0;//capacity of array given the current page count
     tbb::spin_mutex mGrowthMutex;//Mutex-lock required to grow pages
 }; // Public class PagedArray
@@ -781,6 +781,6 @@ protected:
 
 #endif // OPENVDB_UTIL_PAGED_ARRAY_HAS_BEEN_INCLUDED
 
-// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// Copyright (c) 2012-2019 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the
 // Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )


### PR DESCRIPTION
With the combination of GCC 6.3 and TBB 4.4.6 (not one of the VFX platform configurations), I'm getting errors like this:
```
openvdb/tree/LeafBuffer.h:254:19: error: no matching function for call to ‘tbb::atomic<unsigned int>::atomic(int)’
     , mOutOfCore(0)
                   ^
tbb/4.4.6.0/include/tbb/atomic.h:468:1: note: candidate: tbb::atomic<unsigned int>::atomic()
 __TBB_DECL_ATOMIC(unsigned)
 ^
tbb/4.4.6.0/include/tbb/atomic.h:468:1: note:   candidate expects 0 arguments, 1 provided
tbb/4.4.6.0/include/tbb/atomic.h:468:1: note: candidate: constexpr tbb::atomic<unsigned int>::atomic(const tbb::atomic<unsigned int>&)
tbb/4.4.6.0/include/tbb/atomic.h:468:1: note:   no known conversion for argument 1 from ‘int’ to ‘const tbb::atomic<unsigned int>&’


In file included from openvdb/points/AttributeGroup.h:40:0,
                 from openvdb/points/AttributeGroup.cc:33:
openvdb/points/AttributeArray.h:425:39: error: could not convert ‘0’ from ‘int’ to ‘tbb::atomic<unsigned int>’
     tbb::atomic<Index32> mOutOfCore = 0; // interpreted as bool
```

This PR addresses those and a couple of other such errors by substituting assignment for initialization of TBB atomics.

Anyone else run into this issue?