### PR TITLE
OVDB-15: Fix/Suppress Warnings

### DIFF
--- a/openvdb/Grid.h
+++ b/openvdb/Grid.h
@@ -1447,7 +1447,16 @@ template<typename TreeT>
 inline void
 Grid<TreeT>::pruneGrid(float tolerance)
 {
-    this->tree().prune(ValueType(zeroVal<ValueType>() + tolerance));
+    // Suppress conversion warning that GCC 6.3+ emits when ValueType is int or long int
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+    const auto value = zeroVal<ValueType>() + tolerance;
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+    this->tree().prune(static_cast<ValueType>(value));
 }
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 3

--- a/openvdb/Grid.h
+++ b/openvdb/Grid.h
@@ -1447,15 +1447,9 @@ template<typename TreeT>
 inline void
 Grid<TreeT>::pruneGrid(float tolerance)
 {
-    // Suppress conversion warning that GCC 6.3+ emits when ValueType is int or long int
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
     const auto value = zeroVal<ValueType>() + tolerance;
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
     this->tree().prune(static_cast<ValueType>(value));
 }
 

--- a/openvdb/Platform.h
+++ b/openvdb/Platform.h
@@ -192,6 +192,29 @@
 #endif
 
 
+/// @brief Bracket code with OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN/_END,
+/// to inhibit warnings about type conversion.
+/// @note Use this sparingly.  Use static casts and explicit type conversion if at all possible.
+/// @details Example:
+/// @code
+/// float value = 0.1f;
+/// OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+/// int valueAsInt = value;
+/// OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+/// @endcode
+#if defined __GNUC__
+    #define OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN \
+        _Pragma("GCC diagnostic push") \
+        _Pragma("GCC diagnostic ignored \"-Wconversion\"") \
+        _Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"")
+    #define OPENVDB_NO_TYPE_CONVERSION_WARNING_END \
+        _Pragma("GCC diagnostic pop")
+#else
+    #define OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+    #define OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+#endif
+
+
 #ifdef _MSC_VER
     /// Visual C++ does not have constants like M_PI unless this is defined.
     /// @note This is needed even though the core library is built with this but

--- a/openvdb/math/Operators.h
+++ b/openvdb/math/Operators.h
@@ -765,16 +765,11 @@ struct Gradient<ScaleMap, CD_2ND>
         using Vec3Type = typename internal::ReturnValue<Accessor>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(grid, ijk) );
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const auto gradient0 = iGradient[0] * map.getInvTwiceScale()[0];
         const auto gradient1 = iGradient[1] * map.getInvTwiceScale()[1];
         const auto gradient2 = iGradient[2] * map.getInvTwiceScale()[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return  Vec3Type(ValueType(gradient0),
                          ValueType(gradient1),
                          ValueType(gradient2));
@@ -789,16 +784,11 @@ struct Gradient<ScaleMap, CD_2ND>
         using Vec3Type = typename internal::ReturnValue<StencilT>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(stencil) );
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const auto gradient0 = iGradient[0] * map.getInvTwiceScale()[0];
         const auto gradient1 = iGradient[1] * map.getInvTwiceScale()[1];
         const auto gradient2 = iGradient[2] * map.getInvTwiceScale()[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return  Vec3Type(ValueType(gradient0),
                          ValueType(gradient1),
                          ValueType(gradient2));
@@ -819,16 +809,11 @@ struct Gradient<ScaleTranslateMap, CD_2ND>
         using Vec3Type = typename internal::ReturnValue<Accessor>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(grid, ijk) );
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const auto gradient0 = iGradient[0] * map.getInvTwiceScale()[0];
         const auto gradient1 = iGradient[1] * map.getInvTwiceScale()[1];
         const auto gradient2 = iGradient[2] * map.getInvTwiceScale()[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return  Vec3Type(ValueType(gradient0),
                          ValueType(gradient1),
                          ValueType(gradient2));
@@ -843,16 +828,11 @@ struct Gradient<ScaleTranslateMap, CD_2ND>
         using Vec3Type = typename internal::ReturnValue<StencilT>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(stencil) );
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const auto gradient0 = iGradient[0] * map.getInvTwiceScale()[0];
         const auto gradient1 = iGradient[1] * map.getInvTwiceScale()[1];
         const auto gradient2 = iGradient[2] * map.getInvTwiceScale()[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return  Vec3Type(ValueType(gradient0),
                          ValueType(gradient1),
                          ValueType(gradient2));
@@ -1636,16 +1616,10 @@ struct Laplacian<ScaleMap, DiffScheme>
         ValueType iddy = D2<DiffScheme>::inY(grid, ijk);
         ValueType iddz = D2<DiffScheme>::inZ(grid, ijk);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
         const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return value;
     }
 
@@ -1660,16 +1634,10 @@ struct Laplacian<ScaleMap, DiffScheme>
         ValueType iddy = D2<DiffScheme>::inY(stencil);
         ValueType iddz = D2<DiffScheme>::inZ(stencil);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
         const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return value;
     }
 };
@@ -1688,16 +1656,10 @@ struct Laplacian<ScaleTranslateMap, DiffScheme>
         ValueType iddy = D2<DiffScheme>::inY(grid, ijk);
         ValueType iddz = D2<DiffScheme>::inZ(grid, ijk);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
         const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return value;
     }
 
@@ -1711,16 +1673,10 @@ struct Laplacian<ScaleTranslateMap, DiffScheme>
         ValueType iddy = D2<DiffScheme>::inY(stencil);
         ValueType iddz = D2<DiffScheme>::inZ(stencil);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
         const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return value;
     }
 };

--- a/openvdb/math/Operators.h
+++ b/openvdb/math/Operators.h
@@ -765,9 +765,19 @@ struct Gradient<ScaleMap, CD_2ND>
         using Vec3Type = typename internal::ReturnValue<Accessor>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(grid, ijk) );
-        return  Vec3Type(ValueType(iGradient[0] * map.getInvTwiceScale()[0]),
-                         ValueType(iGradient[1] * map.getInvTwiceScale()[1]),
-                         ValueType(iGradient[2] * map.getInvTwiceScale()[2]) );
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const auto gradient0 = iGradient[0] * map.getInvTwiceScale()[0];
+        const auto gradient1 = iGradient[1] * map.getInvTwiceScale()[1];
+        const auto gradient2 = iGradient[2] * map.getInvTwiceScale()[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        return  Vec3Type(ValueType(gradient0),
+                         ValueType(gradient1),
+                         ValueType(gradient2));
     }
 
     // stencil access version
@@ -779,9 +789,19 @@ struct Gradient<ScaleMap, CD_2ND>
         using Vec3Type = typename internal::ReturnValue<StencilT>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(stencil) );
-        return  Vec3Type(ValueType(iGradient[0] * map.getInvTwiceScale()[0]),
-                         ValueType(iGradient[1] * map.getInvTwiceScale()[1]),
-                         ValueType(iGradient[2] * map.getInvTwiceScale()[2]) );
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const auto gradient0 = iGradient[0] * map.getInvTwiceScale()[0];
+        const auto gradient1 = iGradient[1] * map.getInvTwiceScale()[1];
+        const auto gradient2 = iGradient[2] * map.getInvTwiceScale()[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        return  Vec3Type(ValueType(gradient0),
+                         ValueType(gradient1),
+                         ValueType(gradient2));
     }
 };
 
@@ -799,9 +819,19 @@ struct Gradient<ScaleTranslateMap, CD_2ND>
         using Vec3Type = typename internal::ReturnValue<Accessor>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(grid, ijk) );
-        return  Vec3Type(ValueType(iGradient[0] * map.getInvTwiceScale()[0]),
-                         ValueType(iGradient[1] * map.getInvTwiceScale()[1]),
-                         ValueType(iGradient[2] * map.getInvTwiceScale()[2]) );
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const auto gradient0 = iGradient[0] * map.getInvTwiceScale()[0];
+        const auto gradient1 = iGradient[1] * map.getInvTwiceScale()[1];
+        const auto gradient2 = iGradient[2] * map.getInvTwiceScale()[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        return  Vec3Type(ValueType(gradient0),
+                         ValueType(gradient1),
+                         ValueType(gradient2));
     }
 
     // Stencil access version
@@ -813,9 +843,19 @@ struct Gradient<ScaleTranslateMap, CD_2ND>
         using Vec3Type = typename internal::ReturnValue<StencilT>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(stencil) );
-        return  Vec3Type(ValueType(iGradient[0] * map.getInvTwiceScale()[0]),
-                         ValueType(iGradient[1] * map.getInvTwiceScale()[1]),
-                         ValueType(iGradient[2] * map.getInvTwiceScale()[2]) );
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const auto gradient0 = iGradient[0] * map.getInvTwiceScale()[0];
+        const auto gradient1 = iGradient[1] * map.getInvTwiceScale()[1];
+        const auto gradient2 = iGradient[2] * map.getInvTwiceScale()[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        return  Vec3Type(ValueType(gradient0),
+                         ValueType(gradient1),
+                         ValueType(gradient2));
     }
 };
 //@}
@@ -1596,8 +1636,17 @@ struct Laplacian<ScaleMap, DiffScheme>
         ValueType iddy = D2<DiffScheme>::inY(grid, ijk);
         ValueType iddz = D2<DiffScheme>::inZ(grid, ijk);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+  #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#endif
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
-        return ValueType(iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2]);
+        const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        return value;
     }
 
     // stencil access version
@@ -1611,8 +1660,17 @@ struct Laplacian<ScaleMap, DiffScheme>
         ValueType iddy = D2<DiffScheme>::inY(stencil);
         ValueType iddz = D2<DiffScheme>::inZ(stencil);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+  #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#endif
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
-        return ValueType(iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2]);
+        const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        return value;
     }
 };
 
@@ -1630,8 +1688,17 @@ struct Laplacian<ScaleTranslateMap, DiffScheme>
         ValueType iddy = D2<DiffScheme>::inY(grid, ijk);
         ValueType iddz = D2<DiffScheme>::inZ(grid, ijk);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+  #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#endif
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
-        return ValueType(iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2]);
+        const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        return value;
     }
 
     // stencil access version
@@ -1644,8 +1711,17 @@ struct Laplacian<ScaleTranslateMap, DiffScheme>
         ValueType iddy = D2<DiffScheme>::inY(stencil);
         ValueType iddz = D2<DiffScheme>::inZ(stencil);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+  #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#endif
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
-        return ValueType(iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2]);
+        const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        return value;
     }
 };
 

--- a/openvdb/math/Stencils.h
+++ b/openvdb/math/Stencils.h
@@ -334,16 +334,11 @@ public:
     ///     + v100 u(1-v)(1-w)     + v101 u(1-v)w     + v110 uv(1-w)     + v111 uvw
     inline ValueType interpolation(const math::Vec3<ValueType>& xyz) const
     {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const ValueType u = xyz[0] - BaseType::mCenter[0];
         const ValueType v = xyz[1] - BaseType::mCenter[1];
         const ValueType w = xyz[2] - BaseType::mCenter[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
 
         assert(u>=0 && u<=1);
         assert(v>=0 && v<=1);
@@ -373,16 +368,11 @@ public:
     ///     + v100 u(1-v)(1-w)     + v101 u(1-v)w     + v110 uv(1-w)     + v111 uvw
     inline math::Vec3<ValueType> gradient(const math::Vec3<ValueType>& xyz) const
     {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const ValueType u = xyz[0] - BaseType::mCenter[0];
         const ValueType v = xyz[1] - BaseType::mCenter[1];
         const ValueType w = xyz[2] - BaseType::mCenter[2];
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
 
         assert(u>=0 && u<=1);
         assert(v>=0 && v<=1);
@@ -1329,16 +1319,11 @@ public:
     {
         const Coord& ijk = BaseType::getCenterCoord();
         const ValueType d = ValueType(mStencil[0] * 0.5 * mInvDx2); // distance in voxels / (2dx^2)
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const auto value = math::Vec3<ValueType>(   ijk[0] - d*(mStencil[2] - mStencil[1]),
                                                     ijk[1] - d*(mStencil[4] - mStencil[3]),
                                                     ijk[2] - d*(mStencil[6] - mStencil[5]));
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return value;
     }
 

--- a/openvdb/math/Stencils.h
+++ b/openvdb/math/Stencils.h
@@ -334,9 +334,20 @@ public:
     ///     + v100 u(1-v)(1-w)     + v101 u(1-v)w     + v110 uv(1-w)     + v111 uvw
     inline ValueType interpolation(const math::Vec3<ValueType>& xyz) const
     {
-        const ValueType u = xyz[0] - BaseType::mCenter[0]; assert(u>=0 && u<=1);
-        const ValueType v = xyz[1] - BaseType::mCenter[1]; assert(v>=0 && v<=1);
-        const ValueType w = xyz[2] - BaseType::mCenter[2]; assert(w>=0 && w<=1);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const ValueType u = xyz[0] - BaseType::mCenter[0];
+        const ValueType v = xyz[1] - BaseType::mCenter[1];
+        const ValueType w = xyz[2] - BaseType::mCenter[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+
+        assert(u>=0 && u<=1);
+        assert(v>=0 && v<=1);
+        assert(w>=0 && w<=1);
 
         ValueType V = BaseType::template getValue<0,0,0>();
         ValueType A = static_cast<ValueType>(V + (BaseType::template getValue<0,0,1>() - V) * w);
@@ -362,9 +373,20 @@ public:
     ///     + v100 u(1-v)(1-w)     + v101 u(1-v)w     + v110 uv(1-w)     + v111 uvw
     inline math::Vec3<ValueType> gradient(const math::Vec3<ValueType>& xyz) const
     {
-        const ValueType u = xyz[0] - BaseType::mCenter[0]; assert(u>=0 && u<=1);
-        const ValueType v = xyz[1] - BaseType::mCenter[1]; assert(v>=0 && v<=1);
-        const ValueType w = xyz[2] - BaseType::mCenter[2]; assert(w>=0 && w<=1);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const ValueType u = xyz[0] - BaseType::mCenter[0];
+        const ValueType v = xyz[1] - BaseType::mCenter[1];
+        const ValueType w = xyz[2] - BaseType::mCenter[2];
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+
+        assert(u>=0 && u<=1);
+        assert(v>=0 && v<=1);
+        assert(w>=0 && w<=1);
 
         ValueType D[4]={BaseType::template getValue<0,0,1>()-BaseType::template getValue<0,0,0>(),
                         BaseType::template getValue<0,1,1>()-BaseType::template getValue<0,1,0>(),
@@ -1307,9 +1329,17 @@ public:
     {
         const Coord& ijk = BaseType::getCenterCoord();
         const ValueType d = ValueType(mStencil[0] * 0.5 * mInvDx2); // distance in voxels / (2dx^2)
-        return math::Vec3<ValueType>(ijk[0] - d*(mStencil[2] - mStencil[1]),
-                                     ijk[1] - d*(mStencil[4] - mStencil[3]),
-                                     ijk[2] - d*(mStencil[6] - mStencil[5]));
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const auto value = math::Vec3<ValueType>(   ijk[0] - d*(mStencil[2] - mStencil[1]),
+                                                    ijk[1] - d*(mStencil[4] - mStencil[3]),
+                                                    ijk[2] - d*(mStencil[6] - mStencil[5]));
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        return value;
     }
 
     /// Return linear offset for the specified stencil point relative to its center

--- a/openvdb/math/Vec3.h
+++ b/openvdb/math/Vec3.h
@@ -265,16 +265,11 @@ public:
     template <typename S>
     const Vec3<T> &operator*=(S scalar)
     {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const auto value0 = this->mm[0] * scalar;
         const auto value1 = this->mm[1] * scalar;
         const auto value2 = this->mm[2] * scalar;
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         this->mm[0] = static_cast<T>(value0);
         this->mm[1] = static_cast<T>(value1);
         this->mm[2] = static_cast<T>(value2);
@@ -315,16 +310,11 @@ public:
     template <typename S>
     const Vec3<T> &operator+=(S scalar)
     {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const auto value0 = this->mm[0] + scalar;
         const auto value1 = this->mm[1] + scalar;
         const auto value2 = this->mm[2] + scalar;
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         this->mm[0] = static_cast<T>(value0);
         this->mm[1] = static_cast<T>(value1);
         this->mm[2] = static_cast<T>(value2);

--- a/openvdb/math/Vec3.h
+++ b/openvdb/math/Vec3.h
@@ -265,9 +265,19 @@ public:
     template <typename S>
     const Vec3<T> &operator*=(S scalar)
     {
-        this->mm[0] = static_cast<T>(this->mm[0] * scalar);
-        this->mm[1] = static_cast<T>(this->mm[1] * scalar);
-        this->mm[2] = static_cast<T>(this->mm[2] * scalar);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const auto value0 = this->mm[0] * scalar;
+        const auto value1 = this->mm[1] * scalar;
+        const auto value2 = this->mm[2] * scalar;
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        this->mm[0] = static_cast<T>(value0);
+        this->mm[1] = static_cast<T>(value1);
+        this->mm[2] = static_cast<T>(value2);
         return *this;
     }
 
@@ -305,9 +315,19 @@ public:
     template <typename S>
     const Vec3<T> &operator+=(S scalar)
     {
-        this->mm[0] = static_cast<T>(this->mm[0] + scalar);
-        this->mm[1] = static_cast<T>(this->mm[1] + scalar);
-        this->mm[2] = static_cast<T>(this->mm[2] + scalar);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const auto value0 = this->mm[0] + scalar;
+        const auto value1 = this->mm[1] + scalar;
+        const auto value2 = this->mm[2] + scalar;
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+        this->mm[0] = static_cast<T>(value0);
+        this->mm[1] = static_cast<T>(value1);
+        this->mm[2] = static_cast<T>(value2);
         return *this;
     }
 

--- a/openvdb/tools/Filter.h
+++ b/openvdb/tools/Filter.h
@@ -238,7 +238,15 @@ Filter<GridT, MaskT, InterruptT>::Avg<Axis>::operator()(Coord xyz)
     ValueType sum = zeroVal<ValueType>();
     Int32 &i = xyz[Axis], j = i + width;
     for (i -= width; i <= j; ++i) filter_internal::accum(sum, acc.getValue(xyz));
-    return static_cast<ValueType>(sum * frac);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+    ValueType value = static_cast<ValueType>(sum * frac);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+    return value;
 }
 
 
@@ -370,7 +378,16 @@ Filter<GridT, MaskT, InterruptT>::doBox(const RangeType& range, Int32 w)
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 const Coord xyz = iter.getCoord();
                 if (alpha(xyz, a, b)) {
-                    buffer.setValue(iter.pos(), ValueType(b*(*iter) + a*avg(xyz)));
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+  #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#endif
+                    const ValueType value(b*(*iter) + a*avg(xyz));
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+                    buffer.setValue(iter.pos(), value);
                 }
             }
         }
@@ -400,7 +417,16 @@ Filter<GridT, MaskT, InterruptT>::doMedian(const RangeType& range, int width)
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 if (alpha(iter.getCoord(), a, b)) {
                     stencil.moveTo(iter);
-                    buffer.setValue(iter.pos(), ValueType(b*(*iter) + a*stencil.median()));
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+  #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#endif
+                    ValueType value(b*(*iter) + a*stencil.median());
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+                    buffer.setValue(iter.pos(), value);
                 }
             }
         }
@@ -427,7 +453,18 @@ Filter<GridT, MaskT, InterruptT>::doOffset(const RangeType& range, ValueType off
         AlphaMaskT alpha(*mGrid, *mMask, mMinMask, mMaxMask, mInvertMask);
         for (LeafIterT leafIter=range.begin(); leafIter; ++leafIter) {
             for (VoxelIterT iter = leafIter->beginValueOn(); iter; ++iter) {
-                if (alpha(iter.getCoord(), a, b)) iter.setValue(ValueType(*iter + a*offset));
+                if (alpha(iter.getCoord(), a, b)) {
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+  #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#endif
+                    ValueType value(*iter + a*offset);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+                    iter.setValue(value);
+                }
             }
         }
     } else {

--- a/openvdb/tools/Filter.h
+++ b/openvdb/tools/Filter.h
@@ -238,14 +238,9 @@ Filter<GridT, MaskT, InterruptT>::Avg<Axis>::operator()(Coord xyz)
     ValueType sum = zeroVal<ValueType>();
     Int32 &i = xyz[Axis], j = i + width;
     for (i -= width; i <= j; ++i) filter_internal::accum(sum, acc.getValue(xyz));
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
     ValueType value = static_cast<ValueType>(sum * frac);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
     return value;
 }
 
@@ -378,15 +373,9 @@ Filter<GridT, MaskT, InterruptT>::doBox(const RangeType& range, Int32 w)
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 const Coord xyz = iter.getCoord();
                 if (alpha(xyz, a, b)) {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
                     const ValueType value(b*(*iter) + a*avg(xyz));
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
                     buffer.setValue(iter.pos(), value);
                 }
             }
@@ -417,15 +406,9 @@ Filter<GridT, MaskT, InterruptT>::doMedian(const RangeType& range, int width)
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 if (alpha(iter.getCoord(), a, b)) {
                     stencil.moveTo(iter);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
                     ValueType value(b*(*iter) + a*stencil.median());
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
                     buffer.setValue(iter.pos(), value);
                 }
             }
@@ -454,15 +437,9 @@ Filter<GridT, MaskT, InterruptT>::doOffset(const RangeType& range, ValueType off
         for (LeafIterT leafIter=range.begin(); leafIter; ++leafIter) {
             for (VoxelIterT iter = leafIter->beginValueOn(); iter; ++iter) {
                 if (alpha(iter.getCoord(), a, b)) {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
                     ValueType value(*iter + a*offset);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
                     iter.setValue(value);
                 }
             }

--- a/openvdb/tools/GridTransformer.h
+++ b/openvdb/tools/GridTransformer.h
@@ -498,16 +498,11 @@ resampleToMatch(const GridType& inGrid, GridType& outGrid, Interrupter& interrup
         using ValueT = typename GridType::ValueType;
         const bool outIsLevelSet = outGrid.getGridClass() == openvdb::GRID_LEVEL_SET;
 
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         const ValueT halfWidth = outIsLevelSet
             ? ValueT(outGrid.background() * (1.0 / outGrid.voxelSize()[0]))
             : ValueT(inGrid.background() * (1.0 / inGrid.voxelSize()[0]));
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
 
         typename GridType::Ptr tempGrid;
         try {

--- a/openvdb/tools/GridTransformer.h
+++ b/openvdb/tools/GridTransformer.h
@@ -496,9 +496,18 @@ resampleToMatch(const GridType& inGrid, GridType& outGrid, Interrupter& interrup
         // If the output grid is a level set, resample the input grid to have the output grid's
         // background value.  Otherwise, preserve the input grid's background value.
         using ValueT = typename GridType::ValueType;
-        const ValueT halfWidth = ((outGrid.getGridClass() == openvdb::GRID_LEVEL_SET)
+        const bool outIsLevelSet = outGrid.getGridClass() == openvdb::GRID_LEVEL_SET;
+
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+        const ValueT halfWidth = outIsLevelSet
             ? ValueT(outGrid.background() * (1.0 / outGrid.voxelSize()[0]))
-            : ValueT(inGrid.background() * (1.0 / inGrid.voxelSize()[0])));
+            : ValueT(inGrid.background() * (1.0 / inGrid.voxelSize()[0]));
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
 
         typename GridType::Ptr tempGrid;
         try {

--- a/openvdb/tools/Interpolation.h
+++ b/openvdb/tools/Interpolation.h
@@ -738,23 +738,38 @@ template<class ValueT, size_t N>
 inline ValueT
 BoxSampler::trilinearInterpolation(ValueT (&data)[N][N][N], const Vec3R& uvw)
 {
+    struct Local
+    {
+        static ValueT interpolate(const ValueT& a, const ValueT& b, double weight)
+        {
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+            const auto temp = (b - a) * weight;
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+            return a + ValueT(temp);
+        }
+    };
+
     // Trilinear interpolation:
     // The eight surrounding latice values are used to construct the result. \n
     // result(x,y,z) =
     //     v000 (1-x)(1-y)(1-z) + v001 (1-x)(1-y)z + v010 (1-x)y(1-z) + v011 (1-x)yz
     //   + v100 x(1-y)(1-z)     + v101 x(1-y)z     + v110 xy(1-z)     + v111 xyz
 
-    ValueT resultA, resultB;
-
-    resultA = data[0][0][0] + ValueT((data[0][0][1] - data[0][0][0]) * uvw[2]);
-    resultB = data[0][1][0] + ValueT((data[0][1][1] - data[0][1][0]) * uvw[2]);
-    ValueT result1 = resultA + ValueT((resultB-resultA) * uvw[1]);
-
-    resultA = data[1][0][0] + ValueT((data[1][0][1] - data[1][0][0]) * uvw[2]);
-    resultB = data[1][1][0] + ValueT((data[1][1][1] - data[1][1][0]) * uvw[2]);
-    ValueT result2 = resultA + ValueT((resultB - resultA) * uvw[1]);
-
-    return result1 + ValueT(uvw[0] * (result2 - result1));
+    return  Local::interpolate(
+                Local::interpolate(
+                    Local::interpolate(data[0][0][0], data[0][0][1], uvw[2]),
+                    Local::interpolate(data[0][1][0], data[0][1][1], uvw[2]),
+                    uvw[1]),
+                Local::interpolate(
+                    Local::interpolate(data[1][0][0], data[1][0][1], uvw[2]),
+                    Local::interpolate(data[1][1][0], data[1][1][1], uvw[2]),
+                    uvw[1]),
+                uvw[0]);
 }
 
 
@@ -805,6 +820,26 @@ template<class ValueT, size_t N>
 inline ValueT
 QuadraticSampler::triquadraticInterpolation(ValueT (&data)[N][N][N], const Vec3R& uvw)
 {
+    struct Local
+    {
+        static ValueT interpolate(const ValueT* value, double weight)
+        {
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+            const ValueT
+                a = static_cast<ValueT>(0.5 * (value[0] + value[2]) - value[1]),
+                b = static_cast<ValueT>(0.5 * (value[2] - value[0])),
+                c = static_cast<ValueT>(value[1]);
+            const auto temp = weight * (weight * a + b) + c;
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+            return static_cast<ValueT>(temp);
+        }
+    };
+
     /// @todo For vector types, interpolate over each component independently.
     ValueT vx[3];
     for (int dx = 0; dx < 3; ++dx) {
@@ -821,28 +856,16 @@ QuadraticSampler::triquadraticInterpolation(ValueT (&data)[N][N][N], const Vec3R
             //
             // for a, b and c.
             const ValueT* vz = &data[dx][dy][0];
-            const ValueT
-                az = static_cast<ValueT>(0.5 * (vz[0] + vz[2]) - vz[1]),
-                bz = static_cast<ValueT>(0.5 * (vz[2] - vz[0])),
-                cz = static_cast<ValueT>(vz[1]);
-            vy[dy] = static_cast<ValueT>(uvw.z() * (uvw.z() * az + bz) + cz);
+            vy[dy] = Local::interpolate(vz, uvw.z());
         }//loop over y
         // Fit a parabola to three interpolated samples in y, then
         // evaluate the parabola at y', where y' is the fractional
         // part of inCoord.y.
-        const ValueT
-            ay = static_cast<ValueT>(0.5 * (vy[0] + vy[2]) - vy[1]),
-            by = static_cast<ValueT>(0.5 * (vy[2] - vy[0])),
-            cy = static_cast<ValueT>(vy[1]);
-        vx[dx] = static_cast<ValueT>(uvw.y() * (uvw.y() * ay + by) + cy);
+        vx[dx] = Local::interpolate(vy, uvw.y());
     }//loop over x
     // Fit a parabola to three interpolated samples in x, then
     // evaluate the parabola at the fractional part of inCoord.x.
-    const ValueT
-        ax = static_cast<ValueT>(0.5 * (vx[0] + vx[2]) - vx[1]),
-        bx = static_cast<ValueT>(0.5 * (vx[2] - vx[0])),
-        cx = static_cast<ValueT>(vx[1]);
-    return static_cast<ValueT>(uvw.x() * (uvw.x() * ax + bx) + cx);
+    return Local::interpolate(vx, uvw.x());
 }
 
 template<class TreeT>

--- a/openvdb/tools/MultiResGrid.h
+++ b/openvdb/tools/MultiResGrid.h
@@ -575,14 +575,9 @@ sampleValue(const Coord& ijk, double level) const
     if ( level0 == level1 ) return v0;
     assert( level1 - level0 == 1 );
     const ValueType v1 = this->template sampleValue<Order>( ijk, 0, level1 );
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
     const ValueType a = ValueType(level1 - level);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
     return a * v0 + (ValueType(1) - a) * v1;
 }
 
@@ -597,14 +592,9 @@ sampleValue(const Vec3R& xyz, double level) const
     if ( level0 == level1 ) return v0;
     assert( level1 - level0 == 1 );
     const ValueType v1 = this->template sampleValue<Order>( xyz, 0, level1 );
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
     const ValueType a = ValueType(level1 - level);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
     return a * v0 + (ValueType(1) - a) * v1;
 }
 
@@ -816,16 +806,11 @@ struct MultiResGrid<TreeType>::FractionOp
         for (typename Range1::Iterator leafIter = range.begin(); leafIter; ++leafIter) {
             for (VoxelIter voxelIter = leafIter->cbeginValueOn(); voxelIter; ++voxelIter) {
                 Coord ijk = voxelIter.getCoord();
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+                OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
                 const auto value0 = ijk[0] * scale;
                 const auto value1 = ijk[1] * scale;
                 const auto value2 = ijk[2] * scale;
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+                OPENVDB_NO_TYPE_CONVERSION_WARNING_END
                 ijk[0] = int(math::Round(value0));
                 ijk[1] = int(math::Round(value1));
                 ijk[2] = int(math::Round(value2));
@@ -864,15 +849,10 @@ struct MultiResGrid<TreeType>::FractionOp
                 const Vec3R xyz =  Vec3R( voxelIter.getCoord().data() );// mid level coord
                 const ValueType v0 = tools::Sampler<Order>::sample( acc0, xyz * scale0 );
                 const ValueType v1 = tools::Sampler<Order>::sample( acc1, xyz * scale1 );
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+                OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
                 const auto value0 = a*v0;
                 const auto value1 = b*v1;
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+                OPENVDB_NO_TYPE_CONVERSION_WARNING_END
                 voxelIter.setValue( ValueType(value0 + value1) );
             }
         }

--- a/openvdb/tools/MultiResGrid.h
+++ b/openvdb/tools/MultiResGrid.h
@@ -575,7 +575,14 @@ sampleValue(const Coord& ijk, double level) const
     if ( level0 == level1 ) return v0;
     assert( level1 - level0 == 1 );
     const ValueType v1 = this->template sampleValue<Order>( ijk, 0, level1 );
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
     const ValueType a = ValueType(level1 - level);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
     return a * v0 + (ValueType(1) - a) * v1;
 }
 
@@ -590,7 +597,14 @@ sampleValue(const Vec3R& xyz, double level) const
     if ( level0 == level1 ) return v0;
     assert( level1 - level0 == 1 );
     const ValueType v1 = this->template sampleValue<Order>( xyz, 0, level1 );
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
     const ValueType a = ValueType(level1 - level);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
     return a * v0 + (ValueType(1) - a) * v1;
 }
 
@@ -802,9 +816,20 @@ struct MultiResGrid<TreeType>::FractionOp
         for (typename Range1::Iterator leafIter = range.begin(); leafIter; ++leafIter) {
             for (VoxelIter voxelIter = leafIter->cbeginValueOn(); voxelIter; ++voxelIter) {
                 Coord ijk = voxelIter.getCoord();
-                ijk[0] = int(math::Round(ijk[0] * scale));
-                ijk[1] = int(math::Round(ijk[1] * scale));
-                ijk[2] = int(math::Round(ijk[2] * scale));
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+                const auto value0 = ijk[0] * scale;
+                const auto value1 = ijk[1] * scale;
+                const auto value2 = ijk[2] * scale;
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+                ijk[0] = int(math::Round(value0));
+                ijk[1] = int(math::Round(value1));
+                ijk[2] = int(math::Round(value2));
+
                 acc.setValueOn( ijk );
             }//loop over active voxels in the fine tree
         }// loop over leaf nodes in the fine tree
@@ -839,7 +864,16 @@ struct MultiResGrid<TreeType>::FractionOp
                 const Vec3R xyz =  Vec3R( voxelIter.getCoord().data() );// mid level coord
                 const ValueType v0 = tools::Sampler<Order>::sample( acc0, xyz * scale0 );
                 const ValueType v1 = tools::Sampler<Order>::sample( acc1, xyz * scale1 );
-                voxelIter.setValue( ValueType(a*v0 + b*v1) );
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
+                const auto value0 = a*v0;
+                const auto value1 = b*v1;
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+                voxelIter.setValue( ValueType(value0 + value1) );
             }
         }
     }

--- a/openvdb/unittest/TestLevelSetUtil.cc
+++ b/openvdb/unittest/TestLevelSetUtil.cc
@@ -253,8 +253,8 @@ TestLevelSetUtil::testSegmentationTools()
 
         openvdb::FloatGrid::Ptr grid = openvdb::FloatGrid::create(0.0);
 
-        auto* leaf1 = grid->tree().touchLeaf(openvdb::Coord(0,0,0));
-        auto* leaf2 = grid->tree().touchLeaf(openvdb::Coord(100,100,100));
+        grid->tree().touchLeaf(openvdb::Coord(0,0,0));
+        grid->tree().touchLeaf(openvdb::Coord(100,100,100));
 
         CPPUNIT_ASSERT_EQUAL(openvdb::Index32(2), grid->tree().leafCount());
         CPPUNIT_ASSERT_EQUAL(openvdb::Index64(0), grid->tree().activeVoxelCount());

--- a/openvdb/unittest/util.h
+++ b/openvdb/unittest/util.h
@@ -68,7 +68,14 @@ makeSphere(const openvdb::Coord& dim, const openvdb::Vec3f& center, float radius
             for (xyz[2]=0; xyz[2]<dim[2]; ++xyz[2]) {
                 const openvdb::Vec3R p =  grid.transform().indexToWorld(xyz);
                 const float dist = float((p-center).length() - radius);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+#endif
                 ValueT val = ValueT(zero + dist);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
                 switch (mode) {
                 case SPHERE_DENSE:
                     acc.setValue(xyz, val);

--- a/openvdb/unittest/util.h
+++ b/openvdb/unittest/util.h
@@ -68,14 +68,9 @@ makeSphere(const openvdb::Coord& dim, const openvdb::Vec3f& center, float radius
             for (xyz[2]=0; xyz[2]<dim[2]; ++xyz[2]) {
                 const openvdb::Vec3R p =  grid.transform().indexToWorld(xyz);
                 const float dist = float((p-center).length() - radius);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+                OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
                 ValueT val = ValueT(zero + dist);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+                OPENVDB_NO_TYPE_CONVERSION_WARNING_END
                 switch (mode) {
                 case SPHERE_DENSE:
                     acc.setValue(xyz, val);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
@@ -844,14 +844,9 @@ struct MulAdd
 
     void operator()(const ValueT& a, const ValueT&, ValueT& out) const
     {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         out = ValueT(a * scale + offset);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
     }
 
     /// @return true if the scale is 1 and the offset is 0
@@ -890,14 +885,9 @@ struct Blend1
         aMult(a), bMult(b), ONE(openvdb::zeroVal<ValueT>() + 1) {}
     void operator()(const ValueT& a, const ValueT& b, ValueT& out) const
     {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         out = ValueT((ONE - aMult * a) * bMult * b);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
     }
 };
 
@@ -915,14 +905,9 @@ struct Blend2
         aMult(a), bMult(b), ONE(openvdb::zeroVal<ValueT>() + 1) {}
     void operator()(const ValueT& a, const ValueT& b, ValueT& out) const
     {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         out = ValueT(a*aMult); out = out + ValueT((ONE - out) * bMult*b);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
     }
 };
 
@@ -1037,16 +1022,11 @@ struct SOP_OpenVDB_Combine::CombineOp
             // For level set grids, use the level set rebuild tool to both resample the
             // source grid to match the reference grid and to rebuild the resulting level set.
             const bool refIsLevelSet = ref.getGridClass() == openvdb::GRID_LEVEL_SET;
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-#endif
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
             const ValueT halfWidth = refIsLevelSet
                 ? ValueT(ZERO + this->getScalarBackgroundValue(ref) * (1.0 / ref.voxelSize()[0]))
                 : ValueT(src.background() * (1.0 / src.voxelSize()[0]));
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_END
 
             if (!openvdb::math::isFinite(halfWidth)) {
                 std::stringstream msg;
@@ -1439,15 +1419,9 @@ struct SOP_OpenVDB_Combine::CombineOp
         if (deactivate) {
             const float deactivationTolerance =
                 float(self->evalFloat("bgtolerance", 0, self->getTime()));
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
             const ValueT tolerance(ZERO + deactivationTolerance);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_END
             // Mark active output tiles and voxels as inactive if their
             // values match the output grid's background value.
             // Do this first to facilitate pruning.
@@ -1459,15 +1433,9 @@ struct SOP_OpenVDB_Combine::CombineOp
         }
         if (prune) {
             const float pruneTolerance = float(self->evalFloat("tolerance", 0, self->getTime()));
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
             const ValueT tolerance(ZERO + pruneTolerance);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_END
             openvdb::tools::prune(resultGrid->tree(), tolerance);
         }
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
@@ -177,7 +177,7 @@ SOP_OpenVDB_Prune::updateParmsFlags()
 
 namespace {
 struct PruneOp {
-    PruneOp(const std::string m, fpreal tol = 0.0): mode(m), tolerance(tol) {}
+    PruneOp(const std::string m, fpreal tol = 0.0): mode(m), pruneTolerance(tol) {}
 
     template<typename GridT>
     void operator()(GridT& grid) const
@@ -185,7 +185,16 @@ struct PruneOp {
         using ValueT = typename GridT::ValueType;
 
         if (mode == "value") {
-            openvdb::tools::prune(grid.tree(), ValueT(openvdb::zeroVal<ValueT>() + tolerance));
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+  #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#endif
+            const ValueT tolerance(openvdb::zeroVal<ValueT>() + pruneTolerance);
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+            openvdb::tools::prune(grid.tree(), tolerance);
         } else if (mode == "inactive") {
             openvdb::tools::pruneInactive(grid.tree());
         } else if (mode == "levelset") {
@@ -194,7 +203,7 @@ struct PruneOp {
     }
 
     std::string mode;
-    fpreal tolerance;
+    fpreal pruneTolerance;
 };
 }
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
@@ -185,15 +185,9 @@ struct PruneOp {
         using ValueT = typename GridT::ValueType;
 
         if (mode == "value") {
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#endif
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
             const ValueT tolerance(openvdb::zeroVal<ValueT>() + pruneTolerance);
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#endif
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_END
             openvdb::tools::prune(grid.tree(), tolerance);
         } else if (mode == "inactive") {
             openvdb::tools::pruneInactive(grid.tree());


### PR DESCRIPTION
These changes either fix or suppress all warnings on GCC 6.3.0 for the core library, binaries, python module and Houdini SOPs. I've tested on Linux through Circle CI using CMake, which is the first target for enabling this. The changes to enable this in Circle/CMake will be forthcoming once #382 is merged.

This PR represents a kind of amnesty - all existing conversion issues (and there are quite a lot of them!) are simply suppressed using pragmas so that we can switch on warnings as errors. The aim being to ensure that any tools or changes introduced going forward are required to meet the new higher standard. In time, we can discuss the best way to go about resolving the existing issues and removing the pragmas. Where possible, I've refactored slightly to introduce pragmas around the fewest lines of code possible.

The most common conversion issue I encountered is when using an integer grid type and implicitly converting the ValueType into an explicit float/double type, but there are others.