### PR TITLE
Downgrade Circle CI to use 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 
+# A pre-requisite of the GitHub Checks API is:
+# Your project must be using CircleCI 2.0 with Workflows
+# (https://circleci.com/docs/2.0/enable-checks/)
 version: 2
 
 # Default configuration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 
+version: 2
+
 # Default configuration
 
 defaults: &defaults
@@ -121,7 +123,6 @@ _test:
 
 # Jobs
 
-version: 2.1
 jobs:
   testabi6latest:
     <<: *defaults
@@ -256,6 +257,7 @@ jobs:
 # Workflows
 
 workflows:
+  version: 2
   build_and_test:
     jobs:
       - testabi6


### PR DESCRIPTION
None of the 2.1 features are currently being used, so revert back to the older version to attempt to improve stability.