### PR TITLE
Marking base virtual functions deprecated is painful in Windows, so removing it.

### DIFF
--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -277,7 +277,9 @@ public:
     /// @deprecated From ABI 6 on, use copyValues() with source-target index pairs.
 #if OPENVDB_ABI_VERSION_NUMBER >= 6
     // Windows does not allow base classes to be easily deprecated.
-    // OPENVDB_DEPRECATED
+#ifndef _MSC_VER
+    OPENVDB_DEPRECATED
+#endif
 #endif
     virtual void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) = 0;
 
@@ -329,11 +331,15 @@ public:
     OPENVDB_DEPRECATED bool isCompressed() const { return false; }
     /// @deprecated Previously this compressed the attribute array, now it does nothing.
     // Windows does not allow base classes to be deprecated
-    // OPENVDB_DEPRECATED
+#ifndef _MSC_VER
+    OPENVDB_DEPRECATED
+#endif
     virtual bool compress() = 0;
     /// @deprecated Previously this uncompressed the attribute array, now it does nothing.
     // Windows does not allow base classes to be deprecated
-    // OPENVDB_DEPRECATED
+#ifndef _MSC_VER
+    OPENVDB_DEPRECATED
+#endif
     virtual bool decompress() = 0;
 
     /// @brief   Specify whether this attribute should be hidden (e.g., from UI or iterators).

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -276,7 +276,8 @@ public:
     /// @brief Set value at given index @a n from @a sourceIndex of another @a sourceArray.
     /// @deprecated From ABI 6 on, use copyValues() with source-target index pairs.
 #if OPENVDB_ABI_VERSION_NUMBER >= 6
-    OPENVDB_DEPRECATED
+    // Windows does not allow base classes to be easily deprecated.
+    // OPENVDB_DEPRECATED
 #endif
     virtual void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) = 0;
 
@@ -327,9 +328,13 @@ public:
     /// now it always returns @c false.
     OPENVDB_DEPRECATED bool isCompressed() const { return false; }
     /// @deprecated Previously this compressed the attribute array, now it does nothing.
-    OPENVDB_DEPRECATED virtual bool compress() = 0;
+    // Windows does not allow base classes to be deprecated
+    // OPENVDB_DEPRECATED
+    virtual bool compress() = 0;
     /// @deprecated Previously this uncompressed the attribute array, now it does nothing.
-    OPENVDB_DEPRECATED virtual bool decompress() = 0;
+    // Windows does not allow base classes to be deprecated
+    // OPENVDB_DEPRECATED
+    virtual bool decompress() = 0;
 
     /// @brief   Specify whether this attribute should be hidden (e.g., from UI or iterators).
     /// @details This is useful if the attribute is used for blind data or as scratch space
@@ -726,6 +731,9 @@ public:
     static void setUnsafe(AttributeArray* array, const Index n, const ValueType& value);
 
     /// Set value at given index @a n from @a sourceIndex of another @a sourceArray
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+    OPENVDB_DEPRECATED
+#endif
     void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) override;
 
     /// Return @c true if this array is stored as a single uniform value.


### PR DESCRIPTION
I do not like this change overmuch, but it was required for our builds to avoid deprecation failures.  When the compress() method is instantiated in the derived templated class, MSVC will generate deprecation failures since the pure virtual base method is deprecated.  This is clearly wrong as the overridden version has also been marked deprecated.

We have not found a good solution internally to deal with this with our deprecations.  Usually we are forced to just disable deprecations on the entire derived class.

I've also added a missing deprecation on the derived set() method.