### PR TITLE
OVDB-58: Fix bug with filtered point re-bucketing

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -41,6 +41,7 @@ Version 6.0.1 - In development
       [Reported by Rick Hankins]
     - Fixed a bug in tools::segmentActiveVoxels() and tools::segmentSDF() where
       inactive leaf nodes were only pruned when there was more than one segment.
+    - Fixed a crash in point moving when using group filters.
 
     API changes:
     - Moved the CopyConstness metafunction from TreeIterator.h to Types.h.

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -66,6 +66,7 @@ Bug fixes:
 - Fixed a bug in @vdblink::tools::segmentActiveVoxels() segmentActiveVoxels@endlink
   and @vdblink::tools::segmentSDF() segmentSDF@endlink where inactive leaf
   nodes were only pruned when there was more than one segment.
+- Fixed a crash in point moving when using group filters.
 
 @par
 API changes:

--- a/openvdb/points/PointMove.h
+++ b/openvdb/points/PointMove.h
@@ -175,7 +175,6 @@ private:
     friend class ::TestPointMove;
 
     Cache& mCache;
-    LeafVecT mLocalLeafVec;
     const LeafVecT* mLeafVec = nullptr;
     const LeafMapT* mLeafMap = nullptr;
 }; // class CachedDeformer
@@ -1155,10 +1154,6 @@ void CachedDeformer<T>::evaluate(PointDataGridT& grid, DeformerT& deformer, cons
 
         DeformerT newDeformer(deformer);
 
-        // if more than half the number of total points are evaluated by the filter, prefer
-        // accessing the data from a vector instead of a hash map for faster performance
-        const Index64 vectorThreshold = totalPointCount / 2;
-
         newDeformer.reset(leaf, idx);
 
         auto handle = AttributeHandle<Vec3f>::create(leaf.constAttributeArray("P"));
@@ -1166,10 +1161,10 @@ void CachedDeformer<T>::evaluate(PointDataGridT& grid, DeformerT& deformer, cons
         auto& cache = leafs[idx];
         cache.clear();
 
-        // only insert into a vector directly if the filter evaluates all points and the
-        // number of active points is greater than the vector threshold
+        // only insert into a vector directly if the filter evaluates all points
+        // and all points are stored in active voxels
         const bool useVector = filter.state() == index::ALL &&
-            (leaf.isDense() || (leaf.onPointCount() > vectorThreshold));
+            (leaf.isDense() || (leaf.onPointCount() == leaf.pointCount()));
         if (useVector) {
             cache.vecData.resize(totalPointCount);
         }
@@ -1202,16 +1197,6 @@ void CachedDeformer<T>::evaluate(PointDataGridT& grid, DeformerT& deformer, cons
             }
         }
 
-        // after insertion, move the data into a vector if the threshold is reached
-
-        if (!useVector && cache.mapData.size() > vectorThreshold) {
-            cache.vecData.resize(totalPointCount);
-            for (const auto& it : cache.mapData) {
-                cache.vecData[it.first] = it.second;
-            }
-            cache.mapData.clear();
-        }
-
         // store the total number of points to allow use of an expanded vector on access
 
         if (!cache.mapData.empty()) {
@@ -1236,26 +1221,8 @@ void CachedDeformer<T>::reset(const LeafT& /*leaf*/, size_t idx)
     }
     auto& cache = mCache.leafs[idx];
     if (!cache.mapData.empty()) {
-        // expand into a local vector if there are greater than 16 values in the hash map
-        // and the expanded vector would contain fewer values than 256 times those in the
-        // hash map, this trades a little extra storage for faster random access performance
-        if (cache.mapData.size() > 16 &&
-            cache.totalSize < (cache.mapData.size() * 256)) {
-            if (cache.totalSize < cache.mapData.size()) {
-                throw ValueError("Cache total size is not valid.");
-            }
-            mLocalLeafVec.resize(cache.totalSize);
-            for (const auto& it : cache.mapData) {
-                assert(it.first < cache.totalSize);
-                mLocalLeafVec[it.first] = it.second;
-            }
-            mLeafVec = &mLocalLeafVec;
-            mLeafMap = nullptr;
-        }
-        else {
-            mLeafMap = &cache.mapData;
-            mLeafVec = nullptr;
-        }
+        mLeafMap = &cache.mapData;
+        mLeafVec = nullptr;
     }
     else {
         mLeafVec = &cache.vecData;

--- a/openvdb/unittest/TestPointMove.cc
+++ b/openvdb/unittest/TestPointMove.cc
@@ -265,7 +265,6 @@ TestPointMove::testCachedDeformer()
     CachedDeformer<double> cachedDeformer(cache);
 
     // check initialization is as expected
-    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
     CPPUNIT_ASSERT(cachedDeformer.mLeafVec == nullptr);
     CPPUNIT_ASSERT(cachedDeformer.mLeafMap == nullptr);
 
@@ -281,7 +280,6 @@ TestPointMove::testCachedDeformer()
 
     // reset should no longer throw and leaf vec pointer should now be non-null
     CPPUNIT_ASSERT_NO_THROW(cachedDeformer.reset(nullObject, size_t(0)));
-    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
     CPPUNIT_ASSERT(cachedDeformer.mLeafMap == nullptr);
     CPPUNIT_ASSERT(cachedDeformer.mLeafVec != nullptr);
     CPPUNIT_ASSERT(cachedDeformer.mLeafVec->empty());
@@ -309,63 +307,11 @@ TestPointMove::testCachedDeformer()
     // now reset the cached deformer and verify the value is updated
     // (map has precedence over vector)
     cachedDeformer.reset(nullObject, size_t(0));
-    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
     CPPUNIT_ASSERT(cachedDeformer.mLeafMap != nullptr);
     CPPUNIT_ASSERT(cachedDeformer.mLeafVec == nullptr);
     newPosition.setZero();
     cachedDeformer.apply(newPosition, indexIter);
     CPPUNIT_ASSERT(math::isApproxEqual(newDeformedPosition, newPosition));
-
-    // test map -> vector expansion
-    leaf.mapData.clear();
-    for (int i = 0; i < 16; i++) {
-        leaf.mapData.insert({i, Vec3d(0, i, 0)});
-    }
-
-    cachedDeformer.reset(nullObject, size_t(0));
-
-    // 16 values (or less) so local vector is not populated
-    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
-    CPPUNIT_ASSERT(cachedDeformer.mLeafMap != nullptr);
-    CPPUNIT_ASSERT(cachedDeformer.mLeafVec == nullptr);
-
-    // check value access
-    for (int i = 0; i < 16; i++) {
-        DummyIter indexIterI(i);
-        cachedDeformer.apply(newPosition, indexIterI);
-        CPPUNIT_ASSERT(math::isApproxEqual(Vec3d(0, i, 0), newPosition));
-    }
-
-    leaf.mapData.insert({16, Vec3d(0, 16, 0)});
-
-    // ValueError thrown because totalSize has not been set correctly
-    CPPUNIT_ASSERT_THROW(cachedDeformer.reset(nullObject, size_t(0)), openvdb::ValueError);
-
-    // use very large total size to prevent local expansion
-    leaf.totalSize = 17 * 256 + 1;
-
-    CPPUNIT_ASSERT_NO_THROW(cachedDeformer.reset(nullObject, size_t(0)));
-
-    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
-    CPPUNIT_ASSERT(cachedDeformer.mLeafMap != nullptr);
-    CPPUNIT_ASSERT(cachedDeformer.mLeafVec == nullptr);
-
-    // use total size that represents a sequential dataset
-    leaf.totalSize = Index(leaf.mapData.size());
-
-    CPPUNIT_ASSERT_NO_THROW(cachedDeformer.reset(nullObject, size_t(0)));
-
-    // greater than 16 values so local vector is populated
-    CPPUNIT_ASSERT_EQUAL(leaf.mapData.size(), cachedDeformer.mLocalLeafVec.size());
-    CPPUNIT_ASSERT(cachedDeformer.mLeafMap == nullptr);
-    CPPUNIT_ASSERT(cachedDeformer.mLeafVec != nullptr);
-
-    // check value access
-    for (int i = 0; i < 17; i++) {
-        DummyIter indexIterI(i);
-        cachedDeformer.apply(newPosition, indexIterI);
-        CPPUNIT_ASSERT(math::isApproxEqual(Vec3d(0, i, 0), newPosition));
-    }
 
     // four points, some same leaf, some different
     const float voxelSize = 1.0f;


### PR DESCRIPTION
Resolve issues with filtered point re-bucketing by removing the optimization that attempts to use a padded vector instead of a hash map within a certain threshold. There are other potential avenues of optimization that are worth exploring here.