### PR TITLE
Python Module Option Now Off in CMake

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,7 @@ Version 7.0.0 - In development
     - Added support for Boost versions 1.65 and later when building
       the Python module with NumPy support through CMake.
     - Improved CMake Python3 support.
+    - The Python Module is now disabled by default in CMake.
 
     Houdini:
     - Fixed a bug in the Points Convert SOP during conversion from

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ include(GNUInstallDirs)
 # todo epydoc and pdflatex
 option(OPENVDB_BUILD_CORE "Enable the core OpenVDB library. Both static and shared versions are enabled by default" ON)
 option(OPENVDB_BUILD_BINARIES "Enable the vdb binaries. Only vdb_print is enabled by default" ON)
-option(OPENVDB_BUILD_PYTHON_MODULE "Build the pyopenvdb Python module" ON)
+option(OPENVDB_BUILD_PYTHON_MODULE "Build the pyopenvdb Python module" OFF)
 option(OPENVDB_BUILD_UNITTESTS "Build the OpenVDB unit tests" OFF)
 option(OPENVDB_BUILD_DOCS "Build the OpenVDB documentation" OFF)
 option(OPENVDB_BUILD_HOUDINI_PLUGIN "Build the Houdini plugin" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@
 
   This CMakeLists file provides most available options for configuring the
   build and installation of all OpenVDB components. By default the core
-  library, the vdb_print binary and python module are enabled.
+  library and the vdb_print binary are enabled.
 
   Note that various packages have inbuilt CMake module support. See the
   CMake documentation for more ZLib, Doxygen, OpenGL, Boost and Python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ project(OpenVDB)
 include(CMakeDependentOption)
 include(GNUInstallDirs)
 
-# todo SSE/AVX instruction options
 # todo epydoc and pdflatex
 option(OPENVDB_BUILD_CORE "Enable the core OpenVDB library. Both static and shared versions are enabled by default" ON)
 option(OPENVDB_BUILD_BINARIES "Enable the vdb binaries. Only vdb_print is enabled by default" ON)
@@ -404,8 +403,7 @@ endif()
 
 # Compiler configuration. Add definitions for a number of compiler warnings
 # for sub projects and verify version requirements
-# @todo  add definitions for MSVC and Intel.
-# @todo  add minimum version for MSVC
+# @todo  add definitions for Intel.
 
 set(HAS_AVAILABLE_WARNINGS FALSE)
 

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -178,7 +178,7 @@ OpenVDB Print           | Command line binary for displaying information about O
 OpenVDB LOD             | Command line binary for generating volume mipmaps from an OpenVDB grid | OPENVDB_BUILD_BINARIES / OPENVDB_BUILD_VDB_LOD    | ON / OFF   |
 OpenVDB Render          | Command line binary for ray-tracing OpenVDB grids                      | OPENVDB_BUILD_BINARIES / OPENVDB_BUILD_VDB_RENDER | ON / OFF   |
 OpenVDB View            | Command line binary for displaying OpenVDB grids in a GL viewport      | OPENVDB_BUILD_BINARIES / OPENVDB_BUILD_VDB_VIEW   | ON / OFF   |
-OpenVDB Python          | Python module for OpenVDB C++ Python bindings                          | OPENVDB_BUILD_PYTHON_MODULE                       | ON         |
+OpenVDB Python          | Python module for OpenVDB C++ Python bindings                          | OPENVDB_BUILD_PYTHON_MODULE                       | OFF        |
 OpenVDB UnitTests       | OpenVDB's Unit Test suite                                              | OPENVDB_BUILD_UNITTESTS                           | OFF        |
 OpenVDB Houdini Plugin  | The OpenVDB Houdini shared library and OpenVDB Nodes                   | OPENVDB_BUILD_HOUDINI_PLUGIN                      | OFF        |
 OpenVDB Maya Plugin     | The Maya OpenVDB Nodes                                                 | OPENVDB_BUILD_MAYA_PLUGIN                         | OFF        |

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -65,6 +65,7 @@ Python:
 - Added support for Boost versions 1.65 and later when building
   the Python module with NumPy support through CMake.
 - Improved CMake Python3 support.
+- The Python Module is now disabled by default in CMake.
 
 @par
 Houdini:


### PR DESCRIPTION
As discussed here:

https://github.com/AcademySoftwareFoundation/openvdb/blame/master/tsc/meetings/2019-10-10.md#L46

Disable the Python Module in CMake by default so that it's more likely that a first time user attempting to build OpenVDB will succeed.