### PR TITLE
Add the correct pragmas to disable deprecation warnings on MSVC.

### DIFF
--- a/openvdb/Platform.h
+++ b/openvdb/Platform.h
@@ -189,7 +189,9 @@
 #elif defined _MSC_VER
     #define OPENVDB_NO_DEPRECATION_WARNING_BEGIN \
         __pragma(warning(push)) \
-        __pragma(warning(disable : 4996))
+        __pragma(warning(disable : 4996)) \
+        __pragma(message("NOTE: ignoring deprecation warning at " __FILE__  \
+            ":" OPENVDB_PREPROC_STRINGIFY(__LINE__)))
     #define OPENVDB_NO_DEPRECATION_WARNING_END \
         __pragma(warning(pop))
 #else

--- a/openvdb/Platform.h
+++ b/openvdb/Platform.h
@@ -186,6 +186,12 @@
         _Pragma("message(\"NOTE: ignoring deprecation warning\")")
     #define OPENVDB_NO_DEPRECATION_WARNING_END \
         _Pragma("GCC diagnostic pop")
+#elif defined _MSC_VER
+    #define OPENVDB_NO_DEPRECATION_WARNING_BEGIN \
+        __pragma(warning(push)) \
+        __pragma(warning(disable : 4996))
+    #define OPENVDB_NO_DEPRECATION_WARNING_END \
+        __pragma(warning(pop))
 #else
     #define OPENVDB_NO_DEPRECATION_WARNING_BEGIN
     #define OPENVDB_NO_DEPRECATION_WARNING_END

--- a/openvdb/Platform.h
+++ b/openvdb/Platform.h
@@ -190,7 +190,7 @@
     #define OPENVDB_NO_DEPRECATION_WARNING_BEGIN \
         __pragma(warning(push)) \
         __pragma(warning(disable : 4996)) \
-        __pragma(message("NOTE: ignoring deprecation warning at " __FILE__  \
+        __pragma(message("NOTE: ignoring deprecation warning at " __FILE__ \
             ":" OPENVDB_PREPROC_STRINGIFY(__LINE__)))
     #define OPENVDB_NO_DEPRECATION_WARNING_END \
         __pragma(warning(pop))


### PR DESCRIPTION
Attempt to get proper deprecation pragmas on Windows.