### PR TITLE
OVDB-136: Attribute Stealing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,9 @@ Version 7.1.0 - In Development
     New features:
     - Added Grid::isTreeUnique() to tell if the tree is shared with another
       grid.
+    - Added PointDataLeafNode::stealAttributeSet() and
+      AttributeSet::removeAttribute() for releasing ownership of attribute
+      data.
 
     Bug fixes:
     - Fixed a bug where grids with no active values might return true when the

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -28,6 +28,11 @@ Improvements:
 New features:
 - Added @vdblink::Grid::isTreeUnique() Grid::isTreeUnique@endlink to tell if
   the tree is shared with another grid.
+- Added @vdblink::points::PointDataLeafNode::stealAttributeSet()
+  PointDataLeafNode::stealAttributeSet@endlink and
+  @vdblink::points::AttributeSet::removeAttribute()
+  AttributeSet::removeAttribute@endlink for releasing ownership of attribute
+  data.
 
 @par
 Bug fixes:

--- a/openvdb/points/AttributeSet.cc
+++ b/openvdb/points/AttributeSet.cc
@@ -379,9 +379,10 @@ AttributeSet::removeAttribute(const size_t pos)
 {
     if (pos >= mAttrs.size())     return AttributeArray::Ptr();
 
-    AttributeArray::Ptr array = mAttrs[pos];
+    assert(mAttrs[pos]);
+    AttributeArray::Ptr array;
+    std::swap(array, mAttrs[pos]);
     assert(array);
-    mAttrs[pos].reset();
 
     // safely drop the attribute and update the descriptor
     std::vector<size_t> toDrop{pos};
@@ -396,9 +397,10 @@ AttributeSet::removeAttributeUnsafe(const size_t pos)
 {
     if (pos >= mAttrs.size())     return AttributeArray::Ptr();
 
-    AttributeArray::Ptr array = mAttrs[pos];
+    assert(mAttrs[pos]);
+    AttributeArray::Ptr array;
+    std::swap(array, mAttrs[pos]);
     assert(array);
-    mAttrs[pos].reset();
 
     return array;
 }

--- a/openvdb/points/AttributeSet.cc
+++ b/openvdb/points/AttributeSet.cc
@@ -365,6 +365,45 @@ AttributeSet::appendAttribute(  const Descriptor& expected, DescriptorPtr& repla
 }
 
 
+AttributeArray::Ptr
+AttributeSet::removeAttribute(const Name& name)
+{
+    const size_t pos = this->find(name);
+    if (pos == INVALID_POS) return AttributeArray::Ptr();
+    return this->removeAttribute(pos);
+}
+
+
+AttributeArray::Ptr
+AttributeSet::removeAttribute(const size_t pos)
+{
+    if (pos >= mAttrs.size())     return AttributeArray::Ptr();
+
+    AttributeArray::Ptr array = mAttrs[pos];
+    assert(array);
+    mAttrs[pos].reset();
+
+    // safely drop the attribute and update the descriptor
+    std::vector<size_t> toDrop{pos};
+    this->dropAttributes(toDrop);
+
+    return array;
+}
+
+
+AttributeArray::Ptr
+AttributeSet::removeAttributeUnsafe(const size_t pos)
+{
+    if (pos >= mAttrs.size())     return AttributeArray::Ptr();
+
+    AttributeArray::Ptr array = mAttrs[pos];
+    assert(array);
+    mAttrs[pos].reset();
+
+    return array;
+}
+
+
 void
 AttributeSet::dropAttributes(const std::vector<size_t>& pos)
 {

--- a/openvdb/points/AttributeSet.cc
+++ b/openvdb/points/AttributeSet.cc
@@ -400,7 +400,6 @@ AttributeSet::removeAttributeUnsafe(const size_t pos)
     assert(mAttrs[pos]);
     AttributeArray::Ptr array;
     std::swap(array, mAttrs[pos]);
-    assert(array);
 
     return array;
 }

--- a/openvdb/points/AttributeSet.h
+++ b/openvdb/points/AttributeSet.h
@@ -201,6 +201,35 @@ public:
                                         const bool constantStride,
                                         const AttributeArray::ScopedRegistryLock* lock);
 
+    /// @brief Remove and return an attribute array by name
+    /// @param name the name of the attribute array to release
+    /// @details Detaches the attribute array from this attribute set and returns it.
+    /// This also updates the descriptor to remove the reference to the attribute array.
+    /// @note AttributeArrays are stored as shared pointers, so they are not guaranteed
+    /// to be unique. Check the reference count before blindly re-using in a new AttributeSet.
+    AttributeArray::Ptr removeAttribute(const Name& name);
+
+    /// @brief Remove and return an attribute array by index
+    /// @param pos the position index of the attribute to release
+    /// @details Detaches the attribute array from this attribute set and returns it.
+    /// This also updates the descriptor to remove the reference to the attribute array.
+    /// @note AttributeArrays are stored as shared pointers, so they are not guaranteed
+    /// to be unique. Check the reference count before blindly re-using in a new AttributeSet.
+    AttributeArray::Ptr removeAttribute(const size_t pos);
+
+    /// @brief Remove and return an attribute array by index (unsafe method)
+    /// @param pos the position index of the attribute to release
+    /// @details Detaches the attribute array from this attribute set and returns it.
+    /// In cases where the AttributeSet is due to be destroyed, a small performance
+    /// advantage can be gained by leaving the attribute array as a nullptr and not
+    /// updating the descriptor. However, this leaves the AttributeSet in an invalid
+    /// state making it unsafe to call any methods that implicitly derefence the attribute array.
+    /// @note AttributeArrays are stored as shared pointers, so they are not guaranteed
+    /// to be unique. Check the reference count before blindly re-using in a new AttributeSet.
+    /// @warning Only use this method if you're an expert and know the risks of not
+    /// updating the array of attributes or the descriptor.
+    AttributeArray::Ptr removeAttributeUnsafe(const size_t pos);
+
     /// Drop attributes with @a pos indices (simple method)
     /// Creates a new descriptor for this attribute set
     void dropAttributes(const std::vector<size_t>& pos);

--- a/openvdb/points/AttributeSet.h
+++ b/openvdb/points/AttributeSet.h
@@ -42,6 +42,7 @@ public:
 
     using Ptr                   = std::shared_ptr<AttributeSet>;
     using ConstPtr              = std::shared_ptr<const AttributeSet>;
+    using UniquePtr             = std::unique_ptr<AttributeSet>;
 
     class Descriptor;
 
@@ -203,23 +204,26 @@ public:
 
     /// @brief Remove and return an attribute array by name
     /// @param name the name of the attribute array to release
-    /// @details Detaches the attribute array from this attribute set and returns it.
-    /// This also updates the descriptor to remove the reference to the attribute array.
+    /// @details Detaches the attribute array from this attribute set and returns it, if
+    /// @a name is invalid, returns an empty shared pointer. This also updates the descriptor
+    /// to remove the reference to the attribute array.
     /// @note AttributeArrays are stored as shared pointers, so they are not guaranteed
     /// to be unique. Check the reference count before blindly re-using in a new AttributeSet.
     AttributeArray::Ptr removeAttribute(const Name& name);
 
     /// @brief Remove and return an attribute array by index
     /// @param pos the position index of the attribute to release
-    /// @details Detaches the attribute array from this attribute set and returns it.
-    /// This also updates the descriptor to remove the reference to the attribute array.
+    /// @details Detaches the attribute array from this attribute set and returns it, if
+    /// @a pos is invalid, returns an empty shared pointer. This also updates the descriptor
+    /// to remove the reference to the attribute array.
     /// @note AttributeArrays are stored as shared pointers, so they are not guaranteed
     /// to be unique. Check the reference count before blindly re-using in a new AttributeSet.
     AttributeArray::Ptr removeAttribute(const size_t pos);
 
     /// @brief Remove and return an attribute array by index (unsafe method)
     /// @param pos the position index of the attribute to release
-    /// @details Detaches the attribute array from this attribute set and returns it.
+    /// @details Detaches the attribute array from this attribute set and returns it, if
+    /// @a pos is invalid, returns an empty shared pointer.
     /// In cases where the AttributeSet is due to be destroyed, a small performance
     /// advantage can be gained by leaving the attribute array as a nullptr and not
     /// updating the descriptor. However, this leaves the AttributeSet in an invalid

--- a/openvdb/points/PointDataGrid.h
+++ b/openvdb/points/PointDataGrid.h
@@ -320,7 +320,7 @@ public:
     const AttributeSet& attributeSet() const { return *mAttributeSet; }
 
     /// @brief Steal the attribute set, a new, empty attribute set is inserted in it's place.
-    AttributeSet* stealAttributeSet();
+    AttributeSet::UniquePtr stealAttributeSet();
 
     /// @brief Create a new attribute set. Existing attributes will be removed.
     void initializeAttributes(const Descriptor::Ptr& descriptor, const Index arrayLength,
@@ -601,7 +601,7 @@ public:
     using ValueAll  = typename BaseLeaf::ValueAll;
 
 private:
-    std::unique_ptr<AttributeSet> mAttributeSet;
+    AttributeSet::UniquePtr mAttributeSet;
     uint16_t mVoxelBufferSize = 0;
 
 protected:
@@ -749,12 +749,12 @@ public:
 // PointDataLeafNode implementation
 
 template<typename T, Index Log2Dim>
-inline AttributeSet*
+inline AttributeSet::UniquePtr
 PointDataLeafNode<T, Log2Dim>::stealAttributeSet()
 {
-    std::unique_ptr<AttributeSet> ptr(mAttributeSet.release());
-    mAttributeSet.reset(new AttributeSet);
-    return ptr.release();
+    AttributeSet::UniquePtr ptr = std::make_unique<AttributeSet>();
+    std::swap(ptr, mAttributeSet);
+    return ptr;
 }
 
 template<typename T, Index Log2Dim>

--- a/openvdb/points/PointDataGrid.h
+++ b/openvdb/points/PointDataGrid.h
@@ -319,6 +319,9 @@ public:
     /// Retrieve the attribute set.
     const AttributeSet& attributeSet() const { return *mAttributeSet; }
 
+    /// @brief Steal the attribute set, a new, empty attribute set is inserted in it's place.
+    AttributeSet* stealAttributeSet();
+
     /// @brief Create a new attribute set. Existing attributes will be removed.
     void initializeAttributes(const Descriptor::Ptr& descriptor, const Index arrayLength,
         const AttributeArray::ScopedRegistryLock* lock = nullptr);
@@ -744,6 +747,15 @@ public:
 ////////////////////////////////////////
 
 // PointDataLeafNode implementation
+
+template<typename T, Index Log2Dim>
+inline AttributeSet*
+PointDataLeafNode<T, Log2Dim>::stealAttributeSet()
+{
+    std::unique_ptr<AttributeSet> ptr(mAttributeSet.release());
+    mAttributeSet.reset(new AttributeSet);
+    return ptr.release();
+}
 
 template<typename T, Index Log2Dim>
 inline void

--- a/openvdb/unittest/TestAttributeSet.cc
+++ b/openvdb/unittest/TestAttributeSet.cc
@@ -859,6 +859,57 @@ TestAttributeSet::testAttributeSet()
             CPPUNIT_ASSERT(attributeSetMatchesDescriptor(attrSetC, *targetDescr));
         }
 
+        { // remove attribute
+            AttributeSet attrSetC;
+            attrSetC.appendAttribute("test1", AttributeI::attributeType());
+            attrSetC.appendAttribute("test2", AttributeI::attributeType());
+            attrSetC.appendAttribute("test3", AttributeI::attributeType());
+            attrSetC.appendAttribute("test4", AttributeI::attributeType());
+            attrSetC.appendAttribute("test5", AttributeI::attributeType());
+
+            CPPUNIT_ASSERT_EQUAL(attrSetC.size(), size_t(5));
+
+            { // remove test2
+                AttributeArray::Ptr array = attrSetC.removeAttribute(1);
+                CPPUNIT_ASSERT(array);
+                CPPUNIT_ASSERT_EQUAL(array.use_count(), long(1));
+            }
+
+            CPPUNIT_ASSERT_EQUAL(attrSetC.size(), size_t(4));
+            CPPUNIT_ASSERT_EQUAL(attrSetC.descriptor().size(), size_t(4));
+
+            { // remove test5
+                AttributeArray::Ptr array = attrSetC.removeAttribute("test5");
+                CPPUNIT_ASSERT(array);
+                CPPUNIT_ASSERT_EQUAL(array.use_count(), long(1));
+            }
+
+            CPPUNIT_ASSERT_EQUAL(attrSetC.size(), size_t(3));
+            CPPUNIT_ASSERT_EQUAL(attrSetC.descriptor().size(), size_t(3));
+
+            { // remove test3 unsafely
+                AttributeArray::Ptr array = attrSetC.removeAttributeUnsafe(1);
+                CPPUNIT_ASSERT(array);
+                CPPUNIT_ASSERT_EQUAL(array.use_count(), long(1));
+            }
+
+            // array of attributes and descriptor are not updated
+
+            CPPUNIT_ASSERT_EQUAL(attrSetC.size(), size_t(3));
+            CPPUNIT_ASSERT_EQUAL(attrSetC.descriptor().size(), size_t(3));
+
+            const auto& nameToPosMap = attrSetC.descriptor().map();
+
+            CPPUNIT_ASSERT_EQUAL(nameToPosMap.size(), size_t(3));
+            CPPUNIT_ASSERT_EQUAL(nameToPosMap.at("test1"), size_t(0));
+            CPPUNIT_ASSERT_EQUAL(nameToPosMap.at("test3"), size_t(1)); // this array does not exist
+            CPPUNIT_ASSERT_EQUAL(nameToPosMap.at("test4"), size_t(2));
+
+            CPPUNIT_ASSERT(attrSetC.getConst(0));
+            CPPUNIT_ASSERT(!attrSetC.getConst(1)); // this array does not exist
+            CPPUNIT_ASSERT(attrSetC.getConst(2));
+        }
+
         { // test duplicateDrop configures group mapping
             AttributeSet attrSetC;
 

--- a/openvdb/unittest/TestPointDataLeaf.cc
+++ b/openvdb/unittest/TestPointDataLeaf.cc
@@ -31,6 +31,7 @@ public:
     CPPUNIT_TEST(testSetValue);
     CPPUNIT_TEST(testMonotonicity);
     CPPUNIT_TEST(testAttributes);
+    CPPUNIT_TEST(testSteal);
     CPPUNIT_TEST(testTopologyCopy);
     CPPUNIT_TEST(testEquivalence);
     CPPUNIT_TEST(testIterators);
@@ -46,6 +47,7 @@ public:
     void testSetValue();
     void testMonotonicity();
     void testAttributes();
+    void testSteal();
     void testTopologyCopy();
     void testEquivalence();
     void testIterators();
@@ -631,6 +633,39 @@ TestPointDataLeaf::testAttributes()
     const Index64 memUsage = baseLeaf.memUsage() + leaf.attributeSet().memUsage();
 
     CPPUNIT_ASSERT_EQUAL(memUsage, leaf.memUsage());
+}
+
+
+void
+TestPointDataLeaf::testSteal()
+{
+    using AttributeVec3s = TypedAttributeArray<Vec3s>;
+    using Descriptor = AttributeSet::Descriptor;
+
+    // create a descriptor
+
+    Descriptor::Ptr descrA = Descriptor::create(AttributeVec3s::attributeType());
+
+    // create a leaf and initialize attributes using this descriptor
+
+    LeafType leaf(openvdb::Coord(0, 0, 0));
+
+    CPPUNIT_ASSERT_EQUAL(leaf.attributeSet().size(), size_t(0));
+
+    leaf.initializeAttributes(descrA, /*arrayLength=*/100);
+
+    CPPUNIT_ASSERT_EQUAL(leaf.attributeSet().size(), size_t(1));
+
+    // steal the attribute set
+
+    std::unique_ptr<AttributeSet> attributeSet(leaf.stealAttributeSet());
+
+    CPPUNIT_ASSERT(attributeSet);
+    CPPUNIT_ASSERT_EQUAL(attributeSet->size(), size_t(1));
+
+    // ensure a new attribute set has been inserted in it's place
+
+    CPPUNIT_ASSERT_EQUAL(leaf.attributeSet().size(), size_t(0));
 }
 
 

--- a/openvdb/unittest/TestPointDataLeaf.cc
+++ b/openvdb/unittest/TestPointDataLeaf.cc
@@ -658,7 +658,7 @@ TestPointDataLeaf::testSteal()
 
     // steal the attribute set
 
-    std::unique_ptr<AttributeSet> attributeSet(leaf.stealAttributeSet());
+    AttributeSet::UniquePtr attributeSet = leaf.stealAttributeSet();
 
     CPPUNIT_ASSERT(attributeSet);
     CPPUNIT_ASSERT_EQUAL(attributeSet->size(), size_t(1));


### PR DESCRIPTION
Two new additions related to stealing data from a Point Data Grid:

* PointDataLeafNode::stealAttributeSet() - releases ownership of the AttributeSet and replaces it with a new empty AttributeSet.

* AttributeSet::removeAttribute(...) - releases the shared_ptr reference to a specific AttributeArray by index or name and returns it. There is also an "unsafe" variant that doesn't attempt to put the AttributeSet or Descriptor back into a valid state which is useful when you know the AttributeSet is being destroyed and want the extra performance.