### PR TITLE
OpenVDB SOPs Tab Sub-Menu

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -44,6 +44,8 @@ Version 6.1.1 - In development
       from tab menus.
     - Added methods to store parent name and visibility of native SOPs to
       @b openvdb_houdini::OpenVDBOpFactory.
+    - Added a houdini_utils::OpPolicy::getTabSubMenuPath() method to allow
+      OpPolicy subclasses to provide their own tab sub-menu path.
 
 
 Version 6.1.0 - May 8, 2019

--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -46,7 +46,7 @@ Version 6.1.1 - In development
       @b openvdb_houdini::OpenVDBOpFactory.
     - Added a houdini_utils::OpPolicy::getTabSubMenuPath() method to allow
       OpPolicy subclasses to provide their own tab sub-menu path.
-    - OpenVDB SOPs are now displayed in the ASWF tab sub-menu.
+    - OpenVDB SOPs are now displayed in the ASWF tab sub-menu nested under VDB.
 
 
 Version 6.1.0 - May 8, 2019

--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -46,6 +46,7 @@ Version 6.1.1 - In development
       @b openvdb_houdini::OpenVDBOpFactory.
     - Added a houdini_utils::OpPolicy::getTabSubMenuPath() method to allow
       OpPolicy subclasses to provide their own tab sub-menu path.
+    - OpenVDB SOPs are now displayed in the ASWF tab sub-menu.
 
 
 Version 6.1.0 - May 8, 2019

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -59,7 +59,7 @@ Houdini:
   @b openvdb_houdini::OpenVDBOpFactory.
 - Added a houdini_utils::OpPolicy::getTabSubMenuPath() method to allow
   OpPolicy subclasses to provide their own tab sub-menu path.
-- OpenVDB SOPs are now displayed in the ASWF tab sub-menu.
+- OpenVDB SOPs are now displayed in the ASWF tab sub-menu nested under VDB.
 
 
 @htmlonly <a name="v6_1_0_changes"></a>@endhtmlonly

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -57,6 +57,8 @@ Houdini:
   from tab menus.
 - Added methods to store parent name and visibility of native SOPs to
   @b openvdb_houdini::OpenVDBOpFactory.
+- Added a houdini_utils::OpPolicy::getTabSubMenuPath() method to allow
+  OpPolicy subclasses to provide their own tab sub-menu path.
 
 
 @htmlonly <a name="v6_1_0_changes"></a>@endhtmlonly

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -59,6 +59,7 @@ Houdini:
   @b openvdb_houdini::OpenVDBOpFactory.
 - Added a houdini_utils::OpPolicy::getTabSubMenuPath() method to allow
   OpPolicy subclasses to provide their own tab sub-menu path.
+- OpenVDB SOPs are now displayed in the ASWF tab sub-menu.
 
 
 @htmlonly <a name="v6_1_0_changes"></a>@endhtmlonly

--- a/openvdb_houdini/ParmFactory.cc
+++ b/openvdb_houdini/ParmFactory.cc
@@ -1018,6 +1018,7 @@ struct OpFactory::Impl
         mIconName = mPolicy->getIconName(factory);
         mHelpUrl = mPolicy->getHelpURL(factory);
         mFirstName = mPolicy->getFirstName(factory);
+        mTabSubMenuPath = mPolicy->getTabSubMenuPath(factory);
     }
 
     OP_OperatorDW* get()
@@ -1043,6 +1044,8 @@ struct OpFactory::Impl
 
         if (!mIconName.empty()) op->setIconName(mIconName.c_str());
 
+        if (!mTabSubMenuPath.empty()) op->setOpTabSubMenuPath(mTabSubMenuPath.c_str());
+
         if (mObsoleteParms != nullptr) op->setObsoleteTemplates(mObsoleteParms);
 
         if (mVerb) SOP_NodeVerb::registerVerb(mVerb);
@@ -1053,7 +1056,7 @@ struct OpFactory::Impl
     OpPolicyPtr mPolicy; // polymorphic, so stored by pointer
     OpFactory::OpFlavor mFlavor;
     std::string mEnglish, mName, mLabelName, mIconName, mHelpUrl, mDoc, mOperatorTableName;
-    std::string mFirstName;
+    std::string mFirstName, mTabSubMenuPath;
     OP_Constructor mConstruct;
     OP_OperatorTable* mTable;
     PRM_Template *mParms, *mObsoleteParms;

--- a/openvdb_houdini/ParmFactory.h
+++ b/openvdb_houdini/ParmFactory.h
@@ -551,6 +551,10 @@ public:
     /// @brief Return the inital default name of the op.
     /// @note An empty first name will disable, reverting to the usual rules.
     virtual std::string getFirstName(const OpFactory&) { return ""; }
+
+    /// @brief Return the tab sub-menu path of the op.
+    /// @note An empty path will disable, reverting to the usual rules.
+    virtual std::string getTabSubMenuPath(const OpFactory&) { return ""; }
 };
 
 

--- a/openvdb_houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/SOP_NodeVDB.cc
@@ -686,7 +686,7 @@ public:
 
     std::string getTabSubMenuPath(const houdini_utils::OpFactory& factory) override
     {
-        return "ASWF";
+        return "VDB/ASWF";
     }
 };
 

--- a/openvdb_houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/SOP_NodeVDB.cc
@@ -652,6 +652,11 @@ public:
     {
         return this->getLowercaseName(this->getValidName(english));
     }
+
+    std::string getTabSubMenuPath(const houdini_utils::OpFactory& factory) override
+    {
+        return "VDB";
+    }
 };
 
 
@@ -677,6 +682,11 @@ public:
     std::string getNativeName(const houdini_utils::OpFactory& factory) override
     {
         return this->getLowercaseName(this->getValidName(factory.english()));
+    }
+
+    std::string getTabSubMenuPath(const houdini_utils::OpFactory& factory) override
+    {
+        return "ASWF";
     }
 };
 


### PR DESCRIPTION
Add a tab sub-menu option to OpPolicy/OpFactory and set OpenVDB SOPs to use "ASWF" instead of "Custom".