### PR TITLE
OVDB-106: Add spare data support to OpenVDB operators

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -42,8 +42,12 @@ Version 6.1.1 - In development
       is not a VDB.
     - Added a houdini_utils::OpFactory::setInvisible() method to hide nodes
       from tab menus.
-    - Added methods to store parent name and visibility of native SOPs to
-      @b openvdb_houdini::OpenVDBOpFactory.
+    - Added a houdini_utils::OpFactory::addSpareData() method
+      and addOperatorSpareData() and getOperatorSpareData() functions
+      to manage spare data associated with operator types.
+    - Added an opsparedata HScript command and hou.NodeType.spareData()
+      and hou.NodeType.spareDataDict() methods to retrieve spare data
+      associated with operator types.
 
 
 Version 6.1.0 - May 8, 2019

--- a/openvdb/doc/changes.txt
+++ b/openvdb/doc/changes.txt
@@ -55,8 +55,12 @@ Houdini:
   destination is not a&nbsp;VDB.
 - Added a @b houdini_utils::OpFactory::setInvisible method to hide nodes
   from tab menus.
-- Added methods to store parent name and visibility of native SOPs to
-  @b openvdb_houdini::OpenVDBOpFactory.
+- Added a @b houdini_utils::OpFactory::addSpareData method
+  and @b addOperatorSpareData and @b getOperatorSpareData functions
+  to manage spare data associated with operator types.
+- Added an @c opsparedata HScript command and @c hou.NodeType.spareData
+  and @c hou.NodeType.spareDataDict methods to retrieve spare data
+  associated with operator types.
 
 
 @htmlonly <a name="v6_1_0_changes"></a>@endhtmlonly

--- a/openvdb_houdini/ParmFactory.cc
+++ b/openvdb_houdini/ParmFactory.cc
@@ -1083,7 +1083,7 @@ struct OpFactory::Impl
             }
         }
 
-        // Install a Python command to retrieve spare data from operators.
+        // Install Python functions to retrieve spare data from operators.
         static bool sDidInstallHOMModule = false;
         if (!sDidInstallHOMModule) {
             // Install a _dwhoudiniutils module with a NodeType_spareData() function.
@@ -1101,17 +1101,25 @@ struct OpFactory::Impl
             PYrunPythonStatementsAndExpectNoErrors("\
 def _spareData(self, name):\n\
     '''\n\
-    spareData(name) -> str or None\n\n\
-    Return the spare data with the given name,\n\
-    or None if no data with that name exists.\n\
+    spareData(name) -> str or None\n\
+    \n\
+    Return the spare data with the given name, or None\n\
+    if no data with that name is defined for this node type.\n\
+    \n\
+    Currently, only node types defined with OpenVDB's OpFactory\n\
+    can have spare data.  See www.openvdb.org for more information.\n\
     '''\n\
     import _dwhoudiniutils\n\
     return _dwhoudiniutils.NodeType_spareData(self.category().name(), self.name(), name)\n\
 \n\
 def _spareDataDict(self):\n\
     '''\n\
-    spareDataDict() -> dict of str to str\n\n\
+    spareDataDict() -> dict of str to str\n\
+    \n\
     Return a dictionary of the spare data for this node type.\n\
+    \n\
+    Currently, only node types defined with OpenVDB's OpFactory\n\
+    can have spare data.  See www.openvdb.org for more information.\n\
     '''\n\
     import _dwhoudiniutils\n\
     return _dwhoudiniutils.NodeType_spareData(self.category().name(), self.name())\n\

--- a/openvdb_houdini/ParmFactory.h
+++ b/openvdb_houdini/ParmFactory.h
@@ -80,6 +80,22 @@ namespace houdini_utils {
 
 class ParmFactory;
 
+using SpareDataMap = std::map<std::string, std::string>;
+
+/// @brief Return the spare data associated with the given operator.
+/// @details Only operators created with OpFactory will have spare data.
+/// @sa @link addOperatorSpareData() addOperatorSpareData@endlink,
+///     @link OpFactory::addSpareData() OpFactory::addSpareData@endlink
+const SpareDataMap& getOperatorSpareData(const OP_Operator&);
+
+/// @brief Specify (@e key, @e value) pairs of spare data for the given operator.
+/// @details For existing keys, the new value replaces the old one.
+/// @throw std::runtime_error if the given operator does not support spare data
+///     (only operators created with OpFactory will have spare data)
+/// @sa @link getOperatorSpareData() addOperatorSpareData@endlink,
+///     @link OpFactory::addSpareData() OpFactory::addSpareData@endlink
+void addOperatorSpareData(OP_Operator&, const SpareDataMap&);
+
 
 /// @brief Parameter template list that is always terminated.
 class OPENVDB_HOUDINI_API ParmList
@@ -320,7 +336,7 @@ public:
     ParmFactory& setRange(const PRM_Range*);
 
     /// Specify (@e key, @e value) pairs of spare data for this parameter.
-    ParmFactory& setSpareData(const std::map<std::string, std::string>&);
+    ParmFactory& setSpareData(const SpareDataMap&);
     /// Specify spare data for this parameter.
     ParmFactory& setSpareData(const PRM_SpareData*);
 
@@ -500,9 +516,12 @@ public:
     /// @details This is equivalent to using the hscript ophide method.
     OpFactory& setInvisible();
 
-protected:
-    /// @brief Return the non-const operator table with which this factory is associated.
-    OP_OperatorTable& table();
+    /// @brief Specify (@e key, @e value) pairs of spare data for this operator.
+    /// @details If a key already exists, its corresponding value will be
+    /// overwritten with the new value.
+    /// @sa @link addOperatorSpareData() addOperatorSpareData@endlink,
+    ///     @link getOperatorSpareData() getOperatorSpareData@endlink
+    OpFactory& addSpareData(const SpareDataMap&);
 
 private:
     void init(OpPolicyPtr, const std::string& english, OP_Constructor,
@@ -548,7 +567,7 @@ public:
     /// factory.@link OpFactory::english() english()@endlink.
     virtual std::string getLabelName(const OpFactory&);
 
-    /// @brief Return the inital default name of the op.
+    /// @brief Return the inital default name of the operator.
     /// @note An empty first name will disable, reverting to the usual rules.
     virtual std::string getFirstName(const OpFactory&) { return ""; }
 };

--- a/openvdb_houdini/ParmFactory.h
+++ b/openvdb_houdini/ParmFactory.h
@@ -92,7 +92,7 @@ const SpareDataMap& getOperatorSpareData(const OP_Operator&);
 /// @details For existing keys, the new value replaces the old one.
 /// @throw std::runtime_error if the given operator does not support spare data
 ///     (only operators created with OpFactory will have spare data)
-/// @sa @link getOperatorSpareData() addOperatorSpareData@endlink,
+/// @sa @link getOperatorSpareData() getOperatorSpareData@endlink,
 ///     @link OpFactory::addSpareData() OpFactory::addSpareData@endlink
 void addOperatorSpareData(OP_Operator&, const SpareDataMap&);
 

--- a/openvdb_houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/SOP_NodeVDB.cc
@@ -637,7 +637,7 @@ public:
 
     /// @brief Return the name of the equivalent native operator as shipped with Houdini.
     /// @details An empty string indicates that there is no equivalent native operator.
-    virtual std::string getNativeName(const houdini_utils::OpFactory& factory)
+    virtual std::string getNativeName(const houdini_utils::OpFactory&)
     {
         return "";
     }

--- a/openvdb_houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/SOP_NodeVDB.cc
@@ -698,20 +698,7 @@ OpenVDBOpFactory::OpenVDBOpFactory(
     houdini_utils::OpFactory::OpFlavor flavor):
     houdini_utils::OpFactory(OpenVDBOpPolicy(), english, ctor, parms, table, flavor)
 {
-    mNativeName = OpenVDBOpPolicy().getNativeName(*this);
-}
-
-
-OpenVDBOpFactory::~OpenVDBOpFactory()
-{
-    // hide the native node if marked invisble
-    if (!mNativeName.empty()) {
-        bool invisible = mNativeInvisible;
-
-        if (invisible) {
-            this->table().addOpHidden(mNativeName.c_str());
-        }
-    }
+    setNativeName(OpenVDBOpPolicy().getNativeName(*this));
 }
 
 
@@ -720,16 +707,8 @@ OpenVDBOpFactory::setNativeName(const std::string& name)
 {
     // SideFX nodes have no native equivalent.
 #ifndef SESI_OPENVDB
-    mNativeName = name;
+    addSpareData({{"nativename", name}});
 #endif
-    return *this;
-}
-
-
-OpenVDBOpFactory&
-OpenVDBOpFactory::setNativeInvisible()
-{
-    mNativeInvisible = true;
     return *this;
 }
 

--- a/openvdb_houdini/SOP_NodeVDB.h
+++ b/openvdb_houdini/SOP_NodeVDB.h
@@ -62,22 +62,10 @@ public:
     OpenVDBOpFactory(const std::string& english, OP_Constructor, houdini_utils::ParmList&,
         OP_OperatorTable&, houdini_utils::OpFactory::OpFlavor = SOP);
 
-    /// Register the node
-    ~OpenVDBOpFactory();
-
     /// @brief Set the name of the equivalent native operator as shipped with Houdini.
-    /// @details This is only needed where the native name policy doesn't provide
-    /// the correct name. Pass an empty string to indicate that there is no
-    /// equivalent native operator.
+    /// @details This is only needed where the native name policy doesn't provide the correct name.
+    /// Pass an empty string to indicate that there is no equivalent native operator.
     OpenVDBOpFactory& setNativeName(const std::string& name);
-
-    /// @brief Mark the native operator as hidden from the UI tab menu.
-    /// @details This is equivalent to using the hscript ophide method.
-    OpenVDBOpFactory& setNativeInvisible();
-
-private:
-    std::string mNativeName;
-    bool mNativeInvisible = false;
 };
 
 


### PR DESCRIPTION
This PR adds a spare data mechanism to `OP_Operator`s created with `OpFactory`.  I deliberately kept the API simple (we can extend it if the need arises, but multi-gigabyte spare data is already supported), and I have not included any ophide logic (I will file my `pythonrc.py` implementation as a separate PR).

To complement the C++ API, I've added HScript and Python functions to retrieve (but not set) spare data:

**HScript**
```
> opsparedata
opsparedata

    List spare data associated with an operator type.

    USAGE
      opsparedata <networktype> <opname> [<token>]

    When the token is omitted, all (token, value) pairs
    associated with the operator type are displayed.

    Currently, only operator types defined with OpenVDB's OpFactory
    can have spare data.  See www.openvdb.org for more information.

    EXAMPLES
      > opsparedata Sop DW_OpenVDBConvert
        lists all spare data associated with the Convert VDB SOP
      > opsparedata Sop DW_OpenVDBClip nativename
        displays the VDB Clip SOP's native name

> opsparedata Sop DW_OpenVDBClip
nativename vdbclip

> opsparedata Sop DW_OpenVDBClip nativename
vdbclip

> opsparedata Sop vdbclip

```

**HOM**
```
>>> help(hou.NodeType.spareData)
Help on method _spareData in module __main__:

_spareData(self, name) unbound hou.NodeType method
    spareData(name) -> str or None
    
    Return the spare data with the given name, or None
    if no data with that name is defined for this node type.
    
    Currently, only node types defined with OpenVDB's OpFactory
    can have spare data.  See www.openvdb.org for more information.

>>> help(hou.NodeType.spareDataDict)
Help on method _spareDataDict in module __main__:

_spareDataDict(self) unbound hou.NodeType method
    spareDataDict() -> dict of str to str
    
    Return a dictionary of the spare data for this node type.
    
    Currently, only node types defined with OpenVDB's OpFactory
    can have spare data.  See www.openvdb.org for more information.

>>> hou.nodeType('Sop/DW_OpenVDBClip').spareDataDict()
{'nativename': 'vdbclip'}

>>> hou.nodeType('Sop/DW_OpenVDBClip').spareData('nativename')
'vdbclip'

>>> hou.nodeType('Sop/vdbclip').spareDataDict()
{}
```
