### PR TITLE
OVDB-96: CMake Memory Allocators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,11 @@ _blosc:
     name: Install Blosc 1.5.0
     command: bash ci/install_blosc.sh 1.5.0
 
+_jemalloc:
+  jemalloc: &install_jemalloc
+    name: Install Jemalloc
+    command: bash ci/install_jemalloc.sh
+
 _houdini:
   houdini17_5: &install_houdini17_5
     name: Install Houdini 17.5
@@ -138,6 +143,7 @@ jobs:
       - run: *install_tbb_latest
       - run: *install_openexr_latest
       - run: *install_blosc_latest
+      - run: *install_jemalloc
       - run: *build_abi6
       - run: *test
 
@@ -151,6 +157,7 @@ jobs:
       - run: *install_tbb2018
       - run: *install_openexr2_3
       - run: *install_blosc1_5
+      - run: *install_jemalloc
       - run: *build_abi6
       - run: *test
 
@@ -164,6 +171,7 @@ jobs:
       - run: *install_tbb2018
       - run: *install_openexr2_3
       - run: *install_blosc1_5
+      - run: *install_jemalloc
       - run: *build_abi6_debug
 
   testabi6gcc:
@@ -176,6 +184,7 @@ jobs:
       - run: *install_tbb2018
       - run: *install_openexr2_3
       - run: *install_blosc1_5
+      - run: *install_jemalloc
       - run: *build_abi6_gcc
 
   testabi6noblosc:
@@ -187,6 +196,7 @@ jobs:
       - run: *install_boost1_66
       - run: *install_tbb2018
       - run: *install_openexr2_3
+      - run: *install_jemalloc
       - run: *build_abi6_no_blosc
 
   testabi5:
@@ -198,6 +208,7 @@ jobs:
       - run: *install_tbb2017
       - run: *install_openexr2_3
       - run: *install_blosc1_5
+      - run: *install_jemalloc
       - run: *build_abi5
       - run: *test
 
@@ -210,6 +221,7 @@ jobs:
       - run: *install_tbb4_4
       - run: *install_openexr2_3
       - run: *install_blosc1_5
+      - run: *install_jemalloc
       - run: *build_abi4
       - run: *test
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,13 +116,17 @@ option(DISABLE_DEPENDENCY_VERSION_CHECKS [=[
 Disable minimum version checks for OpenVDB dependencies. It is strongly recommended that this remains disabled.
 Consider updating your dependencies where possible if encountering minimum requirement CMake errors.]=] OFF)
 
+set(_CONCURRENT_MALLOC_OPTIONS None Auto Jemalloc Tbbmalloc)
 if(NOT CONCURRENT_MALLOC)
   set(CONCURRENT_MALLOC Auto CACHE STRING
     "Choose a concurrent malloc library, options are: None Auto Jemalloc Tbbmalloc.
     Although not required, it is strongly recommended to use a concurrent memory allocator.
-    Auto is the default and implies Tbbmalloc for Maya and Jemalloc for non-MAYA,
-    with a fallback of Tbbmalloc if unavailable." FORCE
+    Auto is the default and implies Jemalloc, unless USE_MAYA is ON or Jemalloc is unavailable,
+    in which case Tbbmalloc is used." FORCE
   )
+elseif(NOT ${CONCURRENT_MALLOC} IN_LIST _CONCURRENT_MALLOC_OPTIONS)
+  message(WARNING "Unrecognized value for CONCURRENT_MALLOC, using Auto instead.")
+  set(CONCURRENT_MALLOC Auto CACHE STRING FORCE)
 endif()
 
 ###### Deprecated options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,16 +100,6 @@ option(USE_BLOSC [=[
 Use blosc while building openvdb components. If OPENVDB_BUILD_CORE is OFF, CMake attempts to query the located
 openvdb build configuration to decide on blosc support. You may set this to on to force blosc to be used if you
 know it to be required.]=] ON)
-option(USE_JEMALLOC [=[
-Use Jemalloc while building openvdb components. If USE_JEMALLOC is OFF, CMake attempts to query the
-located openvdb build configuration to decide on Jemalloc support. You may set this to off to disable Jemalloc.
-Although not strictly required, it is strongly recommended to use a concurrent memory allocator.
-Note that you must choose between Jemalloc or TBB malloc, or otherwise disable them both.]=] ON)
-option(USE_TBBMALLOC [=[
-Use TBB malloc while building openvdb components. If USE_TBBMALLOC is OFF, CMake attempts to query the
-located openvdb build configuration to decide on TBB malloc support. You may set this to on to force TBB malloc
-to be used. Although not required, it is strongly recommended to use a concurrent memory allocator.
-Note that you must choose between Jemalloc or TBB malloc, or otherwise disable them both.]=] OFF)
 option(USE_LOG4CPLUS [=[
 Use log4cplus while building openvdb components. If OPENVDB_BUILD_CORE is OFF, CMake attempts to query the
 located openvdb build configuration to decide on log4cplus support. You may set this to on to force log4cplus
@@ -125,6 +115,15 @@ option(USE_CCACHE "Build using Ccache if found on the path" ON)
 option(DISABLE_DEPENDENCY_VERSION_CHECKS [=[
 Disable minimum version checks for OpenVDB dependencies. It is strongly recommended that this remains disabled.
 Consider updating your dependencies where possible if encountering minimum requirement CMake errors.]=] OFF)
+
+if(NOT CONCURRENT_MALLOC)
+  set(CONCURRENT_MALLOC Auto CACHE STRING
+    "Choose a concurrent malloc library, options are: None Auto Jemalloc Tbbmalloc.
+    Although not required, it is strongly recommended to use a concurrent memory allocator.
+    Auto is the default and implies Tbbmalloc for Maya and Jemalloc for non-MAYA,
+    with a fallback of Tbbmalloc if unavailable." FORCE
+  )
+endif()
 
 ###### Deprecated options
 
@@ -162,12 +161,12 @@ mark_as_advanced(
   OPENVDB_ENABLE_RPATH
   USE_HOUDINI
   USE_MAYA
-  USE_JEMALLOC
   USE_LOG4CPLUS
   USE_SYSTEM_LIBRARY_PATHS
   USE_CCACHE
   OPENVDB_BUILD_HOUDINI_SOPS
   DISABLE_DEPENDENCY_VERSION_CHECKS
+  CONCURRENT_MALLOC
 )
 
 # Configure minimum version requirements
@@ -427,6 +426,16 @@ endif()
 
 if(USE_MAYA)
   include(OpenVDBMayaSetup)
+endif()
+
+# Configure malloc library. Use Tbbmalloc for Maya and Jemalloc for non-Maya.
+
+if(CONCURRENT_MALLOC STREQUAL "Auto")
+  if(USE_MAYA)
+    set(CONCURRENT_MALLOC "Tbbmalloc")
+  else()
+    set(CONCURRENT_MALLOC "Jemalloc")
+  endif()
 endif()
 
 #########################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,16 @@ option(USE_BLOSC [=[
 Use blosc while building openvdb components. If OPENVDB_BUILD_CORE is OFF, CMake attempts to query the located
 openvdb build configuration to decide on blosc support. You may set this to on to force blosc to be used if you
 know it to be required.]=] ON)
+option(USE_JEMALLOC [=[
+Use Jemalloc while building openvdb components. If USE_JEMALLOC is OFF, CMake attempts to query the
+located openvdb build configuration to decide on Jemalloc support. You may set this to off to disable Jemalloc.
+Although not strictly required, it is strongly recommended to use a concurrent memory allocator.
+Note that you must choose between Jemalloc or TBB malloc, or otherwise disable them both.]=] ON)
+option(USE_TBBMALLOC [=[
+Use TBB malloc while building openvdb components. If USE_TBBMALLOC is OFF, CMake attempts to query the
+located openvdb build configuration to decide on TBB malloc support. You may set this to on to force TBB malloc
+to be used. Although not required, it is strongly recommended to use a concurrent memory allocator.
+Note that you must choose between Jemalloc or TBB malloc, or otherwise disable them both.]=] OFF)
 option(USE_LOG4CPLUS [=[
 Use log4cplus while building openvdb components. If OPENVDB_BUILD_CORE is OFF, CMake attempts to query the
 located openvdb build configuration to decide on log4cplus support. You may set this to on to force log4cplus
@@ -152,6 +162,7 @@ mark_as_advanced(
   OPENVDB_ENABLE_RPATH
   USE_HOUDINI
   USE_MAYA
+  USE_JEMALLOC
   USE_LOG4CPLUS
   USE_SYSTEM_LIBRARY_PATHS
   USE_CCACHE
@@ -233,6 +244,7 @@ if(OPENVDB_INSTALL_CMAKE_MODULES)
   set(OPENVDB_CMAKE_MODULES
     cmake/FindBlosc.cmake
     cmake/FindCppUnit.cmake
+    cmake/FindJemalloc.cmake
     cmake/FindIlmBase.cmake
     cmake/FindLog4cplus.cmake
     cmake/FindOpenEXR.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,14 @@ if(USE_MAYA)
   include(OpenVDBMayaSetup)
 endif()
 
-# Configure malloc library. Use Tbbmalloc for Windows or Maya and Jemalloc otherwise.
+# Configure malloc library. Use Jemalloc for Linux and non-Maya, otherwise Tbbmalloc.
+# * On Mac OSX, linking against Jemalloc < 4.3.0 seg-faults with this error:
+#     malloc: *** malloc_zone_unregister() failed for 0xaddress
+#   Houdini 17.5 and older ships with Jemalloc 3.6.0, so we make Tbbmalloc the default
+#   on Mac OSX (https://github.com/jemalloc/jemalloc/issues/420). Later versions of
+#   Jemalloc are thought to work, but haven't been tested.
+# * On Windows, we follow SideFX's example in using Tbbmalloc due to the challenges
+#   of injecting into the Windows runtime to replace the system allocator.
 
 if(CONCURRENT_MALLOC STREQUAL "Auto")
   if(WIN32 OR APPLE OR USE_MAYA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,7 @@ endif()
 # Configure malloc library. Use Tbbmalloc for Windows or Maya and Jemalloc otherwise.
 
 if(CONCURRENT_MALLOC STREQUAL "Auto")
-  if(WIN32 OR USE_MAYA)
+  if(WIN32 OR APPLE OR USE_MAYA)
     set(CONCURRENT_MALLOC "Tbbmalloc")
   else()
     set(CONCURRENT_MALLOC "Jemalloc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,10 +432,10 @@ if(USE_MAYA)
   include(OpenVDBMayaSetup)
 endif()
 
-# Configure malloc library. Use Tbbmalloc for Maya and Jemalloc for non-Maya.
+# Configure malloc library. Use Tbbmalloc for Windows or Maya and Jemalloc otherwise.
 
 if(CONCURRENT_MALLOC STREQUAL "Auto")
-  if(USE_MAYA)
+  if(WIN32 OR USE_MAYA)
     set(CONCURRENT_MALLOC "Tbbmalloc")
   else()
     set(CONCURRENT_MALLOC "Jemalloc")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ cache: c:\tools\vcpkg\installed\
 
 before_build:
   - cd C:\tools\vcpkg
-  - vcpkg install zlib blosc openexr tbb cppunit
+  - vcpkg install zlib blosc openexr tbb cppunit jemalloc
   - vcpkg integrate install
 
   # - adjust the PATH so that the vdb_test executable picks up all of the dll's correctly
@@ -39,6 +39,7 @@ build_script:
     -DBLOSC_ROOT=C:\tools\vcpkg\installed\x64-windows \
     -DUSE_BLOSC=ON \
     -DCPPUNIT_ROOT=C:\tools\vcpkg\installed\x64-windows \
+    -DJEMALLOC_ROOT=C:\tools\vcpkg\installed\x64-windows \
     -DBOOST_ROOT=C:\Libraries\boost_1_67_0 \
     -DBOOST_LIBRARYDIR=C:\Libraries\boost_1_67_0\lib64-msvc-14.0 \
     ..

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -17,6 +17,7 @@ apt-get install -y pkg-config
 apt-get install -y libglu1-mesa-dev
 apt-get install -y libgl1-mesa-dev
 apt-get install -y libcppunit-dev
+apt-get install -y libjemalloc-dev
 apt-get install -y liblog4cplus-dev
 apt-get install -y libglfw3-dev
 apt-get install -y python-dev

--- a/ci/install_jemalloc.sh
+++ b/ci/install_jemalloc.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ex
+
+apt-get install -y libjemalloc-dev

--- a/cmake/FindJemalloc.cmake
+++ b/cmake/FindJemalloc.cmake
@@ -1,0 +1,165 @@
+#
+# TM & (c) Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+# All rights reserved. This software is distributed under the
+# Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+#
+#[=======================================================================[.rst:
+
+FindJemalloc
+-----------
+
+Find Jemalloc include dirs and libraries
+
+Use this module by invoking find_package with the form::
+
+  find_package(Jemalloc
+    [version] [EXACT]      # Minimum or EXACT version
+    [REQUIRED]             # Fail with error if Jemalloc is not found
+    )
+
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+``Jemalloc::jemalloc``
+  This module defines IMPORTED target Jemalloc::jemalloc, if Jemalloc has been
+  found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``Jemalloc_FOUND``
+  True if the system has the Jemalloc library.
+``Jemalloc_VERSION``
+  The version of the Jemalloc library which was found.
+``Jemalloc_LIBRARIES``
+  Libraries needed to link to Jemalloc.
+``Jemalloc_LIBRARY_DIRS``
+  Jemalloc library directories.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``Jemalloc_LIBRARY``
+  The path to the Jemalloc library.
+
+Hints
+^^^^^
+
+Instead of explicitly setting the cache variables, the following variables
+may be provided to tell this module where to look.
+
+``JEMALLOC_ROOT``
+  Preferred installation prefix.
+``JEMALLOC_LIBRARYDIR``
+  Preferred library directory e.g. <prefix>/lib
+``SYSTEM_LIBRARY_PATHS``
+  Paths appended to all include and lib searches.
+
+#]=======================================================================]
+
+mark_as_advanced(
+  Jemalloc_LIBRARY
+)
+
+# Append JEMALLOC_ROOT or $ENV{JEMALLOC_ROOT} if set (prioritize the direct cmake var)
+set(_JEMALLOC_ROOT_SEARCH_DIR "")
+
+if(JEMALLOC_ROOT)
+  list(APPEND _JEMALLOC_ROOT_SEARCH_DIR ${JEMALLOC_ROOT})
+else()
+  set(_ENV_JEMALLOC_ROOT $ENV{JEMALLOC_ROOT})
+  if(_ENV_JEMALLOC_ROOT)
+    list(APPEND _JEMALLOC_ROOT_SEARCH_DIR ${_ENV_JEMALLOC_ROOT})
+  endif()
+endif()
+
+# Additionally try and use pkconfig to find jemalloc
+
+find_package(PkgConfig)
+pkg_check_modules(PC_Jemalloc QUIET jemalloc)
+
+# ------------------------------------------------------------------------
+#  Search for Jemalloc lib DIR
+# ------------------------------------------------------------------------
+
+set(_JEMALLOC_LIBRARYDIR_SEARCH_DIRS "")
+list(APPEND _JEMALLOC_LIBRARYDIR_SEARCH_DIRS
+  ${JEMALLOC_LIBRARYDIR}
+  ${_JEMALLOC_ROOT_SEARCH_DIR}
+  ${PC_Jemalloc_LIBDIR}
+  ${SYSTEM_LIBRARY_PATHS}
+)
+
+# Library suffix handling
+
+set(_JEMALLOC_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+
+if(WIN32)
+  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
+    "_dll.lib"
+  )
+elseif(UNIX)
+  if(JEMALLOC_USE_STATIC_LIBS)
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
+      ".a"
+    )
+  endif()
+endif()
+
+# Build suffix directories
+
+set(JEMALLOC_PATH_SUFFIXES
+  lib64
+  lib
+)
+
+# platform branching
+
+if(UNIX)
+  list(INSERT JEMALLOC_PATH_SUFFIXES 0 lib/x86_64-linux-gnu)
+endif()
+
+find_library(Jemalloc_LIBRARY jemalloc
+  NO_DEFAULT_PATH
+  PATHS ${_JEMALLOC_LIBRARYDIR_SEARCH_DIRS}
+  PATH_SUFFIXES ${JEMALLOC_PATH_SUFFIXES}
+)
+
+# Reset library suffix
+
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_JEMALLOC_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+unset(_JEMALLOC_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
+
+# ------------------------------------------------------------------------
+#  Cache and set Jemalloc_FOUND
+# ------------------------------------------------------------------------
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Jemalloc
+  FOUND_VAR Jemalloc_FOUND
+  REQUIRED_VARS
+    Jemalloc_LIBRARY
+  VERSION_VAR Jemalloc_VERSION
+)
+
+if(Jemalloc_FOUND)
+  set(Jemalloc_LIBRARIES ${Jemalloc_LIBRARY})
+  set(Jemalloc_DEFINITIONS ${PC_Jemalloc_CFLAGS_OTHER})
+
+  get_filename_component(Jemalloc_LIBRARY_DIRS ${Jemalloc_LIBRARY} DIRECTORY)
+
+  if(NOT TARGET Jemalloc::jemalloc)
+    add_library(Jemalloc::jemalloc UNKNOWN IMPORTED)
+    set_target_properties(Jemalloc::jemalloc PROPERTIES
+      IMPORTED_LOCATION "${Jemalloc_LIBRARIES}"
+      INTERFACE_COMPILE_DEFINITIONS "${Jemalloc_DEFINITIONS}"
+    )
+  endif()
+elseif(Jemalloc_FIND_REQUIRED)
+  message(FATAL_ERROR "Unable to find Jemalloc")
+endif()

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -47,6 +47,8 @@ IMPORTED Targets
   The tbb library target.
 ``TBB::tbbmalloc``
   The tbbmalloc library target.
+``TBB::tbbmalloc_proxy``
+  The tbbmalloc_proxy library target.
 
 Result Variables
 ^^^^^^^^^^^^^^^^
@@ -106,6 +108,7 @@ mark_as_advanced(
 set(_TBB_COMPONENT_LIST
   tbb
   tbbmalloc
+  tbbmalloc_proxy
 )
 
 if(TBB_FIND_COMPONENTS)

--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -74,6 +74,7 @@ overwrite user provided values.
 ``TBB_LIBRARYDIR``
 ``BLOSC_INCLUDEDIR``
 ``BLOSC_LIBRARYDIR``
+``JEMALLOC_LIBRARYDIR``
 
 Hints
 ^^^^^
@@ -269,6 +270,12 @@ if(NOT BLOSC_INCLUDEDIR)
 endif()
 if(NOT BLOSC_LIBRARYDIR)
   set(BLOSC_LIBRARYDIR ${_HOUDINI_LIB_DIR})
+endif()
+
+# Jemalloc
+
+if(NOT JEMALLOC_LIBRARYDIR)
+  set(JEMALLOC_LIBRARYDIR ${_HOUDINI_LIB_DIR})
 endif()
 
 # OpenEXR

--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -11,7 +11,7 @@ Version 6.1.1 - In development
     - LeafNode::modifyValue() and LeafNode::modifyValueAndActiveState()
       now modify voxel values in place for improved performance.
     - Add CMake support for linking against Jemalloc and TBB malloc and enable
-      Jemalloc by default.
+      Jemalloc by default for Linux and non-Maya, otherwise use TBB malloc.
 
     Bug fixes:
     - Fixed a bug in tools::computeScalarPotential() that could produce

--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -9,6 +9,8 @@ Version 6.1.1 - In development
       the root CMakeLists.txt [Reported by Daniel Elliott]
     - LeafNode::modifyValue() and LeafNode::modifyValueAndActiveState() now
       in-place modify voxel values for improved performance.
+    - Add CMake support for linking against Jemalloc and TBB malloc and enable
+      Jemalloc by default.
 
     Bug fixes:
     - Fixed a bug in tools::computeScalarPotential() that could produce a

--- a/openvdb/CMakeLists.txt
+++ b/openvdb/CMakeLists.txt
@@ -77,7 +77,11 @@ else()
   find_package(IlmBase ${MINIMUM_ILMBASE_VERSION} REQUIRED COMPONENTS Half)
 endif()
 
-find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbb)
+if(USE_TBBMALLOC)
+  find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbb tbbmalloc tbbmalloc_proxy)
+else()
+  find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbb)
+endif()
 find_package(ZLIB ${MINIMUM_ZLIB_VERSION} REQUIRED)
 
 if(USE_LOG4CPLUS)
@@ -104,6 +108,10 @@ find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS iostreams system
 
 if(UNIX)
   find_package(Threads REQUIRED)
+endif()
+
+if(USE_JEMALLOC)
+  find_package(Jemalloc REQUIRED)
 endif()
 
 # Set deps. Note that the order here is important. If we're building against
@@ -142,9 +150,19 @@ list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
   TBB::tbb
   ZLIB::ZLIB
 )
+
 if(UNIX)
+  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Threads::Threads)
+endif()
+
+if(USE_JEMALLOC)
+  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Jemalloc::jemalloc)
+endif()
+
+if(USE_TBBMALLOC)
   list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
-    Threads::Threads
+    TBB::tbbmalloc
+    TBB::tbbmalloc_proxy
   )
 endif()
 

--- a/openvdb/CMakeLists.txt
+++ b/openvdb/CMakeLists.txt
@@ -77,11 +77,7 @@ else()
   find_package(IlmBase ${MINIMUM_ILMBASE_VERSION} REQUIRED COMPONENTS Half)
 endif()
 
-if(USE_TBBMALLOC)
-  find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbb tbbmalloc tbbmalloc_proxy)
-else()
-  find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbb)
-endif()
+find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbb)
 find_package(ZLIB ${MINIMUM_ZLIB_VERSION} REQUIRED)
 
 if(USE_LOG4CPLUS)
@@ -110,8 +106,14 @@ if(UNIX)
   find_package(Threads REQUIRED)
 endif()
 
-if(USE_JEMALLOC)
-  find_package(Jemalloc REQUIRED)
+if(CONCURRENT_MALLOC STREQUAL "Jemalloc")
+  find_package(Jemalloc)
+  if(NOT TARGET Jemalloc::jemalloc)
+    message(WARNING "Unable to find Jemalloc, attempting to fall back to TBB malloc.
+      It is recommended to use Jemalloc for optimum performance."
+    )
+    find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbbmalloc tbbmalloc_proxy)
+  endif()
 endif()
 
 # Set deps. Note that the order here is important. If we're building against
@@ -155,11 +157,11 @@ if(UNIX)
   list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Threads::Threads)
 endif()
 
-if(USE_JEMALLOC)
+if(TARGET Jemalloc::jemalloc)
   list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Jemalloc::jemalloc)
 endif()
 
-if(USE_TBBMALLOC)
+if(TARGET TBB::tbbmalloc AND TARGET TBB::tbbmalloc_proxy)
   list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
     TBB::tbbmalloc
     TBB::tbbmalloc_proxy

--- a/openvdb/CMakeLists.txt
+++ b/openvdb/CMakeLists.txt
@@ -114,6 +114,8 @@ if(CONCURRENT_MALLOC STREQUAL "Jemalloc")
     )
     find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbbmalloc tbbmalloc_proxy)
   endif()
+elseif(CONCURRENT_MALLOC STREQUAL "Tbbmalloc")
+  find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbbmalloc tbbmalloc_proxy)
 endif()
 
 # Set deps. Note that the order here is important. If we're building against

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -15,6 +15,8 @@ Improvements:
   @vdblink::tree::LeafNode::modifyValueAndActiveState()
   LeafNode::modifyValueAndActiveState@endlink now in-place modify voxel values
   for improved performance.
+- Add CMake support for linking against Jemalloc and TBB malloc and enable
+  Jemalloc by default.
 
 @par
 Bug fixes:

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -18,7 +18,7 @@ Improvements:
   LeafNode::modifyValueAndActiveState@endlink now modify voxel values
   in place for improved performance.
 - Add CMake support for linking against Jemalloc and TBB malloc and enable
-  Jemalloc by default.
+  Jemalloc by default for Linux and non-Maya, otherwise use TBB malloc.
 
 @par
 Bug fixes:


### PR DESCRIPTION
Add support for Jemalloc and TBB malloc and enable Jemalloc by default.

This seems to build for me on Linux and Windows fine. @jmlait - a quote from your chapter in "Multithreading for Visual Effects":

> On platforms where linking to jemalloc is not practical, we resort to tbb::malloc_proxy.

Can you expand on this? Are there any platforms that you'd suggest we make TBB malloc the default? Also curious to know if there is any configuration in which Houdini is shipped _without_ using Jemalloc?