### PR TITLE
Update OpenVDB Deprecation Strategy

### DIFF
--- a/tsc/process/deprecation.md
+++ b/tsc/process/deprecation.md
@@ -17,6 +17,6 @@ This infers the following support:
 When version 7.0.0 is released, OpenVDB will support VFX Reference Platform
 years 2020, 2019 and 2018. Support for Houdini 16.5 and C++11 will be dropped.
 
-Support for the previous ABI than meets the criteria above will be maintained
-until the subsequent minor release. For example, the latest version to retain
+Support for obsolete ABIs will not be dropped until the first minor release
+after the introduction of a new ABI. For example, the latest version to retain
 support for ABI=4 will be the release prior to 7.1.0.

--- a/tsc/process/deprecation.md
+++ b/tsc/process/deprecation.md
@@ -1,11 +1,12 @@
 **Deprecation Strategy for OpenVDB**
 
-OpenVDB is committed to supporting the current and previous two years of the
+OpenVDB is committed to supporting three years of
 [VFX Reference Platform](http://www.vfxplatform.com/) and all releases of
-Houdini and Maya based on those versions of the platform.
+Houdini and Maya based on those versions of the platform. The latest supported
+year is that in which the VDB version listed matches the major version.
 
-For example, as of writing it is March 2019 which means VFX Reference Platform
-2019, 2018 and 2017
+For example, version 6.1.0 of OpenVDB supports VFX Reference Platform years
+2019, 2018 and 2017.
 
 This infers the following support:
 
@@ -13,5 +14,9 @@ This infers the following support:
 * C++11 and C++14
 * Houdini 16.5, 17.0 and 17.5
 
-In January 2020, OpenVDB will drop support for VFX Reference Platform 2017.
-This will mean eliminating support for Houdini 16.5, ABI=4 and C++11.
+When version 7.0.0 is released, OpenVDB will support VFX Reference Platform
+years 2020, 2019 and 2018. Support for Houdini 16.5 and C++11 will be dropped.
+
+Support for the previous ABI than meets the criteria above will be maintained
+until the subsequent minor release. For example, the latest version to retain
+support for ABI=4 will be the release prior to 7.1.0.


### PR DESCRIPTION
Improve wording of the deprecation strategy to try and eliminate confusion when we support the next year of the VFX Reference Platform before the end of the calendar year, as discussed in:

https://github.com/AcademySoftwareFoundation/openvdb/blame/master/tsc/meetings/2019-08-29.md#L85

Also include a clause that extends support of the previous ABI until the subsequent minor release to allow a little extra migration time.