### PR TITLE
OVDB-69: Remove Support For Houdini <= 16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,6 @@ jobs:
     - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=4 BLOSC=yes MODE=release HOUDINI_MAJOR=16.5 COMPILER=clang
     - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
-      env: ABI=3 BLOSC=yes MODE=release HOUDINI_MAJOR=16.0 COMPILER=clang
-    - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=6 BLOSC=no MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run core $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=5 BLOSC=no MODE=release HOUDINI_MAJOR=none COMPILER=clang
@@ -100,8 +98,6 @@ jobs:
       env: ABI=5 BLOSC=yes MODE=release HOUDINI_MAJOR=17.0 COMPILER=clang
     - script: bash travis/travis.run houdini $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=4 BLOSC=yes MODE=release HOUDINI_MAJOR=16.5 COMPILER=clang
-    - script: bash travis/travis.run houdini $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
-      env: ABI=3 BLOSC=yes MODE=release HOUDINI_MAJOR=16.0 COMPILER=clang
     - script: bash travis/travis.run test $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER
       env: ABI=6 BLOSC=no MODE=release HOUDINI_MAJOR=none COMPILER=clang
     - script: bash travis/travis.run test $ABI $BLOSC $MODE $HOUDINI_MAJOR $COMPILER

--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -3,6 +3,9 @@ OpenVDB Version History
 
 Version 6.0.1 - In development
 
+      As of this release, the minimum Houdini version supported by OpenVDB is
+      now Houdini 16.5.
+
     New features:
     - Added new QuatTraits, MatTraits and ValueTraits type traits to complement
       VecTraits and added an IsSpecializationOf helper metafunction.

--- a/openvdb/INSTALL
+++ b/openvdb/INSTALL
@@ -33,11 +33,11 @@ Optional:
 - CppUnit (www.freedesktop.org/wiki/Software/cppunit), version 1.10 or later
   (Linux: yum install cppunit-devel)
 
-- Houdini HDK (http://www.sidefx.com/get/download-houdini/), version 15.0
+- Houdini HDK (http://www.sidefx.com/get/download-houdini/), version 16.5
   or later
 
 - Blosc compression library (www.blosc.org), version 1.5.0 or later
-  (included in the Houdini HDK as of version 14.0)
+  (included in the Houdini HDK)
 
 - Ghostscript (www.ghostscript.com), version 8.70 or later, for documentation
   in PDF format

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -6,6 +6,11 @@
 @par
 <B>Version 6.0.1</B> - <I>In development</I>
 
+<BLOCKQUOTE>
+As of this release, the minimum Houdini version supported by OpenVDB is now
+Houdini&nbsp;16.5.
+</BLOCKQUOTE>
+
 @par
 New features:
 - Added new @vdblink::QuatTraits QuatTraits@endlink,

--- a/openvdb_houdini/Makefile
+++ b/openvdb_houdini/Makefile
@@ -131,6 +131,11 @@ ifneq (,$(INSTALL_DIR))
     $(warning Warning: $$(INSTALL_DIR) is no longer used; set $$(DESTDIR) instead.)
 endif
 
+# Error if Houdini version is lower than minimum supported version
+ifeq (1,$(shell expr "$(HOUDINI_MAJOR_RELEASE).$(HOUDINI_MINOR_RELEASE)" "<" "16.5"))
+    $(error Error: Unsupported Houdini Version: $(HOUDINI_VERSION))
+endif
+
 # Determine the platform.
 ifeq ("$(OS)","Windows_NT")
     WINDOWS_NT := 1

--- a/openvdb_houdini/houdini/GEO_PrimVDB.cc
+++ b/openvdb_houdini/houdini/GEO_PrimVDB.cc
@@ -47,7 +47,8 @@
  */
 
 #include <UT/UT_Version.h>
-#if (UT_VERSION_INT < 0x0c050157) // earlier than 12.5.343
+
+#if defined(SESI_OPENVDB) || defined(SESI_OPENVDB_PRIM)
 
 #include "GEO_PrimVDB.h"
 
@@ -110,24 +111,6 @@ static const UT_StringHolder    theKWVertex = "vertex"_sh;
 static const UT_StringHolder    theKWVDB = "vdb"_sh;
 static const UT_StringHolder    theKWVDBVis = "vdbvis"_sh;
 
-#if (UT_VERSION_INT < 0x0c0100B6) // earlier than 12.1.182
-static bool
-geo_JVDBError(UT_JSONParser &p, const GA_Primitive *prim, const char *m)
-{
-    p.addFatal("Error loading %s: %s", prim->getTypeName(), m);
-    return false;
-}
-#endif
-
-#if (UT_VERSION_INT < 0x0c010048) // earlier than 12.1.72
-GA_IntrinsicManager::Registrar
-GEO_PrimVDB::registerIntrinsics(GA_PrimitiveDefinition &defn)
-{
-    ///defn.setMergeConstructor(&gaPrimitiveMergeConstructor);
-    return GEO_Primitive::registerIntrinsics(defn);
-}
-#endif
-
 
 GEO_PrimVDB::UniqueId
 GEO_PrimVDB::nextUniqueId()
@@ -146,79 +129,13 @@ GEO_PrimVDB::GEO_PrimVDB(GEO_Detail *d, GA_Offset offset)
     , myMetadataUniqueId(GEO_PrimVDB::nextUniqueId())
     , myTransformUniqueId(GEO_PrimVDB::nextUniqueId())
 {
-#if UT_VERSION_INT < 0x1000011F // earlier than 16.0.287
-    myVertex = allocateVertex();
-#else
-#if (UT_VERSION_INT < 0x10000162)
-    myVertex = GA_INVALID_OFFSET;
-#endif
-#endif
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    myStashedState = false;
-    if (d) d->addVolumeRef();
-#endif
 }
 
-#if UT_VERSION_INT < 0x1000011F // earlier than 16.0.287
-GEO_PrimVDB::GEO_PrimVDB(const GA_MergeMap &map, GA_Detail &detail,
-                         GA_Offset offset, const GEO_PrimVDB &src_prim)
-    : GEO_Primitive(static_cast<GEO_Detail *>(&detail), offset)
-    , myVis(src_prim.myVis)
-{
-    myUniqueId.exchange(src_prim.getUniqueId());
-
-    if (map.isIdentityMap(GA_ATTRIB_VERTEX))
-    {
-        myVertex = src_prim.myVertex;
-    }
-    else
-    {
-        GA_Offset sidx = src_prim.myVertex; // Get source index
-        myVertex = map.mapDestFromSource(GA_ATTRIB_VERTEX, sidx);
-    }
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    myStashedState = false;
-    static_cast<GEO_Detail &>(detail).addVolumeRef();
-#endif
-
-    copyGridFrom(src_prim); // makes a shallow copy
-}
-#endif
-
-#if (UT_VERSION_INT < 0x10000162)
-GEO_PrimVDB::~GEO_PrimVDB()
-{
-    if (GAisValid(myVertex))
-        destroyVertex(myVertex);
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    if (!myStashedState && getParent())
-        getParent()->delVolumeRef();
-#endif
-}
-#endif
-
-#if (UT_VERSION_INT < 0x10000162)
-void
-GEO_PrimVDB::clearForDeletion()
-{
-    myVertex = GA_INVALID_OFFSET;
-    GEO_Primitive::clearForDeletion();
-}
-#endif
-
-#if (UT_VERSION_INT >= 0x0d000000) // 13.0 or later
 void
 GEO_PrimVDB::stashed(bool beingstashed, GA_Offset offset)
 {
     // NB: Base class must be unstashed before we can call allocateVertex().
     GEO_Primitive::stashed(beingstashed, offset);
-#if UT_VERSION_INT < 0x1000011F // earlier than 16.0.287
-    myVertex = beingstashed ? GA_INVALID_OFFSET : allocateVertex();
-#else
-#if (UT_VERSION_INT < 0x10000162)
-    myVertex = GA_INVALID_OFFSET;
-#endif
-#endif
     if (!beingstashed)
     {
         // Reset to state as if freshly constructed
@@ -237,24 +154,7 @@ GEO_PrimVDB::stashed(bool beingstashed, GA_Offset offset)
         // as if freshly constructed when unstashing.
         myGridAccessor.clear();
     }
-#else
-void
-GEO_PrimVDB::stashed(int onoff, GA_Offset offset)
-{
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    if (getParent())
-    {
-        if (onoff)
-            getParent()->delVolumeRef();
-        else
-            getParent()->addVolumeRef();
-    }
-    myStashedState = (onoff != 0);
-#endif
-    // NB: Base class must be unstashed before we can call allocateVertex().
-    GEO_Primitive::stashed(onoff, offset);
-    myVertex = onoff ? GA_INVALID_OFFSET : allocateVertex();
-#endif
+
     // Set our internal state to default
     myVis = GEO_VolumeOptions(GEO_VOLUMEVIS_SMOKE, /*iso*/0.0, /*density*/1.0);
 }
@@ -1061,14 +961,6 @@ GEO_PrimVDB::countBaseMemory(UT_MemoryCounter &counter) const
         counter.countShared(size, refcount, ptr);
     }
 }
-
-#if (UT_VERSION_INT < 0x10000162)
-GA_Size
-GEO_PrimVDB::getVertexCount(void) const
-{
-    return 1;
-}
-#endif
 
 
 template <typename GridType>
@@ -2645,9 +2537,6 @@ public:
         return false;
     }
 
-    // Implement these methods to be the same as the H12.5 base class version.
-    // In H12.1, these methods were pure virtual.
-#if 1
     virtual bool
     saveField(const GA_Primitive *pr, int i, UT_JSONValue &val,
               const GA_SaveMap &map) const
@@ -2666,7 +2555,6 @@ public:
         p.stealErrors(*parser);
         return ok;
     }
-#endif
 
     virtual bool
     isEqual(int i, const GA_Primitive *p0, const GA_Primitive *p1) const
@@ -2976,11 +2864,7 @@ GEO_PrimVDB::isDegenerate() const
 // Methods to handle vertex attributes for the attribute dictionary
 //
 void
-#if (UT_VERSION_INT >= 0x0d000000)
 GEO_PrimVDB::copyPrimitive(const GEO_Primitive *psrc)
-#else
-GEO_PrimVDB::copyPrimitive(const GEO_Primitive *psrc, GEO_Point **ptredirect)
-#endif
 {
     if (psrc == this) return;
 
@@ -2992,57 +2876,10 @@ GEO_PrimVDB::copyPrimitive(const GEO_Primitive *psrc, GEO_Point **ptredirect)
     //       vertices, but we should do so across primitives as well.
     GA_VertexWrangler vertex_wrangler(*getParent(), *src->getParent());
 
-#if (UT_VERSION_INT >= 0x10000162)
     GEO_Primitive::copyPrimitive(psrc);
-#else
-    GA_Offset v = myVertex;
-    const GA_IndexMap &src_points = src->getParent()->getPointMap();
-    GA_Index ptind = src_points.indexFromOffset(src->vertexPoint(0));
-#if (UT_VERSION_INT >= 0x0d000000)
-    GA_Offset ptoff = getParent()->pointOffset(ptind);
-    wireVertex(v, ptoff);
-#else
-    GEO_Point *ppt = ptredirect[ptind];
-    wireVertex(v, ppt ? ppt->getMapOffset() : GA_INVALID_OFFSET);
-#endif
-    vertex_wrangler.copyAttributeValues(v, src->fastVertexOffset(0));
-#endif
 
     myVis = src->myVis;
 }
-
-#if (UT_VERSION_INT < 0x0d000000) // Deleted in 13.0
-#if (UT_VERSION_INT >= 0x0c050132) // 12.5.306 or later
-void
-GEO_PrimVDB::copyOffsetPrimitive(const GEO_Primitive *psrc, GA_Index basept)
-#else
-void
-GEO_PrimVDB::copyOffsetPrimitive(const GEO_Primitive *psrc, int basept)
-#endif
-{
-    if (psrc == this) return;
-
-    const GEO_PrimVDB   *src = (const GEO_PrimVDB *)psrc;
-    const GA_IndexMap   &points = getParent()->getPointMap();
-    const GA_IndexMap   &src_points = src->getParent()->getPointMap();
-    GA_Offset            ppt;
-
-    copyGridFrom(*src); // makes a shallow copy
-
-    // TODO: Well and good to reuse the attribute handle for all our
-    //       points/vertices, but we should do so across primitives
-    //       as well.
-    GA_VertexWrangler            vertex_wrangler(*getParent(),
-                                                 *src->getParent());
-
-    GA_Offset   v = fastVertexOffset(0);
-    ppt = points.offsetFromIndex(
-            src_points.indexFromOffset(src->vertexPoint(0)) + basept);
-    wireVertex(v, ppt);
-    vertex_wrangler.copyAttributeValues(v, src->fastVertexOffset(0));
-    myVis = src->myVis;
-}
-#endif
 
 static inline
 openvdb::math::Vec3d
@@ -3131,12 +2968,7 @@ GEO_PrimVDB::GridAccessor::setGridAdapter(
     if (myGrid.get() == &grid)
         return;
     setVertexPosition(grid.transform(), prim);
-#if OPENVDB_ABI_VERSION_NUMBER <= 3
     myGrid = grid.copyGrid(); // always shallow-copy the source grid
-#else
-    myGrid = openvdb::ConstPtrCast<openvdb::GridBase>(
-        grid.copyGrid()); // always shallow-copy the source grid
-#endif
     myStorageType = UTvdbGetGridType(*myGrid);
 }
 
@@ -3149,67 +2981,12 @@ GEO_PrimVDB::copy(int preserve_shared_pts) const
         return nullptr;
 
     GEO_PrimVDB* vdb = static_cast<GEO_PrimVDB*>(clone);
-#if (UT_VERSION_INT < 0x10000162)
-#if UT_VERSION_INT >= 0x1000011F // 16.0.287 or later
-    vdb->assignVertex(getDetail().appendVertex(), true);
-#endif
-#endif
 
     // Give the clone the same serial number as this primitive.
     vdb->myUniqueId.exchange(this->getUniqueId());
 
     // Give the clone a shallow copy of this primitive's grid.
     vdb->copyGridFrom(*this);
-
-#if (UT_VERSION_INT < 0x10000162)
-    // TODO: Well and good to reuse the attribute handle for all our
-    //       points/vertices, but we should do so across primitives
-    //       as well.
-    GA_ElementWranglerCache      wranglers(*getParent(),
-                                        GA_PointWrangler::INCLUDE_P);
-
-    int nvtx = getVertexCount();
-
-    if (preserve_shared_pts)
-    {
-        UT_SparseArray<GA_Offset *>     addedpoints;
-        GA_Offset                       *ppt_ptr;
-
-        for (int i = 0; i < nvtx; i++)
-        {
-            GA_Offset            src_ppt = vertexPoint(i);
-            GA_Offset            v  = vdb->fastVertexOffset(i);
-            GA_Offset            sv = fastVertexOffset(i);
-
-            GA_Offset ppt;
-            if (!(ppt_ptr = addedpoints(src_ppt)))
-            {
-                ppt = getParent()->appendPointOffset();
-                wranglers.getPoint().copyAttributeValues(ppt, src_ppt);
-                addedpoints.append(src_ppt, new GA_Offset(ppt));
-            }
-            else
-                ppt = *ppt_ptr;
-            vdb->wireVertex(v, ppt);
-            wranglers.getVertex().copyAttributeValues(v, sv);
-        }
-
-        int dummy_index;
-        for (int i = 0; i < addedpoints.entries(); i++)
-            delete (GA_Offset *)addedpoints.getRawEntry(i, dummy_index);
-    }
-    else
-    {
-        for (int i = 0; i < nvtx; i++)
-        {
-            GA_Offset   v = vdb->fastVertexOffset(i);
-            GA_Offset ppt = getParent()->appendPointOffset();
-            vdb->wireVertex(v, ppt);
-            wranglers.getPoint().copyAttributeValues(ppt, vertexPoint(i));
-            wranglers.getVertex().copyAttributeValues(v, fastVertexOffset(i));
-        }
-    }
-#endif
 
     vdb->myVis = myVis;
 
@@ -3223,23 +3000,7 @@ GEO_PrimVDB::copyUnwiredForMerge(const GA_Primitive *prim_src, const GA_MergeMap
 
     const GEO_PrimVDB* src = static_cast<const GEO_PrimVDB*>(prim_src);
 
-#if (UT_VERSION_INT >= 0x10000162)
     GEO_Primitive::copyUnwiredForMerge(prim_src, map);
-#else
-    if (GAisValid(myVertex))
-        destroyVertex(myVertex);
-
-    if (map.isIdentityMap(GA_ATTRIB_VERTEX))
-    {
-        myVertex = src->myVertex;
-    }
-    else
-    {
-        GA_Offset sidx = src->myVertex; // Get source index
-        // Map to dest
-        myVertex = map.mapDestFromSource(GA_ATTRIB_VERTEX, sidx);
-    }
-#endif
 
     copyGridFrom(*src); // makes a shallow copy
 
@@ -3249,7 +3010,6 @@ GEO_PrimVDB::copyUnwiredForMerge(const GA_Primitive *prim_src, const GA_MergeMap
 void
 GEO_PrimVDB::assignVertex(GA_Offset new_vtx, bool update_topology)
 {
-#if (UT_VERSION_INT >= 0x10000162)
     if (getVertexCount() == 1)
     {
         GA_Offset orig_vtx = getVertexOffset();
@@ -3265,29 +3025,7 @@ GEO_PrimVDB::assignVertex(GA_Offset new_vtx, bool update_topology)
     }
     if (update_topology)
         registerVertex(new_vtx);
-#else
-    if (myVertex != new_vtx)
-    {
-        if (GAisValid(myVertex))
-            destroyVertex(myVertex);
-        myVertex = new_vtx;
-        if (update_topology)
-            registerVertex(myVertex);
-    }
-#endif
 }
-
-#if (UT_VERSION_INT < 0x10000162)
-void
-GEO_PrimVDB::swapVertexOffsets(const GA_Defragment &defrag)
-{
-    GA_Offset   v = myVertex;
-    if (defrag.hasOffsetChanged(v))
-    {
-        myVertex = defrag.mapOffset(v);
-    }
-}
-#endif
 
 const char *
 GEO_PrimVDB::getGridName() const
@@ -3566,7 +3304,7 @@ GEO_PrimVDB::isIntrinsicMetadata(const char *name)
     return theMetaNames.contains(name);
 }
 
-#endif // UT_VERSION_INT < 0x0c050157 // earlier than 12.5.343
+#endif // SESI_OPENVDB || SESI_OPENVDB_PRIM
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the

--- a/openvdb_houdini/houdini/GEO_PrimVDB.cc
+++ b/openvdb_houdini/houdini/GEO_PrimVDB.cc
@@ -2968,7 +2968,8 @@ GEO_PrimVDB::GridAccessor::setGridAdapter(
     if (myGrid.get() == &grid)
         return;
     setVertexPosition(grid.transform(), prim);
-    myGrid = grid.copyGrid(); // always shallow-copy the source grid
+    myGrid = openvdb::ConstPtrCast<openvdb::GridBase>(
+        grid.copyGrid()); // always shallow-copy the source grid
     myStorageType = UTvdbGetGridType(*myGrid);
 }
 

--- a/openvdb_houdini/houdini/GEO_PrimVDB.h
+++ b/openvdb_houdini/houdini/GEO_PrimVDB.h
@@ -108,12 +108,7 @@ public:
     virtual int         getBBox(UT_BoundingBox *bbox) const;
     virtual void        reverse();
     virtual UT_Vector3  computeNormal() const;
-#if (UT_VERSION_INT >= 0x0d000000)
     virtual void        copyPrimitive(const GEO_Primitive *src);
-#else
-    virtual void        copyPrimitive(const GEO_Primitive *src,
-                                      GEO_Point **ptredirect);
-#endif
     virtual void        copyUnwiredForMerge(const GA_Primitive *src,
                                             const GA_MergeMap &map);
 

--- a/openvdb_houdini/houdini/GEO_PrimVDB.h
+++ b/openvdb_houdini/houdini/GEO_PrimVDB.h
@@ -47,7 +47,13 @@
  */
 
 #include <UT/UT_Version.h>
-#if !defined(SESI_OPENVDB) && (UT_VERSION_INT >= 0x0c050157) // 12.5.343 or later
+
+// Using the native OpenVDB Primitive shipped with Houdini is strongly recommended,
+// as there is no guarantee that this code will be kept in sync with Houdini.
+// However, for debugging it can be useful, so supply -DSESI_OPENVDB_PRIM to
+// the compiler to build this custom primitive.
+
+#if !defined(SESI_OPENVDB) && !defined(SESI_OPENVDB_PRIM)
 
 #include <GEO/GEO_PrimVDB.h>
 
@@ -56,21 +62,14 @@ using ::GEO_VolumeOptions;
 using ::GEO_PrimVDB;
 }
 
-#else // earlier than 12.5.343
+#else // SESI_OPENVDB || SESI_OPENVDB_PRIM
 
 #ifndef __HDK_GEO_PrimVDB__
 #define __HDK_GEO_PrimVDB__
 
-//#include "GEO_API.h"
-
 #include <GEO/GEO_Primitive.h>
 #include <GEO/GEO_Vertex.h>
-#if (UT_VERSION_INT < 0x0c010072) // earlier than 12.1.114
-#include <GEO/GEO_PrimVolume.h>
-#else
 #include <GEO/GEO_VolumeOptions.h>
-#endif
-
 #include <GA/GA_Defines.h>
 
 #include <SYS/SYS_AtomicInt.h> // for SYS_AtomicCounter
@@ -88,37 +87,6 @@ class   GEO_PrimVolume;
 class   GEO_PrimVolumeXform;
 class   UT_MemoryCounter;
 
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-struct OPENVDB_HOUDINI_API GEO_VolumeOptions
-{
-    GEO_VolumeOptions()
-    {
-    }
-    GEO_VolumeOptions(GEO_VolumeVis mode, fpreal iso, fpreal density)
-        : myMode(mode)
-        , myIso(iso)
-        , myDensity(density)
-    {
-    }
-    bool operator==(const GEO_VolumeOptions &v) const
-    {
-        OPENVDB_NO_FP_EQUALITY_WARNING_BEGIN
-        return (myMode == v.myMode
-                && myIso == v.myIso
-                && myDensity == v.myDensity);
-        OPENVDB_NO_FP_EQUALITY_WARNING_END
-    }
-    bool operator!=(const GEO_VolumeOptions &v) const
-    {
-        return !(*this == v);
-    }
-
-    GEO_VolumeVis           myMode;
-    fpreal                  myIso;
-    fpreal                  myDensity;
-};
-#endif
-
 
 class OPENVDB_HOUDINI_API GEO_PrimVDB : public GEO_Primitive
 {
@@ -129,19 +97,6 @@ protected:
     /// NOTE: The constructor should only be called from subclass
     ///       constructors.
     GEO_PrimVDB(GEO_Detail *d, GA_Offset offset = GA_INVALID_OFFSET);
-
-#if UT_VERSION_INT < 0x1000011F // earlier than 16.0.287
-    /// NOTE: The constructor should only be called from subclass
-    ///       constructors.
-    GEO_PrimVDB(const GA_MergeMap &map, GA_Detail &detail,
-                GA_Offset offset, const GEO_PrimVDB &src_prim);
-#endif
-
-#if (UT_VERSION_INT < 0x10000162)
-    /// NOTE: The destructor should only be called from subclass
-    ///       destructors.
-    virtual ~GEO_PrimVDB();
-#endif
 
 public:
     static GA_PrimitiveFamilyMask       buildFamilyMask()
@@ -161,37 +116,6 @@ public:
 #endif
     virtual void        copyUnwiredForMerge(const GA_Primitive *src,
                                             const GA_MergeMap &map);
-
-#if (UT_VERSION_INT < 0x10000162)
-    // Query the number of vertices in the array. This number may be smaller
-    // than the actual size of the array.
-    virtual GA_Size     getVertexCount() const;
-    virtual GA_Offset   getVertexOffset(GA_Size /*index*/) const
-                            { return myVertex; }
-#endif
-
-#if (UT_VERSION_INT >= 0x10000162)
-    using GEO_Primitive::getVertexOffset;
-    using GEO_Primitive::getPointOffset;
-    using GEO_Primitive::setPointOffset;
-    using GEO_Primitive::getPos3;
-    using GEO_Primitive::setPos3;
-    SYS_FORCE_INLINE
-    GA_Offset getVertexOffset() const
-    { return getVertexOffset(0); }
-    SYS_FORCE_INLINE
-    GA_Offset getPointOffset() const
-    { return getPointOffset(0); }
-    SYS_FORCE_INLINE
-    void setPointOffset(GA_Offset pt)
-    { setPointOffset(0, pt); }
-    SYS_FORCE_INLINE
-    UT_Vector3 getPos3() const
-    { return getPos3(0); }
-    SYS_FORCE_INLINE
-    void setPos3(const UT_Vector3 &pos)
-    { setPos3(0, pos); }
-#endif
 
     /// Convert an index in the voxel array into the corresponding worldspace
     /// location
@@ -282,11 +206,6 @@ public:
     /// This method assigns a preallocated vertex to the quadric, optionally
     /// creating the topological link between the primitive and new vertex.
     void                 assignVertex(GA_Offset new_vtx, bool update_topology);
-
-#if (UT_VERSION_INT < 0x10000162)
-    /// Defragmentation
-    virtual void        swapVertexOffsets(const GA_Defragment &defrag);
-#endif
 
     /// Evalaute a point given a u,v coordinate (with derivatives)
     virtual bool        evaluatePointRefMap(GA_Offset result_vtx,
@@ -393,22 +312,8 @@ public:
     virtual GEO_Primitive       *copy(int preserve_shared_pts = 0) const;
 
     // Have we been deactivated and stashed?
-#if (UT_VERSION_INT >= 0x0d000000) // 13.0 or later
     virtual void        stashed(bool beingstashed, GA_Offset offset=GA_INVALID_OFFSET);
-#else
-    virtual void        stashed(int onoff, GA_Offset offset=GA_INVALID_OFFSET);
-#endif
 
-#if (UT_VERSION_INT < 0x10000162)
-    // We need to invalidate the vertex offsets
-    virtual void        clearForDeletion();
-#endif
-
-#if (UT_VERSION_INT < 0x0c050132) // Before 12.5.306
-    virtual void        copyOffsetPrimitive(const GEO_Primitive *src, int base);
-#elif (UT_VERSION_INT < 0x0d000000) // Before 13.0, when the function was deleted
-    virtual void        copyOffsetPrimitive(const GEO_Primitive *src, GA_Index base);
-#endif
     /// @}
 
     /// @{
@@ -490,21 +395,13 @@ public:
     GA_Offset           fastVertexOffset(GA_Size UT_IF_ASSERT_P(index)) const
                         {
                             UT_ASSERT_P(index < 1);
-#if (UT_VERSION_INT >= 0x10000162)
                             return getVertexOffset();
-#else
-                            return myVertex;
-#endif
                         }
 
     void        setVertexPoint(int i, GA_Offset pt)
                 {
                     if (i == 0)
-#if (UT_VERSION_INT >= 0x10000162)
                         setPointOffset(pt);
-#else
-                        wireVertex(myVertex, pt);
-#endif
                 }
 
     /// @brief Computes the total density of the volume, scaled by
@@ -612,23 +509,14 @@ protected:
     typedef SYS_AtomicCounter AtomicUniqueId; // 64-bit
 
     /// Register intrinsic attributes
-#if (UT_VERSION_INT >= 0x0c010048) // 12.1.72 or later
     GA_DECLARE_INTRINSICS(GA_NO_OVERRIDE)
-#else
-    static GA_IntrinsicManager::Registrar
-                        registerIntrinsics(GA_PrimitiveDefinition &defn);
-#endif
 
     /// Return true if the given metadata token is an intrinsic
     static bool         isIntrinsicMetadata(const char *name);
 
     /// @warning vertexPoint() doesn't check the bounds.  Use with caution.
     GA_Offset           vertexPoint(GA_Size) const
-#if (UT_VERSION_INT >= 0x10000162)
     { return getPointOffset(); }
-#else
-    { return getDetail().vertexPoint(myVertex); }
-#endif
 
     /// Report approximate memory usage, excluding sizeof(*this),
     /// because the subclass doesn't have access to myGridAccessor.
@@ -658,10 +546,6 @@ protected:
     /// @brief Replace this primitive's grid with a shallow copy
     /// of another primitive's grid.
     void                copyGridFrom(const GEO_PrimVDB&);
-
-#if (UT_VERSION_INT < 0x10000162) // earlier than 16.0.354
-    GA_Offset myVertex;
-#endif
 
     /// @brief GridAccessor manages access to a GEO_PrimVDB's grid.
     /// @details In keeping with OpenVDB library conventions, the grid
@@ -744,10 +628,6 @@ private:
     GridAccessor            myGridAccessor;
 
     GEO_VolumeOptions       myVis;
-
-#if (UT_VERSION_INT < 0x0c050000) // earlier than 12.5.0
-    bool                    myStashedState;
-#endif
 
     AtomicUniqueId          myUniqueId;
     AtomicUniqueId          myTreeUniqueId;
@@ -903,7 +783,7 @@ inline bool GEOvdbProcessTypedGridPoint(GEO_PrimVDB &vdb, OpT &op, bool makeUniq
 
 #endif // __HDK_GEO_PrimVDB__
 
-#endif // UT_VERSION_INT < 0x0c050157 // earlier than 12.5.343
+#endif // SESI_OPENVDB || SESI_OPENVDB_PRIM
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the

--- a/openvdb_houdini/houdini/GEO_PrimVDB.h
+++ b/openvdb_houdini/houdini/GEO_PrimVDB.h
@@ -112,6 +112,27 @@ public:
     virtual void        copyUnwiredForMerge(const GA_Primitive *src,
                                             const GA_MergeMap &map);
 
+    using GEO_Primitive::getVertexOffset;
+    using GEO_Primitive::getPointOffset;
+    using GEO_Primitive::setPointOffset;
+    using GEO_Primitive::getPos3;
+    using GEO_Primitive::setPos3;
+    SYS_FORCE_INLINE
+    GA_Offset getVertexOffset() const
+    { return getVertexOffset(0); }
+    SYS_FORCE_INLINE
+    GA_Offset getPointOffset() const
+    { return getPointOffset(0); }
+    SYS_FORCE_INLINE
+    void setPointOffset(GA_Offset pt)
+    { setPointOffset(0, pt); }
+    SYS_FORCE_INLINE
+    UT_Vector3 getPos3() const
+    { return getPos3(0); }
+    SYS_FORCE_INLINE
+    void setPos3(const UT_Vector3 &pos)
+    { setPos3(0, pos); }
+
     /// Convert an index in the voxel array into the corresponding worldspace
     /// location
     void                indexToPos(int x, int y, int z, UT_Vector3 &pos) const;

--- a/openvdb_houdini/houdini/GEO_VDBTranslator.cc
+++ b/openvdb_houdini/houdini/GEO_VDBTranslator.cc
@@ -62,21 +62,15 @@
 #include <UT/UT_DSOVersion.h>
 #endif
 
-#if (UT_VERSION_INT >= 0x0d00023d) // 13.0.573 or later
 #include <UT/UT_EnvControl.h>
-#endif
-
 #include <UT/UT_Error.h>
 #include <UT/UT_ErrorManager.h>
 #include <UT/UT_IOTable.h>
 #include <UT/UT_IStream.h>
 #include <UT/UT_Version.h>
 
-#if (UT_VERSION_INT >= 0x10000000) // 16.0.0 or later
 #include <FS/FS_IStreamDevice.h>
 #include <GA/GA_Stat.h>
-#endif
-
 #include <GU/GU_Detail.h>
 #include <SOP/SOP_Node.h>
 #include <GEO/GEO_IOTranslator.h>
@@ -108,20 +102,13 @@ public:
 
     virtual int         checkMagicNumber(unsigned magic);
 
-#if (UT_VERSION_INT >= 0x10000000) // 16.0.0 or later
     virtual bool        fileStat(const char *filename,
                                 GA_Stat &stat,
                                 uint level);
-#endif
 
     virtual GA_Detail::IOStatus fileLoad(GEO_Detail *gdp, UT_IStream &is, bool ate_magic);
     virtual GA_Detail::IOStatus fileSave(const GEO_Detail *gdp, std::ostream &os);
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
     virtual GA_Detail::IOStatus fileSaveToFile(const GEO_Detail *gdp, const char *fname);
-#else
-    virtual GA_Detail::IOStatus fileSaveToFile(const GEO_Detail *gdp, std::ostream &os,
-                                               const char *fname);
-#endif
 };
 
 GEO_IOTranslator *
@@ -155,7 +142,6 @@ GEO_VDBTranslator::checkMagicNumber(unsigned /*magic*/)
     return 0;
 }
 
-#if (UT_VERSION_INT >= 0x10000000) // 16.0.0 or later
 bool
 GEO_VDBTranslator::fileStat(const char *filename, GA_Stat &stat, uint /*level*/)
 {
@@ -239,10 +225,6 @@ GEO_VDBTranslator::fileStat(const char *filename, GA_Stat &stat, uint /*level*/)
 
     return true;
 }
-#endif
-
-
-#if (UT_VERSION_INT >= 0x10000000) // 16.0.0 or later
 
 GA_Detail::IOStatus
 GEO_VDBTranslator::fileLoad(GEO_Detail *geogdp, UT_IStream &is, bool /*ate_magic*/)
@@ -288,84 +270,6 @@ GEO_VDBTranslator::fileLoad(GEO_Detail *geogdp, UT_IStream &is, bool /*ate_magic
     return ok;
 }
 
-#else
-
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
-GA_Detail::IOStatus
-GEO_VDBTranslator::fileLoad(GEO_Detail *geogdp, UT_IStream &is, bool /*ate_magic*/)
-#else
-GA_Detail::IOStatus
-GEO_VDBTranslator::fileLoad(GEO_Detail *geogdp, UT_IStream &is, int /*ate_magic*/)
-#endif
-{
-    UT_WorkBuffer   buf;
-    GU_Detail       *gdp = static_cast<GU_Detail*>(geogdp);
-
-    if (!is.isRandomAccessFile(buf)) {
-        cerr << "Error: Attempt to load VDB from non-file source.\n";
-        return false;
-    }
-
-    try {
-        // Create and open a VDB file, but don't read any grids yet.
-        openvdb::io::File file(buf.buffer());
-
-        file.open(/*delayLoad*/false);
-
-        // Read the file-level metadata into global attributes.
-        openvdb::MetaMap::Ptr fileMetadata = file.getMetadata();
-#if !defined(SESI_OPENVDB) && (UT_VERSION_INT >= 0x0c050157)
-        if (!fileMetadata) fileMetadata.reset(new openvdb::MetaMap);
-#else
-        if (fileMetadata) {
-            GU_PrimVDB::createAttrsFromMetadata(
-                GA_ATTRIB_GLOBAL, GA_Offset(0), *fileMetadata, *geogdp);
-        }
-#endif
-
-        // Loop over all grids in the file.
-        for (openvdb::io::File::NameIterator nameIter = file.beginName();
-            nameIter != file.endName(); ++nameIter)
-        {
-            const std::string& gridName = nameIter.gridName();
-
-            if (GridPtr grid = file.readGrid(gridName)) {
-
-#if !defined(SESI_OPENVDB) && (UT_VERSION_INT >= 0x0c050157)
-                // Copy file-level metadata into the grid, then create (if
-                // necessary)
-                // and set a primitive attribute for each metadata item.
-                for (openvdb::MetaMap::ConstMetaIterator fileMetaIt = fileMetadata->beginMeta(),
-                    end = fileMetadata->endMeta(); fileMetaIt != end; ++fileMetaIt)
-                {
-                    // Resolve file- and grid-level metadata name conflicts
-                    // in favor of the grid-level metadata.
-                    if (openvdb::Metadata::Ptr meta = fileMetaIt->second) {
-                        const std::string name = fileMetaIt->first;
-                        if (!(*grid)[name]) {
-                            grid->insertMeta(name, *meta);
-                        }
-                    }
-                }
-#endif
-                // Add a new VDB primitive for this grid.
-                // Note: this clears the grid's metadata.
-                createVdbPrimitive(*gdp, grid);
-            }
-        }
-        file.close();
-
-    } catch (std::exception &e) {
-        cerr << "Load failure: " << e.what() << "\n";
-        return false;
-    }
-
-    return true;
-}
-
-#endif // 16.0.0
-
-
 template <typename FileT, typename OutputT>
 bool
 fileSaveVDB(const GEO_Detail *geogdp, OutputT os)
@@ -401,7 +305,7 @@ fileSaveVDB(const GEO_Detail *geogdp, OutputT os)
 
         fileMetadata.insertMeta("creator", openvdb::StringMetadata(versionStr));
 
-#if defined(SESI_OPENVDB) || (UT_VERSION_INT < 0x0c050157)
+#if defined(SESI_OPENVDB)
         GU_PrimVDB::createMetadataFromAttrs(
             fileMetadata, GA_ATTRIB_GLOBAL, GA_Offset(0), *gdp);
 #endif
@@ -412,13 +316,11 @@ fileSaveVDB(const GEO_Detail *geogdp, OutputT os)
         // and compresses level sets and fog volumes well.
         uint32_t compression = openvdb::io::COMPRESS_ACTIVE_MASK;
 
-#if (UT_VERSION_INT >= 0x0d00023d) // 13.0.573 or later
         // Enable Blosc unless backwards compatibility is requested.
         if (openvdb::io::Archive::hasBloscCompression()
             && !UT_EnvControl::getInt(ENV_HOUDINI13_VOLUME_COMPATIBILITY)) {
             compression |= openvdb::io::COMPRESS_BLOSC;
         }
-#endif
         file.setCompression(compression);
 
         file.write(outGrids, fileMetadata);
@@ -439,14 +341,8 @@ GEO_VDBTranslator::fileSave(const GEO_Detail *geogdp, std::ostream &os)
     return fileSaveVDB<openvdb::io::Stream, std::ostream &>(geogdp, os);
 }
 
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
 GA_Detail::IOStatus
 GEO_VDBTranslator::fileSaveToFile(const GEO_Detail *geogdp, const char *fname)
-#else
-GA_Detail::IOStatus
-GEO_VDBTranslator::fileSaveToFile(const GEO_Detail *geogdp, std::ostream &,
-    const char *fname)
-#endif
 {
     // Saving via io::File will save grid offsets that allow for partial
     // reading.

--- a/openvdb_houdini/houdini/GR_PrimVDBPoints.cc
+++ b/openvdb_houdini/houdini/GR_PrimVDBPoints.cc
@@ -1104,13 +1104,6 @@ GR_PrimVDBPoints::renderDecoration(RE_Render* r, GR_Decoration decor, const GR_D
         const UT_Vector3F positionOffset(mCentroid.x(), mCentroid.y(), mCentroid.z());
         (*shader)->bindVector(r, "offset", positionOffset);
 
-        // Assumes some uniform builtins are already bound. These can be bound with
-        // r->bindBuiltInUniform() and queried with r->printBuiltInUniforms(/*bound_only=*/true)
-        //
-        //  RE_UNIFORM_WIRE_COLOR = glH_WireColor
-        //  RE_UNIFORM_DECORATION_SCALE = glH_DecorationScale
-        //
-
         r->pushUniformColor(RE_UNIFORM_WIRE_COLOR, color);
         r->pushUniformData(RE_UNIFORM_DECORATION_SCALE, &scale);
 

--- a/openvdb_houdini/houdini/GR_PrimVDBPoints.cc
+++ b/openvdb_houdini/houdini/GR_PrimVDBPoints.cc
@@ -35,7 +35,6 @@
 /// @brief GR Render Hook and Primitive for VDB PointDataGrid
 
 #include <UT/UT_Version.h>
-#if (UT_VERSION_INT >= 0x0d000000) // 13.0.0 or later
 
 #include <openvdb/Grid.h>
 #include <openvdb/Platform.h>
@@ -44,14 +43,6 @@
 #include <openvdb/points/PointCount.h>
 #include <openvdb/points/PointConversion.h>
 #include <openvdb_houdini/PointUtils.h>
-
-#if (UT_VERSION_INT < 0x0f000000) // earlier than 15.0.0
-#if defined(__APPLE__) || defined(MACOSX)
-#include <GLUT/glut.h>
-#else
-#include <GL/glx.h>
-#endif
-#endif
 
 #include <DM/DM_RenderTable.h>
 #include <GEO/GEO_PrimVDB.h>
@@ -65,6 +56,7 @@
 #include <RE/RE_ShaderHandle.h>
 #include <RE/RE_VertexArray.h>
 #include <UT/UT_DSOVersion.h>
+#include <UT/UT_UniquePtr.h>
 
 #include <tbb/mutex.h>
 
@@ -75,14 +67,6 @@
 #include <utility>
 #include <vector>
 
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-#include <UT/UT_UniquePtr.h>
-#else
-#include <memory>
-template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
-
-
 ////////////////////////////////////////
 
 static RE_ShaderHandle theMarkerDecorShader("decor/GL32/point_marker.prog");
@@ -90,11 +74,7 @@ static RE_ShaderHandle theNormalDecorShader("decor/GL32/point_normal.prog");
 static RE_ShaderHandle theVelocityDecorShader("decor/GL32/user_point_vector3.prog");
 static RE_ShaderHandle theLineShader("basic/GL32/wire_color.prog");
 static RE_ShaderHandle thePixelShader("particle/GL32/pixel.prog");
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
 static RE_ShaderHandle thePointShader("particle/GL32/point.prog");
-#else
-static RE_ShaderHandle thePointShader("basic/GL32/const_color.prog");
-#endif
 
 /// @note  An additional scale for velocity trails to accurately match
 ///        the visualization of velocity for Houdini points
@@ -170,24 +150,12 @@ public:
     /// than one time per viewport redraw (beauty, shadow passes, wireframe-over)
     /// It also may be called outside of a viewport redraw to do picking of the
     /// geometry.
-#if (UT_VERSION_INT >= 0x10000000) // 16.0.0 or later
     void render(RE_Render*, GR_RenderMode, GR_RenderFlags, GR_DrawParms) override;
-#else
-    void render(RE_Render*, GR_RenderMode, GR_RenderFlags,
-        const GR_DisplayOption*, const RE_MaterialList*) override;
-#endif
-
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
-#if (UT_VERSION_INT < 0x10000000) // earlier than 16.0.0
-    void renderInstances(RE_Render*, GR_RenderMode, GR_RenderFlags,
-        const GR_DisplayOption*, const RE_MaterialList*, int) override {}
-#endif
 
     int renderPick(RE_Render*, const GR_DisplayOption*, unsigned int,
         GR_PickStyle, bool) override { return 0; }
 
     void renderDecoration(RE_Render*, GR_Decoration, const GR_DecorationParms&) override;
-#endif
 
 protected:
     void computeCentroid(const openvdb::points::PointDataGrid& grid);
@@ -227,11 +195,7 @@ private:
 
 
 void
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
 newRenderHook(DM_RenderTable* table)
-#else
-newRenderHook(GR_RenderTable* table)
-#endif
 {
     tbb::mutex::scoped_lock lock(sRenderHookRegistryMutex);
 
@@ -259,11 +223,7 @@ grIsPointDataGrid(const GT_PrimitiveHandle& gt_prim)
     const GT_PrimVDB* gt_vdb = static_cast<const GT_PrimVDB*>(gt_prim.get());
     const GEO_PrimVDB* gr_vdb = gt_vdb->getGeoPrimitive();
 
-#if (UT_VERSION_INT >= 0x10000258) // 16.0.600 or later
     return (gr_vdb->getStorageType() == UT_VDB_POINTDATA);
-#else
-    return (gr_vdb->getGrid().isType<openvdb::points::PointDataGrid>());
-#endif
 }
 
 
@@ -643,11 +603,7 @@ GR_PrimVDBPoints::updatePosBuffer(RE_Render* r,
 
     // fetch point position attribute, if its cache version matches, no upload is required.
 
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
     RE_VertexArray* posGeo = myGeo->findCachedAttrib(r, "P", RE_GPU_FLOAT32, 3, RE_ARRAY_POINT, true);
-#else
-    RE_VertexArray* posGeo = myGeo->findCachedAttribOrArray(r, "P", RE_GPU_FLOAT32, 3, RE_ARRAY_POINT, true);
-#endif
 
     if (posGeo->getCacheVersion() != version)
     {
@@ -692,11 +648,7 @@ GR_PrimVDBPoints::updatePosBuffer(RE_Render* r,
 
     RE_PrimType primType = RE_PRIM_POINTS;
 
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
     myGeo->connectAllPrims(r, RE_GEO_WIRE_IDX, primType, nullptr, true);
-#else
-    myGeo->connectAllPrimsI(r, RE_GEO_WIRE_IDX, primType, nullptr, true);
-#endif
 }
 
 void
@@ -733,11 +685,7 @@ GR_PrimVDBPoints::updateWireBuffer(RE_Render *r,
 
     // fetch wireframe position, if its cache version matches, no upload is required.
 
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
     RE_VertexArray* posWire = myWire->findCachedAttrib(r, "P", RE_GPU_FLOAT16, 3, RE_ARRAY_POINT, true);
-#else
-    RE_VertexArray* posWire = myWire->findCachedAttribOrArray(r, "P", RE_GPU_FLOAT16, 3, RE_ARRAY_POINT, true);
-#endif
 
     if (posWire->getCacheVersion() != version)
     {
@@ -783,11 +731,7 @@ GR_PrimVDBPoints::updateWireBuffer(RE_Render *r,
                     instance.data());
     }
 
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
     myWire->connectAllPrims(r, RE_GEO_WIRE_IDX, RE_PRIM_LINES, nullptr, true);
-#else
-    myWire->connectAllPrimsI(r, RE_GEO_WIRE_IDX, RE_PRIM_LINES, nullptr, true);
-#endif
 }
 
 void
@@ -869,11 +813,7 @@ GR_PrimVDBPoints::updateVec3Buffer(RE_Render* r,
 
     // fetch vector attribute, if its cache version matches, no upload is required.
 
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
     RE_VertexArray* bufferGeo = myGeo->findCachedAttrib(r, bufferName.c_str(), RE_GPU_FLOAT16, 3, RE_ARRAY_POINT, true);
-#else
-    RE_VertexArray* bufferGeo = myGeo->findCachedAttribOrArray(r, bufferName.c_str(), RE_GPU_FLOAT16, 3, RE_ARRAY_POINT, true);
-#endif
 
     if (bufferGeo->getCacheVersion() != version)
     {
@@ -935,14 +875,8 @@ GR_PrimVDBPoints::removeBuffer(const std::string& name)
     myGeo->clearAttribute(name.c_str());
 }
 
-#if (UT_VERSION_INT >= 0x10000000) // 16.0.0 or later
 void
 GR_PrimVDBPoints::render(RE_Render *r, GR_RenderMode, GR_RenderFlags, GR_DrawParms dp)
-#else
-void
-GR_PrimVDBPoints::render(RE_Render *r, GR_RenderMode, GR_RenderFlags,
-    const GR_DisplayOption* dopts, const RE_MaterialList*)
-#endif
 {
     if (!myGeo && !myWire)  return;
 
@@ -950,11 +884,7 @@ GR_PrimVDBPoints::render(RE_Render *r, GR_RenderMode, GR_RenderFlags,
 
     if (!gl3)   return;
 
-#if (UT_VERSION_INT >= 0x10000000) // 16.0.0 or later
     const GR_CommonDispOption& commonOpts = dp.opts->common();
-#else
-    const GR_CommonDispOption& commonOpts = dopts->common();
-#endif
 
     // draw points
 
@@ -1018,7 +948,6 @@ GR_PrimVDBPoints::render(RE_Render *r, GR_RenderMode, GR_RenderFlags,
 }
 
 
-#if (UT_VERSION_INT >= 0x0e000000) // 14.0.0 or later
 void
 GR_PrimVDBPoints::renderDecoration(RE_Render* r, GR_Decoration decor, const GR_DecorationParms& p)
 {
@@ -1124,13 +1053,7 @@ GR_PrimVDBPoints::renderDecoration(RE_Render* r, GR_Decoration decor, const GR_D
         GR_Primitive::renderDecoration(r, decor, p);
     }
 }
-#endif
 
-
-////////////////////////////////////////
-
-
-#endif // 13.0.0 or later
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the

--- a/openvdb_houdini/houdini/GT_GEOPrimCollectVDB.cc
+++ b/openvdb_houdini/houdini/GT_GEOPrimCollectVDB.cc
@@ -102,7 +102,6 @@ public:
     appendBox(openvdb::Vec3s corners[NPTS])
     {
         myVertexCounts.append(NPTS * 2);
-#if (UT_VERSION_INT >= 0x0c0002bf) // 12.0.703 or later
         myPos->append(corners[0].asPointer()); // 0
         myPos->append(corners[1].asPointer()); // 1
         myPos->append(corners[2].asPointer()); // 2
@@ -119,26 +118,6 @@ public:
         myPos->append(corners[6].asPointer()); // 13
         myPos->append(corners[7].asPointer()); // 14
         myPos->append(corners[3].asPointer()); // 15
-#else
-        GT_Size offset = myPos->entries();
-        myPos->resize(offset + 16);
-        myPos->setTuple(corners[0].asPointer(), offset++); // 0
-        myPos->setTuple(corners[1].asPointer(), offset++); // 1
-        myPos->setTuple(corners[2].asPointer(), offset++); // 2
-        myPos->setTuple(corners[3].asPointer(), offset++); // 3
-        myPos->setTuple(corners[0].asPointer(), offset++); // 4
-        myPos->setTuple(corners[4].asPointer(), offset++); // 5
-        myPos->setTuple(corners[5].asPointer(), offset++); // 6
-        myPos->setTuple(corners[6].asPointer(), offset++); // 7
-        myPos->setTuple(corners[7].asPointer(), offset++); // 8
-        myPos->setTuple(corners[4].asPointer(), offset++); // 9
-        myPos->setTuple(corners[5].asPointer(), offset++); // 10
-        myPos->setTuple(corners[1].asPointer(), offset++); // 11
-        myPos->setTuple(corners[2].asPointer(), offset++); // 12
-        myPos->setTuple(corners[6].asPointer(), offset++); // 13
-        myPos->setTuple(corners[7].asPointer(), offset++); // 14
-        myPos->setTuple(corners[3].asPointer(), offset++); // 15
-#endif
     }
 
     template <typename GridT>
@@ -203,16 +182,9 @@ public:
 
             for (int i = 0; i < NPTS; i += 2)
             {
-#if (UT_VERSION_INT >= 0x0c0002bf) // 12.0.703 or later
                 myVertexCounts.append(2);
                 myPos->append(lines[i].asPointer());
                 myPos->append(lines[i+1].asPointer());
-#else
-                GT_Size offset = myPos->entries();
-                myPos->resize(offset + 2);
-                myPos->setTuple(lines[i].asPointer(), offset++);
-                myPos->setTuple(lines[i+1].asPointer(), offset++);
-#endif
             }
         }
     }
@@ -234,14 +206,7 @@ public:
     void
     join(const gt_RefineVDB &task)
     {
-#if (UT_VERSION_INT >= 0x0c0002bf) // 12.0.703 or later
         myPos->concat(*task.myPos);
-#else
-        myPos->resize(myPos->entries() + task.myPos->entries());
-        memcpy(myPos->data() + myPos->entries()*myPos->getTupleSize(),
-            task.myPos->data(),
-            task.myPos->entries()*task.myPos->getTupleSize()*sizeof(fpreal32));
-#endif
         myVertexCounts.concat(task.myVertexCounts);
     }
 
@@ -296,13 +261,9 @@ GT_GEOPrimCollectVDB::endCollecting(
     if (!prims.entries())
         return GT_PrimitiveHandle();
 
-#if (UT_VERSION_INT >= 0x0f000000) // 15.0 or later
     GU_DetailHandleAutoReadLock gdl(g->getGeometry(0));
     const GU_Detail* detail = gdl.getGdp();
     gt_RefineVDB task(*detail, prims);
-#else
-    gt_RefineVDB task(g->getGeometry(0), prims);
-#endif
 
     UTparallelReduce(UT_BlockedRange<exint>(0, prims.entries()), task);
 

--- a/openvdb_houdini/houdini/GeometryUtil.cc
+++ b/openvdb_houdini/houdini/GeometryUtil.cc
@@ -47,6 +47,7 @@
 #include <UT/UT_BoundingBox.h>
 #include <UT/UT_String.h>
 #include <UT/UT_Version.h>
+#include <UT/UT_UniquePtr.h>
 
 #include <cmath>
 #include <stdexcept>

--- a/openvdb_houdini/houdini/GeometryUtil.cc
+++ b/openvdb_houdini/houdini/GeometryUtil.cc
@@ -52,13 +52,6 @@
 #include <stdexcept>
 #include <vector>
 
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-#include <UT/UT_UniquePtr.h>
-#else
-#include <memory>
-template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
-
 
 namespace openvdb_houdini {
 
@@ -511,19 +504,10 @@ PrimCpyOp::operator()(const GA_SplittableRange &r) const
 
                 if (primRef->getTypeId() == GEO_PRIMPOLY && (3 == vtxn || 4 == vtxn)) {
 
-#if UT_MAJOR_VERSION_INT >= 16
                     for (int vtx = 0; vtx < int(vtxn); ++vtx) {
                         prim[vtx] = static_cast<openvdb::Vec4I::ValueType>(
                             primRef->getPointIndex(vtx));
                     }
-#else
-                    GA_Primitive::const_iterator vit;
-                    primRef->beginVertex(vit);
-                    for (int vtx = 0; !vit.atEnd(); ++vit, ++vtx) {
-                        prim[vtx] = static_cast<openvdb::Vec4I::ValueType>(
-                            mGdp->pointIndex(vit.getPointOffset()));
-                    }
-#endif
 
                     if (vtxn != 4) prim[3] = openvdb::util::INVALID_IDX;
 
@@ -576,7 +560,6 @@ VertexNormalOp::operator()(const GA_SplittableRange& range) const
                 primN = mDetail.getGEOPrimitive(i)->computeNormal();
                 interiorPrim = isInteriorPrim(i);
 
-#if UT_MAJOR_VERSION_INT >= 16
                 for (GA_Size vtx = 0, vtxN = primRef->getVertexCount(); vtx < vtxN; ++vtx) {
                     avgN = primN;
                     const GA_Offset vtxoff = primRef->getVertexOffset(vtx);
@@ -592,23 +575,6 @@ VertexNormalOp::operator()(const GA_SplittableRange& range) const
                     avgN.normalize();
                     mNormalHandle.set(vtxoff, avgN);
                 }
-#else
-                GA_Primitive::const_iterator it;
-                for (primRef->beginVertex(it); !it.atEnd(); ++it) {
-                    avgN = primN;
-                    GA_Offset vtxOffset = mDetail.pointVertex(it.getPointOffset());
-                    while (GAisValid(vtxOffset)) {
-                        primOffset = mDetail.vertexPrimitive(vtxOffset);
-                        if (interiorPrim == isInteriorPrim(primOffset)) {
-                            tmpN = mDetail.getGEOPrimitive(primOffset)->computeNormal();
-                            if (tmpN.dot(primN) > mAngle) avgN += tmpN;
-                        }
-                        vtxOffset = mDetail.vertexToNextVertex(vtxOffset);
-                    }
-                    avgN.normalize();
-                    mNormalHandle.set(*it, avgN);
-                } // prim vtx iteration.
-#endif
             }
         }
     }

--- a/openvdb_houdini/houdini/GeometryUtil.h
+++ b/openvdb_houdini/houdini/GeometryUtil.h
@@ -296,66 +296,6 @@ GenAdaptivityMaskOp<IndexTreeType, BoolTreeType>::operator()(
 ////////////////////////////////////////
 
 
-#if (UT_VERSION_INT < 0x0c0500F5) // Prior to 12.5.245
-
-// Symbols in namespace GU_Convert_H12_5 were added to GU_ConvertParms.h in 12.5.245
-
-namespace GU_Convert_H12_5 {
-
-/// Simple helper class for tracking a range of new primitives and points
-class GU_ConvertMarker
-{
-public:
-    GU_ConvertMarker(const GA_Detail &geo)
-        : myGeo(geo)
-        , myPrimBegin(primOff())
-        , myPtBegin(ptOff())
-    {
-    }
-
-    GA_Range getPrimitives() const
-    {
-        return GA_Range(myGeo.getPrimitiveMap(), myPrimBegin, primOff());
-    }
-    GA_Range getPoints() const
-    {
-        return GA_Range(myGeo.getPointMap(), myPtBegin, ptOff());
-    }
-
-    GA_Offset primitiveBegin() const { return myPrimBegin; }
-    GA_Offset pointBegin() const { return myPtBegin; }
-
-    GA_Size numPrimitives() const { return primOff() - myPrimBegin; }
-    GA_Size numPoints() const { return ptOff() - myPtBegin; }
-
-private:
-    GA_Offset primOff() const { return myGeo.getPrimitiveMap().lastOffset() + 1; }
-    GA_Offset ptOff() const { return myGeo.getPointMap().lastOffset() + 1; }
-
-private:
-    const GA_Detail& myGeo;
-    GA_Offset myPrimBegin;
-    GA_Offset myPtBegin;
-};
-
-
-OPENVDB_HOUDINI_API
-void
-GUconvertCopySingleVertexPrimAttribsAndGroups(
-    GU_ConvertParms &parms,
-    const GA_Detail &src,
-    GA_Offset src_primoff,
-    GA_Detail &dst,
-    const GA_Range &dst_prims,
-    const GA_Range &dst_points);
-
-} // namespace GU_Convert_H12_5
-
-using GU_Convert_H12_5::GU_ConvertMarker;
-using GU_Convert_H12_5::GUconvertCopySingleVertexPrimAttribsAndGroups;
-
-#endif // Prior to 12.5.245
-
 #endif // OPENVDB_HOUDINI_GEOMETRY_UTIL_HAS_BEEN_INCLUDED
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC

--- a/openvdb_houdini/houdini/OP_NodeChain.h
+++ b/openvdb_houdini/houdini/OP_NodeChain.h
@@ -47,7 +47,6 @@
 #include <SYS/SYS_Types.h> // for fpreal
 #include <UT/UT_String.h>
 #include <UT/UT_Thread.h>
-#include <UT/UT_Version.h> // for UT_VERSION_INT
 #include <algorithm>
 #include <string>
 #include <vector>
@@ -79,25 +78,15 @@ getNodeChain(OP_Context& context, NodeType* startNode, bool addInterest = true)
         /// Return the nearest upstream node to the given node, traversing
         /// only input 0 connections and omitting bypassed nodes.
         static inline OP_Node* nextInput(
-#if (UT_VERSION_INT >= 0x0c0500aa) // 12.5.170
             fpreal now,
-#else
-            fpreal /*now*/,
-#endif
             OP_Node* node)
         {
             OP_Node* input = node->getInput(0, /*mark_used=*/true);
-#if (UT_VERSION_INT >= 0x0c0500aa) // 12.5.170
             while (input) {
                 OP_Node* passThrough = input->getPassThroughNode(now, /*mark_used=*/true);
                 if (!passThrough) break;
                 input = passThrough;
             }
-#else
-            while (input && input->getBypass()) {
-                input = input->getInput(0, /*mark_used=*/true);
-            }
-#endif
             return input;
         }
     }; // struct Local

--- a/openvdb_houdini/houdini/ParmFactory.cc
+++ b/openvdb_houdini/houdini/ParmFactory.cc
@@ -44,9 +44,7 @@
 #include <OP/OP_OperatorTable.h>
 #include <PRM/PRM_Parm.h>
 #include <PRM/PRM_SharedFunc.h>
-#if UT_MAJOR_VERSION_INT >= 16
 #include <SOP/SOP_NodeParmsOptions.h>
-#endif
 #include <UT/UT_IntArray.h>
 #include <UT/UT_WorkArgs.h>
 #include <algorithm> // for std::for_each(), std::max(), std::remove(), std::sort()
@@ -434,7 +432,6 @@ ParmFactory::setChoiceList(const PRM_ChoiceList* c)
 {
     mImpl->choicelist = c;
 
-#if (UT_VERSION_INT >= 0x0e000075) // 14.0.117 or later
     if (c == &PrimGroupMenuInput1) {
         setSpareData(SOP_Node::getGroupSelectButton(GA_GROUP_PRIMITIVE,
             nullptr, 0, &SOP_Node::theFirstInput));
@@ -448,17 +445,6 @@ ParmFactory::setChoiceList(const PRM_ChoiceList* c)
         setSpareData(SOP_Node::getGroupSelectButton(GA_GROUP_PRIMITIVE,
             nullptr, 3, &SOP_Node::theFourthInput));
     }
-#else
-    if (c == &PrimGroupMenuInput1) {
-        setSpareData(&SOP_Node::theFirstInput);
-    } else if (c == &PrimGroupMenuInput2) {
-        setSpareData(&SOP_Node::theSecondInput);
-    } else if (c == &PrimGroupMenuInput3) {
-        setSpareData(&SOP_Node::theThirdInput);
-    } else if (c == &PrimGroupMenuInput4) {
-        setSpareData(&SOP_Node::theFourthInput);
-    }
-#endif
 
     return *this;
 }
@@ -550,12 +536,8 @@ ParmFactory::setGroupChoiceList(size_t inputIndex, PRM_ChoiceListType typ)
 {
     mImpl->choicelist = new PRM_ChoiceList(typ, PrimGroupMenu.getChoiceGenerator());
 
-#if (UT_VERSION_INT >= 0x0e000075) // 14.0.117 or later
     setSpareData(SOP_Node::getGroupSelectButton(GA_GROUP_PRIMITIVE, nullptr,
         static_cast<int>(inputIndex), mImpl->getSopInputSpareData(inputIndex)));
-#else
-    setSpareData(mImpl->getSopInputSpareData(inputIndex));
-#endif
 
     return *this;
 }
@@ -906,9 +888,7 @@ public:
         const char* english,
         OP_Constructor construct,
         PRM_Template* multiparms,
-#if (UT_MAJOR_VERSION_INT >= 16)
         const char* operatorTableName,
-#endif
         unsigned minSources,
         unsigned maxSources,
         CH_LocalVariable* variables,
@@ -917,9 +897,7 @@ public:
         const std::string& helpUrl,
         const std::string& doc)
         : OP_Operator(name, english, construct, multiparms,
-#if (UT_MAJOR_VERSION_INT >= 16)
             operatorTableName,
-#endif
             minSources, maxSources, variables, flags, inputlabels)
         , mHelpUrl(helpUrl)
     {
@@ -968,8 +946,6 @@ private:
 };
 
 
-#if UT_MAJOR_VERSION_INT >= 16
-
 class OpFactoryVerb: public SOP_NodeVerb
 {
 public:
@@ -1001,7 +977,6 @@ private:
     PRM_Template* mParms;
 }; // class OpFactoryVerb
 
-#endif // UT_MAJOR_VERSION_INT >= 16
 
 } // anonymous namespace
 
@@ -1061,9 +1036,7 @@ struct OpFactory::Impl
 
         OP_OperatorDW* op = new OP_OperatorDW(mFlavor, mName.c_str(), mLabelName.c_str(),
             mConstruct, mParms,
-#if (UT_MAJOR_VERSION_INT >= 16)
             UTisstring(mOperatorTableName.c_str()) ? mOperatorTableName.c_str() : 0,
-#endif
             minSources, mMaxSources, mVariables, mFlags,
             const_cast<const char**>(&mInputLabels[0]), mHelpUrl, mDoc);
 
@@ -1071,9 +1044,7 @@ struct OpFactory::Impl
 
         if (mObsoleteParms != nullptr) op->setObsoleteTemplates(mObsoleteParms);
 
-#if UT_MAJOR_VERSION_INT >= 16
         if (mVerb) SOP_NodeVerb::registerVerb(mVerb);
-#endif
 
         return op;
     }
@@ -1090,9 +1061,7 @@ struct OpFactory::Impl
     unsigned mFlags;
     std::vector<std::string> mAliases;
     std::vector<char*> mInputLabels, mOptInputLabels;
-#if UT_MAJOR_VERSION_INT >= 16
     OpFactoryVerb* mVerb = nullptr;
-#endif
 };
 
 
@@ -1277,7 +1246,6 @@ OpFactory::setOperatorTable(const std::string& name)
 }
 
 
-#if UT_MAJOR_VERSION_INT >= 16
 OpFactory&
 OpFactory::setVerb(SOP_NodeVerb::CookMode cookMode, const CacheAllocFunc& allocator)
 {
@@ -1290,7 +1258,6 @@ OpFactory::setVerb(SOP_NodeVerb::CookMode cookMode, const CacheAllocFunc& alloca
 
     return *this;
 }
-#endif
 
 
 ////////////////////////////////////////
@@ -1317,199 +1284,12 @@ OpPolicy::getLabelName(const OpFactory& factory)
 ////////////////////////////////////////
 
 
-#if (UT_VERSION_INT >= 0x0d000000) // 13.0.0 or later
-
 const PRM_ChoiceList PrimGroupMenuInput1 = SOP_Node::primGroupMenu;
 const PRM_ChoiceList PrimGroupMenuInput2 = SOP_Node::primGroupMenu;
 const PRM_ChoiceList PrimGroupMenuInput3 = SOP_Node::primGroupMenu;
 const PRM_ChoiceList PrimGroupMenuInput4 = SOP_Node::primGroupMenu;
 
 const PRM_ChoiceList PrimGroupMenu = SOP_Node::primGroupMenu;
-
-#else // earlier than 13.0.0
-
-namespace {
-
-// Extended group name drop-down menu incorporating @c "@<attr>=<value>" syntax
-// (this functionality was added to SOP_Node::primGroupMenu some time ago,
-// possibly as early as Houdini 12.5)
-
-void
-sopBuildGridMenu(void *data, PRM_Name *menuEntries, int themenusize,
-    const PRM_SpareData *spare, const PRM_Parm *parm)
-{
-    SOP_Node* sop = CAST_SOPNODE((OP_Node *)data);
-    int inputIndex = getSopInputIndex(spare);
-
-    const GU_Detail* gdp = sop->getInputLastGeo(inputIndex, CHgetEvalTime());
-
-    GA_GroupTable::iterator<GA_ElementGroup> ithead;
-
-    GA_GroupTable::iterator<GA_ElementGroup> itpthead;
-    UT_WorkBuffer                buf;
-    UT_String                    primtoken, pttoken;
-    int                          i, n_entries;
-    UT_String                    origgroup;
-    UT_WorkArgs                  wargs;
-    UT_StringArray               allnames;
-    bool                         needseparator = false;
-
-    // Find our original group list so we can flag groups we
-    // as toggleable.
-    origgroup = "";
-    // We don't want to evaluate the expression as the toggle
-    // works on the raw code.
-#if (UT_VERSION_INT >= 0x0c0100B6) // 12.1.182 or later
-    if (parm) parm->getValue(0.0f, origgroup, 0, 0, SYSgetSTID());
-#else
-    if (parm) parm->getValue(0.0f, origgroup, 0, 0, UTgetSTID());
-#endif
-
-    origgroup.tokenize(wargs, ' ');
-
-    UT_SymbolTable table;
-    UT_Thing thing((void *) 0);
-
-    for (i = 0; i < wargs.getArgc(); i++) {
-        table.addSymbol(wargs(i), thing);
-    }
-
-    n_entries = 0;
-
-    if (gdp) {
-        ithead = gdp->primitiveGroups().beginTraverse();
-
-        GA_ROAttributeRef aRef = gdp->findPrimitiveAttribute("name");
-        if (aRef.isValid()) {
-            const GA_AIFSharedStringTuple *stuple = aRef.getAttribute()->getAIFSharedStringTuple();
-            if (stuple) {
-                UT_IntArray handles;
-                stuple->extractStrings(aRef.getAttribute(), allnames, handles);
-            }
-        }
-    }
-
-    if (!ithead.atEnd()) {
-        GA_PrimitiveGroup *primsel;
-        bool includeselection = true;
-
-        if (gdp->selection() && (primsel = gdp->selection()->primitives()) &&
-            includeselection &&
-            primsel->getInternal())     // If not internal we'll catch it below
-        {
-            GOP_GroupParse::buildPrimGroupToken(gdp, primsel, primtoken);
-
-            if (primtoken.length()) {
-                menuEntries[n_entries].setToken(primtoken);
-                menuEntries[n_entries].setLabel("Primitive Selection");
-                n_entries++;
-                needseparator = true;
-            }
-        }
-
-        int                      numprim = 0;
-        int                      startprim = n_entries;
-
-        for (i = n_entries; (i + 1) < themenusize && !ithead.atEnd(); ++ithead, i++) {
-            const GA_PrimitiveGroup* primgrp =
-                static_cast<const GA_PrimitiveGroup *>(ithead.group());
-
-            if (primgrp->getInternal()) continue;
-
-            menuEntries[n_entries].setToken(primgrp->getName());
-
-            // Determine if this group is already in the list.  If so,
-            // we want to put a + in front of it.
-            if (table.findSymbol(primgrp->getName(), &thing)) {
-                buf.sprintf("%s\t*", (const char *) primgrp->getName());
-                menuEntries[n_entries].setLabel(buf.buffer());
-            } else {
-                menuEntries[n_entries].setLabel(primgrp->getName());
-            }
-            numprim++;
-            n_entries++;
-        }
-
-        if (numprim) {
-            PRMsortMenu(&menuEntries[startprim], numprim);
-            needseparator = true;
-        }
-    }
-
-    if (allnames.entries()) {
-        if (needseparator && (n_entries+1 < themenusize)) {
-            needseparator = false;
-            menuEntries[n_entries].setToken(PRM_Name::mySeparator);
-            menuEntries[n_entries].setLabel(PRM_Name::mySeparator);
-            n_entries++;
-        }
-
-        int             numnames = 0;
-        int             startname = n_entries;
-
-        for (int j = 0; j < allnames.entries(); j++) {
-            if (n_entries+1 >= themenusize) break;
-
-            if(!allnames(j).isstring()) continue;
-
-            buf.sprintf("@name=%s", (const char *) allnames(j));
-            menuEntries[n_entries].setToken(buf.buffer());
-
-            // Determine if this group is already in the list.  If so,
-            // we want to put a + in front of it.
-            if (table.findSymbol(buf.buffer(), &thing)) {
-                buf.sprintf("@%s\t*", (const char *) allnames(j));
-                menuEntries[n_entries].setLabel(buf.buffer());
-            } else {
-                buf.sprintf("@%s", (const char *) allnames(j));
-                menuEntries[n_entries].setLabel(buf.buffer());
-            }
-            numnames++;
-            n_entries++;
-        }
-
-        if (numnames) {
-            PRMsortMenu(&menuEntries[startname], numnames);
-            needseparator = true;
-        }
-    }
-
-    menuEntries[n_entries].setToken(0);
-    menuEntries[n_entries].setLabel(0);
-}
-
-} // anonymous namespace
-
-
-#ifdef _MSC_VER
-
-OPENVDB_HOUDINI_API const PRM_ChoiceList
-PrimGroupMenuInput1(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-OPENVDB_HOUDINI_API const PRM_ChoiceList
-PrimGroupMenuInput2(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-OPENVDB_HOUDINI_API const PRM_ChoiceList
-PrimGroupMenuInput3(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-OPENVDB_HOUDINI_API const PRM_ChoiceList
-PrimGroupMenuInput4(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-
-OPENVDB_HOUDINI_API const PRM_ChoiceList PrimGroupMenu(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-
-#else
-
-const PRM_ChoiceList
-PrimGroupMenuInput1(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-const PRM_ChoiceList
-PrimGroupMenuInput2(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-const PRM_ChoiceList
-PrimGroupMenuInput3(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-const PRM_ChoiceList
-PrimGroupMenuInput4(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-
-const PRM_ChoiceList PrimGroupMenu(PRM_CHOICELIST_TOGGLE, sopBuildGridMenu);
-
-#endif
-
-#endif // earlier than 13.0.0
 
 
 } // namespace houdini_utils

--- a/openvdb_houdini/houdini/ParmFactory.h
+++ b/openvdb_houdini/houdini/ParmFactory.h
@@ -44,9 +44,7 @@
 #include <PRM/PRM_Include.h>
 #include <PRM/PRM_SpareData.h>
 #include <SOP/SOP_Node.h>
-#if UT_MAJOR_VERSION_INT >= 16
 #include <SOP/SOP_NodeVerb.h>
-#endif
 #if defined(PRODDEV_BUILD) || defined(DWREAL_IS_DOUBLE)
   // OPENVDB_HOUDINI_API, which has no meaning in a DWA build environment but
   // must at least exist, is normally defined by including openvdb/Platform.h.
@@ -482,7 +480,6 @@ public:
     OpFactory& setInternalName(const std::string& name);
     OpFactory& setOperatorTable(const std::string& name);
 
-#if UT_MAJOR_VERSION_INT >= 16
     /// @brief Functor that returns newly-allocated node caches
     /// for instances of this operator
     /// @details A node cache encapsulates a SOP's cooking logic for thread safety.
@@ -498,7 +495,6 @@ public:
     /// @throw std::runtime_error if this operator is not a SOP
     /// @throw std::invalid_argument if @a allocator is empty
     OpFactory& setVerb(SOP_NodeVerb::CookMode cookMode, const CacheAllocFunc& allocator);
-#endif
 
 private:
     void init(OpPolicyPtr, const std::string& english, OP_Constructor,
@@ -562,11 +558,7 @@ public:
     }
     ~ScopedInputLock() {}
 
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
     void markInputUnlocked(exint input) { mLock.markInputUnlocked(input); }
-#else
-    void markInputUnlocked(exint) {}
-#endif
 
 private:
     OP_AutoLockInputs mLock;

--- a/openvdb_houdini/houdini/PointUtils.cc
+++ b/openvdb_houdini/houdini/PointUtils.cc
@@ -50,6 +50,7 @@
 #include <PRM/PRM_SpareData.h>
 #include <SOP/SOP_Node.h>
 #include <UT/UT_Version.h>
+#include <UT/UT_UniquePtr.h>
 
 #include <algorithm>
 #include <map>
@@ -59,12 +60,6 @@
 #include <string>
 #include <type_traits>
 #include <vector>
-
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-#include <UT/UT_UniquePtr.h>
-#else
-template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
 
 using namespace openvdb;
 using namespace openvdb::points;

--- a/openvdb_houdini/houdini/SHOP_OpenVDB_Points.cc
+++ b/openvdb_houdini/houdini/SHOP_OpenVDB_Points.cc
@@ -200,9 +200,7 @@ newShopOperator(OP_OperatorTable *table)
     SHOP_Operator* shop = new SHOP_Operator(SHOP_OpenVDB_Points::nodeName(), "OpenVDB Points",
         SHOP_OpenVDB_Points::factory,
         parms.get(),
-#if (UT_MAJOR_VERSION_INT >= 16)
         /*child_table_name=*/nullptr,
-#endif
         /*min_sources=*/0, /*max_sources=*/0,
         SHOP_Node::myVariableList,
         OP_FLAG_GENERATOR,

--- a/openvdb_houdini/houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.cc
@@ -34,10 +34,8 @@
 #include "SOP_NodeVDB.h"
 
 #include <houdini_utils/geometry.h>
-//#ifdef OPENVDB_ENABLE_POINTS
 #include <openvdb/points/PointDataGrid.h>
 #include "PointUtils.h"
-//#endif
 #include "Utils.h"
 #include "GEO_PrimVDB.h"
 #include "GU_PrimVDB.h"
@@ -178,17 +176,12 @@ SOP_NodeVDB::SOP_NodeVDB(OP_Network* net, const char* name, OP_Operator* op):
     startLogForwarding(SOP_OPTYPE_ID);
 #endif
 
-//#ifdef OPENVDB_ENABLE_POINTS
     // Register grid-specific info text for Point Data Grids
     node_info_text::registerGridSpecificInfoText<openvdb::points::PointDataGrid>(
         &pointDataGridSpecificInfoText);
-//#endif
 
     // Set the flag to draw guide geometry
     mySopFlags.setNeedGuide1(true);
-
-    // We can use this to optionally draw the local data window?
-    // mySopFlags.setNeedGuide2(true);
 }
 
 

--- a/openvdb_houdini/houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.cc
@@ -229,20 +229,6 @@ SOP_NodeVDB::matchGroup(const GU_Detail& aGdp, const std::string& pattern)
 ////////////////////////////////////////
 
 
-#if (UT_MAJOR_VERSION_INT < 16)
-void
-SOP_NodeVDB::fillInfoTreeNodeSpecific(UT_InfoTree& tree, fpreal time)
-{
-    SOP_Node::fillInfoTreeNodeSpecific(tree, time);
-
-    // Add the OpenVDB library version number to this node's
-    // extended operator information.
-    if (UT_InfoTree* child = tree.addChildBranch("OpenVDB")) {
-        child->addColumnHeading("version");
-        child->addProperties(openvdb::getLibraryVersionString());
-    }
-}
-#else
 void
 SOP_NodeVDB::fillInfoTreeNodeSpecific(UT_InfoTree& tree, const OP_NodeInfoTreeParms& parms)
 {
@@ -291,7 +277,6 @@ SOP_NodeVDB::fillInfoTreeNodeSpecific(UT_InfoTree& tree, const OP_NodeInfoTreePa
     }
 #endif
 }
-#endif
 
 
 void
@@ -450,7 +435,6 @@ SOP_NodeVDB::duplicateSourceStealable(const unsigned index, OP_Context& context)
 ////////////////////////////////////////
 
 
-#if UT_MAJOR_VERSION_INT >= 16
 const SOP_NodeVerb*
 SOP_NodeVDB::cookVerb() const
 {
@@ -459,17 +443,14 @@ SOP_NodeVDB::cookVerb() const
     }
     return SOP_Node::cookVerb();
 }
-#endif
 
 
 OP_ERROR
 SOP_NodeVDB::cookMySop(OP_Context& context)
 {
-#if UT_MAJOR_VERSION_INT >= 16
     if (cookVerb()) {
         return cookMyselfAsVerb(context);
     }
-#endif
     return cookVDBSop(context);
 }
 

--- a/openvdb_houdini/houdini/SOP_NodeVDB.h
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.h
@@ -74,17 +74,11 @@ public:
     SOP_NodeVDB(OP_Network*, const char*, OP_Operator*);
     ~SOP_NodeVDB() override = default;
 
-#if (UT_MAJOR_VERSION_INT < 16)
-    void fillInfoTreeNodeSpecific(UT_InfoTree&, fpreal time) override;
-#else
     void fillInfoTreeNodeSpecific(UT_InfoTree&, const OP_NodeInfoTreeParms&) override;
-#endif
     void getNodeSpecificInfoText(OP_Context&, OP_NodeInfoParms&) override;
 
-#if UT_MAJOR_VERSION_INT >= 16
     /// @brief Return this node's registered verb.
     const SOP_NodeVerb* cookVerb() const override;
-#endif
 
     /// @brief Retrieve a group from a geometry detail by parsing a pattern
     /// (typically, the value of a Group parameter belonging to this node).

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Points.cc
@@ -44,15 +44,10 @@
 #include <GA/GA_PageIterator.h>
 #include <GU/GU_PrimPoly.h>
 #include <UT/UT_Interrupt.h>
-#include <UT/UT_Version.h>
+#include <UT/UT_UniquePtr.h>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/case_conv.hpp>
 #include <hboost/algorithm/string/trim.hpp>
-#else
-#include <boost/algorithm/string/case_conv.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#endif
 
 #include <algorithm>
 #include <memory>
@@ -60,18 +55,9 @@
 #include <string>
 #include <vector>
 
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-#include <UT/UT_UniquePtr.h>
-#else
-template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
-
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 ////////////////////////////////////////

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Points.cc
@@ -66,12 +66,6 @@
 template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
 #endif
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
-
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
@@ -675,16 +669,12 @@ public:
 
     int isRefInput(unsigned i ) const override { return (i > 0); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
         bool evalAdvectionParms(OP_Context&, AdvectionParms&);
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 protected:
     void resolveObsoleteParms(PRM_ParmList*) override;
@@ -860,10 +850,8 @@ newSopOperator(OP_OperatorTable* table)
         .addInput("Points to Advect")
         .addOptionalInput("Velocity VDB")
         .addOptionalInput("Closest Point VDB")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_DUPLICATE,
             []() { return new SOP_OpenVDB_Advect_Points::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -1001,15 +989,9 @@ SOP_OpenVDB_Advect_Points::SOP_OpenVDB_Advect_Points(OP_Network* net,
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Advect_Points)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Advect_Points::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-
-        duplicateSource(0, context);
-#endif
-
         // Evaluate UI parameters
         const fpreal now = context.getTime();
 
@@ -1099,7 +1081,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Advect_Points)::cookVDBSop(OP_
 
 
 bool
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Advect_Points)::evalAdvectionParms(
+SOP_OpenVDB_Advect_Points::Cache::evalAdvectionParms(
     OP_Context& context, AdvectionParms& parms)
 {
     const fpreal now = context.getTime();

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Analysis.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Analysis.cc
@@ -51,12 +51,6 @@
 #include <stdexcept>
 #include <string>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
-
 namespace cvdb = openvdb;
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
@@ -89,12 +83,7 @@ public:
 
     static const char* sOpName[];
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -229,9 +218,7 @@ Normalize (vector -> vector):\n\
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs to Analyze")
         .addOptionalInput("Optional VDB mask input")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Analysis::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -381,15 +368,9 @@ SOP_OpenVDB_Analysis::resolveObsoleteParms(PRM_ParmList* obsoleteParms)
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Analysis)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Analysis::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-        duplicateSource(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         // Get the group of grids to be transformed.

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
@@ -48,11 +48,6 @@
 #include <exception>
 #include <string>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -69,10 +64,8 @@ public:
 
     int isRefInput(unsigned input) const override { return (input == 1); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     public:
         openvdb::math::Transform::Ptr frustum() const { return mFrustum; }
     protected:
@@ -81,9 +74,7 @@ public:
         void getFrustum(OP_Context&);
 
         openvdb::math::Transform::Ptr mFrustum;
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 protected:
     void resolveObsoleteParms(PRM_ParmList*) override;
@@ -201,9 +192,7 @@ Mask VDB:\n\
         .addInput("VDBs")
         .addOptionalInput("Mask VDB or bounding geometry")
         .setObsoleteParms(obsoleteParms)
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Clip::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -471,7 +460,7 @@ struct MaskClipOp
 
 /// Get the selected camera's frustum transform.
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Clip)::getFrustum(OP_Context& context)
+SOP_OpenVDB_Clip::Cache::getFrustum(OP_Context& context)
 {
     mFrustum.reset();
 
@@ -484,17 +473,10 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Clip)::getFrustum(OP_Context& 
     }
 
     OBJ_Camera* camera = nullptr;
-#if VDB_COMPILABLE_SOP
     if (auto* obj = cookparms()->getCwd()->findOBJNode(cameraPath)) {
         camera = obj->castToOBJCamera();
     }
     OP_Node* self = cookparms()->getCwd();
-#else
-    if (auto* obj = findOBJNode(cameraPath)) {
-        camera = obj->castToOBJCamera();
-    }
-    OP_Node* self = this;
-#endif
 
     if (!camera) {
         throw std::runtime_error{"camera \"" + cameraPath.toStdString() + "\" was not found"};
@@ -546,14 +528,10 @@ SOP_OpenVDB_Clip::cookMyGuide1(OP_Context&)
     myGuide1->clearAndDestroy();
 
     openvdb::math::Transform::ConstPtr frustum;
-#if !VDB_COMPILABLE_SOP
-    frustum = mFrustum;
-#else
     // Attempt to extract the frustum from our cache.
     if (auto* cache = dynamic_cast<SOP_OpenVDB_Clip::Cache*>(myNodeVerbCache)) {
         frustum = cache->frustum();
     }
-#endif
 
     if (frustum) {
         const UT_Vector3 color{0.9f, 0.0f, 0.0f};
@@ -565,16 +543,9 @@ SOP_OpenVDB_Clip::cookMyGuide1(OP_Context&)
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Clip)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Clip::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock{*this, context};
-
-        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-        duplicateSource(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         UT_AutoInterrupt progress{"Clipping VDBs"};

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
@@ -335,12 +335,8 @@ struct DilatedMaskOp
         // Since large dilations and erosions can be expensive, apply them
         // in multiple passes and check for interrupts.
         for (int pass = 0; pass < numPasses; ++pass, numIterations -= kNumIterationsPerPass) {
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
             const bool interrupt = progress.wasInterrupted(
                 /*pct=*/int((100.0 * pass * kNumIterationsPerPass) / std::abs(dilation)));
-#else
-            const bool interrupt = progress.wasInterrupted();
-#endif
             if (interrupt) {
                 maskGrid.reset();
                 throw std::runtime_error{"interrupted"};
@@ -602,9 +598,7 @@ SOP_OpenVDB_Clip::Cache::cookVDBSop(OP_Context& context)
                         const auto maskType = UTvdbGetGridType(*maskGrid);
                         DilatedMaskOp op{dilation};
                         if (!UTvdbProcessTypedGridTopology(maskType, *maskGrid, op)) {
-#if UT_VERSION_INT >= 0x10000258 // 16.0.600 or later
                             UTvdbProcessTypedGridPoint(maskType, *maskGrid, op);
-#endif
                         }
                         if (op.maskGrid) maskGrid = op.maskGrid;
                     }

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
@@ -56,11 +56,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -199,10 +194,8 @@ public:
 
     static OP_Node* factory(OP_Network*, const char*, OP_Operator*);
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     public:
         fpreal getTime() const { return mTime; }
     protected:
@@ -214,9 +207,7 @@ public:
             ResampleMode resample);
 
         fpreal mTime = 0.0;
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -493,9 +484,7 @@ Activity Difference:\n\
         .addInput("A VDBs")
         .addOptionalInput("B VDBs")
         .setObsoleteParms(obsoleteParms)
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Combine::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -652,15 +641,9 @@ getGridName(const GU_PrimVDB* vdb, const UT_String& defaultName = "")
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Combine)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Combine::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock{*this, context};
-
-        duplicateSource(0, context);
-#endif
-
         UT_AutoInterrupt progress{"Combining VDBs"};
 
         mTime = context.getTime();
@@ -988,11 +971,7 @@ struct SOP_OpenVDB_Combine::DispatchOp
 // Helper class for use with UTvdbProcessTypedGrid()
 struct SOP_OpenVDB_Combine::CombineOp
 {
-#if VDB_COMPILABLE_SOP
     SOP_OpenVDB_Combine::Cache* self;
-#else
-    SOP_OpenVDB_Combine* self;
-#endif
     Operation op;
     ResampleMode resample;
     UT_String aGridName, bGridName;
@@ -1482,7 +1461,7 @@ SOP_OpenVDB_Combine::DispatchOp<AGridT>::operator()(typename BGridT::ConstPtr)
 
 
 hvdb::GridPtr
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Combine)::combineGrids(
+SOP_OpenVDB_Combine::Cache::combineGrids(
     Operation op,
     hvdb::GridCPtr aGrid,
     hvdb::GridCPtr bGrid,

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
@@ -55,12 +55,9 @@
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_Version.h>
 #include <UT/UT_VoxelArray.h>
+#include <UT/UT_UniquePtr.h>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/join.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#endif
 
 #include <limits>
 #include <list>
@@ -69,19 +66,10 @@
 #include <string>
 #include <vector>
 
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-#include <UT/UT_UniquePtr.h>
-#else
-template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
-
-
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
+
 
 namespace {
 enum ConvertTo { HVOLUME, OPENVDB, POLYGONS, POLYSOUP };

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Create.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Create.cc
@@ -40,13 +40,8 @@
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_Version.h>
 #include <UT/UT_WorkArgs.h>
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/case_conv.hpp>
 #include <hboost/algorithm/string/trim.hpp>
-#else
-#include <boost/algorithm/string/case_conv.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#endif
 #include <OBJ/OBJ_Camera.h>
 #include <cmath>
 #include <stdexcept>
@@ -57,9 +52,6 @@
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
 namespace cvdb = openvdb;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 ////////////////////////////////////////

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Densify.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Densify.cc
@@ -41,11 +41,6 @@
 #include <UT/UT_Version.h>
 #include <stdexcept>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -59,12 +54,7 @@ public:
 
     static OP_Node* factory(OP_Network*, const char* name, OP_Operator*);
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 };
 
 
@@ -88,9 +78,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Densify", SOP_OpenVDB_Densify::factory, parms, *table)
         .addInput("VDBs to densify")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Densify::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -156,15 +144,9 @@ struct DensifyOp {
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Densify)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Densify::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        lock.markInputUnlocked(0);
-        duplicateSourceStealable(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         // Get the group of grids to process.

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Diagnostics.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Diagnostics.cc
@@ -45,6 +45,7 @@
 
 #include <UT/UT_Version.h>
 #include <UT/UT_Interrupt.h>
+#include <UT/UT_UniquePtr.h>
 #include <PRM/PRM_Parm.h>
 
 #ifdef SESI_OPENVDB
@@ -60,13 +61,6 @@
 #include <sstream>
 #include <type_traits>
 #include <vector>
-
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-  #include <UT/UT_UniquePtr.h>
-#else
-  template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
-
 
 
 namespace hvdb = openvdb_houdini;
@@ -1600,11 +1594,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // { Finite values
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "test_finite", "Finite Values"
-#if (UT_MAJOR_VERSION_INT < 16)
-        + spacing(30)
-#else
         + spacing(35)
-#endif
     )
         .setCallbackFunc(&validateOperationTestsCB)
         .setDefault(PRMoneDefaults)
@@ -1625,9 +1615,6 @@ newSopOperator(OP_OperatorTable* table)
 
     // { Uniform background values
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "test_background", "Uniform Background"
-#if (UT_MAJOR_VERSION_INT < 16)
-        + spacing(5)
-#endif
         )
         .setCallbackFunc(&validateOperationTestsCB)
         .setTypeExtended(PRM_TYPE_MENU_JOIN)
@@ -1647,11 +1634,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // { Values in range
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "test_valrange", "Values in Range"
-#if (UT_MAJOR_VERSION_INT < 16)
-        + spacing(19)
-#else
         + spacing(23)
-#endif
         )
         .setCallbackFunc(&validateOperationTestsCB)
         .setTypeExtended(PRM_TYPE_MENU_JOIN)
@@ -1716,11 +1699,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // { Gradient magnitude
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "test_gradient", "Gradient Magnitude"
-#if (UT_MAJOR_VERSION_INT < 16)
-        + spacing(6)
-#else
         + spacing(7)
-#endif
         )
         .setCallbackFunc(&validateOperationTestsCB)
         .setTypeExtended(PRM_TYPE_MENU_JOIN)
@@ -1749,11 +1728,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // { Inactive Tiles
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "test_activetiles", "Inactive Tiles"
-#if (UT_MAJOR_VERSION_INT < 16)
-        + spacing(28)
-#else
         + spacing(36)
-#endif
         )
         .setCallbackFunc(&validateOperationTestsCB)
         .setTypeExtended(PRM_TYPE_MENU_JOIN)
@@ -1784,11 +1759,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // { Background values
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "test_backgroundzero", "Background Zero"
-#if (UT_MAJOR_VERSION_INT < 16)
-        + spacing(15)
-#else
         + spacing(17)
-#endif
         )
         .setCallbackFunc(&validateOperationTestsCB)
         .setTypeExtended(PRM_TYPE_MENU_JOIN)

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Fill.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Fill.cc
@@ -35,20 +35,16 @@
 #include <houdini_utils/ParmFactory.h>
 #include <openvdb_houdini/Utils.h>
 #include <openvdb_houdini/SOP_NodeVDB.h>
+
 #include <PRM/PRM_Parm.h>
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_Version.h>
+#include <UT/UT_UniquePtr.h>
+
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
-
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-#include <UT/UT_UniquePtr.h>
-#else
-template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
-
 
 
 namespace hutil = houdini_utils;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter.cc
@@ -49,11 +49,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -175,17 +170,13 @@ protected:
     void resolveObsoleteParms(PRM_ParmList*) override;
     bool updateParmsFlags() override;
 
-#if VDB_COMPILABLE_SOP
 public:
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
 protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
         OP_ERROR evalFilterParms(OP_Context&, GU_Detail&, FilterParmVec&);
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 private:
     struct FilterOp;
@@ -339,9 +330,7 @@ Offset:\n\
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs to Smooth")
         .addOptionalInput("Optional VDB Alpha Mask")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Filter::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -514,14 +503,9 @@ struct SOP_OpenVDB_Filter::FilterOp
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter)::evalFilterParms(
+SOP_OpenVDB_Filter::Cache::evalFilterParms(
     OP_Context& context, GU_Detail&, FilterParmVec& parmVec)
 {
-#if !VDB_COMPILABLE_SOP
-    hutil::OP_EvalScope evalScope(*this, context);
-    clearErrors(context);
-#endif
-
     const fpreal now = context.getTime();
 
     const Operation op = stringToOp(evalStdString("operation", 0));
@@ -537,16 +521,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter)::evalFilterParms(
 #endif
     openvdb::FloatGrid::ConstPtr maskGrid;
     if (this->nInputs() == 2 && evalInt("mask", 0, now)) {
-#if VDB_COMPILABLE_SOP
         const GU_Detail* maskGeo = inputGeo(1);
-#else
-        OP_Node* maskInputNode = getInput(1, /*mark_used*/true);
-        GU_DetailHandle maskHandle;
-        maskHandle = static_cast<SOP_Node*>(maskInputNode)->getCookedGeoHandle(context);
-
-        GU_DetailHandleAutoReadLock maskScope(maskHandle);
-        const GU_Detail *maskGeo = maskScope.getGdp();
-#endif
 
         const auto maskName = evalStdString("maskname", now);
 
@@ -583,8 +558,6 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter)::evalFilterParms(
 
 ////////////////////////////////////////
 
-
-#if VDB_COMPILABLE_SOP
 
 OP_ERROR
 SOP_OpenVDB_Filter::Cache::cookVDBSop(OP_Context& context)
@@ -635,92 +608,6 @@ SOP_OpenVDB_Filter::Cache::cookVDBSop(OP_Context& context)
     return error();
 }
 
-#else // if !VDB_COMPILABLE_SOP
-
-OP_ERROR
-SOP_OpenVDB_Filter::cookVDBSop(OP_Context& context)
-{
-    try {
-        OP_AutoLockInputs lock;
-
-        const fpreal now = context.getTime();
-
-        FilterOp filterOp;
-
-        SOP_OpenVDB_Filter* startNode = this;
-        {
-            // Find adjacent, upstream nodes of the same type as this node.
-            std::vector<SOP_OpenVDB_Filter*> nodes = hutil::getNodeChain(context, this);
-
-            startNode = nodes[0];
-
-            // Collect filter parameters starting from the topmost node.
-            FilterParmVec& parmVec = filterOp.opSequence;
-            parmVec.reserve(nodes.size());
-            for (size_t n = 0, N = nodes.size(); n < N; ++n) {
-                if (nodes[n]->evalFilterParms(context, *gdp, parmVec) >= UT_ERROR_ABORT) {
-                    addInputError(0);
-                    return error();
-                }
-            }
-        }
-
-        lock.setNode(startNode);
-        if (lock.lock(context) >= UT_ERROR_ABORT) {
-            addInputError(0);
-            return error();
-        }
-
-        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-        lock.markInputUnlocked(0);
-#endif
-        if (startNode->duplicateSourceStealable(0, context, &gdp, myGdpHandle, /*clean=*/true)
-            >= UT_ERROR_ABORT)
-        {
-            return error();
-        }
-
-        // Get the group of grids to process.
-        const GA_PrimitiveGroup* group = matchGroup(*gdp, evalStdString("group", now));
-
-        hvdb::Interrupter progress("Filtering VDB grids");
-        filterOp.interrupt = &progress;
-
-        // Process each VDB primitive in the selected group.
-        for (hvdb::VdbPrimIterator it(gdp, group); it; ++it) {
-
-            if (progress.wasInterrupted()) {
-                throw std::runtime_error("processing was interrupted");
-            }
-
-            GU_PrimVDB* vdbPrim = *it;
-            UT_String name = it.getPrimitiveNameOrIndex();
-
-#ifndef SESI_OPENVDB
-            if (evalInt("verbose", 0, now)) {
-                std::cout << "\nFiltering \"" << name << "\"" << std::endl;
-            }
-#endif
-
-            int success = GEOvdbProcessTypedGridTopology(*vdbPrim, filterOp);
-
-            if (!success) {
-                std::stringstream ss;
-                ss << "VDB grid " << name << " of type "
-                    << vdbPrim->getConstGrid().valueType() << " was skipped";
-                addWarning(SOP_MESSAGE, ss.str().c_str());
-                continue;
-            }
-        }
-
-    } catch (std::exception& e) {
-        addError(SOP_MESSAGE, e.what());
-    }
-    return error();
-}
-
-#endif // VDB_COMPILABLE_SOP
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
@@ -52,13 +52,8 @@
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_Version.h>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/case_conv.hpp>
 #include <hboost/algorithm/string/trim.hpp>
-#else
-#include <boost/algorithm/string/case_conv.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#endif
 
 #include <algorithm>
 #include <iostream>
@@ -74,9 +69,6 @@
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 ////////////////////////////////////////

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
@@ -66,11 +66,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 #undef DWA_DEBUG_MODE
@@ -340,11 +335,7 @@ struct FilterParms
     bool        mInvertMask           = false;
     Accuracy    mAccuracy             = ACCURACY_UPWIND_FIRST;
     TrimMode    mTrimMode             = TrimMode::kAll;
-#if VDB_COMPILABLE_SOP
     bool        mMaskInputNode        = false;
-#else
-    OP_Node*    mMaskInputNode        = nullptr;
-#endif
 };
 
 } // namespace
@@ -371,13 +362,12 @@ protected:
     bool updateParmsFlags() override;
     void resolveObsoleteParms(PRM_ParmList*) override;
 
-#if VDB_COMPILABLE_SOP
 public:
     class Cache: public SOP_VDBCacheOptions
     {
     public:
         Cache(OperatorType op): mOpType{op} {}
-#endif
+
     protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
 
@@ -426,11 +416,9 @@ public:
         template<typename FilterT>
         void track(const FilterParms&, FilterT&, BossT&, bool verbose);
 
-#if VDB_COMPILABLE_SOP
     private:
         const OperatorType mOpType;
     };
-#endif
 
 private:
     const OperatorType mOpType;
@@ -590,9 +578,7 @@ newSopOperator(OP_OperatorTable* table)
         obsoleteParms.add(hutil::ParmFactory(PRM_FLT_J, "minMask", "").setDefault(PRMzeroDefaults));
         obsoleteParms.add(hutil::ParmFactory(PRM_FLT_J, "maxMask", "").setDefault(PRMoneDefaults));
 
-#if VDB_COMPILABLE_SOP
         auto cacheAllocator = [op]() { return new SOP_OpenVDB_Filter_Level_Set::Cache{op}; };
-#endif
 
         // Register operator
         if (OP_TYPE_RENORM == op) {
@@ -604,9 +590,7 @@ newSopOperator(OP_OperatorTable* table)
 #endif
                 .setObsoleteParms(obsoleteParms)
                 .addInput("Input with VDB grids to process")
-#if VDB_COMPILABLE_SOP
                 .setVerb(SOP_NodeVerb::COOK_INPLACE, cacheAllocator)
-#endif
                 .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -646,9 +630,7 @@ and usage examples.\n");
                 .setObsoleteParms(obsoleteParms)
                 .addInput("Input with VDBs to process")
                 .addOptionalInput("Optional VDB Alpha Mask")
-#if VDB_COMPILABLE_SOP
                 .setVerb(SOP_NodeVerb::COOK_INPLACE, cacheAllocator)
-#endif
                 .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -681,9 +663,7 @@ and usage examples.\n");
                 .setObsoleteParms(obsoleteParms)
                 .addInput("Input with VDBs to process")
                 .addOptionalInput("Optional VDB Alpha Mask")
-#if VDB_COMPILABLE_SOP
                 .setVerb(SOP_NodeVerb::COOK_INPLACE, cacheAllocator)
-#endif
                 .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -717,9 +697,7 @@ and usage examples.\n");
                 SOP_OpenVDB_Filter_Level_Set::factoryNarrowBand, parms, *table)
                 .setObsoleteParms(obsoleteParms)
                 .addInput("Input with VDBs to process")
-#if VDB_COMPILABLE_SOP
                 .setVerb(SOP_NodeVerb::COOK_INPLACE, cacheAllocator)
-#endif
                 .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -859,7 +837,7 @@ SOP_OpenVDB_Filter_Level_Set::updateParmsFlags()
 // Cook
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::cookVDBSop(
+SOP_OpenVDB_Filter_Level_Set::Cache::cookVDBSop(
     OP_Context& context)
 {
     try {
@@ -874,49 +852,9 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::cookVDBSop(
 #endif
 
         // Collect filter parameters starting from the topmost node.
-#if VDB_COMPILABLE_SOP
         std::vector<FilterParms> filterParms;
         filterParms.resize(1);
         evalFilterParms(context, filterParms[0]);
-#else
-        OP_AutoLockInputs lock;
-
-        if (verbose) std::cout << "--- " << this->getName() << " ---\n";
-
-        std::vector<FilterParms> filterParms;
-        SOP_OpenVDB_Filter_Level_Set* startNode = this;
-        {
-            // Find adjacent, upstream nodes of the same type as this node.
-            std::vector<SOP_OpenVDB_Filter_Level_Set*> nodes =
-                hutil::getNodeChain(context, this);
-
-            startNode = nodes[0];
-
-            // Collect filter parameters starting from the topmost node.
-            filterParms.resize(nodes.size());
-            for (size_t n = 0, N = filterParms.size(); n < N; ++n) {
-                if (nodes[n]->evalFilterParms(context, filterParms[n]) >= UT_ERROR_ABORT) {
-                    addInputError(0);
-                    return error();
-                }
-            }
-        }
-
-        lock.setNode(startNode);
-        if (lock.lock(context) >= UT_ERROR_ABORT) {
-            addInputError(0);
-            return error();
-        }
-
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-        lock.markInputUnlocked(0);
-#endif
-        if (startNode->duplicateSourceStealable(
-            0, context, &gdp, myGdpHandle, /*clean=*/true) >= UT_ERROR_ABORT)
-        {
-            return error();
-        }
-#endif // VDB_COMPILABLE_SOP
 
         // Filter grids
         const GA_PrimitiveGroup* group = matchGroup(*gdp, evalStdString("group", time));
@@ -970,14 +908,9 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::cookVDBSop(
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::evalFilterParms(
+SOP_OpenVDB_Filter_Level_Set::Cache::evalFilterParms(
     OP_Context& context, FilterParms& parms)
 {
-#if !VDB_COMPILABLE_SOP
-    hutil::OP_EvalScope evalScope(*this, context);
-    clearErrors(context);
-#endif
-
     fpreal now = context.getTime();
 
     parms.mIterations   = static_cast<int>(evalInt("iterations", 0, now));
@@ -1016,11 +949,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::evalFilterP
 
     if (OP_TYPE_SMOOTH == mOpType || OP_TYPE_RESHAPE == mOpType) {
         if (evalInt("mask", 0, now)) {
-#if VDB_COMPILABLE_SOP
             parms.mMaskInputNode = hasInput(1);
-#else
-            parms.mMaskInputNode = getInput(1, /*mark_used*/true);
-#endif
             parms.mMaskName = evalStdString("maskname", now);
         }
     }
@@ -1035,7 +964,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::evalFilterP
 
 template<typename GridT>
 bool
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::applyFilters(
+SOP_OpenVDB_Filter_Level_Set::Cache::applyFilters(
     GU_PrimVDB* vdbPrim,
     std::vector<FilterParms>& filterParms,
     BossT& boss,
@@ -1081,8 +1010,8 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::applyFilter
 
 template<typename FilterT>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::filterGrid(
-    OP_Context& context,
+SOP_OpenVDB_Filter_Level_Set::Cache::filterGrid(
+    OP_Context& /*context*/,
     FilterT& filter,
     const FilterParms& parms,
     BossT& boss,
@@ -1093,21 +1022,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::filterGrid(
     typename MaskT::ConstPtr maskGrid;
 
     if (parms.mMaskInputNode) {
-#if VDB_COMPILABLE_SOP
         const GU_Detail* maskGeo = inputGeo(1);
-        (void)context; // [[maybe_unused]]
-#else
-        // record second input
-        if (getInput(1) != parms.mMaskInputNode) {
-            addExtraInput(parms.mMaskInputNode, OP_INTEREST_DATA);
-        }
-
-        GU_DetailHandle maskHandle;
-        maskHandle = static_cast<SOP_Node*>(parms.mMaskInputNode)->getCookedGeoHandle(context);
-
-        GU_DetailHandleAutoReadLock maskScope(maskHandle);
-        const GU_Detail* maskGeo = maskScope.getGdp();
-#endif
 
         if (maskGeo) {
             const GA_PrimitiveGroup* maskGroup =
@@ -1197,7 +1112,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::filterGrid(
 
 template<typename FilterT>
 inline void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::offset(
+SOP_OpenVDB_Filter_Level_Set::Cache::offset(
     const FilterParms&,
     FilterT& filter,
     const float offset,
@@ -1214,7 +1129,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::offset(
 
 template<typename FilterT>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::mean(
+SOP_OpenVDB_Filter_Level_Set::Cache::mean(
     const FilterParms& parms,
     FilterT& filter,
     BossT& boss,
@@ -1242,7 +1157,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::mean(
 
 template<typename FilterT>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::gaussian(
+SOP_OpenVDB_Filter_Level_Set::Cache::gaussian(
     const FilterParms& parms,
     FilterT& filter,
     BossT& boss,
@@ -1270,7 +1185,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::gaussian(
 
 template<typename FilterT>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::median(
+SOP_OpenVDB_Filter_Level_Set::Cache::median(
     const FilterParms& parms,
     FilterT& filter,
     BossT& boss,
@@ -1298,7 +1213,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::median(
 
 template<typename FilterT>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::meanCurvature(
+SOP_OpenVDB_Filter_Level_Set::Cache::meanCurvature(
     const FilterParms& parms,
     FilterT& filter,
     BossT& boss,
@@ -1315,7 +1230,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::meanCurvatu
 
 template<typename FilterT>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::laplacian(
+SOP_OpenVDB_Filter_Level_Set::Cache::laplacian(
     const FilterParms& parms,
     FilterT& filter,
     BossT& boss,
@@ -1332,7 +1247,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::laplacian(
 
 template<typename FilterT>
 inline void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::renormalize(
+SOP_OpenVDB_Filter_Level_Set::Cache::renormalize(
     const FilterParms& parms,
     FilterT& filter,
     BossT&,
@@ -1356,7 +1271,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::renormalize
 
 template<typename FilterT>
 inline void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::resizeNarrowBand(
+SOP_OpenVDB_Filter_Level_Set::Cache::resizeNarrowBand(
     const FilterParms& parms,
     FilterT& filter,
     BossT&,
@@ -1384,7 +1299,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::resizeNarro
 
 template<typename FilterT>
 inline void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Filter_Level_Set)::track(
+SOP_OpenVDB_Filter_Level_Set::Cache::track(
     const FilterParms& parms,
     FilterT& filter,
     BossT& boss,

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Fracture.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Fracture.cc
@@ -55,13 +55,8 @@
 #include <UT/UT_ValArray.h>
 #include <UT/UT_Version.h>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/join.hpp>
 #include <hboost/math/constants/constants.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#include <boost/math/constants/constants.hpp>
-#endif
 
 #include <cmath>
 #include <iostream>
@@ -74,12 +69,8 @@
 #include <vector>
 
 
-
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 ////////////////////////////////////////
@@ -477,7 +468,6 @@ SOP_OpenVDB_Fracture::Cache::process(
     std::vector<openvdb::Vec3s> instancePoints;
     std::vector<openvdb::math::Quats> instanceRotations;
 
-#if (UT_VERSION_INT >= 0x0d000035) // 13.0.53 or later
     if (pointGeo != nullptr) {
         instancePoints.resize(pointGeo->getNumPoints());
 
@@ -542,108 +532,6 @@ SOP_OpenVDB_Fracture::Cache::process(
             }
         }
     }
-#else // before 13.0.53
-    if (pointGeo != nullptr) {
-        instancePoints.resize(pointGeo->getNumPoints());
-
-        GA_Range range(pointGeo->getPointRange());
-        GA_Offset start, end;
-
-        // Copy world space instance points.
-        GA_ROPageHandleV3 attribP(pointGeo->getP());
-        for (GA_Iterator it(range); it.blockAdvance(start, end); ) {
-            attribP.setPage(start);
-            for (GA_Offset i = start; i < end; ++i) {
-                UT_Vector3 pos = attribP.get(i);
-                instancePoints[pointGeo->pointIndex(i)] =
-                    openvdb::Vec3s(pos.x(), pos.y(), pos.z());
-            }
-        }
-
-        // Add instance offset if found
-        GA_ROPageHandleV3 attribTrans(pointGeo, GA_ATTRIB_POINT, "trans");
-        if (attribTrans.isValid()) {
-            for (GA_Iterator it(range); it.blockAdvance(start, end); ) {
-                attribTrans.setPage(start);
-                for (GA_Offset i = start; i < end; ++i) {
-                    UT_Vector3 trans = attribTrans.get(i);
-                    instancePoints[pointGeo->pointIndex(i)] +=
-                        openvdb::Vec3s(trans.x(), trans.y(), trans.z());
-                }
-            }
-        }
-
-        if (randomizeRotation) {
-
-            instanceRotations.resize(instancePoints.size());
-
-            // Generate uniform random rotations by picking random points
-            // in the unit cube and forming the unit quaternion.
-            using RandGen = std::mt19937;
-            RandGen rng(RandGen::result_type(evalInt("seed", 0, time)));
-            std::uniform_real_distribution<float> uniform01;
-            const float two_pi = 2.0 * hboost::math::constants::pi<float>();
-            for (size_t n = 0, N = instanceRotations.size(); n < N; ++n) {
-
-                const float u  = uniform01(rng);
-                const float c1 = std::sqrt(1-u);
-                const float c2 = std::sqrt(u);
-                const float s1 = two_pi * uniform01(rng);
-                const float s2 = two_pi * uniform01(rng);
-
-                instanceRotations[n][0] = c1 * std::sin(s1);
-                instanceRotations[n][1] = c1 * std::cos(s1);
-                instanceRotations[n][2] = c2 * std::sin(s2);
-                instanceRotations[n][3] = c2 * std::cos(s2);
-            }
-        } else {
-
-            GA_ROAttributeRef refN = pointGeo->findNormalAttribute(GA_ATTRIB_POINT);
-            if (!refN.isValid())
-                refN = pointGeo->findVelocityAttribute(GA_ATTRIB_POINT);
-            GA_ROHandleV3 attrN(refN.getAttribute());
-            GA_ROHandleV3 attrUp(pointGeo, GA_ATTRIB_POINT, "up");
-            GA_ROHandleQ attrRot(pointGeo, GA_ATTRIB_POINT, "rot");
-            GA_ROHandleQ attrOrient(pointGeo, GA_ATTRIB_POINT, "orient");
-
-            if (attrN.isValid() || attrUp.isValid() ||
-                attrRot.isValid() || attrOrient.isValid()) {
-
-                instanceRotations.resize(instancePoints.size());
-                for (size_t i = 0, n = instanceRotations.size(); i < n; ++i) {
-
-                    GA_Offset ptoff = pointGeo->pointOffset(i);
-                    UT_Matrix4D mat4;
-                    UT_QuaternionD quat;
-                    UT_Vector3 normal(0.0, 0.0, 0.0);
-                    UT_Vector3 up(0.0, 0.0, 0.0);
-                    UT_Quaternion rot;
-                    UT_Quaternion orient;
-
-                    if (attrN.isValid())
-                        normal = attrN.get(ptoff);
-                    if (attrUp.isValid())
-                        up = attrUp.get(ptoff);
-                    if (attrRot.isValid())
-                        rot = attrRot.get(ptoff);
-                    if (attrOrient.isValid())
-                        orient = attrOrient.get(ptoff);
-
-                    mat4.instance(UT_Vector3(0.0, 0.0, 0.0),
-                        normal,
-                        /*s*/1.0, /*s3*/nullptr,
-                        attrUp.isValid() ? &up : nullptr,
-                        attrRot.isValid() ? &rot : nullptr,
-                        /*trans*/nullptr,
-                        attrOrient.isValid() ? &orient : nullptr);
-
-                    quat.updateFromRotationMatrix(UT_Matrix3(mat4));
-                    instanceRotations[i].init(quat.x(), quat.y(), quat.z(), quat.w());
-                }
-            }
-        }
-    }
-#endif
     if (boss.wasInterrupted()) return;
 
     std::list<typename GridType::Ptr> residuals;
@@ -724,19 +612,10 @@ SOP_OpenVDB_Fracture::Cache::process(
     }
 
     // Check for multiple cutter objects
-#if (UT_VERSION_INT >= 0x0e000061) // 14.0.97 or later
     GEO_PrimClassifier primClassifier;
     if (separatecutters) {
         primClassifier.classifyBySharedPoints(*cutterGeo);
     }
-#else
-    GEO_PointClassifier pointClassifier;
-    GEO_PrimClassifier primClassifier;
-    if (separatecutters) {
-        pointClassifier.classifyPoints(*cutterGeo);
-        primClassifier.classifyBySharedPoints(*cutterGeo, pointClassifier);
-    }
-#endif
 
     const int cutterObjects = separatecutters ? primClassifier.getNumClass() : 1;
     const float bandWidth = float(backgroundValue / transform->voxelSize()[0]);
@@ -785,19 +664,10 @@ SOP_OpenVDB_Fracture::Cache::process(
                                 if ((primRef->getTypeId() == GEO_PRIMPOLY) &&
                                     (3 == vtxn || 4 == vtxn))
                                 {
-#if UT_MAJOR_VERSION_INT >= 16
                                     for (GA_Size vtx = 0; vtx < vtxn; ++vtx) {
                                         prim[int(vtx)] = static_cast<Vec4IValueType>(
                                             cutterGeo->pointIndex(primRef->getPointOffset(vtx)));
                                     }
-#else
-                                    GA_Primitive::const_iterator it;
-                                    primRef->beginVertex(it);
-                                    for (unsigned int vtx = 0; !it.atEnd(); ++it, ++vtx) {
-                                        prim[vtx] = static_cast<Vec4IValueType>(
-                                            cutterGeo->pointIndex(it.getPointOffset()));
-                                    }
-#endif
 
                                     if (vtxn != 4) prim[3] = openvdb::util::INVALID_IDX;
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Fracture.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Fracture.cc
@@ -73,11 +73,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -100,10 +95,8 @@ public:
 
     int isRefInput(unsigned i ) const override { return (i > 0); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
 
@@ -114,9 +107,7 @@ public:
             const GU_Detail* pointGeo,
             hvdb::Interrupter&,
             const fpreal time);
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -230,9 +221,7 @@ newSopOperator(OP_OperatorTable* table)
         .addOptionalInput("Optional points to instance the cutter object onto\n"
             "(The cutter object is used in place if no points are provided.)")
         .setObsoleteParms(obsoleteParms)
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Fracture::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -336,15 +325,9 @@ SOP_OpenVDB_Fracture::updateParmsFlags()
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Fracture)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Fracture::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        lock.markInputUnlocked(0);
-        duplicateSourceStealable(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         hvdb::Interrupter boss("Converting geometry to volume");
@@ -454,7 +437,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Fracture)::cookVDBSop(OP_Conte
 
 template<class GridType>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Fracture)::process(
+SOP_OpenVDB_Fracture::Cache::process(
     std::list<openvdb::GridBase::Ptr>& grids,
     const GU_Detail* cutterGeo,
     const GU_Detail* pointGeo,

--- a/openvdb_houdini/houdini/SOP_OpenVDB_From_Particles.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_From_Particles.cc
@@ -63,11 +63,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -104,10 +99,8 @@ public:
 
     static const PRM_ChoiceList sPointAttrMenu;
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     public:
         float voxelSize() const { return mVoxelSize; }
 
@@ -137,9 +130,7 @@ public:
             const openvdb::Int32Grid& closestPtIdxGrid);
 
         float mVoxelSize = 0.1f;
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 protected:
     void resolveObsoleteParms(PRM_ParmList*) override;
@@ -425,10 +416,8 @@ newSopOperator(OP_OperatorTable* table)
         .addInput("Points to convert")
         .addOptionalInput("Optional reference VDB")
         .setObsoleteParms(obsoleteParms)
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_GENERATOR,
             []() { return new SOP_OpenVDB_From_Particles::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -587,14 +576,10 @@ SOP_OpenVDB_From_Particles::convertUnits()
     const fpreal time = CHgetEvalTime();
 
     float voxSize = 0.1f;
-#if VDB_COMPILABLE_SOP
     // Attempt to extract the voxel size from our cache.
     if (const auto* cache = dynamic_cast<SOP_OpenVDB_From_Particles::Cache*>(myNodeVerbCache)) {
         voxSize = cache->voxelSize();
     }
-#else
-    voxSize = voxelSize();
-#endif
 
     if (evalInt("useworldspace", 0, time) != 0) {
         setFloat("halfband", 0, time, evalFloat("halfbandvoxels", 0, time) * voxSize);
@@ -887,7 +872,7 @@ getIgnoredParticleWarning(size_t numTooSmall, size_t numTooLarge)
 
 
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Particles)::convert(
+SOP_OpenVDB_From_Particles::Cache::convert(
     fpreal time,
     ParticleList& paList,
     openvdb::FloatGrid::Ptr sdfGrid,
@@ -920,7 +905,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Particles)::convert(
 
 
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Particles)::convertWithAttributes(
+SOP_OpenVDB_From_Particles::Cache::convertWithAttributes(
     fpreal time,
     const GU_Detail& ptGeo,
     ParticleList& paList,
@@ -983,7 +968,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Particles)::convertWithAt
 
 // Helper method for point attribute transfer
 int
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Particles)::constructGenericAtttributeList(
+SOP_OpenVDB_From_Particles::Cache::constructGenericAtttributeList(
     fpreal time,
     hvdb::AttributeDetailList &pointAttributes,
     const GU_Detail& ptGeo,
@@ -1092,14 +1077,9 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Particles)::constructGene
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Particles)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_From_Particles::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        gdp->clearAndDestroy();
-#endif
-
         hvdb::Interrupter boss("Creating VDBs from particles");
 
         const GU_Detail* ptGeo = inputGeo(0, context);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_From_Polygons.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_From_Polygons.cc
@@ -58,11 +58,6 @@
 #include <limits>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -221,10 +216,8 @@ public:
 
     int convertUnits();
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     public:
         float voxelSize() const { return mVoxelSize; }
     protected:
@@ -257,9 +250,7 @@ public:
             const GU_Detail&);
 
         float mVoxelSize = 0.1f;
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -540,10 +531,8 @@ newSopOperator(OP_OperatorTable* table)
         .addInput("Polygons to Convert")
         .addOptionalInput("Optional Reference VDB (for transform matching)")
         .setObsoleteParms(obsoleteParms)
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_GENERATOR,
             []() { return new SOP_OpenVDB_From_Polygons::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -619,14 +608,10 @@ SOP_OpenVDB_From_Polygons::convertUnits()
     float width;
 
     float voxSize = 0.1f;
-#if VDB_COMPILABLE_SOP
     // Attempt to extract the voxel size from our cache.
     if (const auto* cache = dynamic_cast<SOP_OpenVDB_From_Polygons::Cache*>(myNodeVerbCache)) {
         voxSize = cache->voxelSize();
     }
-#else
-    voxSize = voxelSize();
-#endif
 
     if (toWSUnits) {
         width = static_cast<float>(evalInt("exteriorbandvoxels", 0, 0));
@@ -772,14 +757,9 @@ SOP_OpenVDB_From_Polygons::updateParmsFlags()
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Polygons)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_From_Polygons::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        gdp->clearAndDestroy();
-#endif
-
         const fpreal time = context.getTime();
 
         hvdb::Interrupter boss("Converting geometry to volume");
@@ -999,7 +979,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Polygons)::cookVDBSop(OP_
 
 // Helper method constructs the attribute detail lists
 int
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Polygons)::constructGenericAtttributeLists(
+SOP_OpenVDB_From_Polygons::Cache::constructGenericAtttributeLists(
     hvdb::AttributeDetailList &pointAttributes,
     hvdb::AttributeDetailList &vertexAttributes,
     hvdb::AttributeDetailList &primitiveAttributes,
@@ -1139,7 +1119,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Polygons)::constructGener
 
 template<class ValueType>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Polygons)::addAttributeDetails(
+SOP_OpenVDB_From_Polygons::Cache::addAttributeDetails(
     hvdb::AttributeDetailList &attributeList,
     const GA_Attribute *attribute,
     const GA_AIFTuple *tupleAIF,
@@ -1202,7 +1182,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Polygons)::addAttributeDe
 
 
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_From_Polygons)::transferAttributes(
+SOP_OpenVDB_From_Polygons::Cache::transferAttributes(
     hvdb::AttributeDetailList &pointAttributes,
     hvdb::AttributeDetailList &vertexAttributes,
     hvdb::AttributeDetailList &primitiveAttributes,

--- a/openvdb_houdini/houdini/SOP_OpenVDB_LOD.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_LOD.cc
@@ -38,21 +38,15 @@
 #include <openvdb_houdini/SOP_NodeVDB.h>
 #include <openvdb_houdini/Utils.h>
 #include <openvdb/tools/MultiResGrid.h>
-#include <boost/algorithm/string/join.hpp>
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
+
 #include <hboost/algorithm/string/join.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#endif
+
 #include <string>
 #include <vector>
 
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 class SOP_OpenVDB_LOD: public hvdb::SOP_NodeVDB

--- a/openvdb_houdini/houdini/SOP_OpenVDB_LOD.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_LOD.cc
@@ -47,11 +47,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
@@ -70,12 +65,7 @@ public:
 
     int isRefInput(unsigned input) const override { return (input > 0); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -155,9 +145,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB LOD", SOP_OpenVDB_LOD::factory, parms, *table)
         .addInput("VDBs")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_LOD::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -301,15 +289,9 @@ isValidRange(float start, float end, float step)
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_LOD)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_LOD::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-        duplicateSource(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         // Get the group of grids to process.

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Metadata.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Metadata.cc
@@ -41,11 +41,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
@@ -59,12 +54,7 @@ public:
 
     static OP_Node* factory(OP_Network*, const char* name, OP_Operator*);
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -183,9 +173,7 @@ Other:\n\
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Metadata", SOP_OpenVDB_Metadata::factory, parms, *table)
         .addInput("Input with VDBs")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Metadata::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -251,16 +239,9 @@ SOP_OpenVDB_Metadata::SOP_OpenVDB_Metadata(OP_Network* net,
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Metadata)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Metadata::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-
-        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-        duplicateSource(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         // Get UI parameter values.

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Morph_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Morph_Level_Set.cc
@@ -38,23 +38,18 @@
 #include <openvdb_houdini/Utils.h>
 #include <openvdb_houdini/SOP_NodeVDB.h>
 #include <openvdb/tools/LevelSetMorph.h>
+
 #include <UT/UT_Version.h>
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
+
 #include <hboost/algorithm/string/join.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#endif
+
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 
-
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 ////////////////////////////////////////

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Morph_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Morph_Level_Set.cc
@@ -48,11 +48,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -145,17 +140,13 @@ public:
 
     int isRefInput(unsigned i ) const override { return (i > 0); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
         OP_ERROR evalMorphingParms(OP_Context&, MorphingParms&);
         bool processGrids(MorphingParms&, hvdb::Interrupter&);
-#if VDB_COMPILABLE_SOP
     };
-#endif
 
 protected:
     void resolveObsoleteParms(PRM_ParmList*) override;
@@ -359,10 +350,8 @@ newSopOperator(OP_OperatorTable* table)
         .addInput("Source SDF VDBs to Morph")
         .addInput("Target SDF VDB")
         .addOptionalInput("Optional VDB Alpha Mask")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE,
             []() { return new SOP_OpenVDB_Morph_Level_Set::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -447,15 +436,9 @@ SOP_OpenVDB_Morph_Level_Set::SOP_OpenVDB_Morph_Level_Set(OP_Network* net,
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Morph_Level_Set)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Morph_Level_Set::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        gdp->clearAndDestroy();
-        duplicateSource(0, context);
-#endif
-
         // Evaluate UI parameters
         MorphingParms parms;
         if (evalMorphingParms(context, parms) >= UT_ERROR_ABORT) return error();
@@ -479,7 +462,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Morph_Level_Set)::cookVDBSop(O
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Morph_Level_Set)::evalMorphingParms(
+SOP_OpenVDB_Morph_Level_Set::Cache::evalMorphingParms(
     OP_Context& context, MorphingParms& parms)
 {
     const fpreal now = context.getTime();
@@ -575,7 +558,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Morph_Level_Set)::evalMorphing
 
 
 bool
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Morph_Level_Set)::processGrids(
+SOP_OpenVDB_Morph_Level_Set::Cache::processGrids(
     MorphingParms& parms, hvdb::Interrupter& boss)
 {
     MorphOp op(parms, boss);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Noise.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Noise.cc
@@ -46,11 +46,6 @@
 #include <sstream>
 #include <stdexcept>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -138,10 +133,8 @@ public:
 
     int isRefInput(unsigned input) const override { return (input == 1); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
     private:
@@ -151,9 +144,7 @@ public:
         template<typename GridType>
         void applyNoise(hvdb::Grid& grid, const FractalBoltzmannGenerator&,
             const NoiseSettings&, const hvdb::Grid* maskGrid) const;
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -287,9 +278,7 @@ Use mask as frequency multiplier:\n\
     hvdb::OpenVDBOpFactory("VDB Noise", SOP_OpenVDB_Noise::factory, parms, *table)
         .addInput("VDB grids to noise")
         .addOptionalInput("Optional VDB grid to use as mask")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Noise::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -356,7 +345,7 @@ SOP_OpenVDB_Noise::updateParmsFlags()
 
 template<typename GridType>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Noise)::applyNoise(
+SOP_OpenVDB_Noise::Cache::applyNoise(
     hvdb::Grid& grid,
     const FractalBoltzmannGenerator& fbGenerator,
     const NoiseSettings& settings,
@@ -515,17 +504,9 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Noise)::applyNoise(
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Noise)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Noise::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-
-        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-        lock.markInputUnlocked(0);
-        duplicateSourceStealable(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         // Evaluate the FractalBoltzmann noise parameters from UI

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Occlusion_Mask.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Occlusion_Mask.cc
@@ -49,11 +49,6 @@
 #include <cmath> // for std::floor()
 #include <stdexcept>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
@@ -68,19 +63,15 @@ public:
 
     static OP_Node* factory(OP_Network*, const char* name, OP_Operator*);
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     public:
         openvdb::math::Transform::Ptr frustum() const { return mFrustum; }
     protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
     private:
         openvdb::math::Transform::Ptr mFrustum;
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 protected:
     void resolveObsoleteParms(PRM_ParmList*) override;
@@ -159,9 +150,7 @@ newSopOperator(OP_OperatorTable* table)
         SOP_OpenVDB_Occlusion_Mask::factory, parms, *table)
         .addInput("VDBs")
         .setObsoleteParms(obsoleteParms)
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Occlusion_Mask::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -207,14 +196,10 @@ SOP_OpenVDB_Occlusion_Mask::cookMyGuide1(OP_Context&)
     myGuide1->clearAndDestroy();
 
     openvdb::math::Transform::ConstPtr frustum;
-#if !VDB_COMPILABLE_SOP
-    frustum = mFrustum;
-#else
     // Attempt to extract the frustum from our cache.
     if (auto* cache = dynamic_cast<SOP_OpenVDB_Occlusion_Mask::Cache*>(myNodeVerbCache)) {
         frustum = cache->frustum();
     }
-#endif
 
     if (frustum) {
         UT_Vector3 color(0.9f, 0.0f, 0.0f);
@@ -436,15 +421,9 @@ private:
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Occlusion_Mask)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Occlusion_Mask::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-        duplicateSource(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         // Camera reference
@@ -455,13 +434,8 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Occlusion_Mask)::cookVDBSop(OP
         cameraPath.harden();
 
         if (cameraPath.isstring()) {
-#if VDB_COMPILABLE_SOP
             OBJ_Node* camobj = cookparms()->getCwd()->findOBJNode(cameraPath);
             OP_Node* self = cookparms()->getCwd();
-#else
-            OBJ_Node* camobj = findOBJNode(cameraPath);
-            OP_Node* self = this;
-#endif
 
             if (!camobj) {
                 addError(SOP_MESSAGE, "Camera not found");

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Group.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Group.cc
@@ -51,11 +51,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 using namespace openvdb;
@@ -123,10 +118,8 @@ public:
 
     int isRefInput(unsigned i) const override { return (i > 0); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     public:
         OP_ERROR evalGroupParms(OP_Context&, GroupParms&);
         OP_ERROR evalGridGroupParms(const PointDataGrid&, OP_Context&, GroupParms&);
@@ -136,9 +129,7 @@ public:
         void removeViewportMetadata(PointDataGrid&);
     protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -337,9 +328,7 @@ newSopOperator(OP_OperatorTable* table)
         .addInput("VDB Points")
         .addOptionalInput("Optional bounding geometry or level set")
         .setObsoleteParms(obsoleteParms)
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Points_Group::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -443,15 +432,9 @@ SOP_OpenVDB_Points_Group::SOP_OpenVDB_Points_Group(OP_Network* net,
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Points_Group::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        lock.markInputUnlocked(0);
-        if (duplicateSourceStealable(0, context) >= UT_ERROR_ABORT) return error();
-#endif
-
         // Evaluate UI parameters
         GroupParms parms;
         if (evalGroupParms(context, parms) >= UT_ERROR_ABORT) return error();
@@ -567,7 +550,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::cookVDBSop(OP_C
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::evalGroupParms(
+SOP_OpenVDB_Points_Group::Cache::evalGroupParms(
     OP_Context& context, GroupParms& parms)
 {
     const fpreal time = context.getTime();
@@ -773,7 +756,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::evalGroupParms(
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::evalGridGroupParms(
+SOP_OpenVDB_Points_Group::Cache::evalGridGroupParms(
     const PointDataGrid& grid, OP_Context&, GroupParms& parms)
 {
     auto leafIter = grid.tree().cbeginLeaf();
@@ -844,7 +827,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::evalGridGroupPa
 
 
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::performGroupFiltering(
+SOP_OpenVDB_Points_Group::Cache::performGroupFiltering(
     PointDataGrid& outputGrid, const GroupParms& parms)
 {
     // filter typedefs
@@ -978,7 +961,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::performGroupFil
 
 
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::setViewportMetadata(
+SOP_OpenVDB_Points_Group::Cache::setViewportMetadata(
     PointDataGrid& outputGrid, const GroupParms& parms)
 {
     outputGrid.insertMeta(openvdb_houdini::META_GROUP_VIEWPORT,
@@ -987,7 +970,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::setViewportMeta
 
 
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Group)::removeViewportMetadata(
+SOP_OpenVDB_Points_Group::Cache::removeViewportMetadata(
     PointDataGrid& outputGrid)
 {
     outputGrid.removeMeta(openvdb_houdini::META_GROUP_VIEWPORT);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Potential_Flow.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Potential_Flow.cc
@@ -51,11 +51,6 @@
 #include <stdexcept>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -74,12 +69,7 @@ struct SOP_OpenVDB_Potential_Flow: public hvdb::SOP_NodeVDB
 
     int isRefInput(unsigned i) const override { return (i == 1); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -232,10 +222,8 @@ newSopOperator(OP_OperatorTable* table)
         SOP_OpenVDB_Potential_Flow::factory, parms, *table)
         .addInput("VDB Surface and optional velocity VDB")
         .addOptionalInput("Optional VDB Mask")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE,
             []() { return new SOP_OpenVDB_Potential_Flow::Cache; })
-#endif
         .setDocumentation(
     "#icon: COMMON/openvdb\n"
     "#tags: vdb\n"
@@ -401,15 +389,9 @@ private:
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Potential_Flow)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Potential_Flow::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        lock.markInputUnlocked(0);
-        duplicateSourceStealable(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         hvdb::Interrupter boss("Computing Potential Flow");

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Potential_Flow.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Potential_Flow.cc
@@ -460,11 +460,9 @@ SOP_OpenVDB_Potential_Flow::Cache::cookVDBSop(OP_Context& context)
                 if (GEOvdbProcessTypedGridTopology(*vdb, op)) {
                     grid = op.mSdfGrid;
                 }
-#if (UT_VERSION_INT >= 0x10000258) // 16.0.600 or later
                 else if (GEOvdbProcessTypedGridPoint(*vdb, op)) {
                     grid = op.mSdfGrid;
                 }
-#endif
             }
         }
 
@@ -485,12 +483,10 @@ SOP_OpenVDB_Potential_Flow::Cache::cookVDBSop(OP_Context& context)
                         maskIt->getGrid(), op)) {
                         mask = op.mMaskGrid;
                     }
-#if (UT_VERSION_INT >= 0x10000258) // 16.0.600 or later
                     else if (UTvdbProcessTypedGridPoint(maskIt->getStorageType(),
                         maskIt->getGrid(), op)) {
                         mask = op.mMaskGrid;
                     }
-#endif
                     else {
                         addWarning(SOP_MESSAGE, "Cannot convert VDB type to mask.");
                     }

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Rasterize_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Rasterize_Points.cc
@@ -67,6 +67,7 @@
 #include <PRM/PRM_Parm.h>
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_SharedPtr.h>
+#include <UT/UT_UniquePtr.h>
 #include <UT/UT_WorkArgs.h>
 #include <VEX/VEX_Error.h>
 #include <VOP/VOP_CodeCompilerArgs.h>
@@ -81,24 +82,15 @@
 #include <tbb/parallel_reduce.h>
 #include <tbb/task_group.h>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
-  #include <hboost/algorithm/string/classification.hpp> // is_any_of
-  #include <hboost/algorithm/string/join.hpp>
-  #include <hboost/algorithm/string/split.hpp>
-  #ifdef SESI_OPENVDB
-    #include <hboost/mpl/at.hpp>
-    namespace boostmpl = hboost::mpl;
-  #else
-    #include <boost/mpl/at.hpp>
-    namespace boostmpl = boost::mpl;
-  #endif
+#include <hboost/algorithm/string/classification.hpp> // is_any_of
+#include <hboost/algorithm/string/join.hpp>
+#include <hboost/algorithm/string/split.hpp>
+#ifdef SESI_OPENVDB
+#include <hboost/mpl/at.hpp>
+namespace boostmpl = hboost::mpl;
 #else
-  #include <boost/algorithm/string/classification.hpp> // is_any_of
-  #include <boost/algorithm/string/join.hpp>
-  #include <boost/algorithm/string/split.hpp>
-  #include <boost/mpl/at.hpp>
-  namespace hboost = boost;
-  namespace boostmpl = boost::mpl;
+#include <boost/mpl/at.hpp>
+namespace boostmpl = boost::mpl;
 #endif
 
 #include <algorithm> // std::sort
@@ -108,12 +100,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-  #include <UT/UT_UniquePtr.h>
-#else
-  template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -3195,9 +3181,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Rasterize Points",
         SOP_OpenVDB_Rasterize_Points::factory, parms, *table)
-#if (UT_VERSION_INT >= 0x10000000) // later than 16.0.0
         .setOperatorTable(VOP_TABLE_NAME)
-#endif
         .setLocalVariables(VOP_CodeGenerator::theLocalVariables)
         .addInput("Points to rasterize")
         .addOptionalInput("Optional VDB grid that defines the output transform.")
@@ -3261,7 +3245,6 @@ SOP_OpenVDB_Rasterize_Points::factory(OP_Network* net, const char* name, OP_Oper
 }
 
 
-#if UT_MAJOR_VERSION_INT >= 16
 SOP_OpenVDB_Rasterize_Points::SOP_OpenVDB_Rasterize_Points(OP_Network* net,
     const char* name, OP_Operator* op)
     : hvdb::SOP_NodeVDB(net, name, op)
@@ -3269,17 +3252,6 @@ SOP_OpenVDB_Rasterize_Points::SOP_OpenVDB_Rasterize_Points(OP_Network* net,
     , mInitialParmNum(this->getParmList()->getEntries())
 {
 }
-#else
-SOP_OpenVDB_Rasterize_Points::SOP_OpenVDB_Rasterize_Points(OP_Network* net,
-    const char* name, OP_Operator* op)
-    : hvdb::SOP_NodeVDB(net, name, op)
-    , mCodeGenerator(this, new VOP_LanguageContextTypeList(VOP_LANGUAGE_VEX,
-        VOPconvertToContextType(VEX_CVEX_CONTEXT)), 1, 1)
-    , mInitialParmNum(this->getParmList()->getEntries())
-{
-    setOperatorTable(getOperatorTable(VOP_TABLE_NAME));
-}
-#endif
 
 
 OP_ERROR

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Ray.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Ray.cc
@@ -48,11 +48,7 @@
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_Version.h>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/join.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#endif
 
 #include <limits>
 #include <stdexcept>
@@ -63,9 +59,6 @@
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 ////////////////////////////////////////

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
@@ -50,19 +50,12 @@
 #include <string>
 #include <vector>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/join.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#endif
 
 
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 ////////////////////////////////////////

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Remap.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Remap.cc
@@ -63,11 +63,6 @@
 #include <sstream>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -463,17 +458,13 @@ struct SOP_OpenVDB_Remap: public hvdb::SOP_NodeVDB
     int sortInputRange();
     int sortOutputRange();
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     public:
         void evalRamp(UT_Ramp&, fpreal time);
     protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
-#if VDB_COMPILABLE_SOP
     }; // class Cache
-#endif
 };
 
 
@@ -528,15 +519,11 @@ SOP_OpenVDB_Remap::sortOutputRange()
 
 
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Remap)::evalRamp(UT_Ramp& ramp, fpreal time)
+SOP_OpenVDB_Remap::Cache::evalRamp(UT_Ramp& ramp, fpreal time)
 {
-#if !VDB_COMPILABLE_SOP
-    updateRampFromMultiParm(time, getParm("function"), ramp);
-#else
     const auto rampStr = evalStdString("function", time);
     UT_IStream strm(rampStr.c_str(), rampStr.size(), UT_ISTREAM_ASCII);
     ramp.load(strm);
-#endif
 }
 
 
@@ -640,9 +627,7 @@ newSopOperator(OP_OperatorTable* table)
     hvdb::OpenVDBOpFactory("VDB Remap",
         SOP_OpenVDB_Remap::factory, parms, *table)
         .addInput("VDB Grids")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Remap::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -675,14 +660,9 @@ SOP_OpenVDB_Remap::SOP_OpenVDB_Remap(OP_Network* net, const char* name, OP_Opera
 }
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Remap)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Remap::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        duplicateSourceStealable(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         hvdb::Interrupter boss("Remapping values");

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Remove_Divergence.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Remove_Divergence.cc
@@ -910,13 +910,8 @@ SOP_OpenVDB_Remove_Divergence::Cache::cookVDBSop(
                 // Retrieve the collider grid.
                 UT_String colliderStr;
                 evalString(colliderStr, "collider", 0, time);
-#if (UT_MAJOR_VERSION_INT >= 15)
                 const GA_PrimitiveGroup* colliderGroup = parsePrimitiveGroups(
                     colliderStr.buffer(), GroupCreator(colliderGeo));
-#else
-                const GA_PrimitiveGroup* colliderGroup = parsePrimitiveGroups(
-                    colliderStr.buffer(), const_cast<GU_Detail*>(colliderGeo));
-#endif
                 if (hvdb::VdbPrimCIterator colliderIt =
                     hvdb::VdbPrimCIterator(colliderGeo, colliderGroup))
                 {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Resample.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Resample.cc
@@ -53,11 +53,6 @@
 #include <stdexcept>
 #include <string>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -78,12 +73,7 @@ public:
 
     int isRefInput(unsigned i) const override { return (i == 1); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 
 protected:
     void resolveObsoleteParms(PRM_ParmList*) override;
@@ -294,9 +284,7 @@ Using Voxel Scale Only:\n\
         .setObsoleteParms(obsoleteParms)
         .addInput("Source VDB grids to resample")
         .addOptionalInput("Optional transform reference VDB grid")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Resample::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -434,15 +422,9 @@ struct VecXformOp
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Resample)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Resample::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        // This does a shallow copy of VDB grids and deep copy of native Houdini primitives.
-        duplicateSource(0, context);
-#endif
-
         auto addWarningCB = [this](const std::string& s) { addWarning(SOP_MESSAGE, s.c_str()); };
 
         const fpreal time = context.getTime();

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Sample_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Sample_Points.cc
@@ -54,11 +54,7 @@
 #include <GA/GA_PageHandle.h>
 #include <GA/GA_PageIterator.h>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/join.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#endif
 
 #include <algorithm>
 #include <iostream>
@@ -76,9 +72,6 @@
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
 namespace cvdb = openvdb;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 class SOP_OpenVDB_Sample_Points: public hvdb::SOP_NodeVDB

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
@@ -55,11 +55,7 @@
 #include <openvdb/tools/PointScatter.h>
 #include <openvdb/tree/LeafManager.h>
 #include <boost/algorithm/string/join.hpp>
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/join.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#endif
 #include <iostream>
 #include <random>
 #include <stdexcept>
@@ -70,9 +66,6 @@
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 class SOP_OpenVDB_Scatter: public hvdb::SOP_NodeVDB
@@ -682,9 +675,7 @@ process(const UT_VDBType type, const openvdb::GridBase& grid, OpType& op, const 
     bool success(false);
     success = UTvdbProcessTypedGridTopology(type, grid, op);
     if (!success) {
-#if UT_VERSION_INT >= 0x10000258 // 16.0.600 or later
         success = UTvdbProcessTypedGridPoint(type, grid, op);
-#endif
     }
     if (name) op.print(*name);
     return success;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Segment.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Segment.cc
@@ -51,11 +51,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -191,12 +186,7 @@ public:
 
     int isRefInput(unsigned i ) const override { return (i > 0); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -238,9 +228,7 @@ newSopOperator(OP_OperatorTable* table)
         .setInternalName("DW_OpenVDBSegment")
 #endif
         .addInput("OpenVDB grids")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_GENERATOR, []() { return new SOP_OpenVDB_Segment::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -294,14 +282,9 @@ SOP_OpenVDB_Segment::updateParmsFlags()
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Segment)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Segment::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        gdp->clearAndDestroy();
-#endif
-
         const fpreal time = context.getTime();
 
         const GU_Detail* inputGeoPt = inputGeo(0);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Sort_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Sort_Points.cc
@@ -59,11 +59,6 @@
 template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
 #endif
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -135,12 +130,7 @@ struct SOP_OpenVDB_Sort_Points: public hvdb::SOP_NodeVDB
     SOP_OpenVDB_Sort_Points(OP_Network*, const char* name, OP_Operator*);
     static OP_Node* factory(OP_Network*, const char* name, OP_Operator*);
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 };
 
 
@@ -163,9 +153,7 @@ newSopOperator(OP_OperatorTable* table)
     hvdb::OpenVDBOpFactory("VDB Sort Points",
         SOP_OpenVDB_Sort_Points::factory, parms, *table)
         .addInput("points")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_GENERATOR, []() { return new SOP_OpenVDB_Sort_Points::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -200,15 +188,9 @@ SOP_OpenVDB_Sort_Points::SOP_OpenVDB_Sort_Points(OP_Network* net, const char* na
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Sort_Points)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Sort_Points::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-
-        gdp->stashAll();
-#endif
-
         const fpreal time = context.getTime();
         const GU_Detail* srcGeo = inputGeo(0);
 
@@ -245,10 +227,6 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Sort_Points)::cookVDBSop(OP_Co
 
         UTparallelFor(GA_SplittableRange(gdp->getPointRange()),
             CopyElements(ptWrangler, srcOffsetArray.get()));
-
-#if !VDB_COMPILABLE_SOP
-        gdp->destroyStashed();
-#endif
 
     } catch (std::exception& e) {
         addError(SOP_MESSAGE, e.what());

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Sort_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Sort_Points.cc
@@ -46,19 +46,13 @@
 #include <GU/GU_Detail.h>
 #include <PRM/PRM_Parm.h>
 #include <UT/UT_Version.h>
+#include <UT/UT_UniquePtr.h>
 
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
 
 #include <memory>
 #include <stdexcept>
-
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-#include <UT/UT_UniquePtr.h>
-#else
-template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
-
 
 
 namespace hvdb = openvdb_houdini;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_To_Polygons.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_To_Polygons.cc
@@ -81,11 +81,6 @@
 template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
 #endif
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 //#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
@@ -114,10 +109,8 @@ public:
 
     int isRefInput(unsigned i) const override { return (i > 0); }
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions
     {
-#endif
     protected:
         OP_ERROR cookVDBSop(OP_Context&) override;
 
@@ -128,9 +121,7 @@ public:
             const GU_Detail* refGeo,
             hvdb::Interrupter&,
             const fpreal time);
-#if VDB_COMPILABLE_SOP
     };
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -309,9 +300,7 @@ newSopOperator(OP_OperatorTable* table)
             "to transfer attributes, sharpen features and to "
             "eliminate seams from fractured pieces.")
         .addOptionalInput("Optional VDB masks")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_GENERATOR, []() { return new SOP_OpenVDB_To_Polygons::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -627,15 +616,9 @@ getMaskFromGrid(const hvdb::GridCPtr& gridPtr, double isovalue = 0.0)
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_To_Polygons)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_To_Polygons::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-
-        gdp->clearAndDestroy();
-#endif
-
         const fpreal time = context.getTime();
 
         hvdb::Interrupter boss("Surfacing VDB primitives");
@@ -806,7 +789,7 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_To_Polygons)::cookVDBSop(OP_Co
 
 template<class GridType>
 void
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_To_Polygons)::referenceMeshing(
+SOP_OpenVDB_To_Polygons::Cache::referenceMeshing(
     std::list<openvdb::GridBase::ConstPtr>& grids,
     openvdb::tools::VolumeToMesh& mesher,
     const GU_Detail* refGeo,

--- a/openvdb_houdini/houdini/SOP_OpenVDB_To_Polygons.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_To_Polygons.cc
@@ -61,13 +61,10 @@
 #include <GU/GU_Surfacer.h>
 #include <PRM/PRM_Parm.h>
 #include <UT/UT_Interrupt.h>
+#include <UT/UT_UniquePtr.h>
 #include <UT/UT_Version.h>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/join.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#endif
 
 #include <list>
 #include <memory>
@@ -75,25 +72,9 @@
 #include <string>
 #include <vector>
 
-#if UT_VERSION_INT >= 0x0f050000 // 15.5.0 or later
-#include <UT/UT_UniquePtr.h>
-#else
-template<typename T> using UT_UniquePtr = std::unique_ptr<T>;
-#endif
-
-
-
-//#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
-//// GA_RWHandleV3 fails to initialize its member variables in some cases.
-//#pragma GCC diagnostic ignored "-Wuninitialized"
-//#endif
-
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 ////////////////////////////////////////

--- a/openvdb_houdini/houdini/SOP_OpenVDB_To_Spheres.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_To_Spheres.cc
@@ -49,11 +49,7 @@
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_Version.h>
 
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/algorithm/string/join.hpp>
-#else
-#include <boost/algorithm/string/join.hpp>
-#endif
 
 #include <algorithm>
 #include <limits>
@@ -65,9 +61,6 @@
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 ////////////////////////////////////////

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Topology_To_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Topology_To_Level_Set.cc
@@ -354,7 +354,6 @@ SOP_OpenVDB_Topology_To_Level_Set::Cache::cookVDBSop(
             const GU_PrimVDB *vdb = *vdbIt;
 
             if (!GEOvdbProcessTypedGridTopology(*vdb, converter)) {
-#if UT_VERSION_INT >= 0x100001d0 // 16.0.464 or later
                 if (!GEOvdbProcessTypedGridPoint(*vdb, converter)) {
                     if (vdb->getGrid().isType<cvdb::MaskGrid>()) {
                         cvdb::MaskGrid::ConstPtr grid =
@@ -362,22 +361,6 @@ SOP_OpenVDB_Topology_To_Level_Set::Cache::cookVDBSop(
                         converter(*grid);
                     }
                 }
-#else
-                // Handle grid types that are not natively supported by Houdini.
-                if (vdb->getGrid().isType<cvdb::tools::PointIndexGrid>()) {
-                    cvdb::tools::PointIndexGrid::ConstPtr grid =
-                        cvdb::gridConstPtrCast<cvdb::tools::PointIndexGrid>(vdb->getGridPtr());
-                    converter(*grid);
-                } else if (vdb->getGrid().isType<cvdb::points::PointDataGrid>()) {
-                    cvdb::points::PointDataGrid::ConstPtr grid =
-                        cvdb::gridConstPtrCast<cvdb::points::PointDataGrid>(vdb->getGridPtr());
-                    converter(*grid);
-                } else if (vdb->getGrid().isType<cvdb::MaskGrid>()) {
-                    cvdb::MaskGrid::ConstPtr grid =
-                        cvdb::gridConstPtrCast<cvdb::MaskGrid>(vdb->getGridPtr());
-                    converter(*grid);
-                }
-#endif
             }
         }
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Topology_To_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Topology_To_Level_Set.cc
@@ -52,11 +52,6 @@
 #include <stdexcept>
 #include <string>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace cvdb = openvdb;
@@ -74,12 +69,7 @@ public:
 
     static OP_Node* factory(OP_Network*, const char* name, OP_Operator*);
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 
 protected:
     void resolveObsoleteParms(PRM_ParmList*) override;
@@ -230,10 +220,8 @@ newSopOperator(OP_OperatorTable* table)
 #endif
         .addInput("VDB Grids")
         .setObsoleteParms(obsoleteParms)
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_GENERATOR,
             []() { return new SOP_OpenVDB_Topology_To_Level_Set::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -325,15 +313,10 @@ SOP_OpenVDB_Topology_To_Level_Set::resolveObsoleteParms(PRM_ParmList* obsoletePa
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Topology_To_Level_Set)::cookVDBSop(
+SOP_OpenVDB_Topology_To_Level_Set::Cache::cookVDBSop(
     OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        gdp->clearAndDestroy();
-#endif
-
         const fpreal time = context.getTime();
 
         const GU_Detail* inputGeoPt = inputGeo(0);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Transform.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Transform.cc
@@ -37,11 +37,7 @@
 #include <openvdb_houdini/SOP_NodeVDB.h>
 #include <openvdb/tools/VectorTransformer.h> // for transformVectors()
 #include <UT/UT_Interrupt.h>
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/math/constants/constants.hpp>
-#else
-#include <boost/math/constants/constants.hpp>
-#endif
 #include <set>
 #include <sstream>
 #include <stdexcept>
@@ -50,9 +46,6 @@
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 
 class SOP_OpenVDB_Transform: public hvdb::SOP_NodeVDB

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
@@ -48,11 +48,7 @@
 #include <UT/UT_SharedPtr.h>
 #include <UT/UT_String.h>
 #include <UT/UT_Version.h>
-#if UT_VERSION_INT >= 0x10050000 // 16.5.0 or later
 #include <hboost/regex.hpp>
-#else
-#include <boost/regex.hpp>
-#endif
 #include <functional>
 #include <memory>
 #include <set>
@@ -65,9 +61,6 @@
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
-#if UT_VERSION_INT < 0x10050000 // earlier than 16.5.0
-namespace hboost = boost;
-#endif
 
 // HAVE_MERGE_GROUP is disabled in Houdini
 #ifdef SESI_OPENVDB

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Merge.cc
@@ -61,11 +61,6 @@
 #include <string>
 #include <vector>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 
 namespace hvdb = openvdb_houdini;
@@ -90,12 +85,7 @@ public:
 
     static OP_Node* factory(OP_Network*, const char* name, OP_Operator*);
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 
 protected:
     bool updateParmsFlags() override;
@@ -241,9 +231,7 @@ Position:\n\
         SOP_OpenVDB_Vector_Merge::factory, parms, *table)
         .addInput("Scalar VDBs to merge into vector")
         .setObsoleteParms(obsoleteParms)
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Vector_Merge::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -645,14 +633,9 @@ private:
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Vector_Merge)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Vector_Merge::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        duplicateSource(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         const bool copyInactiveValues = evalInt("copyinactive", 0, time);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Split.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Vector_Split.cc
@@ -44,11 +44,6 @@
 #include <stdexcept>
 #include <string>
 
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_COMPILABLE_SOP 1
-#else
-#define VDB_COMPILABLE_SOP 0
-#endif
 
 namespace hvdb = openvdb_houdini;
 namespace hutil = houdini_utils;
@@ -62,12 +57,7 @@ public:
 
     static OP_Node* factory(OP_Network*, const char* name, OP_Operator*);
 
-#if VDB_COMPILABLE_SOP
     class Cache: public SOP_VDBCacheOptions { OP_ERROR cookVDBSop(OP_Context&) override; };
-#else
-protected:
-    OP_ERROR cookVDBSop(OP_Context&) override;
-#endif
 };
 
 
@@ -116,9 +106,7 @@ newSopOperator(OP_OperatorTable* table)
     hvdb::OpenVDBOpFactory("VDB Vector Split",
         SOP_OpenVDB_Vector_Split::factory, parms, *table)
         .addInput("Vector VDBs to split into scalar VDBs")
-#if VDB_COMPILABLE_SOP
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Vector_Split::Cache; })
-#endif
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
@@ -267,14 +255,9 @@ public:
 
 
 OP_ERROR
-VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Vector_Split)::cookVDBSop(OP_Context& context)
+SOP_OpenVDB_Vector_Split::Cache::cookVDBSop(OP_Context& context)
 {
     try {
-#if !VDB_COMPILABLE_SOP
-        hutil::ScopedInputLock lock(*this, context);
-        duplicateSource(0, context);
-#endif
-
         const fpreal time = context.getTime();
 
         const bool copyInactiveValues = evalInt("copyinactive", 0, time);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Visualize.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Visualize.cc
@@ -56,6 +56,7 @@
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_VectorTypes.h> // for UT_Vector3i
 #include <UT/UT_Version.h>
+#include <UT/UT_UniquePtr.h>
 
 #include <algorithm>
 #include <stdexcept>

--- a/openvdb_houdini/houdini/SOP_VDBVerbUtils.h
+++ b/openvdb_houdini/houdini/SOP_VDBVerbUtils.h
@@ -59,76 +59,14 @@
 #define OPENVDB_HOUDINI_SOP_VDBVERBUTILS_HAS_BEEN_INCLUDED
 
 #include <UT/UT_Version.h>
-#if UT_MAJOR_VERSION_INT >= 16
 #include <GOP/GOP_Manager.h>
 #include <SOP/SOP_NodeParmsOptions.h> // for SOP_NodeCacheOptions
 #include <openvdb/Types.h>
 #include <string>
-#endif
-
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-macros"
-#endif
-
-/// @cond SOP_VDBVERBUTILS_INTERNAL
-#if UT_MAJOR_VERSION_INT >= 16
-#define VDB_PREPROC_IF0(val_, _) val_
-#define VDB_PREPROC_IF1(_, val_) val_
-#define VDB_PREPROC_IF(cond_, val0_, val1_) VDB_PREPROC_IF ## cond_(val0_, val1_)
-#else
-#define VDB_PREPROC_IF(cond_, val_, _) val_
-#endif
-/// @endcond
-
-/// @brief Macro function to select between node and node cache implementations of SOP
-/// methods based on a boolean condition (such as whether SOP compilability is enabled)
-/// @param is_cache_  if 0, select the node method, if 1, select the cache method;
-///                   all other values are invalid
-/// @param cls_       the name of the SOP class
-/// @par Example
-/// @code
-/// #define COMPILABLE 1
-///
-/// class SOP_My_Node: public SOP_NodeVDB
-/// {
-///     ...
-/// #if COMPILABLE
-/// public:
-///     // For a compilable SOP, declare cookVDBSop() as a method of
-///     // a public, inner SOP_NodeCacheOptions subclass named Cache.
-///     class Cache: public SOP_VDBCacheOptions {
-///         OP_ERROR cookVDBSop(OP_Context&) override;
-///     };
-/// #else
-/// protected:
-///     // For a non-compilable SOP, declare cookVDBSop() as a SOP method.
-///     OP_ERROR cookVDBSop(OP_Context&) override;
-/// #endif
-/// };
-///
-/// // Implementation of either the node method (if COMPILABLE is 0)
-/// // or the cache method (if COMPILABLE is 1)
-/// OP_ERROR
-/// VDB_NODE_OR_CACHE(COMPILABLE, SOP_My_Node)::cookVDBSop(OP_Context&)
-/// {
-///     ...
-/// }
-/// @endcode
-/// @hideinitializer
-#define VDB_NODE_OR_CACHE(is_cache_, cls_) \
-    VDB_PREPROC_IF(is_cache_, cls_, cls_::Cache)
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 
 ////////////////////////////////////////
 
-
-#if UT_MAJOR_VERSION_INT >= 16
 
 /// @brief SOP_NodeCacheOptions subclass that adds methods specific to SOP_NodeVDB
 class SOP_VDBCacheOptions: public SOP_NodeCacheOptions
@@ -232,8 +170,6 @@ protected:
     // Handles ad-hoc group creation.
     GOP_Manager         gop;
 }; // class SOP_VDBCacheOptions
-
-#endif
 
 #endif // OPENVDB_HOUDINI_SOP_VDBVERBUTILS_HAS_BEEN_INCLUDED
 

--- a/openvdb_houdini/houdini/UT_VDBUtils.h
+++ b/openvdb_houdini/houdini/UT_VDBUtils.h
@@ -44,7 +44,7 @@
 
 #include <UT/UT_Version.h>
 
-#ifndef SESI_OPENVDB
+#if !defined(SESI_OPENVDB) && !defined(SESI_OPENVDB_PRIM)
 
 #include <UT/UT_VDBUtils.h>
 
@@ -766,7 +766,7 @@ inline openvdb::math::Vec2<T>   SYSmax(const openvdb::math::Vec2<T> &v1, const o
 
 #endif // __HDK_UT_VDBUtils__
 
-#endif // UT_VERSION_INT < 0x0c050157 // earlier than 12.5.343
+#endif // SESI_OPENVDB || SESI_OPENVDB_PRIM
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the

--- a/openvdb_houdini/houdini/VRAY_OpenVDB_Points.cc
+++ b/openvdb_houdini/houdini/VRAY_OpenVDB_Points.cc
@@ -35,7 +35,6 @@
 /// @brief The Delayed Load Mantra Procedural for OpenVDB Points.
 
 #include <UT/UT_Version.h>
-#if (UT_VERSION_INT >= 0x10000000) // 16.0.0 or later
 
 #include <UT/UT_DSOVersion.h>
 #include <GU/GU_Detail.h>
@@ -612,7 +611,6 @@ VRAY_OpenVDB_Points::render()
     obj->changeSetting("renderpoints", 1, &one);
 }
 
-#endif // 16.0.0 or later
 
 // Copyright (c) 2012-2018 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the

--- a/openvdb_houdini/houdini/geometry.cc
+++ b/openvdb_houdini/houdini/geometry.cc
@@ -51,22 +51,14 @@ createBox(GU_Detail& gdp, UT_Vector3 corners[8],
     }
 
     if (color != NULL) {
-#if (UT_VERSION_INT >= 0x0e0000b4) // 14.0.180 or later
         GA_RWHandleV3 cd(gdp.addDiffuseAttribute(GA_ATTRIB_POINT));
-#else
-        GA_RWHandleV3 cd(gdp.addDiffuseAttribute(GA_ATTRIB_POINT).getAttribute());
-#endif
         for (size_t i = 0; i < 8; ++i) {
             cd.set(ptoff[i], *color);
         }
     }
 
     if (alpha < 0.99) {
-#if (UT_VERSION_INT >= 0x0e0000b4) // 14.0.180 or later
         GA_RWHandleF A(gdp.addAlphaAttribute(GA_ATTRIB_POINT));
-#else
-        GA_RWHandleF A(gdp.addAlphaAttribute(GA_ATTRIB_POINT).getAttribute());
-#endif
         for (size_t i = 0; i < 8; ++i) {
             A.set(ptoff[i], alpha);
         }


### PR DESCRIPTION
Removing support for building with Houdini 16.0 or earlier. This includes eliminating the ability to build SOPs without verbification (for those that have been converted). Also, the SideFX primitive is now gated by an undefined SESI_OPENVDB_PRIM variable and remains in the codebase primarily as an example without being actively built through CI. The Travis 16.0 build has been deprecated and an error check added to the Makefile to catch when the version is too old. The release notes and INSTALL file have been updated to reflect this change.

This deletes over 2,500 lines of code! There's are now just two cases of Houdini version checks.