### PR TITLE
Add OPENVDB_LOG statements to empty catch blocks

### DIFF
--- a/openvdb/Exceptions.h
+++ b/openvdb/Exceptions.h
@@ -32,6 +32,7 @@
 #define OPENVDB_EXCEPTIONS_HAS_BEEN_INCLUDED
 
 #include <openvdb/version.h>
+#include <openvdb/util/logging.h> // OPENVDB_LOG_ERROR
 #include <exception>
 #include <sstream>
 #include <string>
@@ -52,7 +53,11 @@ public:
 
     const char* what() const noexcept override
     {
-        try { return mMessage.c_str(); } catch (...) {}
+        try {
+            return mMessage.c_str();
+        } catch (...) {
+            OPENVDB_LOG_ERROR("Unexpected exception thrown in io::Exception::what().");
+        }
         return nullptr;
     }
 
@@ -63,7 +68,9 @@ protected:
         try {
             if (eType) mMessage = eType;
             if (msg) mMessage += ": " + (*msg);
-        } catch (...) {}
+        } catch (...) {
+            OPENVDB_LOG_ERROR("Unexpected exception thrown in io::Exception constructor.");
+        }
     }
 
 private:

--- a/openvdb/Metadata.cc
+++ b/openvdb/Metadata.cc
@@ -153,7 +153,10 @@ Metadata::operator==(const Metadata& other) const
         this->writeValue(bytes);
         other.writeValue(otherBytes);
         return (bytes.str() == otherBytes.str());
-    } catch (Exception&) {}
+    } catch (Exception&) {
+        OPENVDB_LOG_INFO(
+            "Ignoring exception thrown in Metadata::operator==().");
+    }
     return false;
 }
 

--- a/openvdb/io/Queue.cc
+++ b/openvdb/io/Queue.cc
@@ -102,6 +102,8 @@ public:
                 OPENVDB_LOG_ERROR(msg);
             }
         } catch (...) {
+            OPENVDB_LOG_ERROR(
+                "Unexpected exception thrown in io::OutputTask::execute().");
         }
         this->notify(status);
         return nullptr; // no successor to this task

--- a/openvdb/math/Maps.cc
+++ b/openvdb/math/Maps.cc
@@ -232,7 +232,8 @@ approxInverse(const Mat4d& mat4d)
         try {
             return mat4d.inverse();
         } catch (ArithmeticError& ) {
-            // Mat4 code couldn't invert.
+            OPENVDB_LOG_INFO(
+                "Mat4 couldn't be inverted in approxInverse(const Mat4d&)");
         }
     }
 


### PR DESCRIPTION
This is to address CWE-391 as picked up by SonarCloud. The main concern is that the exception can be caught silently which could potentially lead to a security vulnerability. Adding a log statement is sufficient to address the SonarCloud vulnerability.

These five empty catch statements seem to fall into two categories:

* an exception that we don't believe should ever be thrown, but we catch for safety as method is marked "noexcept" - I've added OPENVDB_LOG_ERROR to these
* a specific exception that is an allowed and expected method failure and the logic is designed to handle this being thrown - I've added OPENVDB_LOG_INFO to these