### PR TITLE
Add Houdini 18.0 to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,17 @@ jobs:
     - name: test
       run: cd build && ctest -V
 
+  testhou180:
+    runs-on: ubuntu-16.04
+    container:
+      image: aswf/ci-base:2019
+    steps:
+    - uses: actions/checkout@v1
+    - name: houdini
+      run: ./ci/install_houdini.sh 18.0 ${{ secrets.HOUPASS }}
+    - name: build
+      run: ./ci/build_houdini.sh clang++ Release ON
+
   testhou175:
     runs-on: ubuntu-16.04
     container:
@@ -81,25 +92,25 @@ jobs:
     - name: test
       run: cd build && ctest -V
 
-  testhou175gcc:
+  testhou180gcc:
     runs-on: ubuntu-16.04
     container:
-      image: aswf/ci-base:2018
+      image: aswf/ci-base:2019
     steps:
     - uses: actions/checkout@v1
     - name: houdini
-      run: ./ci/install_houdini.sh 17.5 ${{ secrets.HOUPASS }}
+      run: ./ci/install_houdini.sh 18.0 ${{ secrets.HOUPASS }}
     - name: build
       run: ./ci/build_houdini.sh g++ Release OFF
 
-  testhou175debug:
+  testhou180debug:
     runs-on: ubuntu-16.04
     container:
-      image: aswf/ci-base:2018
+      image: aswf/ci-base:2019
     steps:
     - uses: actions/checkout@v1
     - name: houdini
-      run: ./ci/install_houdini.sh 17.5 ${{ secrets.HOUPASS }}
+      run: ./ci/install_houdini.sh 18.0 ${{ secrets.HOUPASS }}
     - name: build
       run: ./ci/build_houdini.sh clang++ Debug OFF
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,17 @@ stages:
     - bash: ci/build.sh clang++ Release 4 ON None
     - bash: cd build && ctest -V; cd -
 
+  - job: testhou180
+    displayName: Houdini 18.0
+    pool:
+      vmImage: 'ubuntu-16.04'
+    container: aswf/ci-base:2019
+    timeoutInMinutes: 0
+    condition: variables['HOUPASS']
+    steps:
+    - bash: ci/install_houdini.sh 18.0 ${HOUPASS}
+    - bash: ci/build_houdini.sh clang++ Release ON
+
   - job: testhou175
     displayName: Houdini 17.5
     pool:
@@ -94,26 +105,26 @@ stages:
     - bash: ci/build.sh clang++ Release 7 OFF None
     - bash: cd build && ctest -V; cd -
 
-  - job: testhou175gcc
-    displayName: Houdini 17.5 (GCC)
+  - job: testhou180gcc
+    displayName: Houdini 18.0 (GCC)
     pool:
       vmImage: 'ubuntu-16.04'
-    container: aswf/ci-base:2018
+    container: aswf/ci-base:2019
     timeoutInMinutes: 0
     condition: variables['HOUPASS']
     steps:
-    - bash: ci/install_houdini.sh 17.5 ${HOUPASS}
+    - bash: ci/install_houdini.sh 18.0 ${HOUPASS}
     - bash: ci/build_houdini.sh g++ Release OFF
 
-  - job: testhou175debug
-    displayName: Houdini 17.5 (Debug Mode)
+  - job: testhou180debug
+    displayName: Houdini 18.0 (Debug Mode)
     pool:
       vmImage: 'ubuntu-16.04'
-    container: aswf/ci-base:2018
+    container: aswf/ci-base:2019
     timeoutInMinutes: 0
     condition: variables['HOUPASS']
     steps:
-    - bash: ci/install_houdini.sh 17.5 ${HOUPASS}
+    - bash: ci/install_houdini.sh 18.0 ${HOUPASS}
     - bash: ci/build_houdini.sh clang++ Debug OFF
 
   - job: testabi7gcc

--- a/ci/build_houdini.sh
+++ b/ci/build_houdini.sh
@@ -20,6 +20,7 @@ cmake \
     -DOPENVDB_BUILD_BINARIES=${EXTRAS} \
     -DOPENVDB_BUILD_PYTHON_MODULE=${EXTRAS} \
     -DOPENVDB_BUILD_UNITTESTS=${EXTRAS} \
+    -DOPENVDB_HOUDINI_INSTALL_PREFIX=/tmp \
      ..
 
 # Can only build using one thread with GCC due to memory constraints

--- a/ci/install_houdini.sh
+++ b/ci/install_houdini.sh
@@ -5,6 +5,8 @@ set -e
 HOUDINI_MAJOR="$1"
 HOUPASS="$2"
 
+pip install --user future
+pip install --user lxml
 pip install --user mechanize
 
 export PYTHONPATH=${PYTHONPATH}:/usr/lib/python2.7/dist-packages


### PR DESCRIPTION
@jmlait - I just tried adding H18 to the CI and aside from having to install the future and lxml python modules, am now getting this error:

> CMake Error at hou/toolkit/cmake/HoudiniConfig.cmake:130 (message):
>   Error running /__w/openvdb/openvdb/hou/bin/hython: No licenses could be
>   found to run this application.
> 
>   	Please check for a valid license server host

Any ideas what might be going on? This works for H17 and H17.5, I'm not aware there's been any license server changes. :/