### PR TITLE
Update references to project license

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This GitHub repository hosts the trunk of the OpenVDB development. This implies 
 
 ### License
 
-OpenVDB is released under the [Mozilla Public License Version 2.0](https://www.mozilla.org/MPL/2.0/), which is a free, open source software license developed and maintained by the Mozilla Foundation. The LICENSE file also contains a short notice and disclaimer statement for redistributions of OpenVDB source code.
+OpenVDB is released under the [Mozilla Public License Version 2.0](https://www.mozilla.org/MPL/2.0/), which is a free, open source software license developed and maintained by the Mozilla Foundation.
 
 The trademarks of any contributor to this project may not be used in association with the project without the contributor's express permission.
 

--- a/doc/faq.txt
+++ b/doc/faq.txt
@@ -47,9 +47,12 @@ Foundation. For more information about this license, see the
 
 @section sWhatCLA Is there a Contributor License Agreement for OpenVDB?
 Yes, developers who wish to contribute code to be considered for inclusion
-in the OpenVDB distribution must first complete this
-<a href="http://www.openvdb.org//download/OpenVDBContributorLicenseAgreement.pdf" target="_blank">Contributor License Agreement</a>
-and submit it to DreamWorks (directions are in the CLA).
+in the OpenVDB distribution must first be authorized under a signed Contributor
+License Agreement. The signature and authorization process is managed via
+the Linux Foundation's EasyCLA system, to handle the different CLAs depending
+on whether you are contributing on your own behalf or on behalf of your
+employer. The EasyCLA process will begin the first time you submit a PR
+to the project.
 
 @section sWhyUseVDB Why should I use OpenVDB?
 The typical reasons to adopt OpenVDB are if you are <b>storing sparse

--- a/doc/faq.txt
+++ b/doc/faq.txt
@@ -43,9 +43,7 @@ details of VDB are described in the paper
 OpenVDB is released under the Mozilla Public License Version 2.0, which is a
 free, open source software license developed and maintained by the Mozilla
 Foundation. For more information about this license, see the
-<a href="http://www.mozilla.org/MPL" target="_blank">Mozilla FAQ</a>. The
-LICENSE file also contains a short notice and disclaimer statement for
-redistributions of OpenVDB source code.
+<a href="https://www.mozilla.org/en-US/MPL/" target="_blank">Mozilla FAQ</a>.
 
 @section sWhatCLA Is there a Contributor License Agreement for OpenVDB?
 Yes, developers who wish to contribute code to be considered for inclusion


### PR DESCRIPTION
In connection with #560 and #565, this PR removes a couple
of statements that referred to the extra contents of the old
LICENSE file. It also updates the Mozilla Public License URL
to an https version.

Signed-off-by: Steve Winslow <swinslow@gmail.com>