### PR TITLE
OVDB-68: Add an error directive if using a deprecated version of the OpenVDB ABI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,13 +69,9 @@ jobs:
     - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=4 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
-      env: ABI=3 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
-    - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=5 BLOSC=yes MODE=release HOUDINI_MAJOR=17.0 COMPILER=clang
     - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=4 BLOSC=yes MODE=release HOUDINI_MAJOR=16.5 COMPILER=clang
-    - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
-      env: ABI=3 BLOSC=yes MODE=release HOUDINI_MAJOR=16.0 COMPILER=clang
     - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=6 BLOSC=no MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
@@ -94,14 +90,10 @@ jobs:
       env: ABI=5 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run test $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=4 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
-    - script: bash travis/travis.run test $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
-      env: ABI=3 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run houdini $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=5 BLOSC=yes MODE=release HOUDINI_MAJOR=17.0 COMPILER=clang
     - script: bash travis/travis.run houdini $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=4 BLOSC=yes MODE=release HOUDINI_MAJOR=16.5 COMPILER=clang
-    - script: bash travis/travis.run houdini $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
-      env: ABI=3 BLOSC=yes MODE=release HOUDINI_MAJOR=16.0 COMPILER=clang
     - script: bash travis/travis.run test $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=6 BLOSC=no MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run test $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
@@ -124,8 +116,6 @@ jobs:
       env: ABI=5 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run run $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=4 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
-    - script: bash travis/travis.run run $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
-      env: ABI=3 BLOSC=yes MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run run $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=6 BLOSC=no MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run run $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER

--- a/openvdb/Grid.h
+++ b/openvdb/Grid.h
@@ -119,6 +119,7 @@ public:
 #if OPENVDB_ABI_VERSION_NUMBER <= 3
     /// @brief Return a new grid of the same type as this grid and whose
     /// metadata and transform are deep copies of this grid's.
+    /// @deprecated ABI versions older than 4 are deprecated.
     OPENVDB_DEPRECATED virtual GridBase::Ptr copyGrid(CopyPolicy treePolicy = CP_SHARE) const = 0;
 #else
     /// @brief Return a new grid of the same type as this grid whose metadata is a
@@ -502,6 +503,7 @@ protected:
 
 #if OPENVDB_ABI_VERSION_NUMBER <= 3
     /// @brief Copy another grid's metadata but share its transform.
+    /// @deprecated ABI versions older than 4 are deprecated.
     OPENVDB_DEPRECATED GridBase(const GridBase& other, ShallowCopy): MetaMap(other), mTransform(other.mTransform) {}
 #else
     /// @brief Copy another grid's metadata but share its transform.
@@ -650,6 +652,7 @@ public:
     explicit Grid(const Grid<OtherTreeType>&);
 #if OPENVDB_ABI_VERSION_NUMBER <= 3
     /// Deep copy another grid's metadata, but share its tree and transform.
+    /// @deprecated ABI versions older than 4 are deprecated.
     OPENVDB_DEPRECATED Grid(const Grid&, ShallowCopy);
 #else
     /// Deep copy another grid's metadata and transform, but share its tree.
@@ -673,6 +676,7 @@ public:
     /// and it shares its transform with this grid;
     /// if @c CP_SHARE, the new grid shares this grid's tree and transform;
     /// if @c CP_COPY, the new grid's tree and transform are deep copies of this grid's.
+    /// @deprecated ABI versions older than 4 are deprecated.
     OPENVDB_DEPRECATED Ptr copy(CopyPolicy treePolicy = CP_SHARE) const;
     OPENVDB_DEPRECATED GridBase::Ptr copyGrid(CopyPolicy treePolicy = CP_SHARE) const override;
     //@}

--- a/openvdb/Grid.h
+++ b/openvdb/Grid.h
@@ -119,7 +119,7 @@ public:
 #if OPENVDB_ABI_VERSION_NUMBER <= 3
     /// @brief Return a new grid of the same type as this grid and whose
     /// metadata and transform are deep copies of this grid's.
-    virtual GridBase::Ptr copyGrid(CopyPolicy treePolicy = CP_SHARE) const = 0;
+    OPENVDB_DEPRECATED virtual GridBase::Ptr copyGrid(CopyPolicy treePolicy = CP_SHARE) const = 0;
 #else
     /// @brief Return a new grid of the same type as this grid whose metadata is a
     /// deep copy of this grid's and whose tree and transform are shared with this grid.
@@ -502,7 +502,7 @@ protected:
 
 #if OPENVDB_ABI_VERSION_NUMBER <= 3
     /// @brief Copy another grid's metadata but share its transform.
-    GridBase(const GridBase& other, ShallowCopy): MetaMap(other), mTransform(other.mTransform) {}
+    OPENVDB_DEPRECATED GridBase(const GridBase& other, ShallowCopy): MetaMap(other), mTransform(other.mTransform) {}
 #else
     /// @brief Copy another grid's metadata but share its transform.
     GridBase(GridBase& other, ShallowCopy): MetaMap(other), mTransform(other.mTransform) {}
@@ -650,7 +650,7 @@ public:
     explicit Grid(const Grid<OtherTreeType>&);
 #if OPENVDB_ABI_VERSION_NUMBER <= 3
     /// Deep copy another grid's metadata, but share its tree and transform.
-    Grid(const Grid&, ShallowCopy);
+    OPENVDB_DEPRECATED Grid(const Grid&, ShallowCopy);
 #else
     /// Deep copy another grid's metadata and transform, but share its tree.
     Grid(Grid&, ShallowCopy);
@@ -673,8 +673,8 @@ public:
     /// and it shares its transform with this grid;
     /// if @c CP_SHARE, the new grid shares this grid's tree and transform;
     /// if @c CP_COPY, the new grid's tree and transform are deep copies of this grid's.
-    Ptr copy(CopyPolicy treePolicy = CP_SHARE) const;
-    GridBase::Ptr copyGrid(CopyPolicy treePolicy = CP_SHARE) const override;
+    OPENVDB_DEPRECATED Ptr copy(CopyPolicy treePolicy = CP_SHARE) const;
+    OPENVDB_DEPRECATED GridBase::Ptr copyGrid(CopyPolicy treePolicy = CP_SHARE) const override;
     //@}
 #else
     //@{

--- a/openvdb/Types.h
+++ b/openvdb/Types.h
@@ -737,7 +737,7 @@ struct SwappedCombineOp
 /// <dt><b>CP_COPY</b>
 /// <dd>Create a deep copy of the member.
 /// </dl>
-enum CopyPolicy { CP_NEW, CP_SHARE, CP_COPY };
+enum OPENVDB_DEPRECATED CopyPolicy { CP_NEW, CP_SHARE, CP_COPY };
 #endif
 
 

--- a/openvdb/Types.h
+++ b/openvdb/Types.h
@@ -737,6 +737,7 @@ struct SwappedCombineOp
 /// <dt><b>CP_COPY</b>
 /// <dd>Create a deep copy of the member.
 /// </dl>
+/// @deprecated ABI versions older than 4 are deprecated.
 enum OPENVDB_DEPRECATED CopyPolicy { CP_NEW, CP_SHARE, CP_COPY };
 #endif
 

--- a/openvdb/version.h
+++ b/openvdb/version.h
@@ -95,6 +95,14 @@
     #endif
 #endif
 
+// If using an OPENVDB_ABI_VERSION_NUMBER that has been deprecated, issue an error
+// directive.  This can be optionally suppressed by defining OPENVDB_USE_DEPRECATED_ABI.
+#ifndef OPENVDB_USE_DEPRECATED_ABI
+    #if OPENVDB_ABI_VERSION_NUMBER <= 3
+        #error ABI <= 3 is deprecated, define OPENVDB_USE_DEPRECATED_ABI to suppress this error
+    #endif
+#endif
+
 #if OPENVDB_ABI_VERSION_NUMBER == OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER
     /// @brief The version namespace name for this library version
     /// @hideinitializer


### PR DESCRIPTION
I looked at adding deprecations around all functions and classes, but it didn't seem all that useful. Most of the ABI macro branching is to add new functions which is obviously not going to trigger deprecated warnings. In addition, many of the ABI changes are subtly changing the existing function signature (adding a const for example). I think this might not be a particularly obvious way of alerting the user.

Instead I've gone with the following, simply making a compile error with a clear error message. A compiler flag can then optionally suppress the error. I considered using #warning or pragma warnings to achieve the same thing, but this is not very portable, so this approach seemed less problematic.

Looking for some input on the mechanism that the user could use to provide the OPENVDB_USE_DEPRECATED_ABI flag?