### PR TITLE
OVDB-64: Add SOP Pairing Logic

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -38,6 +38,10 @@ Version 6.1.1 - In development
       in the input detail.
     - The Combine SOP no longer crashes in Copy B mode when the destination
       is not a VDB.
+    - Added a houdini_utils::OpFactory::setInvisible() method to hide nodes
+      from tab menus.
+    - Added methods to store parent name and visibility of native SOPs to
+      @b openvdb_houdini::OpenVDBOpFactory.
 
 
 Version 6.1.0 - May 8, 2019

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -51,6 +51,10 @@ Houdini:
   in the input detail.
 - The Combine&nbsp;SOP no longer crashes in <B>Copy&nbsp;B</B> mode when the
   destination is not a&nbsp;VDB.
+- Added a @b houdini_utils::OpFactory::setInvisible method to hide nodes
+  from tab menus.
+- Added methods to store parent name and visibility of native SOPs to
+  @b openvdb_houdini::OpenVDBOpFactory.
 
 
 @htmlonly <a name="v6_1_0_changes"></a>@endhtmlonly

--- a/openvdb_houdini/ParmFactory.cc
+++ b/openvdb_houdini/ParmFactory.cc
@@ -1180,6 +1180,13 @@ OpFactory::table() const
 }
 
 
+OP_OperatorTable&
+OpFactory::table()
+{
+    return *mImpl->mTable;
+}
+
+
 OpFactory&
 OpFactory::addAlias(const std::string& english)
 {

--- a/openvdb_houdini/ParmFactory.cc
+++ b/openvdb_houdini/ParmFactory.cc
@@ -1064,6 +1064,7 @@ struct OpFactory::Impl
     std::vector<std::string> mAliases;
     std::vector<char*> mInputLabels, mOptInputLabels;
     OpFactoryVerb* mVerb = nullptr;
+    bool mInvisible = false;
 };
 
 
@@ -1089,6 +1090,12 @@ OpFactory::~OpFactory()
 
     if (!mImpl->mFirstName.empty()) {
         mImpl->mTable->setOpFirstName(mImpl->mName.c_str(), mImpl->mFirstName.c_str());
+    }
+
+    // hide node if marked as invisible
+
+    if (mImpl->mInvisible) {
+        mImpl->mTable->addOpHidden(mImpl->mName.c_str());
     }
 }
 
@@ -1264,6 +1271,14 @@ OpFactory::setVerb(SOP_NodeVerb::CookMode cookMode, const CacheAllocFunc& alloca
 
     mImpl->mVerb = new OpFactoryVerb{name(), cookMode, allocator, mImpl->mParms};
 
+    return *this;
+}
+
+
+OpFactory&
+OpFactory::setInvisible()
+{
+    mImpl->mInvisible = true;
     return *this;
 }
 

--- a/openvdb_houdini/ParmFactory.h
+++ b/openvdb_houdini/ParmFactory.h
@@ -500,6 +500,10 @@ public:
     /// @details This is equivalent to using the hscript ophide method.
     OpFactory& setInvisible();
 
+protected:
+    /// @brief Return the non-const operator table with which this factory is associated.
+    OP_OperatorTable& table();
+
 private:
     void init(OpPolicyPtr, const std::string& english, OP_Constructor,
         ParmList&, OP_OperatorTable&, OpFlavor);

--- a/openvdb_houdini/ParmFactory.h
+++ b/openvdb_houdini/ParmFactory.h
@@ -496,6 +496,10 @@ public:
     /// @throw std::invalid_argument if @a allocator is empty
     OpFactory& setVerb(SOP_NodeVerb::CookMode cookMode, const CacheAllocFunc& allocator);
 
+    /// @brief Mark this node as hidden from the UI tab menu.
+    /// @details This is equivalent to using the hscript ophide method.
+    OpFactory& setInvisible();
+
 private:
     void init(OpPolicyPtr, const std::string& english, OP_Constructor,
         ParmList&, OP_OperatorTable&, OpFlavor);

--- a/openvdb_houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/SOP_NodeVDB.cc
@@ -635,9 +635,9 @@ public:
         return factory.flavorString() + "_OpenVDB";
     }
 
-    /// @brief Return the name of the parent operator.
-    /// @note This is typically the name of the native operator if shipped with Houdini.
-    virtual std::string getParentName(const houdini_utils::OpFactory& factory)
+    /// @brief Return the name of the equivalent native operator as shipped with Houdini.
+    /// @details An empty string indicates that there is no equivalent native operator.
+    virtual std::string getNativeName(const houdini_utils::OpFactory& factory)
     {
         return "";
     }
@@ -674,7 +674,7 @@ public:
         return this->getLowercaseName(this->getValidName(this->getLabelName(factory)));
     }
 
-    std::string getParentName(const houdini_utils::OpFactory& factory) override
+    std::string getNativeName(const houdini_utils::OpFactory& factory) override
     {
         return this->getLowercaseName(this->getValidName(factory.english()));
     }
@@ -698,35 +698,38 @@ OpenVDBOpFactory::OpenVDBOpFactory(
     houdini_utils::OpFactory::OpFlavor flavor):
     houdini_utils::OpFactory(OpenVDBOpPolicy(), english, ctor, parms, table, flavor)
 {
-    mParentName = OpenVDBOpPolicy().getParentName(*this);
+    mNativeName = OpenVDBOpPolicy().getNativeName(*this);
 }
 
 
 OpenVDBOpFactory::~OpenVDBOpFactory()
 {
-    // hide the parent node if marked invisble
-    if (!mParentName.empty()) {
-        bool invisible = mParentInvisible;
+    // hide the native node if marked invisble
+    if (!mNativeName.empty()) {
+        bool invisible = mNativeInvisible;
 
         if (invisible) {
-            this->table().addOpHidden(mParentName.c_str());
+            this->table().addOpHidden(mNativeName.c_str());
         }
     }
 }
 
 
 OpenVDBOpFactory&
-OpenVDBOpFactory::setParentName(const std::string& name)
+OpenVDBOpFactory::setNativeName(const std::string& name)
 {
-    mParentName = name;
+    // SideFX nodes have no native equivalent.
+#ifndef SESI_OPENVDB
+    mNativeName = name;
+#endif
     return *this;
 }
 
 
 OpenVDBOpFactory&
-OpenVDBOpFactory::setParentInvisible()
+OpenVDBOpFactory::setNativeInvisible()
 {
-    mParentInvisible = true;
+    mNativeInvisible = true;
     return *this;
 }
 

--- a/openvdb_houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/SOP_NodeVDB.cc
@@ -634,6 +634,13 @@ public:
     {
         return factory.flavorString() + "_OpenVDB";
     }
+
+    /// @brief Return the name of the parent operator.
+    /// @note This is typically the name of the native operator if shipped with Houdini.
+    virtual std::string getParentName(const houdini_utils::OpFactory& factory)
+    {
+        return "";
+    }
 };
 
 
@@ -666,6 +673,11 @@ public:
     {
         return this->getLowercaseName(this->getValidName(this->getLabelName(factory)));
     }
+
+    std::string getParentName(const houdini_utils::OpFactory& factory) override
+    {
+        return this->getLowercaseName(this->getValidName(factory.english()));
+    }
 };
 
 
@@ -686,6 +698,36 @@ OpenVDBOpFactory::OpenVDBOpFactory(
     houdini_utils::OpFactory::OpFlavor flavor):
     houdini_utils::OpFactory(OpenVDBOpPolicy(), english, ctor, parms, table, flavor)
 {
+    mParentName = OpenVDBOpPolicy().getParentName(*this);
+}
+
+
+OpenVDBOpFactory::~OpenVDBOpFactory()
+{
+    // hide the parent node if marked invisble
+    if (!mParentName.empty()) {
+        bool invisible = mParentInvisible;
+
+        if (invisible) {
+            this->table().addOpHidden(mParentName.c_str());
+        }
+    }
+}
+
+
+OpenVDBOpFactory&
+OpenVDBOpFactory::setParentName(const std::string& name)
+{
+    mParentName = name;
+    return *this;
+}
+
+
+OpenVDBOpFactory&
+OpenVDBOpFactory::setParentInvisible()
+{
+    mParentInvisible = true;
+    return *this;
 }
 
 } // namespace openvdb_houdini

--- a/openvdb_houdini/SOP_NodeVDB.h
+++ b/openvdb_houdini/SOP_NodeVDB.h
@@ -65,18 +65,22 @@ public:
     /// Register the node
     ~OpenVDBOpFactory();
 
-    /// @brief Set the name of the parent operator.
-    /// @details This is typically the name of the operator shipped with Houdini and is
-    /// only needed where the parent name policy doesn't provide the correct name.
-    OpenVDBOpFactory& setParentName(const std::string& name);
+    /// @brief Return the name of the equivalent native operator as shipped with Houdini.
+    /// @details An empty string indicates that there is no equivalent native operator.
 
-    /// @brief Mark the parent node as hidden from the UI tab menu.
+    /// @brief Set the name of the equivalent native operator as shipped with Houdini.
+    /// @details This is only needed where the native name policy doesn't provide
+    /// the correct name. Pass an empty string to indicate that there is no
+    /// equivalent native operator.
+    OpenVDBOpFactory& setNativeName(const std::string& name);
+
+    /// @brief Mark the native operator as hidden from the UI tab menu.
     /// @details This is equivalent to using the hscript ophide method.
-    OpenVDBOpFactory& setParentInvisible();
+    OpenVDBOpFactory& setNativeInvisible();
 
 private:
-    std::string mParentName;
-    bool mParentInvisible = false;
+    std::string mNativeName;
+    bool mNativeInvisible = false;
 };
 
 

--- a/openvdb_houdini/SOP_NodeVDB.h
+++ b/openvdb_houdini/SOP_NodeVDB.h
@@ -61,6 +61,22 @@ public:
     /// Construct an OpFactory that on destruction registers a new OpenVDB operator type.
     OpenVDBOpFactory(const std::string& english, OP_Constructor, houdini_utils::ParmList&,
         OP_OperatorTable&, houdini_utils::OpFactory::OpFlavor = SOP);
+
+    /// Register the node
+    ~OpenVDBOpFactory();
+
+    /// @brief Set the name of the parent operator.
+    /// @details This is typically the name of the operator shipped with Houdini and is
+    /// only needed where the parent name policy doesn't provide the correct name.
+    OpenVDBOpFactory& setParentName(const std::string& name);
+
+    /// @brief Mark the parent node as hidden from the UI tab menu.
+    /// @details This is equivalent to using the hscript ophide method.
+    OpenVDBOpFactory& setParentInvisible();
+
+private:
+    std::string mParentName;
+    bool mParentInvisible = false;
 };
 
 

--- a/openvdb_houdini/SOP_NodeVDB.h
+++ b/openvdb_houdini/SOP_NodeVDB.h
@@ -65,9 +65,6 @@ public:
     /// Register the node
     ~OpenVDBOpFactory();
 
-    /// @brief Return the name of the equivalent native operator as shipped with Houdini.
-    /// @details An empty string indicates that there is no equivalent native operator.
-
     /// @brief Set the name of the equivalent native operator as shipped with Houdini.
     /// @details This is only needed where the native name policy doesn't provide
     /// the correct name. Pass an empty string to indicate that there is no

--- a/openvdb_houdini/SOP_OpenVDB_Advect.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Advect.cc
@@ -286,6 +286,9 @@ newSopOperator(OP_OperatorTable* table)
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Advect",
         SOP_OpenVDB_Advect::factory, parms, *table)
+#ifndef SESI_OPENVDB
+        .setParentName("vdbadvectsdf")
+#endif
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs to Advect")
         .addInput("Velocity VDB")

--- a/openvdb_houdini/SOP_OpenVDB_Advect.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Advect.cc
@@ -286,9 +286,7 @@ newSopOperator(OP_OperatorTable* table)
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Advect",
         SOP_OpenVDB_Advect::factory, parms, *table)
-#ifndef SESI_OPENVDB
-        .setParentName("vdbadvectsdf")
-#endif
+        .setNativeName("vdbadvectsdf")
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs to Advect")
         .addInput("Velocity VDB")

--- a/openvdb_houdini/SOP_OpenVDB_Convert.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Convert.cc
@@ -408,6 +408,7 @@ Polygon Soup:\n\
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Convert",
         SOP_OpenVDB_Convert::factory, parms, *table)
+        .setNativeName("convertvdb")
 #ifndef SESI_OPENVDB
         .setInternalName("DW_OpenVDBConvert")
 #endif

--- a/openvdb_houdini/SOP_OpenVDB_Densify.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Densify.cc
@@ -77,7 +77,7 @@ newSopOperator(OP_OperatorTable* table)
             " (see [specifying volumes|/model/volumes#group])"));
 
     hvdb::OpenVDBOpFactory("VDB Densify", SOP_OpenVDB_Densify::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .addInput("VDBs to densify")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Densify::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Densify.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Densify.cc
@@ -77,6 +77,7 @@ newSopOperator(OP_OperatorTable* table)
             " (see [specifying volumes|/model/volumes#group])"));
 
     hvdb::OpenVDBOpFactory("VDB Densify", SOP_OpenVDB_Densify::factory, parms, *table)
+        .setParentName("")
         .addInput("VDBs to densify")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Densify::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Fill.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Fill.cc
@@ -153,7 +153,7 @@ newSopOperator(OP_OperatorTable* table)
 
 
     hvdb::OpenVDBOpFactory("VDB Fill", SOP_OpenVDB_Fill::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .setObsoleteParms(obsoleteParms)
         .addInput("Input with VDB grids to operate on")
         .addOptionalInput("Optional bounding geometry")

--- a/openvdb_houdini/SOP_OpenVDB_Fill.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Fill.cc
@@ -153,6 +153,7 @@ newSopOperator(OP_OperatorTable* table)
 
 
     hvdb::OpenVDBOpFactory("VDB Fill", SOP_OpenVDB_Fill::factory, parms, *table)
+        .setParentName("")
         .setObsoleteParms(obsoleteParms)
         .addInput("Input with VDB grids to operate on")
         .addOptionalInput("Optional bounding geometry")

--- a/openvdb_houdini/SOP_OpenVDB_Filter.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Filter.cc
@@ -326,9 +326,7 @@ Offset:\n\
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Filter", SOP_OpenVDB_Filter::factory, parms, *table)
-#ifndef SESI_OPENVDB
-        .setParentName("vdbsmooth")
-#endif
+        .setNativeName("vdbsmooth")
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs to Smooth")
         .addOptionalInput("Optional VDB Alpha Mask")

--- a/openvdb_houdini/SOP_OpenVDB_Filter.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Filter.cc
@@ -326,6 +326,9 @@ Offset:\n\
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Filter", SOP_OpenVDB_Filter::factory, parms, *table)
+#ifndef SESI_OPENVDB
+        .setParentName("vdbsmooth")
+#endif
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs to Smooth")
         .addOptionalInput("Optional VDB Alpha Mask")

--- a/openvdb_houdini/SOP_OpenVDB_Metadata.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Metadata.cc
@@ -172,7 +172,7 @@ Other:\n\
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Metadata", SOP_OpenVDB_Metadata::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .addInput("Input with VDBs")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Metadata::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Metadata.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Metadata.cc
@@ -172,6 +172,7 @@ Other:\n\
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Metadata", SOP_OpenVDB_Metadata::factory, parms, *table)
+        .setParentName("")
         .addInput("Input with VDBs")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Metadata::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Noise.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Noise.cc
@@ -276,6 +276,7 @@ Use mask as frequency multiplier:\n\
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Noise", SOP_OpenVDB_Noise::factory, parms, *table)
+        .setParentName("")
         .addInput("VDB grids to noise")
         .addOptionalInput("Optional VDB grid to use as mask")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Noise::Cache; })

--- a/openvdb_houdini/SOP_OpenVDB_Noise.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Noise.cc
@@ -276,7 +276,7 @@ Use mask as frequency multiplier:\n\
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Noise", SOP_OpenVDB_Noise::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .addInput("VDB grids to noise")
         .addOptionalInput("Optional VDB grid to use as mask")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Noise::Cache; })

--- a/openvdb_houdini/SOP_OpenVDB_Platonic.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Platonic.cc
@@ -132,7 +132,7 @@ Signed Distance Field:\n\
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Platonic",
         SOP_OpenVDB_Platonic::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\

--- a/openvdb_houdini/SOP_OpenVDB_Platonic.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Platonic.cc
@@ -132,6 +132,7 @@ Signed Distance Field:\n\
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Platonic",
         SOP_OpenVDB_Platonic::factory, parms, *table)
+        .setParentName("")
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\

--- a/openvdb_houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Points_Convert.cc
@@ -458,6 +458,7 @@ Unit Vector:\n\
 
     hvdb::OpenVDBOpFactory("VDB Points Convert",
         SOP_OpenVDB_Points_Convert::factory, parms, *table)
+        .setNativeName("convertvdbpoints")
 #ifndef SESI_OPENVDB
         .setInternalName("DW_OpenVDBPointsConvert")
 #endif

--- a/openvdb_houdini/SOP_OpenVDB_Points_Delete.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Points_Delete.cc
@@ -113,7 +113,7 @@ newSopOperator(OP_OperatorTable* table)
     hvdb::OpenVDBOpFactory("VDB Points Delete",
         SOP_OpenVDB_Points_Delete::factory, parms, *table)
 #if UT_VERSION_INT < 0x11050000 // earlier than 17.5.0
-        .setParentName("")
+        .setNativeName("")
 #endif
         .addInput("VDB Points")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Points_Delete::Cache; })

--- a/openvdb_houdini/SOP_OpenVDB_Points_Delete.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Points_Delete.cc
@@ -112,6 +112,9 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Points Delete",
         SOP_OpenVDB_Points_Delete::factory, parms, *table)
+#if UT_VERSION_INT < 0x11050000 // earlier than 17.5.0
+        .setParentName("")
+#endif
         .addInput("VDB Points")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Points_Delete::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Potential_Flow.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Potential_Flow.cc
@@ -221,7 +221,7 @@ newSopOperator(OP_OperatorTable* table)
     hvdb::OpenVDBOpFactory("VDB Potential Flow",
         SOP_OpenVDB_Potential_Flow::factory, parms, *table)
 #if UT_VERSION_INT < 0x11050000 // earlier than 17.5.0
-        .setParentName("")
+        .setNativeName("")
 #endif
         .addInput("VDB Surface and optional velocity VDB")
         .addOptionalInput("Optional VDB Mask")

--- a/openvdb_houdini/SOP_OpenVDB_Potential_Flow.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Potential_Flow.cc
@@ -220,6 +220,9 @@ newSopOperator(OP_OperatorTable* table)
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Potential Flow",
         SOP_OpenVDB_Potential_Flow::factory, parms, *table)
+#if UT_VERSION_INT < 0x11050000 // earlier than 17.5.0
+        .setParentName("")
+#endif
         .addInput("VDB Surface and optional velocity VDB")
         .addOptionalInput("Optional VDB Mask")
         .setVerb(SOP_NodeVerb::COOK_INPLACE,

--- a/openvdb_houdini/SOP_OpenVDB_Prune.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Prune.cc
@@ -111,6 +111,7 @@ newSopOperator(OP_OperatorTable* table)
             "by less than the specified threshold."));
 
     hvdb::OpenVDBOpFactory("VDB Prune", SOP_OpenVDB_Prune::factory, parms, *table)
+        .setParentName("")
         .addInput("Grids to process")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Prune::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Prune.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Prune.cc
@@ -111,7 +111,7 @@ newSopOperator(OP_OperatorTable* table)
             "by less than the specified threshold."));
 
     hvdb::OpenVDBOpFactory("VDB Prune", SOP_OpenVDB_Prune::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .addInput("Grids to process")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Prune::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
@@ -3181,6 +3181,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Rasterize Points",
         SOP_OpenVDB_Rasterize_Points::factory, parms, *table)
+        .setParentName("")
         .setOperatorTable(VOP_TABLE_NAME)
         .setLocalVariables(VOP_CodeGenerator::theLocalVariables)
         .addInput("Points to rasterize")

--- a/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
@@ -3181,7 +3181,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Rasterize Points",
         SOP_OpenVDB_Rasterize_Points::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .setOperatorTable(VOP_TABLE_NAME)
         .setLocalVariables(VOP_CodeGenerator::theLocalVariables)
         .addInput("Points to rasterize")

--- a/openvdb_houdini/SOP_OpenVDB_Read.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Read.cc
@@ -265,7 +265,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Read", SOP_OpenVDB_Read::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
 #if OPENVDB_ABI_VERSION_NUMBER >= 3
         .addOptionalInput("Optional Bounding Geometry")
 #endif

--- a/openvdb_houdini/SOP_OpenVDB_Read.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Read.cc
@@ -265,6 +265,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Read", SOP_OpenVDB_Read::factory, parms, *table)
+        .setParentName("")
 #if OPENVDB_ABI_VERSION_NUMBER >= 3
         .addOptionalInput("Optional Bounding Geometry")
 #endif

--- a/openvdb_houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
@@ -157,7 +157,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Rebuild SDF",
         SOP_OpenVDB_Rebuild_Level_Set::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
 #ifndef SESI_OPENVDB
         .setInternalName("DW_OpenVDBRebuildLevelSet")
 #endif

--- a/openvdb_houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
@@ -157,6 +157,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Rebuild SDF",
         SOP_OpenVDB_Rebuild_Level_Set::factory, parms, *table)
+        .setParentName("")
 #ifndef SESI_OPENVDB
         .setInternalName("DW_OpenVDBRebuildLevelSet")
 #endif

--- a/openvdb_houdini/SOP_OpenVDB_Remap.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Remap.cc
@@ -626,7 +626,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Remap",
         SOP_OpenVDB_Remap::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .addInput("VDB Grids")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Remap::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Remap.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Remap.cc
@@ -626,6 +626,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Remap",
         SOP_OpenVDB_Remap::factory, parms, *table)
+        .setParentName("")
         .addInput("VDB Grids")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Remap::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Sample_Points.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Sample_Points.cc
@@ -135,6 +135,7 @@ newSopOperator(OP_OperatorTable* table)
     // Register the SOP
     hvdb::OpenVDBOpFactory("VDB Sample Points",
         SOP_OpenVDB_Sample_Points::factory, parms, *table)
+        .setParentName("")
         .setObsoleteParms(obsoleteParms)
         .addInput("Points")
         .addInput("VDBs")

--- a/openvdb_houdini/SOP_OpenVDB_Sample_Points.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Sample_Points.cc
@@ -135,7 +135,7 @@ newSopOperator(OP_OperatorTable* table)
     // Register the SOP
     hvdb::OpenVDBOpFactory("VDB Sample Points",
         SOP_OpenVDB_Sample_Points::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .setObsoleteParms(obsoleteParms)
         .addInput("Points")
         .addInput("VDBs")

--- a/openvdb_houdini/SOP_OpenVDB_Scatter.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Scatter.cc
@@ -227,6 +227,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // Register the SOP.
     hvdb::OpenVDBOpFactory("VDB Scatter", SOP_OpenVDB_Scatter::factory, parms, *table)
+        .setParentName("")
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs on which points will be scattered")
         .setVerb(SOP_NodeVerb::COOK_GENERIC, []() { return new SOP_OpenVDB_Scatter::Cache; })

--- a/openvdb_houdini/SOP_OpenVDB_Scatter.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Scatter.cc
@@ -227,7 +227,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // Register the SOP.
     hvdb::OpenVDBOpFactory("VDB Scatter", SOP_OpenVDB_Scatter::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs on which points will be scattered")
         .setVerb(SOP_NodeVerb::COOK_GENERIC, []() { return new SOP_OpenVDB_Scatter::Cache; })

--- a/openvdb_houdini/SOP_OpenVDB_Sort_Points.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Sort_Points.cc
@@ -146,6 +146,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Sort Points",
         SOP_OpenVDB_Sort_Points::factory, parms, *table)
+        .setParentName("")
         .addInput("points")
         .setVerb(SOP_NodeVerb::COOK_GENERATOR, []() { return new SOP_OpenVDB_Sort_Points::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Sort_Points.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Sort_Points.cc
@@ -146,7 +146,7 @@ newSopOperator(OP_OperatorTable* table)
 
     hvdb::OpenVDBOpFactory("VDB Sort Points",
         SOP_OpenVDB_Sort_Points::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .addInput("points")
         .setVerb(SOP_NodeVerb::COOK_GENERATOR, []() { return new SOP_OpenVDB_Sort_Points::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_To_Polygons.cc
+++ b/openvdb_houdini/SOP_OpenVDB_To_Polygons.cc
@@ -272,7 +272,7 @@ newSopOperator(OP_OperatorTable* table)
     obsoleteParms.add(hutil::ParmFactory(PRM_INT_J, "activepart", ""));
 
     hvdb::OpenVDBOpFactory("VDB to Polygons", SOP_OpenVDB_To_Polygons::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
 #ifndef SESI_OPENVDB
         .setInternalName("DW_OpenVDBToPolygons")
 #endif

--- a/openvdb_houdini/SOP_OpenVDB_To_Polygons.cc
+++ b/openvdb_houdini/SOP_OpenVDB_To_Polygons.cc
@@ -272,6 +272,7 @@ newSopOperator(OP_OperatorTable* table)
     obsoleteParms.add(hutil::ParmFactory(PRM_INT_J, "activepart", ""));
 
     hvdb::OpenVDBOpFactory("VDB to Polygons", SOP_OpenVDB_To_Polygons::factory, parms, *table)
+        .setParentName("")
 #ifndef SESI_OPENVDB
         .setInternalName("DW_OpenVDBToPolygons")
 #endif

--- a/openvdb_houdini/SOP_OpenVDB_Transform.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Transform.cc
@@ -125,6 +125,7 @@ newSopOperator(OP_OperatorTable* table)
             " for example, with the [OpenVDB Create|Node:sop/DW_OpenVDBCreate] node)."));
 
     hvdb::OpenVDBOpFactory("VDB Transform", SOP_OpenVDB_Transform::factory, parms, *table)
+        .setParentName("")
         .addInput("VDBs to transform")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Transform::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Transform.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Transform.cc
@@ -125,7 +125,7 @@ newSopOperator(OP_OperatorTable* table)
             " for example, with the [OpenVDB Create|Node:sop/DW_OpenVDBCreate] node)."));
 
     hvdb::OpenVDBOpFactory("VDB Transform", SOP_OpenVDB_Transform::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .addInput("VDBs to transform")
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Transform::Cache; })
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Write.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Write.cc
@@ -174,6 +174,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Write", SOP_OpenVDB_Write::factory, parms, *table)
+        .setParentName("")
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs to be written to disk")
         .setDocumentation("\

--- a/openvdb_houdini/SOP_OpenVDB_Write.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Write.cc
@@ -174,7 +174,7 @@ newSopOperator(OP_OperatorTable* table)
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Write", SOP_OpenVDB_Write::factory, parms, *table)
-        .setParentName("")
+        .setNativeName("")
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs to be written to disk")
         .setDocumentation("\


### PR DESCRIPTION
This adds the ability to hide an open-source SOP from the tab menu using OpFactory::setInvisible(). It also adds the ability to "pair" an open-source SOP with a native SOP shipped by SideFX. This is achieved through a getParentName() rule in the OpPolicy classes and by using OpenVDBOpFactory::setParentName("...") for cases where it deviates from this logic (currently Advect and Filter SOP).

I have included setParentName("") with an empty string for cases where the open-source SOP **isn't** shipped with Houdini (OpenVDB Densify SOP for example). If the sole use-case is for ophiding, this isn't strictly necessary because it shouldn't matter if the native SOP doesn't exist, but I included it anyway so the pairing is accurate. 

No SOPs are being marked invisible with this PR, so this is just a stepping stone to figuring out the best way to proceed with #404.