### PR TITLE
Removed -Wfloat-conversion from the conversion warnings as it's impli…

### DIFF
--- a/openvdb/Platform.h
+++ b/openvdb/Platform.h
@@ -202,7 +202,10 @@
 /// int valueAsInt = value;
 /// OPENVDB_NO_TYPE_CONVERSION_WARNING_END
 /// @endcode
-#if defined __GNUC__
+#if defined __INTEL_COMPILER
+    #define OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+    #define OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+#elif defined __GNUC__
     #define OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN \
         _Pragma("GCC diagnostic push") \
         _Pragma("GCC diagnostic ignored \"-Wconversion\"")

--- a/openvdb/Platform.h
+++ b/openvdb/Platform.h
@@ -205,8 +205,7 @@
 #if defined __GNUC__
     #define OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN \
         _Pragma("GCC diagnostic push") \
-        _Pragma("GCC diagnostic ignored \"-Wconversion\"") \
-        _Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"")
+        _Pragma("GCC diagnostic ignored \"-Wconversion\"")
     #define OPENVDB_NO_TYPE_CONVERSION_WARNING_END \
         _Pragma("GCC diagnostic pop")
 #else


### PR DESCRIPTION
…ed by -Wconversion

Note that `-Wfloat-conversion` was only introduced in GCC 4.9 so 4.8 (for Houdini 16.5) complains that it's unknown. It's also implied by `-Wconversion` so I removed it instead of branching

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>