### PR TITLE
Fix Stride for AttributeSet Copy-Constructor

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -45,6 +45,8 @@ Version 6.0.1 - In development
     - Fixed a bug in tools::segmentActiveVoxels() and tools::segmentSDF() where
       inactive leaf nodes were only pruned when there was more than one segment.
     - Fixed a crash in point moving when using group filters.
+    - Fixed a bug where the stride of existing attributes was being ignored
+      during copy-construction of an AttributeSet.
 
     API changes:
     - Moved the CopyConstness metafunction from TreeIterator.h to Types.h.

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -72,6 +72,8 @@ Bug fixes:
   and @vdblink::tools::segmentSDF() segmentSDF@endlink where inactive leaf
   nodes were only pruned when there was more than one segment.
 - Fixed a crash in point moving when using group filters.
+- Fixed a bug where the stride of existing attributes was being ignored
+  during copy-construction of an AttributeSet.
 
 @par
 API changes:

--- a/openvdb/points/AttributeSet.cc
+++ b/openvdb/points/AttributeSet.cc
@@ -96,11 +96,13 @@ AttributeSet::AttributeSet(const AttributeSet& attrSet, Index arrayLength)
 {
     for (const auto& namePos : mDescr->map()) {
         const size_t& pos = namePos.second;
-        AttributeArray::Ptr array = AttributeArray::create(mDescr->type(pos), arrayLength, 1);
+        const AttributeArray* existingArray = attrSet.getConst(pos);
+        AttributeArray::Ptr array =
+            AttributeArray::create(mDescr->type(pos), arrayLength, existingArray->stride());
 
         // transfer hidden and transient flags
-        if (attrSet.getConst(pos)->isHidden())      array->setHidden(true);
-        if (attrSet.getConst(pos)->isTransient())   array->setTransient(true);
+        if (existingArray->isHidden())      array->setHidden(true);
+        if (existingArray->isTransient())   array->setTransient(true);
 
         mAttrs[pos] = array;
     }

--- a/openvdb/unittest/TestAttributeSet.cc
+++ b/openvdb/unittest/TestAttributeSet.cc
@@ -517,6 +517,7 @@ TestAttributeSet::testAttributeSet()
 {
     // Define and register some common attribute types
     using AttributeS        = TypedAttributeArray<float>;
+    using AttributeB        = TypedAttributeArray<bool>;
     using AttributeI        = TypedAttributeArray<int32_t>;
     using AttributeL        = TypedAttributeArray<int64_t>;
     using AttributeVec3s    = TypedAttributeArray<Vec3s>;
@@ -568,6 +569,52 @@ TestAttributeSet::testAttributeSet()
         CPPUNIT_ASSERT_NO_THROW(
             invalidAttrSetA.appendAttribute("testStride2", AttributeI::attributeType(),
             /*stride=*/51, /*constantStride=*/false));
+    }
+
+    { // copy construction with varying attribute types and strides
+        Descriptor::Ptr descr = Descriptor::create(AttributeVec3s::attributeType());
+        AttributeSet attrSet(descr, /*arrayLength=*/50);
+
+        attrSet.appendAttribute("float1", AttributeS::attributeType(), /*stride=*/1);
+        attrSet.appendAttribute("int1", AttributeI::attributeType(), /*stride=*/1);
+        attrSet.appendAttribute("float3", AttributeS::attributeType(), /*stride=*/3);
+        attrSet.appendAttribute("vector", AttributeVec3s::attributeType(), /*stride=*/1);
+        attrSet.appendAttribute("vector3", AttributeVec3s::attributeType(), /*stride=*/3);
+        attrSet.appendAttribute("bool100", AttributeB::attributeType(), /*stride=*/100);
+
+        CPPUNIT_ASSERT_EQUAL(std::string("float"), attrSet.getConst("float1")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("int32"), attrSet.getConst("int1")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("float"), attrSet.getConst("float3")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("vec3s"), attrSet.getConst("vector")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("vec3s"), attrSet.getConst("vector3")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("bool"), attrSet.getConst("bool100")->type().first);
+
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(1), attrSet.getConst("float1")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(1), attrSet.getConst("int1")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(3), attrSet.getConst("float3")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(1), attrSet.getConst("vector")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(3), attrSet.getConst("vector3")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(100), attrSet.getConst("bool100")->stride());
+
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(50), attrSet.getConst("float1")->size());
+
+        AttributeSet attrSet2(attrSet, /*arrayLength=*/200);
+
+        CPPUNIT_ASSERT_EQUAL(std::string("float"), attrSet2.getConst("float1")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("int32"), attrSet2.getConst("int1")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("float"), attrSet2.getConst("float3")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("vec3s"), attrSet2.getConst("vector")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("vec3s"), attrSet2.getConst("vector3")->type().first);
+        CPPUNIT_ASSERT_EQUAL(std::string("bool"), attrSet2.getConst("bool100")->type().first);
+
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(1), attrSet2.getConst("float1")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(1), attrSet2.getConst("int1")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(3), attrSet2.getConst("float3")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(1), attrSet2.getConst("vector")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(3), attrSet2.getConst("vector3")->stride());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(100), attrSet2.getConst("bool100")->stride());
+
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index(200), attrSet2.getConst("float1")->size());
     }
 
     Descriptor::Ptr descr = Descriptor::create(AttributeVec3s::attributeType());


### PR DESCRIPTION
Fix a bug where the stride of existing attribute arrays was being ignored during copy construction of AttributeSets. This was reported as a result of attempting to use point deletion through the VDB Points Delete SOP in which an error was displayed on the SOP.

The itself fix is trivial, so I'd like to include it in the upcoming release if possible.