### PR TITLE
OVDB-121: Counting Tools

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,10 @@ Version 7.0.0 - In development
     As of this release, a C++14 compiler is required and the oldest
     supported Houdini version is 17.0.
 
+    New features:
+    - Added Tree::nodeCount, which counts the number and type of nodes
+      in a tree very efficiently.
+
     Improvements:
     - The minimum ABI for OpenVDB is now always enforced through CMake
       separately from other minimum dependency version variables.

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -13,6 +13,11 @@ Houdini version is 17.0.
 </BLOCKQUOTE>
 
 @par
+New features:
+- Added @vdblink{tree::Tree::nodeCount,Tree::nodeCount}, which counts
+  the number and type of nodes in a tree very efficiently.
+
+@par
 Improvements:
 - The minimum ABI for OpenVDB is now always enforced through CMake
   separately from other minimum dependency version variables.

--- a/openvdb/CMakeLists.txt
+++ b/openvdb/CMakeLists.txt
@@ -328,6 +328,7 @@ set(OPENVDB_LIBRARY_TOOLS_INCLUDE_FILES
   tools/ChangeBackground.h
   tools/Clip.h
   tools/Composite.h
+  tools/Count.h
   tools/Dense.h
   tools/DenseSparseTools.h
   tools/Diagnostics.h

--- a/openvdb/tools/Count.h
+++ b/openvdb/tools/Count.h
@@ -1,0 +1,220 @@
+//////////////////////////////////////////////////////////////////////////
+//
+// TM & (c) Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+///////////////////////////////////////////////////////////////////////////
+//
+/// @file Count.h
+///
+/// @author Dan Bailey
+///
+/// @brief Counting tools.
+
+#ifndef OPENVDB_TOOLS_COUNT_HAS_BEEN_INCLUDED
+#define OPENVDB_TOOLS_COUNT_HAS_BEEN_INCLUDED
+
+#include <openvdb/tree/NodeManager.h>
+
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace tools {
+
+
+/// @brief Return a vector with node counts. The number of node of type
+/// NodeType is given as element NodeType::LEVEL in the return vector.
+/// Thus, the size if this vector corresponds to the height (or depth)
+/// of this tree.
+///
+/// @param tree       the tree to be counted
+/// @param threaded   enable or disable threading (threading is enabled by default)
+template <typename TreeT>
+std::vector<Index>
+nodeCount(const TreeT& tree, bool threaded = true);
+
+
+/// @brief Return the total number of active voxels.
+///
+/// @param tree       the tree to be counted
+/// @param threaded   enable or disable threading (threading is enabled by default)
+template <typename TreeT>
+Index64
+activeVoxelCount(TreeT& tree, bool threaded = true);
+
+
+////////////////////////////////////////
+
+
+namespace count_internal {
+
+
+template <Index DEPTH>
+struct NodeCountOp
+{
+    template <typename ArrayT, typename NodeT>
+    static void count(ArrayT& array, const NodeT& node)
+    {
+        for (auto iter = node.cbeginChildOn(); iter; ++iter) {
+            array[DEPTH-1] += iter->getChildMask().countOn();
+            NodeCountOp<DEPTH-1>::count(array, *iter);
+        }
+    }
+};
+
+template <>
+struct NodeCountOp<0>
+{
+    template <typename ArrayT, typename NodeT>
+    static void count(ArrayT&, const NodeT&) { }
+};
+
+
+template<typename TreeT>
+class ActiveVoxelCountOp
+{
+public:
+    using RootT = typename TreeT::RootNodeType;
+    using LeafT = typename TreeT::LeafNodeType;
+
+    ActiveVoxelCountOp() { }
+    ActiveVoxelCountOp(const ActiveVoxelCountOp&, tbb::split) { }
+    void join(const ActiveVoxelCountOp& other) { count += other.count; }
+
+    void operator()(RootT& root)
+    {
+        count += root.onTileCount() * RootT::ChildNodeType::NUM_VOXELS;
+    }
+    void operator()(LeafT& node)
+    {
+        count += node.onVoxelCount();
+    }
+    template<typename NodeT>
+    void operator()(NodeT& node)
+    {
+        count += node.getValueMask().countOn() * NodeT::ChildNodeType::NUM_VOXELS;
+    }
+
+    Index64 count = Index64(0);
+};// ActiveVoxelCountOp
+
+
+} // namespace count_internal
+
+
+////////////////////////////////////////
+
+
+template <typename TreeT>
+std::vector<Index> nodeCount(const TreeT& tree, bool threaded)
+{
+    using RootT = typename TreeT::RootNodeType;
+
+    using namespace count_internal;
+
+    std::vector<Index> countArray(TreeT::DEPTH, Index(0));
+
+    // root node
+
+    auto countIter = countArray.rbegin();
+    *(countIter++) = 1;
+
+    if (TreeT::DEPTH == 1)  return countArray;
+
+    // root node children
+
+    Index rootNodeChildren(0);
+
+    const typename TreeT::RootNodeType& root = tree.root();
+    for (auto iter = root.cbeginChildOn(); iter; ++iter) {
+        rootNodeChildren++;
+    }
+
+    *(countIter++) = rootNodeChildren;
+
+    if (TreeT::DEPTH == 2)  return countArray;
+
+    // other children
+
+    static constexpr Index LEVELS = RootT::LEVEL-1;
+
+    if (threaded) {
+        using ArrayT = std::array<Index, LEVELS>;
+
+        std::vector<ArrayT> arrays(rootNodeChildren, ArrayT());
+        tbb::parallel_for(
+            tbb::blocked_range<Index>(0, rootNodeChildren),
+            [&](tbb::blocked_range<Index>& r) {
+                for (Index n = r.begin(); n < r.end(); n++) {
+                    auto rootIter = root.cbeginChildOn();
+                    rootIter.increment(n);
+                    arrays[n].fill(Index(0));
+                    arrays[n].back() += rootIter->getChildMask().countOn();
+                    NodeCountOp<LEVELS-1>::count(arrays[n], *rootIter);
+                }
+            }
+        );
+        for (size_t i = 0; i < LEVELS; i++) {
+            for (size_t n = 0; n < rootNodeChildren; n++) {
+                countArray[i] += arrays[n][i];
+            }
+        }
+    } else {
+        NodeCountOp<LEVELS>::count(countArray, root);
+    }
+
+    return countArray;
+}
+
+
+template <>
+std::vector<Index> nodeCount(const GridBase& grid, bool threaded)
+{
+    using AllowedGridTypes = openvdb::TypeList<
+        openvdb::Int32Grid, openvdb::Int64Grid,
+        openvdb::FloatGrid, openvdb::DoubleGrid>;
+
+    std::vector<Index> counts;
+    grid.apply<AllowedGridTypes>(
+        [&](auto& grid) {
+            counts = nodeCount(grid.constTree(), threaded);
+        }
+    );
+    return counts;
+}
+
+
+template <typename TreeT>
+Index64 activeVoxelCount(TreeT& tree, bool threaded)
+{
+    tree::NodeManager<TreeT> nodeManager(tree);
+    count_internal::ActiveVoxelCountOp<TreeT> op;
+    nodeManager.reduceTopDown(op, threaded);
+    return op.count;
+}
+
+
+template <>
+Index64 activeVoxelCount(GridBase& grid, bool threaded)
+{
+    using AllowedGridTypes = openvdb::TypeList<
+        openvdb::Int32Grid, openvdb::Int64Grid,
+        openvdb::FloatGrid, openvdb::DoubleGrid>;
+
+    Index64 count(0);
+    grid.apply<AllowedGridTypes>(
+        [&](auto& grid) {
+            count = activeVoxelCount(grid.tree(), threaded);
+        }
+    );
+    return count;
+}
+
+
+} // namespace tools
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif // OPENVDB_TOOLS_COUNT_HAS_BEEN_INCLUDED

--- a/openvdb/tree/InternalNode.h
+++ b/openvdb/tree/InternalNode.h
@@ -302,6 +302,15 @@ public:
     void setOrigin(const Coord& origin) { mOrigin = origin; }
 
     Index32 leafCount() const;
+    void nodeCount(std::vector<Index32> &vec) const
+    {
+        assert(vec.size() > ChildNodeType::LEVEL);
+        const auto count = mChildMask.countOn();
+        if (ChildNodeType::LEVEL > 0 && count > 0) {
+            for (auto iter = this->cbeginChildOn(); iter; ++iter) iter->nodeCount(vec);
+        }
+        vec[ChildNodeType::LEVEL] += count;
+    }
     Index32 nonLeafCount() const;
     Index64 onVoxelCount() const;
     Index64 offVoxelCount() const;

--- a/openvdb/tree/LeafNode.h
+++ b/openvdb/tree/LeafNode.h
@@ -159,6 +159,8 @@ public:
     static Index getChildDim() { return 1; }
     /// Return the leaf count for this node, which is one.
     static Index32 leafCount() { return 1; }
+    /// no-op
+    void nodeCount(std::vector<Index32> &) const {}
     /// Return the non-leaf count for this node, which is zero.
     static Index32 nonLeafCount() { return 0; }
 

--- a/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/tree/LeafNodeBool.h
@@ -138,6 +138,8 @@ public:
     static Index getChildDim() { return 1; }
 
     static Index32 leafCount() { return 1; }
+    /// no-op
+    void nodeCount(std::vector<Index32> &) const {}
     static Index32 nonLeafCount() { return 0; }
 
     /// Return the number of active voxels.

--- a/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/tree/LeafNodeMask.h
@@ -141,6 +141,8 @@ public:
     static Index getChildDim() { return 1; }
     /// Return the leaf count for this node, which is one.
     static Index32 leafCount() { return 1; }
+    /// no-op
+    void nodeCount(std::vector<Index32> &) const {}
     /// Return the non-leaf count for this node, which is zero.
     static Index32 nonLeafCount() { return 0; }
 

--- a/openvdb/tree/RootNode.h
+++ b/openvdb/tree/RootNode.h
@@ -51,7 +51,8 @@
 #include <map>
 #include <set>
 #include <sstream>
-#include <deque>
+#include <vector>
+#include <memory> // for std::make_unique
 
 
 namespace openvdb {
@@ -516,6 +517,19 @@ public:
     Index64 onLeafVoxelCount() const;
     Index64 offLeafVoxelCount() const;
     Index64 onTileCount() const;
+    void nodeCount(std::vector<Index32> &vec) const
+    {
+        assert(vec.size() > LEVEL);
+        Index32 sum = 0;
+        for (MapCIter i = mTable.begin(), e = mTable.end(); i != e; ++i) {
+          if (isChild(i)) {
+              ++sum;
+              getChild(i).nodeCount(vec);
+          }
+        }
+        vec[LEVEL] = 1;// one root node
+        vec[ChildNodeType::LEVEL] = sum;
+    }
 
     bool isValueOn(const Coord& xyz) const;
 

--- a/openvdb/tree/RootNode.h
+++ b/openvdb/tree/RootNode.h
@@ -262,7 +262,7 @@ private:
 
         void increment() { if (this->test()) { ++mIter; } this->skip(); }
         bool next() { this->increment(); return this->test(); }
-        void increment(Index n) { for (int i = 0; i < n && this->next(); ++i) {} }
+        void increment(Index n) { for (Index i = 0; i < n && this->next(); ++i) {} }
 
         /// @brief Return this iterator's position as an offset from
         /// the beginning of the parent node's map.

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -51,6 +51,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <memory> // for std::make_unique
 
 
 namespace openvdb {
@@ -139,6 +140,10 @@ public:
     virtual Index treeDepth() const = 0;
     /// Return the number of leaf nodes.
     virtual Index32 leafCount() const = 0;
+    /// Return a unique pointer to a vector with node counts. The number of node of type NodeType
+    /// is given as element NodeType::LEVEL in the return vector. Thus, the size if this vector
+    /// corresponds to the height (or depth) of this tree.
+    virtual std::unique_ptr<std::vector<Index32>> nodeCount() const = 0;
     /// Return the number of non-leaf nodes.
     virtual Index32 nonLeafCount() const = 0;
     /// Return the number of active voxels stored in leaf nodes.
@@ -366,6 +371,16 @@ public:
     Index treeDepth() const override { return DEPTH; }
     /// Return the number of leaf nodes.
     Index32 leafCount() const override { return mRoot.leafCount(); }
+    /// Return a unique pointer to a vector with node counts. The number of node of type NodeType
+    /// is given as element NodeType::LEVEL in the return vector. Thus, the size if this vector
+    /// corresponds to the height (or depth) of this tree.
+    std::unique_ptr<std::vector<Index32>> nodeCount() const override
+    {
+        //auto ptr = std::make_unique<std::vector<Index32>>(DEPTH, 0); // once C++14 is supported
+        std::unique_ptr<std::vector<Index32>> ptr(new std::vector<Index32>(DEPTH, 0));
+        mRoot.nodeCount( *ptr );
+        return ptr;// invokes move construction
+    }
     /// Return the number of non-leaf nodes.
     Index32 nonLeafCount() const override { return mRoot.nonLeafCount(); }
     /// Return the number of active voxels stored in leaf nodes.
@@ -2264,7 +2279,7 @@ Tree<RootNodeType>::print(std::ostream& os, int verboseLevel) const
             for (size_t i = 1, N = dims.size() - 1; i < N; ++i) {
                 os << ", Internal(" << (1 << dims[i]) << "^3)";
             }
-            os << ", Leaf(" << (1 << *dims.rbegin()) << "^3)\n";
+            os << ", Leaf(" << (1 << dims.back()) << "^3)\n";
         }
         os << "  Background value: " << mRoot.background() << "\n";
         return;
@@ -2278,22 +2293,21 @@ Tree<RootNodeType>::print(std::ostream& os, int verboseLevel) const
         this->evalMinMax(minVal, maxVal);
     }
 
-    std::vector<Index64> nodeCount(dims.size());
-    for (NodeCIter it = cbeginNode(); it; ++it) ++(nodeCount[it.getDepth()]);
-
+    auto nodeCountPtr = this->nodeCount();
     Index64 totalNodeCount = 0;
-    for (size_t i = 0; i < nodeCount.size(); ++i) totalNodeCount += nodeCount[i];
+    for (size_t i = 0; i < nodeCountPtr->size(); ++i) totalNodeCount += (*nodeCountPtr)[i];
 
     // Print node types, counts and sizes.
     os << "    Root(1 x " << mRoot.getTableSize() << ")";
     if (dims.size() > 1) {
-        for (size_t i = 1, N = dims.size() - 1; i < N; ++i) {
-            os << ", Internal(" << util::formattedInt(nodeCount[i]);
+        for (int i = nodeCountPtr->size() - 2; i > 0; --i) {
+            os << ", Internal(" << util::formattedInt((*nodeCountPtr)[i]);
             os << " x " << (1 << dims[i]) << "^3)";
         }
-        os << ", Leaf(" << util::formattedInt(*nodeCount.rbegin());
-        os << " x " << (1 << *dims.rbegin()) << "^3)\n";
+        os << ", Leaf(" << util::formattedInt(nodeCountPtr->front());
+        os << " x " << (1 << dims.back()) << "^3)\n";
     }
+
     os << "  Background value: " << mRoot.background() << "\n";
 
     // Statistics of topology and values
@@ -2303,8 +2317,8 @@ Tree<RootNodeType>::print(std::ostream& os, int verboseLevel) const
         os << "  Max value: " << maxVal << "\n";
     }
 
+    const Index32 leafCount = nodeCountPtr->front();
     const Index64
-        leafCount = *nodeCount.rbegin(),
         numActiveVoxels = this->activeVoxelCount(),
         numActiveLeafVoxels = this->activeLeafVoxelCount(),
         numActiveTiles = this->activeTileCount();

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -2294,13 +2294,14 @@ Tree<RootNodeType>::print(std::ostream& os, int verboseLevel) const
     }
 
     auto nodeCountPtr = this->nodeCount();
+    assert(dims.size() == nodeCountPtr->size());
     Index64 totalNodeCount = 0;
     for (size_t i = 0; i < nodeCountPtr->size(); ++i) totalNodeCount += (*nodeCountPtr)[i];
 
     // Print node types, counts and sizes.
     os << "    Root(1 x " << mRoot.getTableSize() << ")";
-    if (dims.size() > 1) {
-        for (int i = nodeCountPtr->size() - 2; i > 0; --i) {
+    if (dims.size() >= 2) {
+        for (size_t i = dims.size() - 2; i > 0; --i) {
             os << ", Internal(" << util::formattedInt((*nodeCountPtr)[i]);
             os << " x " << (1 << dims[i]) << "^3)";
         }

--- a/openvdb/unittest/TestGrid.cc
+++ b/openvdb/unittest/TestGrid.cc
@@ -140,6 +140,8 @@ public:
 
     openvdb::Index treeDepth() const override { return 0; }
     openvdb::Index leafCount() const override { return 0; }
+    std::unique_ptr<std::vector<openvdb::Index32>> nodeCount() const override
+        { return std::unique_ptr<std::vector<openvdb::Index32>>(new std::vector<openvdb::Index32>(DEPTH, 0)); }
     openvdb::Index nonLeafCount() const override { return 0; }
     openvdb::Index64 activeVoxelCount() const override { return 0UL; }
     openvdb::Index64 inactiveVoxelCount() const override { return 0UL; }

--- a/openvdb/unittest/TestTree.cc
+++ b/openvdb/unittest/TestTree.cc
@@ -3003,8 +3003,11 @@ TestTree::testNodeCount()
     for (auto it = tree.cbeginNode(); it; ++it) ++(nodeCount[dims.size()-1-it.getDepth()]);
     //timer.restart("New technique");// use for benchmark test
     auto ptr = tree.nodeCount();
+    //timer.restart("Newer technique");// use for benchmark test
+    auto vec = openvdb::tools::nodeCount(tree);
     //timer.stop();// use for benchmark test
     CPPUNIT_ASSERT_EQUAL(nodeCount.size(), ptr->size());
+    CPPUNIT_ASSERT_EQUAL(nodeCount.size(), vec.size());
     //for (size_t i=0; i<ptr->size(); ++i) std::cerr << "nodeCount("<<i<<") OLD/NEW: " << nodeCount[i] << "/" << (*ptr)[i] << std::endl;
     CPPUNIT_ASSERT_EQUAL(1U, ptr->back());// one root node
     CPPUNIT_ASSERT_EQUAL(tree.leafCount(), ptr->front());// leaf nodes

--- a/openvdb/unittest/TestTree.cc
+++ b/openvdb/unittest/TestTree.cc
@@ -41,6 +41,7 @@
 #include <openvdb/math/Math.h> // for Abs()
 #include <openvdb/openvdb.h>
 #include <openvdb/util/CpuTimer.h>
+#include <openvdb/tools/Count.h>
 #include <openvdb/tools/LevelSetSphere.h>
 #include <openvdb/tools/Prune.h>
 #include <openvdb/tools/ChangeBackground.h>


### PR DESCRIPTION
This introduces a new tools/Count.h header with two counting tools - activeVoxelCount() and nodeCount(). I've marked this as a draft PR so it can't be merged. There are a few things to discuss here about whether this is the right approach to take.

This is built on top of Ken's PR and performance is as follows:

ActiveVoxelCount:

* tree.activeVoxelCount() ... completed in 506.420 milliseconds
* openvdb::tools::activeVoxelCount(tree) ... completed in 123.230 milliseconds

Node Count:

* Old method ... completed in 89.398 milliseconds
* tree.nodeCount() ... completed in 9.955 milliseconds
* openvdb::tools::nodeCount(tree) ... completed in 1.938 milliseconds