### PR TITLE
Fixed Point Optimization

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Version 7.1.0 - In Development
     - Added new group inspection methods to the AttributeSet::Descriptor.
     - Introduced a StringMetaCache class for convenient string attribute
       metadata lookup and performed some minor optimizations.
+    - Removed redundant floor in points::floatingPointToFixedPoint.
 
     Bug fixes:
     - Fixed a bug where grids with no active values might return true when the

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -20,6 +20,8 @@ Improvements:
 - Introduced a @vdblink::points::StringMetaCache StringMetaCache@endlink class
   for convenient string attribute metadata lookup and performed some minor
   optimizations.
+- Removed redundant floor in @vdblink::points::floatingPointToFixedPoint
+  floatingPointToFixedPoint@endlink.
 
 @par
 Bug fixes:

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -52,7 +52,7 @@ floatingPointToFixedPoint(const FloatT s)
     static_assert(std::is_unsigned<IntegerT>::value, "IntegerT must be unsigned");
     if (FloatT(0.0) > s) return std::numeric_limits<IntegerT>::min();
     else if (FloatT(1.0) <= s) return std::numeric_limits<IntegerT>::max();
-    return IntegerT(std::floor(s * FloatT(std::numeric_limits<IntegerT>::max())));
+    return IntegerT(s * FloatT(std::numeric_limits<IntegerT>::max()));
 }
 
 


### PR DESCRIPTION
Rounding from float -> int can be achieved with a simple cast *provided* that the floating-point value is always positive. As we're independently handling the case where the value is not positive, we can remove the redundant floor operation. This improved performance of this method by ~10% in my testing.

This method is used a lot so I tested all possible 32-bit floating-point values to be sure I wasn't missing something.