### PR TITLE
Fix OpenEXR VDB Render issue on Windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Version 7.0.0 - In development
     Bug fixes:
     - Fixed a bug in FindJemalloc.cmake where paths were not being handled
       correctly.
+    - Fixed a Windows build issue in openvdb_render.
 
     ABI changes:
     - OpFactory destructor is now virtual as of ABI=7

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -29,6 +29,7 @@ Improvements:
 Bug fixes:
 - Fixed a bug in <TT>FindJemalloc.cmake</TT> where paths were not being handled
   correctly.
+- Fixed a Windows build issue in openvdb_render.
 
 @par
 ABI changes:

--- a/openvdb/cmd/openvdb_render.cc
+++ b/openvdb/cmd/openvdb_render.cc
@@ -46,6 +46,7 @@
 #include <vector>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <openvdb/PlatformConfig.h> // defines OPENEXR_DLL if required, must come before OpenEXR includes
 #include <OpenEXR/ImfChannelList.h>
 #include <OpenEXR/ImfFrameBuffer.h>
 #include <OpenEXR/ImfHeader.h>


### PR DESCRIPTION
Paraphrasing from an OpenEXR change log:

> If you are using any OpenEXR DLLs on Windows, you must define OPENEXR_DLL in your project's preprocessor directives.

My understanding is that we're handling this with the following logic in openvdb/PlatformConfig.h:

```
    // By default, assume that we're dynamically linking OpenEXR, unless
    // OPENVDB_OPENEXR_STATICLIB is defined.
    #if !defined(OPENVDB_OPENEXR_STATICLIB) && !defined(OPENEXR_DLL)
        #define OPENEXR_DLL
    #endif
```

However in the vdb_render binary, the OpenEXR headers are included before this PlatformConfig header so this OPENEXR_DLL is not defined early enough which causes an undefined symbol issue as described in detail here (https://github.com/AcademySoftwareFoundation/openvdb/issues/496).

I believe a pending change in OpenEXR 2.4 will solve this properly using a new cmake module.

(@e4lam)