### PR TITLE
Add missing internal name for VDB Filter SOP and alias

### DIFF
--- a/openvdb_houdini/SOP_OpenVDB_Filter.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Filter.cc
@@ -326,6 +326,10 @@ Offset:\n\
 
     // Register this operator.
     hvdb::OpenVDBOpFactory("VDB Smooth", SOP_OpenVDB_Filter::factory, parms, *table)
+#ifndef SESI_OPENVDB
+        .setInternalName("DW_OpenVDBFilter")
+        .addAliasVerbatim("DW_OpenVDBSmooth")
+#endif
         .setObsoleteParms(obsoleteParms)
         .addInput("VDBs to Smooth")
         .addOptionalInput("Optional VDB Alpha Mask")


### PR DESCRIPTION
The OpenVDB Filter SOP label was renamed to VDB Smooth SOP, but the underlying operator type name wasn't set back to the original name as it should have been. This corrects that error and adds an alias just in case anyone has picked this up in the interim.