### PR TITLE
OVDB-53: Provide OP_Operator::getVersion override to return VDB version

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -89,6 +89,9 @@ Version 6.2.0 - In development
     - Added a houdini_utils::OpPolicy::getTabSubMenuPath() method to allow
       OpPolicy subclasses to provide their own tab sub-menu path.
     - OpenVDB SOPs are now displayed in an ASWF sub-menu of the VDB tab menu.
+    - Added an houdini_utils::OP_OperatorDW::getVersion() override which
+      returns the operator version that is set in the OpenVDBOpFactory
+      constructor.
 
 
 Version 6.1.0 - May 8, 2019

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -113,6 +113,9 @@ Houdini:
 - Added an @hulink{OpPolicy::getTabSubMenuPath(),OpPolicy::getTabSubMenuPath}
   method to allow @b OpPolicy subclasses to provide their own tab sub-menu path.
 - OpenVDB SOPs are now displayed in an ASWF sub-menu of the VDB tab menu.
+- Added an @hulink{OP_OperatorDW::getVersion(),OP_OperatorDW::getVersion}
+  override which returns the operator version that is set in the
+  @hulink{OpenVDBOpFactory,OpenVDBOpFactory} constructor.
 
 
 @htmlonly <a name="v6_1_0_changes"></a>@endhtmlonly

--- a/openvdb_houdini/ParmFactory.cc
+++ b/openvdb_houdini/ParmFactory.cc
@@ -957,6 +957,19 @@ public:
         return !mDoc.empty();
     }
 
+#ifndef SESI_OPENVDB
+    bool getVersion(UT_String &version) override
+    {
+        auto it = spareData().find("operatorversion");
+        if (it != spareData().end()) {
+            version = it->second;
+            return true;
+        }
+
+        return OP_Operator::getVersion(version);
+    }
+#endif
+
     const SpareDataMap& spareData() const { return mSpareData; }
     SpareDataMap& spareData() { return mSpareData; }
 

--- a/openvdb_houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/SOP_NodeVDB.cc
@@ -749,6 +749,12 @@ OpenVDBOpFactory::OpenVDBOpFactory(
     houdini_utils::OpFactory(OpenVDBOpPolicy(), english, ctor, parms, table, flavor)
 {
     setNativeName(OpenVDBOpPolicy().getNativeName(*this));
+
+    // store the packed integer library number as the operator version,
+    // which if defined is returned by OP_OperatorDW::getVersion().
+    // note that this differs from the Houdini default which is X.Y.Z.W
+    addSpareData({{"operatorversion",
+        std::to_string(openvdb::OPENVDB_LIBRARY_VERSION)}});
 }
 
 OpenVDBOpFactory&

--- a/openvdb_houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/SOP_NodeVDB.cc
@@ -45,6 +45,7 @@
 #include <PRM/PRM_Parm.h>
 #include <PRM/PRM_Type.h>
 #include <SOP/SOP_Cache.h> // for stealable
+#include <SYS/SYS_Version.h>
 #include <UT/UT_InfoTree.h>
 #include <UT/UT_SharedPtr.h>
 #include <tbb/mutex.h>
@@ -750,11 +751,14 @@ OpenVDBOpFactory::OpenVDBOpFactory(
 {
     setNativeName(OpenVDBOpPolicy().getNativeName(*this));
 
-    // store the packed integer library number as the operator version,
-    // which if defined is returned by OP_OperatorDW::getVersion().
-    // note that this differs from the Houdini default which is X.Y.Z.W
-    addSpareData({{"operatorversion",
-        std::to_string(openvdb::OPENVDB_LIBRARY_VERSION)}});
+    std::stringstream ss;
+    ss << "vdb" << OPENVDB_LIBRARY_VERSION_STRING << " ";
+    ss << "houdini" << SYS_Version::full();
+
+    // Define an operator version of the format "vdb6.1.0 houdini18.0.222",
+    // which can be returned by OP_OperatorDW::getVersion() and used to
+    // handle compatibility between specific versions of VDB or Houdini
+    addSpareData({{"operatorversion", ss.str()}});
 }
 
 OpenVDBOpFactory&


### PR DESCRIPTION
By introducing this override we need to be able to distinguish between the Houdini default (such as "17.5.204") and the VDB version (such as "6.2.0") in a syncNodeVersion() override.

I considered adding a prefix (such as "vdb:6.2.0") then settled on using the packed integer representation (such as "100794368"). Simply checking the string is non-empty and contains no "." characters is thus sufficient to determine this is a VDB version and not a Houdini version. I also couldn't think of any reason to need to preserve which version of Houdini this node was created in, in addition to which version of VDB was used. Native Houdini VDB nodes will still use the Houdini version.

Of course if there's any logic expecting the Houdini default form (X.Y.Z.W) then this will break, but I'm not aware of anything here.