### PR TITLE
Run verbose tests and use ctest in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
     timeoutInMinutes: 0
     steps:
     - bash: ci/build_sonar.sh
-    - bash: ./build/openvdb/unittest/vdb_test -v
+    - bash: cd build && ctest -V; cd -
     - bash: ci/test_sonar.sh
 
   - job: testabi7
@@ -30,7 +30,7 @@ stages:
     timeoutInMinutes: 0
     steps:
     - bash: ci/build.sh clang++ Release 7 ON
-    - bash: ./build/openvdb/unittest/vdb_test -v
+    - bash: cd build && ctest -V; cd -
 
   - job: testabi6
     displayName: and Test ABI=6 (VFX2019)
@@ -40,7 +40,7 @@ stages:
     timeoutInMinutes: 0
     steps:
     - bash: ci/build.sh clang++ Release 6 ON
-    - bash: ./build/openvdb/unittest/vdb_test -v
+    - bash: cd build && ctest -V; cd -
 
   - job: testabi5
     displayName: and Test ABI=5 (VFX2018)
@@ -50,7 +50,7 @@ stages:
     timeoutInMinutes: 0
     steps:
     - bash: ci/build.sh clang++ Release 5 ON
-    - bash: ./build/openvdb/unittest/vdb_test -v
+    - bash: cd build && ctest -V; cd -
 
   - job: testabi4
     displayName: and Test ABI=4 (VFX2018)
@@ -60,7 +60,7 @@ stages:
     timeoutInMinutes: 0
     steps:
     - bash: ci/build.sh clang++ Release 4 ON
-    - bash: ./build/openvdb/unittest/vdb_test -v
+    - bash: cd build && ctest -V; cd -
 
   - job: testhou175
     displayName: Houdini 17.5
@@ -92,7 +92,7 @@ stages:
     timeoutInMinutes: 0
     steps:
     - bash: ci/build.sh clang++ Release 7 OFF
-    - bash: ./build/openvdb/unittest/vdb_test -v
+    - bash: cd build && ctest -V; cd -
 
   - job: testhou175gcc
     displayName: Houdini 17.5 (GCC)

--- a/openvdb/python/CMakeLists.txt
+++ b/openvdb/python/CMakeLists.txt
@@ -325,7 +325,7 @@ install(FILES ${PYTHON_PUBLIC_INCLUDE_NAMES} DESTINATION include/openvdb/python)
 
 # pytest
 
-add_test(pytest ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/TestOpenVDB.py)
+add_test(pytest ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/TestOpenVDB.py -v)
 set_tests_properties(pytest PROPERTIES ENVIRONMENT "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_CURRENT_BINARY_DIR}")
 
 

--- a/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/unittest/CMakeLists.txt
@@ -218,4 +218,4 @@ if(OPENVDB_ENABLE_RPATH)
   )
 endif()
 
-add_test(vdb_unit_test vdb_test)
+add_test(vdb_unit_test vdb_test -v)


### PR DESCRIPTION
Using ctest ensures that the python tests are also run

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>