### PR TITLE
OVDB-71: Update INSTALL file minimum versions and add link to build documentation

### DIFF
--- a/openvdb/INSTALL
+++ b/openvdb/INSTALL
@@ -56,7 +56,7 @@ Optional:
 
 - OpenGL 3.2 or later, for the OpenVDB viewer
 
-- Python 2.7, for the Python module
+- Python 2.7 or later, for the Python module
 
 - NumPy (www.numpy.org), version 1.12.1 or later, for the Python module
 
@@ -69,9 +69,9 @@ Other versions might work but have not been tested.
 Installation
 ------------
 
-This documentation is for building with GNU Make which is now deprecated, it
-is strongly recommended to use CMake to build OpenVDB as this will be removed
-in an upcoming release.
+This documentation is for building with GNU Make. It is strongly recommended to
+use CMake to build OpenVDB as the Makefiles will be removed in an upcoming
+release.
 See the build documentation here -
 https://www.openvdb.org/documentation/doxygen/build.html for more information.
 

--- a/openvdb/INSTALL
+++ b/openvdb/INSTALL
@@ -3,6 +3,11 @@ Installing OpenVDB
 
 Requirements
 ------------
+
+See the dependencies documentation here -
+https://www.openvdb.org/documentation/doxygen/dependencies.html for more
+information.
+
 - A C++11-compatible compiler, such as
   GNU GCC (gcc.gnu.org), version 4.8.2 (with bugfix) or later,
   Clang (clang.llvm.org), version 3.8 or later,
@@ -47,7 +52,7 @@ Optional:
 - log4cplus (log4cplus.sourceforge.net), version 1.1.2 or later,
   for error logging
 
-- GLFW 2.7 (www.glfw.org), for the OpenVDB viewer
+- GLFW 3.0 (www.glfw.org), for the OpenVDB viewer
 
 - OpenGL 3.2 or later, for the OpenVDB viewer
 
@@ -64,8 +69,10 @@ Other versions might work but have not been tested.
 Installation
 ------------
 
-This documentation is for building with GNU Make, it is recommended to use
-CMake to build OpenVDB. See the build documentation here -
+This documentation is for building with GNU Make which is now deprecated, it
+is strongly recommended to use CMake to build OpenVDB as this will be removed
+in an upcoming release.
+See the build documentation here -
 https://www.openvdb.org/documentation/doxygen/build.html for more information.
 
 1.  Set values appropriate to your environment for the following variables

--- a/openvdb/INSTALL
+++ b/openvdb/INSTALL
@@ -4,39 +4,38 @@ Installing OpenVDB
 Requirements
 ------------
 - A C++11-compatible compiler, such as
-  GNU GCC (gcc.gnu.org), version 4.8 or later,
+  GNU GCC (gcc.gnu.org), version 4.8.2 (with bugfix) or later,
   Clang (clang.llvm.org), version 3.8 or later,
   or Intel ICC (software.intel.com), version 15 or later
 
-- GNU gmake (www.gnu.org/software/make/), version 3.81 or later
+- GNU gmake (www.gnu.org/software/make/), version 4.1 or later
 
-- Boost (www.boost.org), version 1.53.0 or later; 1.57.0 or later
-  for the Python module
+- Boost (www.boost.org), version 1.61.0 or later
   (Linux: yum install boost-devel; OS X: port install boost +python27)
 
 - libz (zlib.net)
   (Linux: yum install zlib-devel)
 
 - OpenEXR (www.openexr.com), for the 16-bit float Half class in half.h
-  and for .exr file output in vdb_render
+  and for .exr file output in vdb_render, version 2.2.0 or later
 
 - Intel Threading Building Blocks (threadingbuildingblocks.org),
-  version 3.0 or later
+  version 4.4.6 or later
 
 Other compilers or versions might work but have not been tested.
 
 
 Optional:
 
-- Doxygen 1.8.11 or later (www.stack.nl/~dimitri/doxygen/), for documentation
+- Doxygen 1.8.13 or later (www.stack.nl/~dimitri/doxygen/), for documentation
 
-- CppUnit (www.freedesktop.org/wiki/Software/cppunit), version 1.10 or later
+- CppUnit (www.freedesktop.org/wiki/Software/cppunit), version 1.13.0 or later
   (Linux: yum install cppunit-devel)
 
 - Houdini HDK (http://www.sidefx.com/get/download-houdini/), version 16.5
   or later
 
-- Blosc compression library (www.blosc.org), version 1.5.0 or later
+- Blosc compression library (www.blosc.org), version 1.5.0
   (included in the Houdini HDK)
 
 - Ghostscript (www.ghostscript.com), version 8.70 or later, for documentation
@@ -52,9 +51,9 @@ Optional:
 
 - OpenGL 3.2 or later, for the OpenVDB viewer
 
-- Python 2.5, 2.6 or 2.7, for the Python module
+- Python 2.7, for the Python module
 
-- NumPy (www.numpy.org), for the Python module
+- NumPy (www.numpy.org), version 1.12.1 or later, for the Python module
 
 - Epydoc (http://epydoc.sourceforge.net/), version 3.0 or later,
   for Python module documentation
@@ -64,6 +63,11 @@ Other versions might work but have not been tested.
 
 Installation
 ------------
+
+This documentation is for building with GNU Make, it is recommended to use
+CMake to build OpenVDB. See the build documentation here -
+https://www.openvdb.org/documentation/doxygen/build.html for more information.
+
 1.  Set values appropriate to your environment for the following variables
     at the top of the Makefile:
 


### PR DESCRIPTION
There's a good argument to remove this file entirely, but for the time being, just update the versions and add a link to point to the CMake build documentation.