### PR TITLE
OVDB-33: AttributeArray Thread-Safety

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,10 +34,12 @@ Version 7.0.0 - In development
       the metadata and/or the transform - GridBase::copyGridReplacingMetadata,
       GridBase::copyGridReplacingTransform and
       GridBase::copyGridReplacingMetadataAndTransform.
+    - AttributeArray copy constructor is now thread-safe.
 
     API changes:
     - VolumeToMesh::pointList() and VolumeToMesh::polygonPoolList() now return
       a std::unique_ptr instead of a boost::scoped_array.
+    - AttributeArray::copyUncompressed() is now deprecated.
 
     Python:
     - Removed the requirement of CMake 3.14 for NumPy usage.

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -45,12 +45,15 @@ ABI changes:
   @vdblink::GridBase::copyGridReplacingTransform() GridBase::copyGridReplacingTransform@endlink
   and @vdblink::GridBase::copyGridReplacingMetadataAndTransform()
   GridBase::copyGridReplacingMetadataAndTransform@endlink.
+- AttributeArray copy constructor is now thread-safe.
 
 @par
 API changes:
 - @vdblink{tools::VolumeToMesh::pointList(),VolumeToMesh::pointList} and
   @vdblink{tools::VolumeToMesh::polygonPoolList(),VolumeToMesh::polygonPoolList}
   now return a std::unique_ptr instead of a boost::scoped_array.
+- @vdblink::points::AttributeArray::copyUncompressed() AttributeArray::copyUncompressed@endlink
+  is now deprecated.
 
 @par
 Python:

--- a/openvdb/points/AttributeArray.cc
+++ b/openvdb/points/AttributeArray.cc
@@ -78,6 +78,37 @@ AttributeArray::ScopedRegistryLock::ScopedRegistryLock()
 // AttributeArray implementation
 
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+AttributeArray::AttributeArray(const AttributeArray& rhs)
+    : mIsUniform(rhs.mIsUniform)
+    , mFlags(rhs.mFlags)
+    , mUsePagedRead(rhs.mUsePagedRead)
+    , mOutOfCore(rhs.mOutOfCore)
+    , mPageHandle()
+{
+    if (mFlags & PARTIALREAD)       mCompressedBytes = rhs.mCompressedBytes;
+    else if (rhs.mPageHandle)       mPageHandle = rhs.mPageHandle->copy();
+}
+
+
+AttributeArray&
+AttributeArray::operator=(const AttributeArray& rhs)
+{
+    // if this AttributeArray has been partially read, zero the compressed bytes,
+    // so the page handle won't attempt to clean up invalid memory
+    if (mFlags & PARTIALREAD)       mCompressedBytes = 0;
+    mIsUniform = rhs.mIsUniform;
+    mFlags = rhs.mFlags;
+    mUsePagedRead = rhs.mUsePagedRead;
+    mOutOfCore = rhs.mOutOfCore;
+    if (mFlags & PARTIALREAD)       mCompressedBytes = rhs.mCompressedBytes;
+    else if (rhs.mPageHandle)       mPageHandle = rhs.mPageHandle->copy();
+    else                            mPageHandle.reset();
+    return *this;
+}
+#endif
+
+
 AttributeArray::Ptr
 AttributeArray::create(const NamePair& type, Index length, Index stride,
     bool constantStride, const ScopedRegistryLock* lock)

--- a/openvdb/points/AttributeArray.cc
+++ b/openvdb/points/AttributeArray.cc
@@ -79,7 +79,18 @@ AttributeArray::ScopedRegistryLock::ScopedRegistryLock()
 
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 6
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 7
 AttributeArray::AttributeArray(const AttributeArray& rhs)
+    : AttributeArray(rhs, tbb::spin_mutex::scoped_lock(rhs.mMutex))
+{
+}
+
+
+AttributeArray::AttributeArray(const AttributeArray& rhs, const tbb::spin_mutex::scoped_lock&)
+#else
+AttributeArray::AttributeArray(const AttributeArray& rhs)
+#endif
     : mIsUniform(rhs.mIsUniform)
     , mFlags(rhs.mFlags)
     , mUsePagedRead(rhs.mUsePagedRead)

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -186,6 +186,9 @@ public:
 
     /// Return an uncompressed copy of this attribute (will return a copy if not compressed).
     /// @note This method is thread-safe.
+#ifndef _MSC_VER
+    OPENVDB_DEPRECATED
+#endif
     virtual AttributeArray::Ptr copyUncompressed() const = 0;
 
     /// Return the number of elements in this array.
@@ -623,7 +626,7 @@ public:
 
     /// Return an uncompressed copy of this attribute (will just return a copy if not compressed).
     /// @note This method is thread-safe.
-    AttributeArray::Ptr copyUncompressed() const override;
+    OPENVDB_DEPRECATED AttributeArray::Ptr copyUncompressed() const override;
 
     /// Return a new attribute array of the given length @a n and @a stride with uniform value zero.
     static Ptr create(Index n, Index strideOrTotalSize = 1, bool constantStride = true);

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -609,14 +609,19 @@ public:
         const ValueType& uniformValue = zeroVal<ValueType>());
 #if OPENVDB_ABI_VERSION_NUMBER >= 7
     /// Deep copy constructor.
-    /// @note this method is thread-safe as of ABI=7
+    /// @note This method is thread-safe (as of ABI=7) for concurrently reading from the
+    /// source attribute array while being deep-copied. Specifically, this means that the
+    /// attribute array being deep-copied can be out-of-core and safely loaded in one thread
+    /// while being copied using this copy-constructor in another thread.
+    /// It is not thread-safe for write.
     TypedAttributeArray(const TypedAttributeArray&);
     /// Deep copy constructor.
     /// @deprecated Use copy-constructor without unused bool parameter
     OPENVDB_DEPRECATED TypedAttributeArray(const TypedAttributeArray&, bool /*unused*/);
 #else
     /// Deep copy constructor.
-    /// @note not thread-safe, use TypedAttributeArray::copy() to ensure thread-safety
+    /// @note This method is not thread-safe for reading or writing, use
+    /// TypedAttributeArray::copy() to ensure thread-safety when reading concurrently.
     TypedAttributeArray(const TypedAttributeArray&, bool uncompress = false);
 #endif
     /// Deep copy assignment operator.

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -609,7 +609,12 @@ public:
         const ValueType& uniformValue = zeroVal<ValueType>());
     /// Deep copy constructor.
     /// @note not thread-safe, use TypedAttributeArray::copy() to ensure thread-safety
+#if OPENVDB_ABI_VERSION_NUMBER >= 7
+    TypedAttributeArray(const TypedAttributeArray&);
+    OPENVDB_DEPRECATED TypedAttributeArray(const TypedAttributeArray&, bool /*unused*/);
+#else
     TypedAttributeArray(const TypedAttributeArray&, bool uncompress = false);
+#endif
     /// Deep copy assignment operator.
     /// @note this operator is thread-safe.
     TypedAttributeArray& operator=(const TypedAttributeArray&);
@@ -1182,8 +1187,19 @@ TypedAttributeArray<ValueType_, Codec_>::TypedAttributeArray(
 }
 
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 7
 template<typename ValueType_, typename Codec_>
 TypedAttributeArray<ValueType_, Codec_>::TypedAttributeArray(const TypedAttributeArray& rhs, bool)
+    : TypedAttributeArray(rhs)
+{
+}
+
+
+template<typename ValueType_, typename Codec_>
+TypedAttributeArray<ValueType_, Codec_>::TypedAttributeArray(const TypedAttributeArray& rhs)
+#else
+TypedAttributeArray<ValueType_, Codec_>::TypedAttributeArray(const TypedAttributeArray& rhs, bool)
+#endif
     : AttributeArray(rhs)
     , mSize(rhs.mSize)
     , mStrideOrTotalSize(rhs.mStrideOrTotalSize)

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -168,32 +168,13 @@ public:
         if (mFlags & PARTIALREAD)       mCompressedBytes = 0;
     }
 #if OPENVDB_ABI_VERSION_NUMBER >= 6
-    AttributeArray(const AttributeArray& rhs)
-        : mIsUniform(rhs.mIsUniform)
-        , mFlags(rhs.mFlags)
-        , mUsePagedRead(rhs.mUsePagedRead)
-        , mOutOfCore(rhs.mOutOfCore)
-        , mPageHandle()
-    {
-        if (mFlags & PARTIALREAD)       mCompressedBytes = rhs.mCompressedBytes;
-        else if (rhs.mPageHandle)       mPageHandle = rhs.mPageHandle->copy();
-    }
-    AttributeArray& operator=(const AttributeArray& rhs)
-    {
-        // if this AttributeArray has been partially read, zero the compressed bytes,
-        // so the page handle won't attempt to clean up invalid memory
-        if (mFlags & PARTIALREAD)       mCompressedBytes = 0;
-        mIsUniform = rhs.mIsUniform;
-        mFlags = rhs.mFlags;
-        mUsePagedRead = rhs.mUsePagedRead;
-        mOutOfCore = rhs.mOutOfCore;
-        if (mFlags & PARTIALREAD)       mCompressedBytes = rhs.mCompressedBytes;
-        else if (rhs.mPageHandle)       mPageHandle = rhs.mPageHandle->copy();
-        else                            mPageHandle.reset();
-        return *this;
-    }
+    AttributeArray(const AttributeArray& rhs);
 #else
     AttributeArray(const AttributeArray&) = default;
+#endif
+#if OPENVDB_ABI_VERSION_NUMBER >= 6
+    AttributeArray& operator=(const AttributeArray& rhs);
+#else
     AttributeArray& operator=(const AttributeArray&) = default;
 #endif
     AttributeArray(AttributeArray&&) = default;


### PR DESCRIPTION
This is an ABI=7 change to make the AttributeArray copy constructor thread-safe.

I also made a few minor improvements, deprecating the bool argument in the copy constructor and marking the copyUncompressed() method as deprecated.

I recommend looking at this PR commit-by-commit as it should be easier to see what's changing.