### PR TITLE
Add SIMD Instructions to NodeMask

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,3 +129,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: build
       run: ./ci/build.sh clang++ Debug 7 ON SSE42
+    - name: test
+      run: cd build && ctest -V

--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,8 @@ Version 7.0.0 - In development
       deprecate some logic for compilers older than Visual Studio 2017.
     - Standardized CMake install locations using GNUInstallDirs
       [Contributed by David Aguilar]
+    - Added SIMD intrinsics to a few common NodeMask methods.
+      [Contributed by Konstantin]
 
     Bug fixes:
     - Fixed a bug in FindJemalloc.cmake where paths were not being handled

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,3 +142,4 @@ stages:
     timeoutInMinutes: 0
     steps:
     - bash: ci/build.sh g++ Release 7 ON SSE42
+    - bash: cd build && ctest -V; cd -

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -31,6 +31,8 @@ Improvements:
   deprecate some logic for compilers older than Visual Studio&nbsp;2017.
 - Standardized CMake install locations using GNUInstallDirs
   <I>[Contributed&nbsp;by&nbsp;David&nbsp;Aguilar]</I>
+- Added SIMD intrinsics to a few common NodeMask methods.
+  <I>[Contributed&nbsp;by&nbsp;Konstantin]</I>
 
 @par
 Bug fixes:

--- a/openvdb/Platform.h
+++ b/openvdb/Platform.h
@@ -63,6 +63,20 @@
 #endif
 
 
+/// SIMD Intrinsic Headers
+#if defined(OPENVDB_USE_SSE42) || defined(OPENVDB_USE_AVX)
+    #if defined(_WIN32)
+        #include <intrin.h>
+    #elif defined(__GNUC__)
+        #if defined(__x86_64__) || defined(__i386__)
+            #include <x86intrin.h>
+        #elif defined(__ARM_NEON__)
+            #include <arm_neon.h>
+        #endif
+    #endif
+#endif
+
+
 /// Bracket code with OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN/_END,
 /// as in the following example, to inhibit ICC remarks about unreachable code:
 /// @code


### PR DESCRIPTION
This is an implementation derived from #493 to be included in the 7.0 release. Differences between that PR include:

* OPENVDB_SSE42 flag used to opt-in to using hardware intrinsics
* Intrinsic headers included in Platform.h
* Hardware intrinsics only used for the two most common methods (CountOn() and FindLowestOn() with Byte and Index64 variants)
* 32-bit Windows uses software implementation for CountOn(Index64)
* Implementation introduced directly into NodeMasks.h using conditional macros instead of additional header files
* CI extended to evaluate the unit tests on SSE 4.2 builds of OpenVDB

@Const-me - I'd much appreciate you reviewing this change. Also, we typically use the contributors full name in the release notes, but I only have your first name - so let me know if you'd like me to change the way you're credited.