### PR TITLE
Add isGridUnique.

### DIFF
--- a/openvdb_houdini/GEO_PrimVDB.cc
+++ b/openvdb_houdini/GEO_PrimVDB.cc
@@ -1672,6 +1672,22 @@ GEO_PrimVDB::GridAccessor::makeGridUnique()
     }
 }
 
+bool
+GEO_PrimVDB::GridAccessor::isGridUnique() const
+{
+    if (myGrid) {
+        // We require the grid to always be unique, it is the tree
+        // that is allowed to be shared.
+	UT_ASSERT(myGrid.unique());
+	openvdb::TreeBase::Ptr localTreePtr = myGrid->baseTreePtr();
+	if (localTreePtr.use_count() > 2) { // myGrid + localTreePtr = 2
+            return false;
+	}
+        return true;
+    }
+    // Empty grids are trivially unique
+    return true;
+}
 
 void
 GEO_PrimVDB::setTransform4(const UT_Matrix4 &xform4)

--- a/openvdb_houdini/GEO_PrimVDB.cc
+++ b/openvdb_houdini/GEO_PrimVDB.cc
@@ -1678,11 +1678,11 @@ GEO_PrimVDB::GridAccessor::isGridUnique() const
     if (myGrid) {
         // We require the grid to always be unique, it is the tree
         // that is allowed to be shared.
-	UT_ASSERT(myGrid.unique());
-	openvdb::TreeBase::Ptr localTreePtr = myGrid->baseTreePtr();
-	if (localTreePtr.use_count() > 2) { // myGrid + localTreePtr = 2
+        UT_ASSERT(myGrid.unique());
+        openvdb::TreeBase::Ptr localTreePtr = myGrid->baseTreePtr();
+        if (localTreePtr.use_count() > 2) { // myGrid + localTreePtr = 2
             return false;
-	}
+        }
         return true;
     }
     // Empty grids are trivially unique

--- a/openvdb_houdini/GEO_PrimVDB.h
+++ b/openvdb_houdini/GEO_PrimVDB.h
@@ -429,6 +429,11 @@ public:
     void                        makeGridUnique()
                                     { myGridAccessor.makeGridUnique(); }
 
+    /// @brief Returns if the tree is not shared.  If it is not shared,
+    /// one can make destructive edits without makeGridUnique.
+    bool                        isGridUnique() const
+                                    { return myGridAccessor.isGridUnique(); }
+
     /// @brief Return a reference to this primitive's grid.
     /// @note Calling setGrid() invalidates all references previously returned.
     const openvdb::GridBase &   getConstGrid() const
@@ -670,6 +675,7 @@ protected:
                         { setTransformAdapter(&xform, prim); }
 
         void            makeGridUnique();
+        bool            isGridUnique() const;
 
         UT_VDBType      getStorageType() const { return myStorageType; }
         bool            hasGrid() const { return myGrid != 0; }

--- a/openvdb_houdini/GEO_PrimVDB.h
+++ b/openvdb_houdini/GEO_PrimVDB.h
@@ -429,7 +429,7 @@ public:
     void                        makeGridUnique()
                                     { myGridAccessor.makeGridUnique(); }
 
-    /// @brief Returns if the tree is not shared.  If it is not shared,
+    /// @brief Returns true if the tree is not shared.  If it is not shared,
     /// one can make destructive edits without makeGridUnique.
     bool                        isGridUnique() const
                                     { return myGridAccessor.isGridUnique(); }


### PR DESCRIPTION
Duplicate the makeGridUnique as isGridUnique that allows testing if grids are shared before necessarily uniquing them.

This is a non-compiling reference change to track the internal GEO_PrimVDB version of Houdini 18.