### PR TITLE
Use hash map with Coord key for faster performance

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -14,6 +14,7 @@ Version 6.1.1 - In development
       Jemalloc by default for Linux and non-Maya, otherwise use TBB malloc.
     - Added math::isInfinite() and math::isNan() to resolve Visual Studio
       compatibility issues with integer types.
+    - Minor performance improvements to moving and filtering VDB points.
 
     Bug fixes:
     - Fixed a bug in tools::computeScalarPotential() that could produce

--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -1,7 +1,7 @@
 OpenVDB Version History
 =======================
 
-Version 6.1.1 - In development
+Version 6.2.0 - In development
 
     Improvements:
     - FindOpenVDB.cmake now correctly propagates CXX version requirements.
@@ -27,6 +27,9 @@ Version 6.1.1 - In development
       OPENVDB_USE_DEPRECATED_ABI (or set the CMake OPENVDB_USE_DEPRECATED_ABI
       option to ON) to suppress deprecation messages when compiling OpenVDB or
       dependent code.
+
+    API changes:
+    - Changed a type alias in points::RandomLeafFilter.
 
     Python:
     - CMake now always produces a .so for the Python module on UNIX platforms.

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -2,9 +2,9 @@
 
 @page changes Release Notes
 
-@htmlonly <a name="v6_1_1_changes"></a>@endhtmlonly
+@htmlonly <a name="v6_2_0_changes"></a>@endhtmlonly
 @par
-<B>Version 6.1.1</B> - <I>In development</I>
+<B>Version 6.2.0</B> - <I>In development</I>
 
 @par
 Improvements:
@@ -37,6 +37,11 @@ ABI changes:
   OPENVDB_USE_DEPRECATED_ABI (or set the CMake OPENVDB_USE_DEPRECATED_ABI
   option to ON) to suppress deprecation messages when compiling OpenVDB or
   dependent code.
+
+@par
+API changes:
+- Changed a type alias in
+  @vdblink::points::RandomLeafFilter RandomLeafFilter@endlink.
 
 @par
 Python:

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -21,6 +21,7 @@ Improvements:
   Jemalloc by default for Linux and non-Maya, otherwise use TBB malloc.
 - Added math::isInfinite() and math::isNan() to resolve Visual Studio
   compatibility issues with integer types.
+- Minor performance improvements to moving and filtering VDB points.
 
 @par
 Bug fixes:

--- a/openvdb/points/IndexFilter.h
+++ b/openvdb/points/IndexFilter.h
@@ -79,6 +79,7 @@
 
 #include <random> // std::mt19937
 #include <numeric> // std::iota
+#include <unordered_map>
 
 
 class TestIndexFilter;
@@ -255,7 +256,7 @@ class RandomLeafFilter
 {
 public:
     using SeedCountPair = std::pair<Index, Index>;
-    using LeafMap       = std::map<openvdb::Coord, SeedCountPair>;
+    using LeafMap       = std::unordered_map<openvdb::Coord, SeedCountPair>;
 
     RandomLeafFilter(   const PointDataTreeT& tree,
                         const Index64 targetPoints,

--- a/openvdb/points/PointMove.h
+++ b/openvdb/points/PointMove.h
@@ -198,7 +198,7 @@ using LocalPointIndexMap = std::vector<IndexPairArray>;
 
 using LeafIndexArray = std::vector<LeafIndex>;
 using LeafOffsetArray = std::vector<LeafIndexArray>;
-using LeafMap = std::map<Coord, LeafIndex>;
+using LeafMap = std::unordered_map<Coord, LeafIndex>;
 
 
 template <typename DeformerT, typename TreeT, typename FilterT>


### PR DESCRIPTION
This is a simple performance improvement to switch a couple of std::maps to std::unordered_maps as an openvdb::Coord hash is now available.