### PR TITLE
Add minimum MSVC version to CMake

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Version 7.1.0 - In Development
     - Added new group inspection methods to the AttributeSet::Descriptor.
     - Introduced a StringMetaCache class for convenient string attribute
       metadata lookup and performed some minor optimizations.
+    - CMake now checks the minimum supported MSVC compiler for Windows.
 
     Bug fixes:
     - Fixed a bug where grids with no active values might return true when the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-fdiagnostics-color=always)
   endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS MINIMUM_ICC_VERSION})
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS MINIMUM_ICC_VERSION)
     message(FATAL_ERROR "Insufficient ICC version. Minimum required is "
       "\"${MINIMUM_ICC_VERSION}\". Found version \"${CMAKE_CXX_COMPILER_VERSION}\""
     )
@@ -480,6 +480,11 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
     endif()
   endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS MINIMUM_MSVC_VERSION)
+    message(FATAL_ERROR "Insufficient MSVC version. Minimum required is "
+      "\"${MINIMUM_MSVC_VERSION}\". Found version \"${CMAKE_CXX_COMPILER_VERSION}\""
+  )
+  endif()
   if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_MSVC_VERSION)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS FUTURE_MINIMUM_MSVC_VERSION)
       message(DEPRECATION "Support for MSVC versions < ${FUTURE_MINIMUM_MSVC_VERSION} "

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -20,6 +20,7 @@ Improvements:
 - Introduced a @vdblink::points::StringMetaCache StringMetaCache@endlink class
   for convenient string attribute metadata lookup and performed some minor
   optimizations.
+- CMake now checks the minimum supported MSVC compiler for Windows.
 
 @par
 Bug fixes:


### PR DESCRIPTION
As discussed, add a CMake check to ensure that at least the minimum supported version of MSVC is being used.

(@e4lam)