### PR TITLE
The interface for evalActiveVoxelBoundingBox suggests it returns false.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@ OpenVDB Version History
 
 Version 7.0.1 - In Development
 
+    Bug fixes:
+    - Fixed a bug where empty grids were still returning true from
+      evalActiveVoxelBoundingBox when leaf nodes were still present.
 
 Version 7.0.0 - December 6, 2019
 

--- a/CHANGES
+++ b/CHANGES
@@ -4,8 +4,9 @@ OpenVDB Version History
 Version 7.0.1 - In Development
 
     Bug fixes:
-    - Fixed a bug where empty grids were still returning true from
-      evalActiveVoxelBoundingBox when leaf nodes were still present.
+    - Fixed a bug where grids with no active values might return true when the
+      method evalActiveVoxelBoundingBox is called. The correct behavior is to
+      only return true if the grid contains any active values.
 
 Version 7.0.0 - December 6, 2019
 

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -8,8 +8,9 @@
 
 @par
 Bug fixes:
-- Fixed a bug where empty grids were still returning true from
-  <TT>evalActiveVoxelBoundingBox</TT> when leaf nodes were still present.
+- Fixed a bug where grids with no active values might return true when the
+  method <TT>evalActiveVoxelBoundingBox</TT> is called. The correct behavior is to
+  only return true if the grid contains any active values.
 
 @htmlonly <a name="v7_0_0_changes"></a>@endhtmlonly
 @par

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -2,6 +2,15 @@
 
 @page changes Release Notes
 
+@htmlonly <a name="v7_0_1_changes"></a>@endhtmlonly
+@par
+<B>Version 7.0.1</B> - <I>In Development</I>
+
+@par
+Bug fixes:
+- Fixed a bug where empty grids were still returning true from
+  <TT>evalActiveVoxelBoundingBox</TT> when leaf nodes were still present.
+
 @htmlonly <a name="v7_0_0_changes"></a>@endhtmlonly
 @par
 <B>Version 7.0.0</B> - <I>December 6, 2019</I>

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -2138,7 +2138,7 @@ Tree<RootNodeType>::evalLeafBoundingBox(CoordBBox& bbox) const
 
     mRoot.evalActiveBoundingBox(bbox, false);
 
-    return true;// not empty
+    return !bbox.empty();
 }
 
 template<typename RootNodeType>
@@ -2151,7 +2151,7 @@ Tree<RootNodeType>::evalActiveVoxelBoundingBox(CoordBBox& bbox) const
 
     mRoot.evalActiveBoundingBox(bbox, true);
 
-    return true;// not empty
+    return !bbox.empty();
 }
 
 

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -60,7 +60,7 @@ public:
     virtual Metadata::Ptr getBackgroundValue() const { return Metadata::Ptr(); }
 
     /// @brief Return in @a bbox the axis-aligned bounding box of all
-    /// leaf nodes and active tiles.
+    /// active tiles and leaf nodes with active values.
     /// @details This is faster than calling evalActiveVoxelBoundingBox,
     /// which visits the individual active voxels, and hence
     /// evalLeafBoundingBox produces a less tight, i.e. approximate, bbox.

--- a/openvdb/unittest/TestGridBbox.cc
+++ b/openvdb/unittest/TestGridBbox.cc
@@ -51,6 +51,12 @@ TestGridBbox::testLeafBbox()
     CPPUNIT_ASSERT(tree.evalLeafBoundingBox(bbox));
     CPPUNIT_ASSERT_EQUAL(openvdb::Coord(-104,   -40,  -800), bbox.min());
     CPPUNIT_ASSERT_EQUAL(openvdb::Coord(104-1, 40-1, 808-1), bbox.max());
+
+    // Clear the tree without trimming.
+    tree.setValueOff(openvdb::Coord(  0,  9,   9));
+    tree.setValueOff(openvdb::Coord(100, 35, 800));
+    tree.setValueOff(openvdb::Coord(-100, -35, -800));
+    CPPUNIT_ASSERT(!tree.evalLeafBoundingBox(bbox));
 }
 
 
@@ -80,4 +86,13 @@ TestGridBbox::testGridBbox()
     CPPUNIT_ASSERT(tree.evalActiveVoxelBoundingBox(bbox));
     CPPUNIT_ASSERT_EQUAL(openvdb::Coord(-100,   -35,  -800), bbox.min());
     CPPUNIT_ASSERT_EQUAL(openvdb::Coord(100, 35, 800), bbox.max());
+
+    // Clear the tree without trimming.
+    tree.setValueOff(openvdb::Coord(  1,  0,   0));
+    tree.setValueOff(openvdb::Coord(  0, 12,   8));
+    tree.setValueOff(openvdb::Coord(  1, 35, 800));
+    tree.setValueOff(openvdb::Coord(100,  0,  16));
+    tree.setValueOff(openvdb::Coord(  1,  0,  16));
+    tree.setValueOff(openvdb::Coord(-100, -35, -800));
+    CPPUNIT_ASSERT(!tree.evalActiveVoxelBoundingBox(bbox));
 }


### PR DESCRIPTION
The interface for evalActiveVoxelBoundingBox suggests it returns false.
if empty, but only does so if the tree is empty.  This will change
it so it will also do so if the computed bounds are empty.