### PR TITLE
CMake root path improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,12 +218,12 @@ enable_testing()
 
 # Add our cmake modules
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # Add backports to support older versions of CMake
 
 if(${CMAKE_VERSION} VERSION_LESS 3.8)
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/backports")
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/backports")
 endif()
 
 # Add cmake modules to installation command
@@ -434,7 +434,7 @@ if(NOT OPENVDB_BUILD_CORE)
     endif()
   endif()
 else()
-  include("${CMAKE_SOURCE_DIR}/cmake/OpenVDBUtils.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/cmake/OpenVDBUtils.cmake")
   OPENVDB_VERSION_FROM_HEADER("${CMAKE_CURRENT_SOURCE_DIR}/openvdb/version.h"
     VERSION OpenVDB_VERSION
     MAJOR   OpenVDB_MAJOR_VERSION

--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -3,6 +3,10 @@ OpenVDB Version History
 
 Version 6.1.1 - In development
 
+    Improvements:
+    - Improved directory and file path lookups of some CMake commands in
+      the root CMakeLists.txt [Reported by Daniel Elliott]
+
     Bug fixes:
     - Fixed a bug in tools::computeScalarPotential() that could produce a
       corrupt result due to invalid memory access. [Reported by Edwin Braun]

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -7,6 +7,11 @@
 <B>Version 6.1.1</B> - <I>In development</I>
 
 @par
+Improvements:
+- Improved directory and file path lookups of some CMake commands in
+  the root CMakeLists.txt <I>[Reported by Daniel Elliott]</I>
+
+@par
 Bug fixes:
 - Fixed a bug in @vdblink::tools::computeScalarPotential() computeScalarPotential
   @endlink that could produce a corrupt result due to invalid memory access.


### PR DESCRIPTION
This fixes the case where users have wrapped our CMakeLists.txt with their own via things like `include()`, which results in a different value for CMAKE_SOURCE_DIR