### PR TITLE
Added FindActiveValues

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,10 @@ OpenVDB Version History
 
 Version 6.2.0 - In development
 
+    New Features:
+    - Added tools::FindActiveValues that finds (and optionally counts)
+      the active values in a tree which intersects a bounding box.
+
     Improvements:
     - FindOpenVDB.cmake now correctly propagates CXX version requirements.
     - Improved directory and file path lookups of some CMake commands in

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -7,6 +7,12 @@
 <B>Version 6.2.0</B> - <I>In development</I>
 
 @par
+New features:
+- Added @vdblink{tools::FindActiveValues, tools::FindActiveValues} that
+  finds (and optionally counts) the active values in a tree which
+  intersects a bounding box.
+
+@par
 Improvements:
 - <TT>FindOpenVDB.cmake</TT> now correctly propagates @c CXX version
   requirements.

--- a/openvdb/tools/FindActiveValues.h
+++ b/openvdb/tools/FindActiveValues.h
@@ -341,18 +341,7 @@ Index64 FindActiveValues<TreeT>::count(const NodeT* node, const CoordBBox &bbox)
     const auto childMask = mask & node->getChildMask();// prune the child mask with the bbox mask
     mask &= node->getValueMask();// prune active tile mask with the bbox mask
     const auto* table = node->getTable();
-#if 0
-    // Check child nodes
-    for (auto i = childMask.beginOn(); i; ++i) {
-        count += this->count(table[i.pos()].getChild(), bbox);
-    }
-    // Check active tiles
-    for (auto i = mask.beginOn(); i; ++i) {
-        auto b = CoordBBox::createCube(node->offsetToGlobalCoord(i.pos()), NodeT::ChildNodeType::DIM);
-        b.intersect(bbox);
-        count += b.volume();
-    }
-#else
+
     {// Check child nodes
         using ChildT = typename NodeT::ChildNodeType;
         using RangeT = tbb::blocked_range<typename std::vector<const ChildT*>::iterator>;
@@ -366,6 +355,7 @@ Index64 FindActiveValues<TreeT>::count(const NodeT* node, const CoordBBox &bbox)
             }, []( Index64 a, Index64 b )->Index64 { return a+b; }
         );
     }
+
     {// Check active tiles
         std::vector<Coord> coords(mask.countOn());
         using RangeT = tbb::blocked_range<typename std::vector<Coord>::iterator>;
@@ -382,7 +372,7 @@ Index64 FindActiveValues<TreeT>::count(const NodeT* node, const CoordBBox &bbox)
             }, []( Index64 a, Index64 b )->Index64 { return a+b; }
         );
     }
-#endif
+
     return count;
 }
 

--- a/openvdb/tools/FindActiveValues.h
+++ b/openvdb/tools/FindActiveValues.h
@@ -1,0 +1,437 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) Ken Museth
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+//
+/// @file FindActiveValues.h
+///
+/// @brief Finds the active values in a tree which intersects a bounding box.
+///        Two methods are provided, one that counts the number of active values
+///        and one that simply tests if any active values intersect the bbox.
+///
+/// @warning For repeated calls to the free-standing functions defined below
+///          consider instead creating an instance of FindActiveValues
+///          and then repeatedly call its member methods. This assumes the tree
+///          to be constant between calls but is sightly faster.
+///
+/// @author Ken Museth
+
+#ifndef OPENVDB_TOOLS_FINDACTIVEVALUES_HAS_BEEN_INCLUDED
+#define OPENVDB_TOOLS_FINDACTIVEVALUES_HAS_BEEN_INCLUDED
+
+#include <vector>
+#include <openvdb/version.h> // for OPENVDB_VERSION_NAME
+#include <openvdb/Types.h>
+#include <openvdb/tree/ValueAccessor.h>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace tools {
+
+/// @brief Returns true if the bounding box intersects any of the active
+///        values in a tree, i.e. either active voxels or active tiles.
+///
+/// @warning For repeated calls to this method consider instead creating an instance of
+///          FindActiveValues and then repeatedly call any(). This assumes the tree
+///          to be constant between calls but is sightly faster.
+///
+/// @param tree   const tree to be tested for active values.
+/// @param bbox   index bounding box which is intersected against the active values.
+template<typename TreeT>
+inline bool
+anyActiveValues(const TreeT& tree, const CoordBBox &bbox);
+
+/// @brief Returns true if the bounding box intersects none of the active
+///        values in a tree, i.e. neither active voxels or active tiles.
+///
+/// @warning For repeated calls to this method consider instead creating an instance of
+///          FindActiveValues and then repeatedly call none(). This assumes the tree
+///          to be constant between calls but is sightly faster.
+///
+/// @param tree   const tree to be tested for active values.
+/// @param bbox   index bounding box which is intersected against the active values.
+template<typename TreeT>
+inline bool
+noActiveValues(const TreeT& tree, const CoordBBox &bbox);
+
+/// @brief Returns the number of active values that intersects a bounding box intersects,
+///        i.e. the count includes both active voxels and virtual voxels in active tiles.
+///
+/// @warning For repeated calls to this method consider instead creating an instance of
+///          FindActiveValues and then repeatedly call count(). This assumes the tree
+///          to be constant between calls but is sightly faster.
+///
+/// @param tree   const tree to be tested for active values.
+/// @param bbox   index bounding box which is intersected against the active values.
+template<typename TreeT>
+inline Index64
+countActiveValues(const TreeT& tree, const CoordBBox &bbox);
+
+//////////////////////////////////////////////////////////////////////////////////////////
+
+/// @brief   Finds the active values in a tree which intersects a bounding box.
+///
+/// @details Two methods are provided, one that count the number of active values
+///          and one that simply tests if any active values intersect the bbox.
+///
+/// @warning Tree nodes are cached by this class so it's important that the tree is not
+///          modified after this class is instantiated and before its methods are called.
+template<typename TreeT>
+class FindActiveValues
+{
+public:
+
+    /// @brief Constructor from a const tree, which is assumed not to be modified after construction.
+    FindActiveValues(const TreeT& tree);
+
+    /// @brief Default destructor
+    ~FindActiveValues();
+
+    /// @brief Initiate this class with a new (or modified) tree.
+    void update(const TreeT& tree);
+
+    /// @brief Returns true if the specified bounding box intersects any active values.
+    ///
+    /// @warning Using a ValueAccessor (i.e. useAccessor = true) can improve performance for especailly
+    ///          small bounding boxes, but at the cost of none-thread-safety. So if multiple threads are
+    ///          calling this method concurrently use the default setting, useAccessor = false.
+    bool any(const CoordBBox &bbox, bool useAccessor = false) const;
+
+    /// @brief Returns true if the specified bounding box doens not intersect any active values.
+    ///
+    /// @warning Using a ValueAccessor (i.e. useAccessor = true) can improve performance for especailly
+    ///          small bounding boxes, but at the cost of none-thread-safety. So if multiple threads are
+    ///          calling this method concurrently use the default setting, useAccessor = false.
+    bool none(const CoordBBox &bbox, bool useAccessor = false) const { return !this->any(bbox, useAccessor); }
+
+    /// @brief Returns the number of active voxels intersected by the specified bounding box.
+    Index64 count(const CoordBBox &bbox) const;
+
+private:
+
+    // Cleans up internal data structures
+    void clear();
+
+    // builds internal data structures
+    void init(const TreeT &tree);
+
+    template<typename NodeT>
+    typename NodeT::NodeMaskType getBBoxMask(const CoordBBox &bbox, const NodeT* node) const;
+
+    // process leaf node
+    inline bool any(const typename TreeT::LeafNodeType* leaf, const CoordBBox &bbox ) const;
+
+    // process leaf node
+    inline Index64 count(const typename TreeT::LeafNodeType* leaf, const CoordBBox &bbox ) const;
+
+    // process internal node
+    template<typename NodeT>
+    bool any(const NodeT* node, const CoordBBox &bbox) const;
+
+    // process internal node
+    template<typename NodeT>
+    Index64 count(const NodeT* node, const CoordBBox &bbox) const;
+
+    using AccT = tree::ValueAccessor<const TreeT, false/* IsSafe */>;
+    using RootChildT = typename TreeT::RootNodeType::ChildNodeType;
+
+    struct NodePairT;
+
+    AccT mAcc;
+    std::vector<CoordBBox> mRootTiles;// cache bbox of child nodes (faster to cache than access RootNode)
+    std::vector<NodePairT> mRootNodes;// cache bbox of acive tiles (faster to cache than access RootNode)
+
+};// FindActiveValues class
+
+//////////////////////////////////////////////////////////////////////////////////////////
+
+template<typename TreeT>
+FindActiveValues<TreeT>::FindActiveValues(const TreeT& tree) : mAcc(tree), mRootTiles(), mRootNodes()
+{
+    this->init(tree);
+}
+
+template<typename TreeT>
+FindActiveValues<TreeT>::~FindActiveValues()
+{
+    this->clear();
+}
+
+template<typename TreeT>
+void FindActiveValues<TreeT>::update(const TreeT& tree)
+{
+    this->clear();
+    mAcc = AccT(tree);
+    this->init(tree);
+}
+
+template<typename TreeT>
+void FindActiveValues<TreeT>::clear()
+{
+    mRootNodes.clear();
+    mRootTiles.clear();
+}
+
+template<typename TreeT>
+void FindActiveValues<TreeT>::init(const TreeT& tree)
+{
+    for (auto i = tree.root().cbeginChildOn(); i; ++i) {
+        mRootNodes.emplace_back(i.getCoord(), &*i);
+    }
+    for (auto i = tree.root().cbeginValueOn(); i; ++i) {
+        mRootTiles.emplace_back(CoordBBox::createCube(i.getCoord(), RootChildT::DIM));
+    }
+}
+
+template<typename TreeT>
+bool FindActiveValues<TreeT>::any(const CoordBBox &bbox, bool useAccessor) const
+{
+    if (useAccessor) {
+        if (mAcc.isValueOn( (bbox.min() + bbox.max())>>1 )) return true;
+    } else {
+        if (mAcc.tree().isValueOn( (bbox.min() + bbox.max())>>1 )) return true;
+    }
+
+    for (auto& tile : mRootTiles) {
+        if (tile.hasOverlap(bbox)) return true;
+    }
+    for (auto& node : mRootNodes) {
+        if (!node.bbox.hasOverlap(bbox)) {
+            continue;
+        } else if (node.bbox.isInside(bbox)) {
+            return this->any(node.child, bbox);
+        } else if (this->any(node.child, bbox)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template<typename TreeT>
+Index64 FindActiveValues<TreeT>::count(const CoordBBox &bbox) const
+{
+    Index64 count = 0;
+    for (auto& tile : mRootTiles) {//loop over active tiles only
+        if (!tile.hasOverlap(bbox)) {
+            continue;//ignore non-overlapping tiles
+        } else if (tile.isInside(bbox)) {
+            return bbox.volume();// bbox is completely inside the active tile
+        } else if (bbox.isInside(tile)) {
+            count += RootChildT::NUM_VOXELS;
+        } else {
+            auto tmp = tile;
+            tmp.intersect(bbox);
+            count += tmp.volume();
+        }
+    }
+    for (auto &node : mRootNodes) {//loop over child nodes of the root node only
+        if ( !node.bbox.hasOverlap(bbox) ) {
+            continue;//ignore non-overlapping child nodes
+        } else if ( node.bbox.isInside(bbox) ) {
+            return this->count(node.child, bbox);// bbox is completely inside the child node
+        } else {
+            count += this->count(node.child, bbox);
+        }
+    }
+    return count;
+}
+
+template<typename TreeT>
+template<typename NodeT>
+typename NodeT::NodeMaskType FindActiveValues<TreeT>::getBBoxMask(const CoordBBox &bbox, const NodeT* node) const
+{
+    typename NodeT::NodeMaskType mask;
+    auto b = node->getNodeBoundingBox();
+    assert( bbox.hasOverlap(b) );
+    if ( bbox.isInside(b) ) {
+        mask.setOn();//node is completely inside the bbox so early out
+    } else {
+        b.intersect(bbox);
+        b.min() &=  NodeT::DIM-1u;
+        b.min() >>= NodeT::ChildNodeType::TOTAL;
+        b.max() &=  NodeT::DIM-1u;
+        b.max() >>= NodeT::ChildNodeType::TOTAL;
+        assert( b.hasVolume() );
+        auto it = b.begin();
+        for (const Coord& x = *it; it; ++it) {
+            mask.setOn(x[2] + (x[1] << NodeT::LOG2DIM) + (x[0] << 2*NodeT::LOG2DIM));
+        }
+    }
+    return mask;
+}
+
+template<typename TreeT>
+template<typename NodeT>
+bool FindActiveValues<TreeT>::any(const NodeT* node, const CoordBBox &bbox) const
+{
+    // Generate a bit mask of the bbox coverage
+    auto mask = this->getBBoxMask(bbox, node);
+
+    // Check active tiles
+    const auto tmp = mask & node->getValueMask();// prune active the tile mask with the bbox mask
+    if (!tmp.isOff()) return true;
+
+    // Check child nodes
+    mask &= node->getChildMask();// prune the child mask with the bbox mask
+    const auto* table = node->getTable();
+    bool test = false;
+    for (auto i = mask.beginOn(); !test && i; ++i) {
+        test = this->any(table[i.pos()].getChild(), bbox);
+    }
+    return test;
+}
+
+template<typename TreeT>
+inline bool FindActiveValues<TreeT>::any(const typename TreeT::LeafNodeType* leaf, const CoordBBox &bbox ) const
+{
+    bool test = leaf->getValueMask().isOn();
+
+    for (auto i = leaf->cbeginValueOn(); !test && i; ++i) {
+        test = bbox.isInside(i.getCoord());
+    }
+    return test;
+}
+
+template<typename TreeT>
+inline Index64 FindActiveValues<TreeT>::count(const typename TreeT::LeafNodeType* leaf, const CoordBBox &bbox ) const
+{
+    Index64 count = 0;
+    if (leaf->getValueMask().isOn()) {
+        auto b = leaf->getNodeBoundingBox();
+        b.intersect(bbox);
+        count = b.volume();
+    } else {
+        for (auto i = leaf->cbeginValueOn(); i; ++i) {
+            if (bbox.isInside(i.getCoord())) ++count;
+        }
+    }
+    return count;
+}
+
+template<typename TreeT>
+template<typename NodeT>
+Index64 FindActiveValues<TreeT>::count(const NodeT* node, const CoordBBox &bbox) const
+{
+    Index64 count = 0;
+
+    // Generate a bit masks
+    auto mask = this->getBBoxMask(bbox, node);
+    const auto childMask = mask & node->getChildMask();// prune the child mask with the bbox mask
+    mask &= node->getValueMask();// prune active tile mask with the bbox mask
+    const auto* table = node->getTable();
+#if 0
+    // Check child nodes
+    for (auto i = childMask.beginOn(); i; ++i) {
+        count += this->count(table[i.pos()].getChild(), bbox);
+    }
+    // Check active tiles
+    for (auto i = mask.beginOn(); i; ++i) {
+        auto b = CoordBBox::createCube(node->offsetToGlobalCoord(i.pos()), NodeT::ChildNodeType::DIM);
+        b.intersect(bbox);
+        count += b.volume();
+    }
+#else
+    {// Check child nodes
+        using ChildT = typename NodeT::ChildNodeType;
+        using RangeT = tbb::blocked_range<typename std::vector<const ChildT*>::iterator>;
+        std::vector<const ChildT*> childNodes(childMask.countOn());
+        int j=0;
+        for (auto i = childMask.beginOn(); i; ++i, ++j) childNodes[j] = table[i.pos()].getChild();
+        count += tbb::parallel_reduce( RangeT(childNodes.begin(), childNodes.end()), 0,
+            [&](const RangeT& r, Index64 sum)->Index64 {
+                for ( auto i = r.begin(); i != r.end(); ++i ) sum += this->count(*i, bbox);
+                return sum;
+            }, []( Index64 a, Index64 b )->Index64 { return a+b; }
+        );
+    }
+    {// Check active tiles
+        std::vector<Coord> coords(mask.countOn());
+        using RangeT = tbb::blocked_range<typename std::vector<Coord>::iterator>;
+        int j=0;
+        for (auto i = mask.beginOn(); i; ++i, ++j) coords[j] = node->offsetToGlobalCoord(i.pos());
+        count += tbb::parallel_reduce( RangeT(coords.begin(), coords.end()), 0,
+            [&bbox](const RangeT& r, Index64 sum)->Index64 {
+                for ( auto i = r.begin(); i != r.end(); ++i ) {
+                    auto b = CoordBBox::createCube(*i, NodeT::ChildNodeType::DIM);
+                    b.intersect(bbox);
+                    sum += b.volume();
+                }
+                return sum;
+            }, []( Index64 a, Index64 b )->Index64 { return a+b; }
+        );
+    }
+#endif
+    return count;
+}
+
+template<typename TreeT>
+struct FindActiveValues<TreeT>::NodePairT
+{
+    const RootChildT* child;
+    const CoordBBox   bbox;
+    NodePairT(const Coord& c = Coord(), const RootChildT* p = nullptr)
+        : child(p), bbox(CoordBBox::createCube(c, RootChildT::DIM))
+    {
+    }
+};// NodePairT struct
+
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// Implementation of stand-alone function
+template<typename TreeT>
+inline bool
+anyActiveValues(const TreeT& tree, const CoordBBox &bbox)
+{
+    FindActiveValues<TreeT> op(tree);
+    return op.any(bbox);
+}
+
+// Implementation of stand-alone function
+template<typename TreeT>
+inline bool
+noActiveValues(const TreeT& tree, const CoordBBox &bbox)
+{
+    FindActiveValues<TreeT> op(tree);
+    return op.none(bbox);
+}
+
+// Implementation of stand-alone function
+template<typename TreeT>
+inline bool
+countActiveValues(const TreeT& tree, const CoordBBox &bbox)
+{
+    FindActiveValues<TreeT> op(tree);
+    return op.count(bbox);
+}
+
+} // namespace tools
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif // OPENVDB_TOOLS_FINDACTIVEVALUES_HAS_BEEN_INCLUDED
+
+// Copyright (c) Ken Museth
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/unittest/CMakeLists.txt
@@ -95,6 +95,7 @@ set(UNITTEST_SOURCE_FILES
   TestDoubleMetadata.cc
   TestExceptions.cc
   TestFile.cc
+  TestFindActiveValues.cc
   TestFloatMetadata.cc
   TestGradient.cc
   TestGrid.cc

--- a/openvdb/unittest/TestFindActiveValues.cc
+++ b/openvdb/unittest/TestFindActiveValues.cc
@@ -191,33 +191,33 @@ void
 TestFindActiveValues::testSparseBox()
 {
     {//test active tiles in a sparsely filled box
-      const int half_dim = 256;
-      const openvdb::CoordBBox bbox(openvdb::Coord(-half_dim), openvdb::Coord(half_dim));
-      openvdb::FloatTree tree;
-      CPPUNIT_ASSERT(tree.activeTileCount() == 0);
-      CPPUNIT_ASSERT(tree.getValueDepth(openvdb::Coord(0)) == -1);//background value
-      openvdb::tools::FindActiveValues<openvdb::FloatTree> op(tree);
-      tree.sparseFill(bbox, 1.0f, true);
-      op.update(tree);//tree was modified to op needs to be updated
-      CPPUNIT_ASSERT(tree.activeTileCount() > 0);
-      CPPUNIT_ASSERT(tree.getValueDepth(openvdb::Coord(0)) == 1);//upper internal tile value
-      for (int i=1; i<half_dim; ++i) {
-          CPPUNIT_ASSERT(op.any(openvdb::CoordBBox::createCube(openvdb::Coord(-half_dim), i)));
-      }
-      CPPUNIT_ASSERT(op.count(bbox) == bbox.volume());
+        const int half_dim = 256;
+        const openvdb::CoordBBox bbox(openvdb::Coord(-half_dim), openvdb::Coord(half_dim));
+        openvdb::FloatTree tree;
+        CPPUNIT_ASSERT(tree.activeTileCount() == 0);
+        CPPUNIT_ASSERT(tree.getValueDepth(openvdb::Coord(0)) == -1);//background value
+        openvdb::tools::FindActiveValues<openvdb::FloatTree> op(tree);
+        tree.sparseFill(bbox, 1.0f, true);
+        op.update(tree);//tree was modified to op needs to be updated
+        CPPUNIT_ASSERT(tree.activeTileCount() > 0);
+        CPPUNIT_ASSERT(tree.getValueDepth(openvdb::Coord(0)) == 1);//upper internal tile value
+        for (int i=1; i<half_dim; ++i) {
+            CPPUNIT_ASSERT(op.any(openvdb::CoordBBox::createCube(openvdb::Coord(-half_dim), i)));
+        }
+        CPPUNIT_ASSERT(op.count(bbox) == bbox.volume());
 
-      auto bbox2 = openvdb::CoordBBox::createCube(openvdb::Coord(-half_dim), 1);
-      //double t = 0.0;
-      //openvdb::util::CpuTimer timer;
-      for (bool test = true; test; ) {
-          //timer.restart();
-          test = op.any(bbox2);
-          //t = std::max(t, timer.restart());
-          if (test) bbox2.translate(openvdb::Coord(1));
-      }
-      //std::cerr << "bbox = " << bbox2 << std::endl;
-      //openvdb::util::printTime(std::cout, t, "The slowest sparse test ", "\n", true, 4, 3);
-      CPPUNIT_ASSERT(bbox2 == openvdb::CoordBBox::createCube(openvdb::Coord(half_dim + 1), 1));
+        auto bbox2 = openvdb::CoordBBox::createCube(openvdb::Coord(-half_dim), 1);
+        //double t = 0.0;
+        //openvdb::util::CpuTimer timer;
+        for (bool test = true; test; ) {
+            //timer.restart();
+            test = op.any(bbox2);
+            //t = std::max(t, timer.restart());
+            if (test) bbox2.translate(openvdb::Coord(1));
+        }
+        //std::cerr << "bbox = " << bbox2 << std::endl;
+        //openvdb::util::printTime(std::cout, t, "The slowest sparse test ", "\n", true, 4, 3);
+        CPPUNIT_ASSERT(bbox2 == openvdb::CoordBBox::createCube(openvdb::Coord(half_dim + 1), 1));
     }
 }
 

--- a/openvdb/unittest/TestFindActiveValues.cc
+++ b/openvdb/unittest/TestFindActiveValues.cc
@@ -1,0 +1,309 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) Ken Museth
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+
+#include <cstdio> // for remove()
+#include <fstream>
+#include <sstream>
+#include <cppunit/extensions/HelperMacros.h>
+#include <openvdb/Exceptions.h>
+#include <openvdb/Types.h>
+#include <openvdb/openvdb.h>
+#include <openvdb/util/CpuTimer.h>
+#include <openvdb/tools/LevelSetSphere.h>
+#include <openvdb/tools/FindActiveValues.h>
+#include "util.h" // for unittest_util::makeSphere()
+
+#define ASSERT_DOUBLES_EXACTLY_EQUAL(expected, actual) \
+    CPPUNIT_ASSERT_DOUBLES_EQUAL((expected), (actual), /*tolerance=*/0.0);
+
+
+class TestFindActiveValues: public CppUnit::TestFixture
+{
+public:
+    void setUp() override { openvdb::initialize(); }
+    void tearDown() override { openvdb::uninitialize(); }
+
+    CPPUNIT_TEST_SUITE(TestFindActiveValues);
+    CPPUNIT_TEST(testBasic);
+    CPPUNIT_TEST(testSphere1);
+    CPPUNIT_TEST(testSphere2);
+    CPPUNIT_TEST(testSparseBox);
+    CPPUNIT_TEST(testDenseBox);
+    CPPUNIT_TEST(testBenchmarks);
+    CPPUNIT_TEST_SUITE_END();
+
+    void testBasic();
+    void testSphere1();
+    void testSphere2();
+    void testSparseBox();
+    void testDenseBox();
+    void testBenchmarks();
+};
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestFindActiveValues);
+
+void
+TestFindActiveValues::testBasic()
+{
+    const float background = 5.0f;
+    openvdb::FloatTree tree(background);
+    const openvdb::Coord min(-1,-2,30), max(20,30,55);
+    const openvdb::CoordBBox bbox(min[0], min[1], min[2],
+                                  max[0], max[1], max[2]);
+
+    CPPUNIT_ASSERT(openvdb::tools::noActiveValues(tree, bbox));
+
+    tree.setValue(min.offsetBy(-1), 1.0f);
+    CPPUNIT_ASSERT(openvdb::tools::noActiveValues(tree, bbox));
+    tree.setValue(max.offsetBy( 1), 1.0f);
+    CPPUNIT_ASSERT(openvdb::tools::noActiveValues(tree, bbox));
+    tree.setValue(min, 1.0f);
+    CPPUNIT_ASSERT(openvdb::tools::anyActiveValues(tree, bbox));
+    tree.setValue(max, 1.0f);
+    CPPUNIT_ASSERT(openvdb::tools::anyActiveValues(tree, bbox));
+}
+
+void
+TestFindActiveValues::testSphere1()
+{
+    const openvdb::Vec3f center(0.5f, 0.5f, 0.5f);
+    const float radius = 0.3f;
+    const int dim = 100, half_width = 3;
+    const float voxel_size = 1.0f/dim;
+
+    openvdb::FloatGrid::Ptr grid = openvdb::FloatGrid::create(/*background=*/half_width*voxel_size);
+    const openvdb::FloatTree& tree = grid->tree();
+    grid->setTransform(openvdb::math::Transform::createLinearTransform(/*voxel size=*/voxel_size));
+    unittest_util::makeSphere<openvdb::FloatGrid>(
+        openvdb::Coord(dim), center, radius, *grid, unittest_util::SPHERE_SPARSE_NARROW_BAND);
+
+    const int c = int(0.5f/voxel_size);
+    const openvdb::CoordBBox a(openvdb::Coord(c), openvdb::Coord(c+ 8));
+    CPPUNIT_ASSERT(!tree.isValueOn(openvdb::Coord(c)));
+    CPPUNIT_ASSERT(!openvdb::tools::anyActiveValues(tree, a));
+
+    const openvdb::Coord d(c + int(radius/voxel_size), c, c);
+    CPPUNIT_ASSERT(tree.isValueOn(d));
+    const auto b = openvdb::CoordBBox::createCube(d, 4);
+    CPPUNIT_ASSERT(openvdb::tools::anyActiveValues(tree, b));
+
+    const openvdb::CoordBBox e(openvdb::Coord(0), openvdb::Coord(dim));
+    CPPUNIT_ASSERT(openvdb::tools::anyActiveValues(tree, e));
+}
+
+void
+TestFindActiveValues::testSphere2()
+{
+    const openvdb::Vec3f center(0.0f);
+    const float radius = 0.5f;
+    const int dim = 400, halfWidth = 3;
+    const float voxelSize = 2.0f/dim;
+    auto grid  = openvdb::tools::createLevelSetSphere<openvdb::FloatGrid>(radius, center, voxelSize, halfWidth);
+    openvdb::FloatTree& tree = grid->tree();
+
+    {//test center
+        const openvdb::CoordBBox bbox(openvdb::Coord(0), openvdb::Coord(8));
+        CPPUNIT_ASSERT(!tree.isValueOn(openvdb::Coord(0)));
+        //openvdb::util::CpuTimer timer("\ncenter");
+        CPPUNIT_ASSERT(!openvdb::tools::anyActiveValues(tree, bbox));
+        //timer.stop();
+    }
+    {//test on sphere
+        const openvdb::Coord d(int(radius/voxelSize), 0, 0);
+        CPPUNIT_ASSERT(tree.isValueOn(d));
+        const auto bbox = openvdb::CoordBBox::createCube(d, 4);
+        //openvdb::util::CpuTimer timer("\non sphere");
+        CPPUNIT_ASSERT(openvdb::tools::anyActiveValues(tree, bbox));
+        //timer.stop();
+    }
+    {//test full domain
+        const openvdb::CoordBBox bbox(openvdb::Coord(-4000), openvdb::Coord(4000));
+        //openvdb::util::CpuTimer timer("\nfull domain");
+        CPPUNIT_ASSERT(openvdb::tools::anyActiveValues(tree, bbox));
+        //timer.stop();
+        openvdb::tools::FindActiveValues<openvdb::FloatTree> op(tree);
+        CPPUNIT_ASSERT(op.count(bbox) == tree.activeVoxelCount());
+    }
+    {// find largest instribed cube in index space containing NO active values
+        openvdb::tools::FindActiveValues<openvdb::FloatTree> op(tree);
+        auto bbox = openvdb::CoordBBox::createCube(openvdb::Coord(0), 1);
+        //openvdb::util::CpuTimer timer("\nInscribed cube (class)");
+        int count = 0;
+        while(op.none(bbox)) {
+            ++count;
+            bbox.expand(1);
+        }
+        //const double t = timer.stop();
+        //std::cerr << "Inscribed bbox = " << bbox << std::endl;
+        const int n = int(openvdb::math::Sqrt(openvdb::math::Pow2(radius-halfWidth*voxelSize)/3.0f)/voxelSize) + 1;
+        //std::cerr << "n=" << n << std::endl;
+        CPPUNIT_ASSERT( bbox.max() == openvdb::Coord( n));
+        CPPUNIT_ASSERT( bbox.min() == openvdb::Coord(-n));
+        //openvdb::util::printTime(std::cerr, t/count, "time per lookup ", "\n", true, 4, 3);
+    }
+    {// find largest instribed cube in index space containing NO active values
+        auto bbox = openvdb::CoordBBox::createCube(openvdb::Coord(0), 1);
+        //openvdb::util::CpuTimer timer("\nInscribed cube (func)");
+        int count = 0;
+        while(!openvdb::tools::anyActiveValues(tree, bbox)) {
+            bbox.expand(1);
+            ++count;
+        }
+        //const double t = timer.stop();
+        //std::cerr << "Inscribed bbox = " << bbox << std::endl;
+        const int n = int(openvdb::math::Sqrt(openvdb::math::Pow2(radius-halfWidth*voxelSize)/3.0f)/voxelSize) + 1;
+        //std::cerr << "n=" << n << std::endl;
+        //openvdb::util::printTime(std::cerr, t/count, "time per lookup ", "\n", true, 4, 3);
+        CPPUNIT_ASSERT( bbox.max() == openvdb::Coord( n));
+        CPPUNIT_ASSERT( bbox.min() == openvdb::Coord(-n));
+    }
+}
+
+void
+TestFindActiveValues::testSparseBox()
+{
+    {//test active tiles in a sparsely filled box
+      const int half_dim = 256;
+      const openvdb::CoordBBox bbox(openvdb::Coord(-half_dim), openvdb::Coord(half_dim));
+      openvdb::FloatTree tree;
+      CPPUNIT_ASSERT(tree.activeTileCount() == 0);
+      CPPUNIT_ASSERT(tree.getValueDepth(openvdb::Coord(0)) == -1);//background value
+      openvdb::tools::FindActiveValues<openvdb::FloatTree> op(tree);
+      tree.sparseFill(bbox, 1.0f, true);
+      op.update(tree);//tree was modified to op needs to be updated
+      CPPUNIT_ASSERT(tree.activeTileCount() > 0);
+      CPPUNIT_ASSERT(tree.getValueDepth(openvdb::Coord(0)) == 1);//upper internal tile value
+      for (int i=1; i<half_dim; ++i) {
+          CPPUNIT_ASSERT(op.any(openvdb::CoordBBox::createCube(openvdb::Coord(-half_dim), i)));
+      }
+      CPPUNIT_ASSERT(op.count(bbox) == bbox.volume());
+
+      auto bbox2 = openvdb::CoordBBox::createCube(openvdb::Coord(-half_dim), 1);
+      //double t = 0.0;
+      //openvdb::util::CpuTimer timer;
+      for (bool test = true; test; ) {
+          //timer.restart();
+          test = op.any(bbox2);
+          //t = std::max(t, timer.restart());
+          if (test) bbox2.translate(openvdb::Coord(1));
+      }
+      //std::cerr << "bbox = " << bbox2 << std::endl;
+      //openvdb::util::printTime(std::cout, t, "The slowest sparse test ", "\n", true, 4, 3);
+      CPPUNIT_ASSERT(bbox2 == openvdb::CoordBBox::createCube(openvdb::Coord(half_dim + 1), 1));
+    }
+}
+
+void
+TestFindActiveValues::testDenseBox()
+{
+     {//test active voxels in a densely filled box
+      const int half_dim = 256;
+      const openvdb::CoordBBox bbox(openvdb::Coord(-half_dim), openvdb::Coord(half_dim));
+      openvdb::FloatTree tree;
+      CPPUNIT_ASSERT(tree.activeTileCount() == 0);
+      CPPUNIT_ASSERT(tree.getValueDepth(openvdb::Coord(0)) == -1);//background value
+      tree.denseFill(bbox, 1.0f, true);
+      CPPUNIT_ASSERT(tree.activeTileCount() == 0);
+      openvdb::tools::FindActiveValues<openvdb::FloatTree> op(tree);
+      CPPUNIT_ASSERT(tree.getValueDepth(openvdb::Coord(0)) == 3);// leaf value
+      for (int i=1; i<half_dim; ++i) {
+          CPPUNIT_ASSERT(op.any(openvdb::CoordBBox::createCube(openvdb::Coord(0), i)));
+      }
+      CPPUNIT_ASSERT(op.count(bbox) == bbox.volume());
+
+      auto bbox2 = openvdb::CoordBBox::createCube(openvdb::Coord(-half_dim), 1);
+      //double t = 0.0;
+      //openvdb::util::CpuTimer timer;
+      for (bool test = true; test; ) {
+          //timer.restart();
+          test = op.any(bbox2);
+          //t = std::max(t, timer.restart());
+          if (test) bbox2.translate(openvdb::Coord(1));
+      }
+      //std::cerr << "bbox = " << bbox2 << std::endl;
+      //openvdb::util::printTime(std::cout, t, "The slowest dense test ", "\n", true, 4, 3);
+      CPPUNIT_ASSERT(bbox2 == openvdb::CoordBBox::createCube(openvdb::Coord(half_dim + 1), 1));
+    }
+}
+
+void
+TestFindActiveValues::testBenchmarks()
+{
+    {//benchmark test against active tiles in a sparsely filled box
+      using namespace openvdb;
+      const int half_dim = 512, bbox_size = 6;
+      const CoordBBox bbox(Coord(-half_dim), Coord(half_dim));
+      FloatTree tree;
+      tree.sparseFill(bbox, 1.0f, true);
+      tools::FindActiveValues<FloatTree> op(tree);
+      //double t = 0.0;
+      //util::CpuTimer timer;
+      for (auto b = CoordBBox::createCube(Coord(-half_dim), bbox_size); true; b.translate(Coord(1))) {
+          //timer.restart();
+          bool test = op.any(b);
+          //t = std::max(t, timer.restart());
+          if (!test) break;
+      }
+      //std::cout << "\n*The slowest sparse test " << t << " milliseconds\n";
+      CPPUNIT_ASSERT(op.count(bbox) == bbox.volume());
+    }
+    {//benchmark test against active voxels in a densely filled box
+      using namespace openvdb;
+      const int half_dim = 256, bbox_size = 1;
+      const CoordBBox bbox(Coord(-half_dim), Coord(half_dim));
+      FloatTree tree;
+      tree.denseFill(bbox, 1.0f, true);
+      tools::FindActiveValues<FloatTree> op(tree);
+      //double t = 0.0;
+      //openvdb::util::CpuTimer timer;
+      for (auto b = CoordBBox::createCube(Coord(-half_dim), bbox_size); true; b.translate(Coord(1))) {
+          //timer.restart();
+          bool test = op.any(b);
+          //t = std::max(t, timer.restart());
+          if (!test) break;
+      }
+      //std::cout << "*The slowest dense test " << t << " milliseconds\n";
+      CPPUNIT_ASSERT(op.count(bbox) == bbox.volume());
+    }
+    {//benchmark test against active voxels in a densely filled box
+      using namespace openvdb;
+      FloatTree tree;
+      tree.denseFill(CoordBBox::createCube(Coord(0), 256), 1.0f, true);
+      tools::FindActiveValues<FloatTree> op(tree);
+      //openvdb::util::CpuTimer timer("new test");
+      CPPUNIT_ASSERT(op.none(CoordBBox::createCube(Coord(256), 1)));
+      //timer.stop();
+    }
+}
+
+// Copyright (c) Ken Museth
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )


### PR DESCRIPTION
Finds the active values in a tree which intersects a bounding box.
Two methods are provided, one that counts the number of active values
and one that simply tests if any active values intersect the bbox.

Signed-off-by: Ken Museth <ken.museth@gmail.com>