### PR TITLE
OVDB-135: Point Partitioner Determinism Test

### DIFF
--- a/openvdb/tools/PointPartitioner.h
+++ b/openvdb/tools/PointPartitioner.h
@@ -709,10 +709,10 @@ struct OrderSegmentsOp
     using IndexArray = boost::scoped_array<PointIndexType>;
     using SegmentPtr = typename Array<PointIndexType>::Ptr;
 
-    OrderSegmentsOp(SegmentPtr* indexSegments, SegmentPtr* offestSegments,
+    OrderSegmentsOp(SegmentPtr* indexSegments, SegmentPtr* offsetSegments,
         IndexArray* pageOffsetArrays, Index binVolume)
         : mIndexSegments(indexSegments)
-        , mOffsetSegments(offestSegments)
+        , mOffsetSegments(offsetSegments)
         , mPageOffsetArrays(pageOffsetArrays)
         , mBinVolume(binVolume)
     {
@@ -871,10 +871,10 @@ inline void partition(
     size_t numSegments = 0;
 
     boost::scoped_array<typename Array<PointIndexType>::Ptr> indexSegments;
-    boost::scoped_array<typename Array<PointIndexType>::Ptr> offestSegments;
+    boost::scoped_array<typename Array<PointIndexType>::Ptr> offsetSegments;
 
     binAndSegment<PointIndexType, VoxelOffsetType, PointArray>(points, xform,
-        indexSegments, offestSegments, numSegments, binLog2Dim, bucketLog2Dim,
+        indexSegments, offsetSegments, numSegments, binLog2Dim, bucketLog2Dim,
             voxelOffsets.get(), cellCenteredTransform);
 
     const tbb::blocked_range<size_t> segmentRange(0, numSegments);
@@ -885,7 +885,7 @@ inline void partition(
     const Index binVolume = 1u << (3u * binLog2Dim);
 
     tbb::parallel_for(segmentRange, OrderSegmentsOp<PointIndexType>
-        (indexSegments.get(), offestSegments.get(), pageOffsetArrays.get(), binVolume));
+        (indexSegments.get(), offsetSegments.get(), pageOffsetArrays.get(), binVolume));
 
     indexSegments.reset();
 
@@ -918,11 +918,11 @@ inline void partition(
     PointIndexType* index = pointIndices.get();
     for (size_t n = 0; n < numSegments; ++n) {
         indexArray.push_back(index);
-        index += offestSegments[n]->size();
+        index += offsetSegments[n]->size();
     }
 
     tbb::parallel_for(segmentRange,
-        MoveSegmentDataOp<PointIndexType>(indexArray, offestSegments.get()));
+        MoveSegmentDataOp<PointIndexType>(indexArray, offsetSegments.get()));
 }
 
 

--- a/openvdb/unittest/TestPointPartitioner.cc
+++ b/openvdb/unittest/TestPointPartitioner.cc
@@ -4,6 +4,8 @@
 #include <cppunit/extensions/HelperMacros.h>
 #include <openvdb/tools/PointPartitioner.h>
 
+#include <openvdb/math/Math.h> // math::Rand01
+
 #include <vector>
 
 
@@ -12,9 +14,11 @@ class TestPointPartitioner: public CppUnit::TestCase
 public:
     CPPUNIT_TEST_SUITE(TestPointPartitioner);
     CPPUNIT_TEST(testPartitioner);
+    CPPUNIT_TEST(testDeterminism);
     CPPUNIT_TEST_SUITE_END();
 
     void testPartitioner();
+    void testDeterminism();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestPointPartitioner);
@@ -96,3 +100,62 @@ TestPointPartitioner::testPartitioner()
     }
 }
 
+void
+TestPointPartitioner::testDeterminism()
+{
+    const size_t pointCount = 1000*1000;
+    const float voxelSize = 0.1f;
+
+    // create a box of points positioned randomly between -1.0 and 1.0
+
+    openvdb::math::Rand01<float> rand01(0);
+
+    std::vector<openvdb::Vec3s> points(pointCount, openvdb::Vec3s(0.f));
+    for (size_t n = 0; n < pointCount; ++n) {
+        points[n].x() = (rand01() * 2.0f) - 1.0f;
+        points[n].y() = (rand01() * 2.0f) - 1.0f;
+        points[n].z() = (rand01() * 2.0f) - 1.0f;
+    }
+
+    PointList pointList(points);
+
+    const openvdb::math::Transform::Ptr transform =
+            openvdb::math::Transform::createLinearTransform(voxelSize);
+
+    typedef openvdb::tools::UInt32PointPartitioner PointPartitioner;
+
+    std::vector<PointPartitioner::Ptr> partitioners;
+
+    // create 10 point partitioners
+
+    for (size_t i = 0; i < 10; i++) {
+        partitioners.push_back(PointPartitioner::create(pointList, *transform));
+    }
+
+    // verify their sizes are the same
+
+    for (size_t i = 1; i < partitioners.size(); i++) {
+        CPPUNIT_ASSERT_EQUAL(partitioners[0]->size(), partitioners[i]->size());
+    }
+
+    // verify their contents are the same
+
+    for (size_t i = 1; i < partitioners.size(); i++) {
+        for (size_t n = 1; n < partitioners[0]->size(); n++) {
+            CPPUNIT_ASSERT_EQUAL(partitioners[0]->origin(n), partitioners[i]->origin(n));
+
+            auto it1 = partitioners[0]->indices(n);
+            auto it2 = partitioners[i]->indices(n);
+
+            size_t bucketSize = it1.size();
+            CPPUNIT_ASSERT_EQUAL(bucketSize, it2.size());
+
+            for (size_t j = 0; j < bucketSize; j++) {
+                CPPUNIT_ASSERT_EQUAL(*it1, *it2);
+
+                ++it1;
+                ++it2;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix a typo and add a unit test to validate that the point partitioner is deterministic (it's easy to accidentally break determinism when refactoring)

To be clear - the point partitioner **is** currently deterministic (to the best of my knowledge).