### PR TITLE
Rasterize Points SOP non-finite value fix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,8 @@ Version 7.0.0 - In development
       point offsets (mesh inputs).
     - Threaded the population of point group memberships during conversion
       from Houdini geometry to OpenVDB Points
+    - Added logic to the Rasterize Points SOP to suppress the output of
+      non-finite attribute values due to subnormal input densities.
 
 
 Version 6.2.1 - September 30, 2019

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -49,6 +49,8 @@ Houdini:
   inputs).
 - Threaded the population of point group memberships during conversion from
   Houdini geometry to OpenVDB Points
+- Added logic to the Rasterize&nbsp;Points SOP to suppress the output of
+  non-finite attribute values due to subnormal input densities.
 
 
 @htmlonly <a name="v6_2_1_changes"></a>@endhtmlonly

--- a/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
@@ -2185,8 +2185,10 @@ struct RasterizePoints
 
                 if (transferAttributes) {
                     for (size_t nn = 0; nn < BoolLeafNodeType::SIZE; ++nn) {
-                        voxelWeightArray[nn] =
-                            voxelWeightArray[nn] > 0.0f ? 1.0f / voxelWeightArray[nn] : 0.0f;
+                        const float weight = (voxelWeightArray[nn] > 0.0f) ?
+                            (1.0f / voxelWeightArray[nn]) : 0.0f;
+                        // Subnormal input values are nonzero but can result in infinite weights.
+                        voxelWeightArray[nn] = openvdb::math::isFinite(weight) ? weight : 0.0f;
                     }
 
                     for (size_t i = 0, I = vecAttributes.size(); i < I; ++i) {


### PR DESCRIPTION
When transferring attributes, the Rasterize Points SOP computes density-weighted sums over neighboring points, and if there are clusters of points with extremely small (subnormal) densities, normalization by the sum of those densities can produce NaNs or infs.  This PR adds logic to check for and suppress non-finite values.

This also serves as a DWA test of EasyCLA.