### PR TITLE
OVDB-69: Remove code < 16.5 for custom prim and guard on SESI_OPENVDB_PRIM

### DIFF
--- a/openvdb_houdini/houdini/GEO_PrimVDB.cc
+++ b/openvdb_houdini/houdini/GEO_PrimVDB.cc
@@ -47,7 +47,8 @@
  */
 
 #include <UT/UT_Version.h>
-#if (UT_VERSION_INT < 0x0c050157) // earlier than 12.5.343
+
+#if defined(SESI_OPENVDB) || defined(SESI_OPENVDB_PRIM)
 
 #include "GEO_PrimVDB.h"
 
@@ -110,24 +111,6 @@ static const UT_StringHolder    theKWVertex = "vertex"_sh;
 static const UT_StringHolder    theKWVDB = "vdb"_sh;
 static const UT_StringHolder    theKWVDBVis = "vdbvis"_sh;
 
-#if (UT_VERSION_INT < 0x0c0100B6) // earlier than 12.1.182
-static bool
-geo_JVDBError(UT_JSONParser &p, const GA_Primitive *prim, const char *m)
-{
-    p.addFatal("Error loading %s: %s", prim->getTypeName(), m);
-    return false;
-}
-#endif
-
-#if (UT_VERSION_INT < 0x0c010048) // earlier than 12.1.72
-GA_IntrinsicManager::Registrar
-GEO_PrimVDB::registerIntrinsics(GA_PrimitiveDefinition &defn)
-{
-    ///defn.setMergeConstructor(&gaPrimitiveMergeConstructor);
-    return GEO_Primitive::registerIntrinsics(defn);
-}
-#endif
-
 
 GEO_PrimVDB::UniqueId
 GEO_PrimVDB::nextUniqueId()
@@ -146,79 +129,13 @@ GEO_PrimVDB::GEO_PrimVDB(GEO_Detail *d, GA_Offset offset)
     , myMetadataUniqueId(GEO_PrimVDB::nextUniqueId())
     , myTransformUniqueId(GEO_PrimVDB::nextUniqueId())
 {
-#if UT_VERSION_INT < 0x1000011F // earlier than 16.0.287
-    myVertex = allocateVertex();
-#else
-#if (UT_VERSION_INT < 0x10000162)
-    myVertex = GA_INVALID_OFFSET;
-#endif
-#endif
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    myStashedState = false;
-    if (d) d->addVolumeRef();
-#endif
 }
 
-#if UT_VERSION_INT < 0x1000011F // earlier than 16.0.287
-GEO_PrimVDB::GEO_PrimVDB(const GA_MergeMap &map, GA_Detail &detail,
-                         GA_Offset offset, const GEO_PrimVDB &src_prim)
-    : GEO_Primitive(static_cast<GEO_Detail *>(&detail), offset)
-    , myVis(src_prim.myVis)
-{
-    myUniqueId.exchange(src_prim.getUniqueId());
-
-    if (map.isIdentityMap(GA_ATTRIB_VERTEX))
-    {
-        myVertex = src_prim.myVertex;
-    }
-    else
-    {
-        GA_Offset sidx = src_prim.myVertex; // Get source index
-        myVertex = map.mapDestFromSource(GA_ATTRIB_VERTEX, sidx);
-    }
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    myStashedState = false;
-    static_cast<GEO_Detail &>(detail).addVolumeRef();
-#endif
-
-    copyGridFrom(src_prim); // makes a shallow copy
-}
-#endif
-
-#if (UT_VERSION_INT < 0x10000162)
-GEO_PrimVDB::~GEO_PrimVDB()
-{
-    if (GAisValid(myVertex))
-        destroyVertex(myVertex);
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    if (!myStashedState && getParent())
-        getParent()->delVolumeRef();
-#endif
-}
-#endif
-
-#if (UT_VERSION_INT < 0x10000162)
-void
-GEO_PrimVDB::clearForDeletion()
-{
-    myVertex = GA_INVALID_OFFSET;
-    GEO_Primitive::clearForDeletion();
-}
-#endif
-
-#if (UT_VERSION_INT >= 0x0d000000) // 13.0 or later
 void
 GEO_PrimVDB::stashed(bool beingstashed, GA_Offset offset)
 {
     // NB: Base class must be unstashed before we can call allocateVertex().
     GEO_Primitive::stashed(beingstashed, offset);
-#if UT_VERSION_INT < 0x1000011F // earlier than 16.0.287
-    myVertex = beingstashed ? GA_INVALID_OFFSET : allocateVertex();
-#else
-#if (UT_VERSION_INT < 0x10000162)
-    myVertex = GA_INVALID_OFFSET;
-#endif
-#endif
     if (!beingstashed)
     {
         // Reset to state as if freshly constructed
@@ -237,24 +154,7 @@ GEO_PrimVDB::stashed(bool beingstashed, GA_Offset offset)
         // as if freshly constructed when unstashing.
         myGridAccessor.clear();
     }
-#else
-void
-GEO_PrimVDB::stashed(int onoff, GA_Offset offset)
-{
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    if (getParent())
-    {
-        if (onoff)
-            getParent()->delVolumeRef();
-        else
-            getParent()->addVolumeRef();
-    }
-    myStashedState = (onoff != 0);
-#endif
-    // NB: Base class must be unstashed before we can call allocateVertex().
-    GEO_Primitive::stashed(onoff, offset);
-    myVertex = onoff ? GA_INVALID_OFFSET : allocateVertex();
-#endif
+
     // Set our internal state to default
     myVis = GEO_VolumeOptions(GEO_VOLUMEVIS_SMOKE, /*iso*/0.0, /*density*/1.0);
 }
@@ -1061,14 +961,6 @@ GEO_PrimVDB::countBaseMemory(UT_MemoryCounter &counter) const
         counter.countShared(size, refcount, ptr);
     }
 }
-
-#if (UT_VERSION_INT < 0x10000162)
-GA_Size
-GEO_PrimVDB::getVertexCount(void) const
-{
-    return 1;
-}
-#endif
 
 
 template <typename GridType>
@@ -2645,9 +2537,6 @@ public:
         return false;
     }
 
-    // Implement these methods to be the same as the H12.5 base class version.
-    // In H12.1, these methods were pure virtual.
-#if 1
     virtual bool
     saveField(const GA_Primitive *pr, int i, UT_JSONValue &val,
               const GA_SaveMap &map) const
@@ -2666,7 +2555,6 @@ public:
         p.stealErrors(*parser);
         return ok;
     }
-#endif
 
     virtual bool
     isEqual(int i, const GA_Primitive *p0, const GA_Primitive *p1) const
@@ -2976,11 +2864,7 @@ GEO_PrimVDB::isDegenerate() const
 // Methods to handle vertex attributes for the attribute dictionary
 //
 void
-#if (UT_VERSION_INT >= 0x0d000000)
 GEO_PrimVDB::copyPrimitive(const GEO_Primitive *psrc)
-#else
-GEO_PrimVDB::copyPrimitive(const GEO_Primitive *psrc, GEO_Point **ptredirect)
-#endif
 {
     if (psrc == this) return;
 
@@ -2992,57 +2876,10 @@ GEO_PrimVDB::copyPrimitive(const GEO_Primitive *psrc, GEO_Point **ptredirect)
     //       vertices, but we should do so across primitives as well.
     GA_VertexWrangler vertex_wrangler(*getParent(), *src->getParent());
 
-#if (UT_VERSION_INT >= 0x10000162)
     GEO_Primitive::copyPrimitive(psrc);
-#else
-    GA_Offset v = myVertex;
-    const GA_IndexMap &src_points = src->getParent()->getPointMap();
-    GA_Index ptind = src_points.indexFromOffset(src->vertexPoint(0));
-#if (UT_VERSION_INT >= 0x0d000000)
-    GA_Offset ptoff = getParent()->pointOffset(ptind);
-    wireVertex(v, ptoff);
-#else
-    GEO_Point *ppt = ptredirect[ptind];
-    wireVertex(v, ppt ? ppt->getMapOffset() : GA_INVALID_OFFSET);
-#endif
-    vertex_wrangler.copyAttributeValues(v, src->fastVertexOffset(0));
-#endif
 
     myVis = src->myVis;
 }
-
-#if (UT_VERSION_INT < 0x0d000000) // Deleted in 13.0
-#if (UT_VERSION_INT >= 0x0c050132) // 12.5.306 or later
-void
-GEO_PrimVDB::copyOffsetPrimitive(const GEO_Primitive *psrc, GA_Index basept)
-#else
-void
-GEO_PrimVDB::copyOffsetPrimitive(const GEO_Primitive *psrc, int basept)
-#endif
-{
-    if (psrc == this) return;
-
-    const GEO_PrimVDB   *src = (const GEO_PrimVDB *)psrc;
-    const GA_IndexMap   &points = getParent()->getPointMap();
-    const GA_IndexMap   &src_points = src->getParent()->getPointMap();
-    GA_Offset            ppt;
-
-    copyGridFrom(*src); // makes a shallow copy
-
-    // TODO: Well and good to reuse the attribute handle for all our
-    //       points/vertices, but we should do so across primitives
-    //       as well.
-    GA_VertexWrangler            vertex_wrangler(*getParent(),
-                                                 *src->getParent());
-
-    GA_Offset   v = fastVertexOffset(0);
-    ppt = points.offsetFromIndex(
-            src_points.indexFromOffset(src->vertexPoint(0)) + basept);
-    wireVertex(v, ppt);
-    vertex_wrangler.copyAttributeValues(v, src->fastVertexOffset(0));
-    myVis = src->myVis;
-}
-#endif
 
 static inline
 openvdb::math::Vec3d
@@ -3131,12 +2968,7 @@ GEO_PrimVDB::GridAccessor::setGridAdapter(
     if (myGrid.get() == &grid)
         return;
     setVertexPosition(grid.transform(), prim);
-#if OPENVDB_ABI_VERSION_NUMBER <= 3
     myGrid = grid.copyGrid(); // always shallow-copy the source grid
-#else
-    myGrid = openvdb::ConstPtrCast<openvdb::GridBase>(
-        grid.copyGrid()); // always shallow-copy the source grid
-#endif
     myStorageType = UTvdbGetGridType(*myGrid);
 }
 
@@ -3149,67 +2981,12 @@ GEO_PrimVDB::copy(int preserve_shared_pts) const
         return nullptr;
 
     GEO_PrimVDB* vdb = static_cast<GEO_PrimVDB*>(clone);
-#if (UT_VERSION_INT < 0x10000162)
-#if UT_VERSION_INT >= 0x1000011F // 16.0.287 or later
-    vdb->assignVertex(getDetail().appendVertex(), true);
-#endif
-#endif
 
     // Give the clone the same serial number as this primitive.
     vdb->myUniqueId.exchange(this->getUniqueId());
 
     // Give the clone a shallow copy of this primitive's grid.
     vdb->copyGridFrom(*this);
-
-#if (UT_VERSION_INT < 0x10000162)
-    // TODO: Well and good to reuse the attribute handle for all our
-    //       points/vertices, but we should do so across primitives
-    //       as well.
-    GA_ElementWranglerCache      wranglers(*getParent(),
-                                        GA_PointWrangler::INCLUDE_P);
-
-    int nvtx = getVertexCount();
-
-    if (preserve_shared_pts)
-    {
-        UT_SparseArray<GA_Offset *>     addedpoints;
-        GA_Offset                       *ppt_ptr;
-
-        for (int i = 0; i < nvtx; i++)
-        {
-            GA_Offset            src_ppt = vertexPoint(i);
-            GA_Offset            v  = vdb->fastVertexOffset(i);
-            GA_Offset            sv = fastVertexOffset(i);
-
-            GA_Offset ppt;
-            if (!(ppt_ptr = addedpoints(src_ppt)))
-            {
-                ppt = getParent()->appendPointOffset();
-                wranglers.getPoint().copyAttributeValues(ppt, src_ppt);
-                addedpoints.append(src_ppt, new GA_Offset(ppt));
-            }
-            else
-                ppt = *ppt_ptr;
-            vdb->wireVertex(v, ppt);
-            wranglers.getVertex().copyAttributeValues(v, sv);
-        }
-
-        int dummy_index;
-        for (int i = 0; i < addedpoints.entries(); i++)
-            delete (GA_Offset *)addedpoints.getRawEntry(i, dummy_index);
-    }
-    else
-    {
-        for (int i = 0; i < nvtx; i++)
-        {
-            GA_Offset   v = vdb->fastVertexOffset(i);
-            GA_Offset ppt = getParent()->appendPointOffset();
-            vdb->wireVertex(v, ppt);
-            wranglers.getPoint().copyAttributeValues(ppt, vertexPoint(i));
-            wranglers.getVertex().copyAttributeValues(v, fastVertexOffset(i));
-        }
-    }
-#endif
 
     vdb->myVis = myVis;
 
@@ -3223,23 +3000,7 @@ GEO_PrimVDB::copyUnwiredForMerge(const GA_Primitive *prim_src, const GA_MergeMap
 
     const GEO_PrimVDB* src = static_cast<const GEO_PrimVDB*>(prim_src);
 
-#if (UT_VERSION_INT >= 0x10000162)
     GEO_Primitive::copyUnwiredForMerge(prim_src, map);
-#else
-    if (GAisValid(myVertex))
-        destroyVertex(myVertex);
-
-    if (map.isIdentityMap(GA_ATTRIB_VERTEX))
-    {
-        myVertex = src->myVertex;
-    }
-    else
-    {
-        GA_Offset sidx = src->myVertex; // Get source index
-        // Map to dest
-        myVertex = map.mapDestFromSource(GA_ATTRIB_VERTEX, sidx);
-    }
-#endif
 
     copyGridFrom(*src); // makes a shallow copy
 
@@ -3249,7 +3010,6 @@ GEO_PrimVDB::copyUnwiredForMerge(const GA_Primitive *prim_src, const GA_MergeMap
 void
 GEO_PrimVDB::assignVertex(GA_Offset new_vtx, bool update_topology)
 {
-#if (UT_VERSION_INT >= 0x10000162)
     if (getVertexCount() == 1)
     {
         GA_Offset orig_vtx = getVertexOffset();
@@ -3265,29 +3025,7 @@ GEO_PrimVDB::assignVertex(GA_Offset new_vtx, bool update_topology)
     }
     if (update_topology)
         registerVertex(new_vtx);
-#else
-    if (myVertex != new_vtx)
-    {
-        if (GAisValid(myVertex))
-            destroyVertex(myVertex);
-        myVertex = new_vtx;
-        if (update_topology)
-            registerVertex(myVertex);
-    }
-#endif
 }
-
-#if (UT_VERSION_INT < 0x10000162)
-void
-GEO_PrimVDB::swapVertexOffsets(const GA_Defragment &defrag)
-{
-    GA_Offset   v = myVertex;
-    if (defrag.hasOffsetChanged(v))
-    {
-        myVertex = defrag.mapOffset(v);
-    }
-}
-#endif
 
 const char *
 GEO_PrimVDB::getGridName() const
@@ -3566,7 +3304,7 @@ GEO_PrimVDB::isIntrinsicMetadata(const char *name)
     return theMetaNames.contains(name);
 }
 
-#endif // UT_VERSION_INT < 0x0c050157 // earlier than 12.5.343
+#endif // SESI_OPENVDB || SESI_OPENVDB_PRIM
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the

--- a/openvdb_houdini/houdini/GEO_PrimVDB.h
+++ b/openvdb_houdini/houdini/GEO_PrimVDB.h
@@ -47,7 +47,13 @@
  */
 
 #include <UT/UT_Version.h>
-#if !defined(SESI_OPENVDB) && (UT_VERSION_INT >= 0x0c050157) // 12.5.343 or later
+
+// Using the native OpenVDB Primitive shipped with Houdini is strongly recommended,
+// as there is no guarantee that this code will be kept in sync with Houdini.
+// However, for debugging it can be useful, so supply -DSESI_OPENVDB_PRIM to
+// the compiler to build this custom primitive.
+
+#if !defined(SESI_OPENVDB) && !defined(SESI_OPENVDB_PRIM)
 
 #include <GEO/GEO_PrimVDB.h>
 
@@ -56,20 +62,14 @@ using ::GEO_VolumeOptions;
 using ::GEO_PrimVDB;
 }
 
-#else // earlier than 12.5.343
+#else // SESI_OPENVDB || SESI_OPENVDB_PRIM
 
 #ifndef __HDK_GEO_PrimVDB__
 #define __HDK_GEO_PrimVDB__
 
-//#include "GEO_API.h"
-
 #include <GEO/GEO_Primitive.h>
 #include <GEO/GEO_Vertex.h>
-#if (UT_VERSION_INT < 0x0c010072) // earlier than 12.1.114
-#include <GEO/GEO_PrimVolume.h>
-#else
 #include <GEO/GEO_VolumeOptions.h>
-#endif
 
 #include <GA/GA_Defines.h>
 
@@ -88,37 +88,6 @@ class   GEO_PrimVolume;
 class   GEO_PrimVolumeXform;
 class   UT_MemoryCounter;
 
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-struct OPENVDB_HOUDINI_API GEO_VolumeOptions
-{
-    GEO_VolumeOptions()
-    {
-    }
-    GEO_VolumeOptions(GEO_VolumeVis mode, fpreal iso, fpreal density)
-        : myMode(mode)
-        , myIso(iso)
-        , myDensity(density)
-    {
-    }
-    bool operator==(const GEO_VolumeOptions &v) const
-    {
-        OPENVDB_NO_FP_EQUALITY_WARNING_BEGIN
-        return (myMode == v.myMode
-                && myIso == v.myIso
-                && myDensity == v.myDensity);
-        OPENVDB_NO_FP_EQUALITY_WARNING_END
-    }
-    bool operator!=(const GEO_VolumeOptions &v) const
-    {
-        return !(*this == v);
-    }
-
-    GEO_VolumeVis           myMode;
-    fpreal                  myIso;
-    fpreal                  myDensity;
-};
-#endif
-
 
 class OPENVDB_HOUDINI_API GEO_PrimVDB : public GEO_Primitive
 {
@@ -129,19 +98,6 @@ protected:
     /// NOTE: The constructor should only be called from subclass
     ///       constructors.
     GEO_PrimVDB(GEO_Detail *d, GA_Offset offset = GA_INVALID_OFFSET);
-
-#if UT_VERSION_INT < 0x1000011F // earlier than 16.0.287
-    /// NOTE: The constructor should only be called from subclass
-    ///       constructors.
-    GEO_PrimVDB(const GA_MergeMap &map, GA_Detail &detail,
-                GA_Offset offset, const GEO_PrimVDB &src_prim);
-#endif
-
-#if (UT_VERSION_INT < 0x10000162)
-    /// NOTE: The destructor should only be called from subclass
-    ///       destructors.
-    virtual ~GEO_PrimVDB();
-#endif
 
 public:
     static GA_PrimitiveFamilyMask       buildFamilyMask()
@@ -161,37 +117,6 @@ public:
 #endif
     virtual void        copyUnwiredForMerge(const GA_Primitive *src,
                                             const GA_MergeMap &map);
-
-#if (UT_VERSION_INT < 0x10000162)
-    // Query the number of vertices in the array. This number may be smaller
-    // than the actual size of the array.
-    virtual GA_Size     getVertexCount() const;
-    virtual GA_Offset   getVertexOffset(GA_Size /*index*/) const
-                            { return myVertex; }
-#endif
-
-#if (UT_VERSION_INT >= 0x10000162)
-    using GEO_Primitive::getVertexOffset;
-    using GEO_Primitive::getPointOffset;
-    using GEO_Primitive::setPointOffset;
-    using GEO_Primitive::getPos3;
-    using GEO_Primitive::setPos3;
-    SYS_FORCE_INLINE
-    GA_Offset getVertexOffset() const
-    { return getVertexOffset(0); }
-    SYS_FORCE_INLINE
-    GA_Offset getPointOffset() const
-    { return getPointOffset(0); }
-    SYS_FORCE_INLINE
-    void setPointOffset(GA_Offset pt)
-    { setPointOffset(0, pt); }
-    SYS_FORCE_INLINE
-    UT_Vector3 getPos3() const
-    { return getPos3(0); }
-    SYS_FORCE_INLINE
-    void setPos3(const UT_Vector3 &pos)
-    { setPos3(0, pos); }
-#endif
 
     /// Convert an index in the voxel array into the corresponding worldspace
     /// location
@@ -282,11 +207,6 @@ public:
     /// This method assigns a preallocated vertex to the quadric, optionally
     /// creating the topological link between the primitive and new vertex.
     void                 assignVertex(GA_Offset new_vtx, bool update_topology);
-
-#if (UT_VERSION_INT < 0x10000162)
-    /// Defragmentation
-    virtual void        swapVertexOffsets(const GA_Defragment &defrag);
-#endif
 
     /// Evalaute a point given a u,v coordinate (with derivatives)
     virtual bool        evaluatePointRefMap(GA_Offset result_vtx,
@@ -393,22 +313,8 @@ public:
     virtual GEO_Primitive       *copy(int preserve_shared_pts = 0) const;
 
     // Have we been deactivated and stashed?
-#if (UT_VERSION_INT >= 0x0d000000) // 13.0 or later
     virtual void        stashed(bool beingstashed, GA_Offset offset=GA_INVALID_OFFSET);
-#else
-    virtual void        stashed(int onoff, GA_Offset offset=GA_INVALID_OFFSET);
-#endif
 
-#if (UT_VERSION_INT < 0x10000162)
-    // We need to invalidate the vertex offsets
-    virtual void        clearForDeletion();
-#endif
-
-#if (UT_VERSION_INT < 0x0c050132) // Before 12.5.306
-    virtual void        copyOffsetPrimitive(const GEO_Primitive *src, int base);
-#elif (UT_VERSION_INT < 0x0d000000) // Before 13.0, when the function was deleted
-    virtual void        copyOffsetPrimitive(const GEO_Primitive *src, GA_Index base);
-#endif
     /// @}
 
     /// @{
@@ -490,21 +396,13 @@ public:
     GA_Offset           fastVertexOffset(GA_Size UT_IF_ASSERT_P(index)) const
                         {
                             UT_ASSERT_P(index < 1);
-#if (UT_VERSION_INT >= 0x10000162)
                             return getVertexOffset();
-#else
-                            return myVertex;
-#endif
                         }
 
     void        setVertexPoint(int i, GA_Offset pt)
                 {
                     if (i == 0)
-#if (UT_VERSION_INT >= 0x10000162)
                         setPointOffset(pt);
-#else
-                        wireVertex(myVertex, pt);
-#endif
                 }
 
     /// @brief Computes the total density of the volume, scaled by
@@ -612,23 +510,14 @@ protected:
     typedef SYS_AtomicCounter AtomicUniqueId; // 64-bit
 
     /// Register intrinsic attributes
-#if (UT_VERSION_INT >= 0x0c010048) // 12.1.72 or later
     GA_DECLARE_INTRINSICS(GA_NO_OVERRIDE)
-#else
-    static GA_IntrinsicManager::Registrar
-                        registerIntrinsics(GA_PrimitiveDefinition &defn);
-#endif
 
     /// Return true if the given metadata token is an intrinsic
     static bool         isIntrinsicMetadata(const char *name);
 
     /// @warning vertexPoint() doesn't check the bounds.  Use with caution.
     GA_Offset           vertexPoint(GA_Size) const
-#if (UT_VERSION_INT >= 0x10000162)
     { return getPointOffset(); }
-#else
-    { return getDetail().vertexPoint(myVertex); }
-#endif
 
     /// Report approximate memory usage, excluding sizeof(*this),
     /// because the subclass doesn't have access to myGridAccessor.
@@ -658,10 +547,6 @@ protected:
     /// @brief Replace this primitive's grid with a shallow copy
     /// of another primitive's grid.
     void                copyGridFrom(const GEO_PrimVDB&);
-
-#if (UT_VERSION_INT < 0x10000162) // earlier than 16.0.354
-    GA_Offset myVertex;
-#endif
 
     /// @brief GridAccessor manages access to a GEO_PrimVDB's grid.
     /// @details In keeping with OpenVDB library conventions, the grid
@@ -744,10 +629,6 @@ private:
     GridAccessor            myGridAccessor;
 
     GEO_VolumeOptions       myVis;
-
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    bool                    myStashedState;
-#endif
 
     AtomicUniqueId          myUniqueId;
     AtomicUniqueId          myTreeUniqueId;
@@ -903,7 +784,7 @@ inline bool GEOvdbProcessTypedGridPoint(GEO_PrimVDB &vdb, OpT &op, bool makeUniq
 
 #endif // __HDK_GEO_PrimVDB__
 
-#endif // UT_VERSION_INT < 0x0c050157 // earlier than 12.5.343
+#endif // SESI_OPENVDB || SESI_OPENVDB_PRIM
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the


### PR DESCRIPTION
Currently, the VDB custom primitive is disabled unless SESI_OPENVDB is set or the Houdini version is lower than H12.5.

This change removes all the logic that applies for Houdini versions less than 16.5 and changes the second guard condition from "lower than H12.5" to "SESI_OPENVDB_PRIM being defined". 