### PR TITLE
OVDB-94: makeGridUnique fix for Fill SOP

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -6,17 +6,25 @@ Version 6.1.1 - In development
     Improvements:
     - FindOpenVDB.cmake now correctly propagates CXX version requirements.
     - Improved directory and file path lookups of some CMake commands in
-      the root CMakeLists.txt [Reported by Daniel Elliott]
+      the root CMakeLists.txt
+      [Reported by Daniel Elliott]
 
     Bug fixes:
-    - Fixed a bug in tools::computeScalarPotential() that could produce a
-      corrupt result due to invalid memory access. [Reported by Edwin Braun]
+    - Fixed a bug in tools::computeScalarPotential() that could produce
+      a corrupt result due to invalid memory access.
+      [Reported by Edwin Braun]
 
     Python:
-    - Updated python module CMake to always produce a .so for the python plugin
-      on UNIX platforms.
-    - Python 3 support improvements to python/pyOpenVDBModule.cc
+    - CMake now always produces a .so for the Python module on UNIX platforms.
+    - Fixed a compile-time error when building the Python module for Python 3.
       [Reported by yurivict]
+
+    Houdini:
+    - Added openvdb_houdini::GEOvdbApply(), which invokes a functor
+      on a VDB primitive if the resolved grid type is a member of
+      a given type list.
+    - Fixed a regression in the Fill SOP that caused it to modify VDBs
+      in the input detail.
 
 
 Version 6.1.0 - May 8, 2019

--- a/openvdb/Grid.h
+++ b/openvdb/Grid.h
@@ -279,6 +279,8 @@ public:
     /// @see @vdblink::TypeList TypeList@endlink
     template<typename GridTypeListT, typename OpT> inline bool apply(OpT&) const;
     template<typename GridTypeListT, typename OpT> inline bool apply(OpT&);
+    template<typename GridTypeListT, typename OpT> inline bool apply(const OpT&) const;
+    template<typename GridTypeListT, typename OpT> inline bool apply(const OpT&);
     /// @}
 
     /// @name Metadata
@@ -1754,6 +1756,20 @@ inline bool
 GridBase::apply(OpT& op)
 {
     return internal::GridApplyImpl<OpT, GridBase, GridTypeListT>::apply(*this, op);
+}
+
+template<typename GridTypeListT, typename OpT>
+inline bool
+GridBase::apply(const OpT& op) const
+{
+    return internal::GridApplyImpl<const OpT, const GridBase, GridTypeListT>::apply(*this, op);
+}
+
+template<typename GridTypeListT, typename OpT>
+inline bool
+GridBase::apply(const OpT& op)
+{
+    return internal::GridApplyImpl<const OpT, GridBase, GridTypeListT>::apply(*this, op);
 }
 
 } // namespace OPENVDB_VERSION_NAME

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -8,22 +8,33 @@
 
 @par
 Improvements:
-- FindOpenVDB.cmake now correctly propagates CXX version requirements.
+- <TT>FindOpenVDB.cmake</TT> now correctly propagates @c CXX version
+  requirements.
 - Improved directory and file path lookups of some CMake commands in
-  the root CMakeLists.txt <I>[Reported by Daniel Elliott]</I>
+  the root <TT>CMakeLists.txt</TT>.
+  <I>[Reported&nbsp;by&nbsp;Daniel&nbsp;Elliott]</I>
 
 @par
 Bug fixes:
-- Fixed a bug in @vdblink::tools::computeScalarPotential() computeScalarPotential
-  @endlink that could produce a corrupt result due to invalid memory access.
-  <I>[Reported by Edwin Braun]</I>
+- Fixed a bug in
+  @vdblink::tools::computeScalarPotential() computeScalarPotential@endlink
+  that could produce a corrupt result due to invalid memory access.
+  <I>[Reported&nbsp;by&nbsp;Edwin&nbsp;Braun]</I>
 
 @par
 Python:
-- Updated python module CMake to always produce a .so for the python plugin
+- CMake now always produces a <TT>.so</TT> for the Python module
   on UNIX platforms.
-- Python 3 support improvements to python/pyOpenVDBModule.cc
-  <I>[Reported by yurivict]</I>
+- Fixed a compile-time error when building the Python module for Python&nbsp;3.
+  <I>[Reported&nbsp;by&nbsp;yurivict]</I>
+
+@par
+Houdini:
+- Added <B>openvdb_houdini::GEOvdbApply</B>, which invokes a functor
+  on a VDB primitive if the resolved grid type is a member of
+  a given type list.
+- Fixed a regression in the Fill&nbsp;SOP that caused it to modify VDBs
+  in the input detail.
 
 
 @htmlonly <a name="v6_1_0_changes"></a>@endhtmlonly

--- a/openvdb/unittest/TestGrid.cc
+++ b/openvdb/unittest/TestGrid.cc
@@ -524,6 +524,19 @@ TestGrid::testApply()
         CPPUNIT_ASSERT(floatCGrid->apply<AllowedGridTypes>(op));  CPPUNIT_ASSERT(op.isConst);
         CPPUNIT_ASSERT(doubleCGrid->apply<AllowedGridTypes>(op)); CPPUNIT_ASSERT(op.isConst);
     }
+    {
+        using AllowedGridTypes = TypeList<FloatGrid, DoubleGrid>;
+
+        // Verify that rvalue functors are supported.
+        CPPUNIT_ASSERT(!boolGrid->apply<AllowedGridTypes>([](GridBase&) {}));
+        CPPUNIT_ASSERT(!intGrid->apply<AllowedGridTypes>([](GridBase&) {}));
+        CPPUNIT_ASSERT(floatGrid->apply<AllowedGridTypes>([](GridBase&) {}));
+        CPPUNIT_ASSERT(doubleGrid->apply<AllowedGridTypes>([](GridBase&) {}));
+        CPPUNIT_ASSERT(!boolCGrid->apply<AllowedGridTypes>([](const GridBase&) {}));
+        CPPUNIT_ASSERT(!intCGrid->apply<AllowedGridTypes>([](const GridBase&) {}));
+        CPPUNIT_ASSERT(floatCGrid->apply<AllowedGridTypes>([](const GridBase&) {}));
+        CPPUNIT_ASSERT(doubleCGrid->apply<AllowedGridTypes>([](const GridBase&) {}));
+    }
 }
 
 // Copyright (c) DreamWorks Animation LLC

--- a/openvdb/unittest/TestGrid.cc
+++ b/openvdb/unittest/TestGrid.cc
@@ -528,14 +528,16 @@ TestGrid::testApply()
         using AllowedGridTypes = TypeList<FloatGrid, DoubleGrid>;
 
         // Verify that rvalue functors are supported.
-        CPPUNIT_ASSERT(!boolGrid->apply<AllowedGridTypes>([](GridBase&) {}));
-        CPPUNIT_ASSERT(!intGrid->apply<AllowedGridTypes>([](GridBase&) {}));
-        CPPUNIT_ASSERT(floatGrid->apply<AllowedGridTypes>([](GridBase&) {}));
-        CPPUNIT_ASSERT(doubleGrid->apply<AllowedGridTypes>([](GridBase&) {}));
-        CPPUNIT_ASSERT(!boolCGrid->apply<AllowedGridTypes>([](const GridBase&) {}));
-        CPPUNIT_ASSERT(!intCGrid->apply<AllowedGridTypes>([](const GridBase&) {}));
-        CPPUNIT_ASSERT(floatCGrid->apply<AllowedGridTypes>([](const GridBase&) {}));
-        CPPUNIT_ASSERT(doubleCGrid->apply<AllowedGridTypes>([](const GridBase&) {}));
+        int n = 0;
+        CPPUNIT_ASSERT(  !boolGrid->apply<AllowedGridTypes>([&n](GridBase&) { ++n; }));
+        CPPUNIT_ASSERT(   !intGrid->apply<AllowedGridTypes>([&n](GridBase&) { ++n; }));
+        CPPUNIT_ASSERT(  floatGrid->apply<AllowedGridTypes>([&n](GridBase&) { ++n; }));
+        CPPUNIT_ASSERT( doubleGrid->apply<AllowedGridTypes>([&n](GridBase&) { ++n; }));
+        CPPUNIT_ASSERT( !boolCGrid->apply<AllowedGridTypes>([&n](const GridBase&) { ++n; }));
+        CPPUNIT_ASSERT(  !intCGrid->apply<AllowedGridTypes>([&n](const GridBase&) { ++n; }));
+        CPPUNIT_ASSERT( floatCGrid->apply<AllowedGridTypes>([&n](const GridBase&) { ++n; }));
+        CPPUNIT_ASSERT(doubleCGrid->apply<AllowedGridTypes>([&n](const GridBase&) { ++n; }));
+        CPPUNIT_ASSERT_EQUAL(4, n);
     }
 }
 

--- a/openvdb_houdini/SOP_OpenVDB_Fill.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Fill.cc
@@ -38,8 +38,8 @@
 
 #include <PRM/PRM_Parm.h>
 #include <UT/UT_Interrupt.h>
-#include <UT/UT_Version.h>
 #include <UT/UT_UniquePtr.h>
+#include <UT/UT_Version.h>
 
 #include <memory>
 #include <stdexcept>
@@ -415,7 +415,7 @@ SOP_OpenVDB_Fill::Cache::cookVDBSop(OP_Context& context)
             if (progress.wasInterrupted()) {
                 throw std::runtime_error("processing was interrupted");
             }
-            it->getGrid().apply<hvdb::VolumeGridTypes>(*fillOp);
+            hvdb::GEOvdbApply<hvdb::VolumeGridTypes>(**it, *fillOp);
         }
     } catch (std::exception& e) {
         addError(SOP_MESSAGE, e.what());

--- a/openvdb_houdini/Utils.h
+++ b/openvdb_houdini/Utils.h
@@ -369,11 +369,8 @@ GEOvdbApply(GEO_PrimVDB& vdb, OpT& op, bool makeUnique = true)
             if (treePtr.use_count() > 2) { // grid + treePtr = 2
                 // If the grid resolves to one of the listed types and its tree
                 // is shared with other grids, replace the tree with a deep copy.
-                gridPtr->apply<GridTypeListT>([](Grid& baseGrid) {
-                    if (auto treePtr = baseGrid.constBaseTreePtr()) {
-                        baseGrid.setTree(treePtr->copy());
-                    }
-                });
+                gridPtr->apply<GridTypeListT>(
+                    [](Grid& baseGrid) { baseGrid.setTree(baseGrid.constBaseTree().copy()); });
             }
         }
         return gridPtr->apply<GridTypeListT>(op);

--- a/openvdb_houdini/Utils.h
+++ b/openvdb_houdini/Utils.h
@@ -342,6 +342,9 @@ using AllGridTypes = VolumeGridTypes::Append<PointGridTypes>;
 
 namespace internal {
 
+// Functor for use with GEOvdbApply() to deep copy a grid's tree,
+// if it is shared with other grids, before invoking a user-supplied
+// functor on the grid
 /// @private
 template<typename OpT>
 class MakeUniqueOp
@@ -381,8 +384,9 @@ GEOvdbApply(const GEO_PrimVDB& vdb, OpT& op)
 
 /// @brief If the given primitive's grid resolves to one of the listed grid types,
 /// invoke the functor @a op on the resolved grid.
-/// @details If @a makeUnique is true, deep copy the grid's tree before invoking the functor.
 /// @return @c true if the functor was invoked, @c false otherwise
+/// @details If @a makeUnique is true, deep copy the grid's tree before
+/// invoking the functor if the tree is shared with other grids.
 template<typename GridTypeListT, typename OpT>
 inline bool
 GEOvdbApply(GEO_PrimVDB& vdb, OpT& op, bool makeUnique = true)

--- a/openvdb_houdini/Utils.h
+++ b/openvdb_houdini/Utils.h
@@ -308,7 +308,8 @@ bool isLogForwarding(OP_OpTypeId);
 ////////////////////////////////////////
 
 
-// Grid type lists, for use with openvdb::GridBase::apply()
+// Grid type lists, for use with GEO_PrimVDB::apply(), GEOvdbApply(),
+// or openvdb::GridBase::apply()
 
 using ScalarGridTypes = openvdb::TypeList<
     openvdb::BoolGrid,


### PR DESCRIPTION
I would actually prefer `GEOvdbApply` to be a member of the primitive (i.e., `GEO_PrimVDB::apply`), but then for older Houdini versions we'd still need a free function.
