### PR TITLE
Using x86 instructions instead of software emulation

### DIFF
--- a/openvdb/util/NodeMasksGccClang.h
+++ b/openvdb/util/NodeMasksGccClang.h
@@ -1,0 +1,40 @@
+// This header implements performance-critical bitwise routines with gcc and clang compiler intrinsics, which compile into BSR, BSF, POPCNT instructions.
+
+/// Return the number of on bits in the given 8-bit value.
+inline Index32 CountOn( Byte v )
+{
+    return __builtin_popcount( v );
+}
+
+/// Return the number of on bits in the given 32-bit value.
+inline Index32 CountOn( Index32 v )
+{
+    return __builtin_popcount( v );
+}
+
+inline Index32 CountOn( Index64 v )
+{
+    return static_cast<Index32>( __builtin_popcountll( v ) );
+}
+
+/// Return the least significant on bit of the given 32-bit value.
+inline Index32 FindLowestOn( Index32 v )
+{
+    assert( v );
+    return __builtin_ctz( v );
+}
+
+/// Return the least significant on bit of the given 8-bit value.
+inline Index32 FindLowestOn( Byte v )
+{
+    assert( v );
+    return __builtin_ctz( v );
+}
+
+/// Return the most significant on bit of the given 32-bit value.
+inline Index32 FindHighestOn( Index32 v )
+{
+    // BSR is very fast, computing result anyway so the compiler can emit CMOV for `operator ?`
+    const Index32 result = 31 - __builtin_clz( v );
+    return ( 0 != v ) ? result : 0;
+}

--- a/openvdb/util/NodeMasksMSVC.h
+++ b/openvdb/util/NodeMasksMSVC.h
@@ -1,0 +1,46 @@
+// This header implements performance-critical bitwise routines with vc++ compiler intrinsics, which compile into BSR, BSF, POPCNT instructions.
+
+/// Return the number of on bits in the given 8-bit value.
+inline Index32 CountOn( Byte v )
+{
+    return __popcnt16( v );
+}
+
+/// Return the number of on bits in the given 32-bit value.
+inline Index32 CountOn( Index32 v )
+{
+    return __popcnt( v );
+}
+
+/// Return the number of on bits in the given 64-bit value.
+inline Index32 CountOn( Index64 v )
+{
+#ifdef _M_X64
+    return static_cast<Index32>( __popcnt64( v ) );
+#else
+    return __popcnt( static_cast<Index32>( v ) ) + __popcnt( static_cast<Index32>( v >> 32 ) );
+#endif
+}
+
+/// Return the least significant on bit of the given 32-bit value.
+inline Index32 FindLowestOn( Index32 v )
+{
+    assert( v );
+    unsigned long index;
+    _BitScanForward( &index, v );
+    return index;
+}
+
+/// Return the least significant on bit of the given 8-bit value.
+inline Index32 FindLowestOn( Byte v )
+{
+    return FindLowestOn( static_cast<Index32>( v ) );
+}
+
+/// Return the most significant on bit of the given 32-bit value.
+inline Index32 FindHighestOn( Index32 v )
+{
+    unsigned long index;
+    const uint8_t anyBit = _BitScanReverse( &index, v );
+    return anyBit ? index : 0;
+}


### PR DESCRIPTION
I’ve noticed you use lookup tables and bit tricks in performance-critical parts of the code, for functionality that’s implemented in hardware.

Intel introduces `BSR` and `BSF` instructions in 80386, i.e. they support them since 1985.

`POPCNT` is slightly newer, but it’s reasonable to assume it’s present, introduced in SSE4a by AMD in 2007, supported by Intel since 2008. Most people don't use 12 years old computers.

This pull request implements them for vc++, gcc and clang compilers. For unknown ones it falls back to your original software implementation.

Please let me know if you’re willing to accept the PR, is yes I should probably implement a couple of tests, so far I've only built with vc++ but haven't tested yet. Also you wrote you want me to sigh something.

If you’re not interested, I’ll just keep these changes in my private branch.