### PR TITLE
Replace the PROPRIETARY notices with copyright notices to make

### DIFF
--- a/openvdb_houdini/GEO_PrimVDB.cc
+++ b/openvdb_houdini/GEO_PrimVDB.cc
@@ -29,12 +29,9 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * PROPRIETARY INFORMATION.  This software is proprietary to
- * Side Effects Software Inc., and is not to be reproduced,
- * transmitted, or disclosed in any way without written permission.
+ * Copyright (c) Side Effects Software Inc.
  *
  * Produced by:
- *      Jeff Lait
  *      Side Effects Software Inc
  *      477 Richmond Street West
  *      Toronto, Ontario

--- a/openvdb_houdini/GEO_PrimVDB.h
+++ b/openvdb_houdini/GEO_PrimVDB.h
@@ -29,12 +29,9 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * PROPRIETARY INFORMATION.  This software is proprietary to
- * Side Effects Software Inc., and is not to be reproduced,
- * transmitted, or disclosed in any way without written permission.
+ * Copyright (c) Side Effects Software Inc.
  *
  * Produced by:
- *      Jeff Lait
  *      Side Effects Software Inc
  *      477 Richmond Street West
  *      Toronto, Ontario

--- a/openvdb_houdini/GEO_VDBTranslator.cc
+++ b/openvdb_houdini/GEO_VDBTranslator.cc
@@ -29,30 +29,8 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * Copyright (c) 2012
+ * Copyright (c)
  *      Side Effects Software Inc.  All rights reserved.
- *
- * Redistribution and use of Houdini Development Kit samples in source and
- * binary forms, with or without modification, are permitted provided that the
- * following conditions are met:
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. The name of Side Effects Software may not be used to endorse or
- *    promote products derived from this software without specific prior
- *    written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY SIDE EFFECTS SOFTWARE `AS IS' AND ANY EXPRESS
- * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN
- * NO EVENT SHALL SIDE EFFECTS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
- * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *----------------------------------------------------------------------------
  */
 
 #include "GU_PrimVDB.h"

--- a/openvdb_houdini/GT_GEOPrimCollectVDB.cc
+++ b/openvdb_houdini/GT_GEOPrimCollectVDB.cc
@@ -29,9 +29,7 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * PROPRIETARY INFORMATION.  This software is proprietary to
- * Side Effects Software Inc., and is not to be reproduced,
- * transmitted, or disclosed in any way without written permission.
+ * Copyright (c) Side Effects Software Inc.
  *
  * Produced by:
  *      Side Effects Software Inc

--- a/openvdb_houdini/GT_GEOPrimCollectVDB.h
+++ b/openvdb_houdini/GT_GEOPrimCollectVDB.h
@@ -29,9 +29,7 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * PROPRIETARY INFORMATION.  This software is proprietary to
- * Side Effects Software Inc., and is not to be reproduced,
- * transmitted, or disclosed in any way without written permission.
+ * Copyright (c) Side Effects Software Inc.
  *
  * Produced by:
  *      Side Effects Software Inc

--- a/openvdb_houdini/GU_PrimVDB.cc
+++ b/openvdb_houdini/GU_PrimVDB.cc
@@ -29,12 +29,9 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * PROPRIETARY INFORMATION.  This software is proprietary to
- * Side Effects Software Inc., and is not to be reproduced,
- * transmitted, or disclosed in any way without written permission.
+ * Copyright (c) Side Effects Software Inc.
  *
  * Produced by:
- *      Jeff Lait
  *      Side Effects Software Inc
  *      477 Richmond Street West
  *      Toronto, Ontario

--- a/openvdb_houdini/GU_PrimVDB.h
+++ b/openvdb_houdini/GU_PrimVDB.h
@@ -29,12 +29,9 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * PROPRIETARY INFORMATION.  This software is proprietary to
- * Side Effects Software Inc., and is not to be reproduced,
- * transmitted, or disclosed in any way without written permission.
+ * Copyright (c) Side Effects Software Inc.
  *
  * Produced by:
- *      Jeff Lait
  *      Side Effects Software Inc
  *      477 Richmond Street West
  *      Toronto, Ontario

--- a/openvdb_houdini/SOP_VDBVerbUtils.h
+++ b/openvdb_houdini/SOP_VDBVerbUtils.h
@@ -29,30 +29,8 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * Copyright (c) 2016
+ * Copyright (c)
  *      Side Effects Software Inc.  All rights reserved.
- *
- * Redistribution and use of Houdini Development Kit samples in source and
- * binary forms, with or without modification, are permitted provided that the
- * following conditions are met:
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. The name of Side Effects Software may not be used to endorse or
- *    promote products derived from this software without specific prior
- *    written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY SIDE EFFECTS SOFTWARE `AS IS' AND ANY EXPRESS
- * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN
- * NO EVENT SHALL SIDE EFFECTS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
- * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *----------------------------------------------------------------------------
  */
 
 #ifndef OPENVDB_HOUDINI_SOP_VDBVERBUTILS_HAS_BEEN_INCLUDED

--- a/openvdb_houdini/UT_VDBUtils.cc
+++ b/openvdb_houdini/UT_VDBUtils.cc
@@ -29,12 +29,9 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * PROPRIETARY INFORMATION.  This software is proprietary to
- * Side Effects Software Inc., and is not to be reproduced,
- * transmitted, or disclosed in any way without written permission.
+ * Copyright (c) Side Effects Software Inc.
  *
  * Produced by:
- *      Adrian Saldanha
  *      Side Effects Software Inc
  *      477 Richmond Street West
  *      Toronto, Ontario

--- a/openvdb_houdini/UT_VDBUtils.h
+++ b/openvdb_houdini/UT_VDBUtils.h
@@ -29,12 +29,9 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /*
- * PROPRIETARY INFORMATION.  This software is proprietary to
- * Side Effects Software Inc., and is not to be reproduced,
- * transmitted, or disclosed in any way without written permission.
+ * Copyright (c) Side Effects Software Inc.
  *
  * Produced by:
- *      Adrian Saldanha
  *      Side Effects Software Inc.
  *      123 Front Street West, Suite 1401
  *      Toronto, Ontario


### PR DESCRIPTION
Replace the PROPRIETARY notices with copyright notices to make
the intention clear.  This should make it clear that the wrapped
Dreamworks license applies to the content.