### PR TITLE
Add option to use colored output through CMake

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Version 6.2.0 - In development
       multithreading.
     - Increase minimum supported version of GLFW to 3.1 and improve CMake
       support for GLFW versions >= 3.1.
+    - Add a USE_COLORED_OUTPUT option to CMake to add the compiler flag to
+      color the compiler output.
 
     Bug fixes:
     - Replaced std::vector with std::deque as the underlying container

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ option(DISABLE_DEPENDENCY_VERSION_CHECKS [=[
 Disable minimum version checks for OpenVDB dependencies. It is strongly recommended that this remains disabled.
 Consider updating your dependencies where possible if encountering minimum requirement CMake errors.]=] OFF)
 option(OPENVDB_USE_DEPRECATED_ABI "Bypass minimum ABI requirement checks" OFF)
+option(USE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." OFF)
 
 set(_CONCURRENT_MALLOC_OPTIONS None Auto Jemalloc Tbbmalloc)
 if(NOT CONCURRENT_MALLOC)
@@ -173,6 +174,7 @@ mark_as_advanced(
   DISABLE_DEPENDENCY_VERSION_CHECKS
   OPENVDB_USE_DEPRECATED_ABI
   CONCURRENT_MALLOC
+  USE_COLORED_OUTPUT
 )
 
 # Configure minimum version requirements
@@ -371,6 +373,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
       -Wno-sign-conversion
     )
   endif()
+  if(USE_COLORED_OUTPUT)
+    message(STATUS "Enabling colored compiler output")
+    add_compile_options(-fcolor-diagnostics)
+  endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS MINIMUM_GCC_VERSION)
     message(FATAL_ERROR "Insufficient g++ version. Minimum required is "
@@ -391,6 +397,10 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       -Wdisabled-optimization
       -Woverloaded-virtual
     )
+  endif()
+  if(USE_COLORED_OUTPUT)
+    message(STATUS "Enabling colored compiler output")
+    add_compile_options(-fdiagnostics-color=always)
   endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS MINIMUM_ICC_VERSION})

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -31,6 +31,8 @@ Improvements:
   multithreading.
 - Increase minimum supported version of GLFW to 3.1 and improve CMake support
   for GLFW versions >= 3.1.
+- Add a USE_COLORED_OUTPUT option to CMake to add the compiler flag to color
+  the compiler output.
 
 @par
 Bug fixes:


### PR DESCRIPTION
Not sure how much collective time has been spent over the years wrangling colored output from compilers. Many google hits still seem to reference a perl script to color the output.

One simple solution is to define GCC_COLORS in the environment which will be recognized by GCC >= 4.9. This is a convenient alternative that simply sets -fdiagnostics-color=always in GCC or -fcolor-diagnostics in Clang. Perhaps when we deprecate support for GCC 4.8 we could even enable this by default.