### PR TITLE
Proof of concept: Remove OpenEXR (half) dependency.

### DIFF
--- a/openvdb/Grid.cc
+++ b/openvdb/Grid.cc
@@ -338,21 +338,27 @@ GridBase::setCreator(const std::string& creator)
 ////////////////////////////////////////
 
 
-bool
+StoredAsHalf
 GridBase::saveFloatAsHalf() const
 {
     if (Metadata::ConstPtr meta = (*this)[META_SAVE_HALF_FLOAT]) {
-        return meta->asBool();
+        if (meta->asBool()) {
+#ifdef OPENVDB_WITH_OPENEXR_HALF
+            return StoredAsHalf::yes;
+#else
+            throw std::runtime_error("half type not supported");
+#endif
+        }
     }
-    return false;
+    return StoredAsHalf::no;
 }
 
 
 void
-GridBase::setSaveFloatAsHalf(bool saveAsHalf)
+GridBase::setSaveFloatAsHalf(StoredAsHalf saveAsHalf)
 {
     this->removeMeta(META_SAVE_HALF_FLOAT);
-    this->insertMeta(META_SAVE_HALF_FLOAT, BoolMetadata(saveAsHalf));
+    this->insertMeta(META_SAVE_HALF_FLOAT, BoolMetadata(saveAsHalf != StoredAsHalf::no));
 }
 
 

--- a/openvdb/Grid.h
+++ b/openvdb/Grid.h
@@ -279,8 +279,8 @@ public:
 
     /// @brief Return @c true if this grid should be written out with floating-point
     /// voxel values (including components of vectors) quantized to 16 bits.
-    bool saveFloatAsHalf() const;
-    void setSaveFloatAsHalf(bool);
+    StoredAsHalf saveFloatAsHalf() const;
+    void setSaveFloatAsHalf(StoredAsHalf);
 
     /// @brief Return the class of volumetric data (level set, fog volume, etc.)
     /// that is stored in this grid.

--- a/openvdb/Types.h
+++ b/openvdb/Types.h
@@ -6,7 +6,10 @@
 
 #include "version.h"
 #include "Platform.h"
+//#define OPENVDB_WITH_OPENEXR_HALF
+#ifdef OPENVDB_WITH_OPENEXR_HALF
 #include <OpenEXR/half.h>
+#endif
 #include <openvdb/math/Math.h>
 #include <openvdb/math/BBox.h>
 #include <openvdb/math/Quat.h>
@@ -40,8 +43,10 @@ using Real    = double;
 using Vec2R = math::Vec2<Real>;
 using Vec2I = math::Vec2<Index32>;
 using Vec2f = math::Vec2<float>;
+#ifdef OPENVDB_WITH_OPENEXR_HALF
 using Vec2H = math::Vec2<half>;
-using math::Vec2i;
+#endif
+    using math::Vec2i;
 using math::Vec2s;
 using math::Vec2d;
 
@@ -49,7 +54,9 @@ using math::Vec2d;
 using Vec3R = math::Vec3<Real>;
 using Vec3I = math::Vec3<Index32>;
 using Vec3f = math::Vec3<float>;
+#ifdef OPENVDB_WITH_OPENEXR_HALF
 using Vec3H = math::Vec3<half>;
+#endif
 using Vec3U8 = math::Vec3<uint8_t>;
 using Vec3U16 = math::Vec3<uint16_t>;
 using math::Vec3i;
@@ -64,7 +71,9 @@ using BBoxd = math::BBox<Vec3d>;
 using Vec4R = math::Vec4<Real>;
 using Vec4I = math::Vec4<Index32>;
 using Vec4f = math::Vec4<float>;
+#ifdef OPENVDB_WITH_OPENEXR_HALF
 using Vec4H = math::Vec4<half>;
+#endif
 using math::Vec4i;
 using math::Vec4s;
 using math::Vec4d;
@@ -83,6 +92,22 @@ using math::Mat4d;
 using QuatR = math::Quat<Real>;
 using math::Quats;
 using math::Quatd;
+
+// Type-safe flag for reading/writing as half.
+enum class StoredAsHalf {
+    no,
+#ifdef OPENVDB_WITH_OPENEXR_HALF
+    yes
+#endif
+};
+
+#ifdef OPENVDB_WITH_OPENEXR_HALF
+#define OPENVDB_DEFAULT_STORAGE_IF_NO_OPENEXR_HALF
+#else
+#define OPENVDB_DEFAULT_STORAGE_IF_NO_OPENEXR_HALF = StoredAsHalf::no
+#endif
+
+
 
 // Dummy type for a voxel with a binary mask value, e.g. the active state
 class ValueMask {};
@@ -515,7 +540,9 @@ enum MergePolicy {
 template<typename T> const char* typeNameAsString()                 { return typeid(T).name(); }
 template<> inline const char* typeNameAsString<bool>()              { return "bool"; }
 template<> inline const char* typeNameAsString<ValueMask>()         { return "mask"; }
+#ifdef OPENVDB_WITH_OPENEXR_HALF
 template<> inline const char* typeNameAsString<half>()              { return "half"; }
+#endif
 template<> inline const char* typeNameAsString<float>()             { return "float"; }
 template<> inline const char* typeNameAsString<double>()            { return "double"; }
 template<> inline const char* typeNameAsString<int8_t>()            { return "int8"; }

--- a/openvdb/io/GridDescriptor.h
+++ b/openvdb/io/GridDescriptor.h
@@ -20,7 +20,7 @@ class OPENVDB_API GridDescriptor
 {
 public:
     GridDescriptor();
-    GridDescriptor(const Name& name, const Name& gridType, bool saveFloatAsHalf = false);
+    GridDescriptor(const Name& name, const Name& gridType, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no);
     GridDescriptor(const GridDescriptor&) = default;
     GridDescriptor& operator=(const GridDescriptor&) = default;
     ~GridDescriptor();
@@ -33,7 +33,7 @@ public:
     void setInstanceParentName(const Name& name) { mInstanceParentName = name; }
     bool isInstance() const { return !mInstanceParentName.empty(); }
 
-    bool saveFloatAsHalf() const { return mSaveFloatAsHalf; }
+    StoredAsHalf saveFloatAsHalf() const { return mSaveFloatAsHalf; }
 
     void setGridPos(int64_t pos) { mGridPos = pos; }
     int64_t getGridPos() const { return mGridPos; }
@@ -89,7 +89,7 @@ private:
     /// The type of the grid
     Name mGridType;
     /// Are floats quantized to 16 bits on disk?
-    bool mSaveFloatAsHalf;
+    StoredAsHalf mSaveFloatAsHalf;
     /// Location in the stream where the grid data is stored
     int64_t mGridPos;
     /// Location in the stream where the grid blocks are stored

--- a/openvdb/io/io.h
+++ b/openvdb/io/io.h
@@ -59,8 +59,8 @@ public:
     const void* backgroundPtr() const;
     void setBackgroundPtr(const void*);
 
-    bool halfFloat() const;
-    void setHalfFloat(bool);
+    StoredAsHalf halfFloat() const;
+    void setHalfFloat(StoredAsHalf);
 
     bool writeGridStats() const;
     void setWriteGridStats(bool);
@@ -223,10 +223,10 @@ OPENVDB_API void setGridClass(std::ios_base&, uint32_t);
 
 /// @brief Return true if floating-point values should be quantized to 16 bits when writing
 /// to the given stream or promoted back from 16-bit to full precision when reading from it.
-OPENVDB_API bool getHalfFloat(std::ios_base&);
+OPENVDB_API StoredAsHalf getHalfFloat(std::ios_base&);
 /// @brief Specify whether floating-point values should be quantized to 16 bits when writing
 /// to the given stream or promoted back from 16-bit to full precision when reading from it.
-OPENVDB_API void setHalfFloat(std::ios_base&, bool);
+OPENVDB_API void setHalfFloat(std::ios_base&, StoredAsHalf);
 
 /// @brief Return a pointer to the background value of the grid
 /// currently being read from or written to the given stream.

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -463,7 +463,9 @@ struct AttributeArray::Accessor : public AttributeArray::AccessorBase
 namespace attribute_traits
 {
     template <typename T> struct TruncateTrait { };
+#ifdef OPENVDB_WITH_OPENEXR_HALF
     template <> struct TruncateTrait<float> { using Type = half; };
+#endif
     template <> struct TruncateTrait<int> { using Type = short; };
 
     template <typename T> struct TruncateTrait<math::Vec3<T>> {
@@ -1379,7 +1381,11 @@ TypedAttributeArray<ValueType_, Codec_>::valueTypeIsFloatingPoint() const
     using ElementT = typename VecTraits<ValueType>::ElementType;
 
     // half is not defined as float point as expected, so explicitly handle it
-    return std::is_floating_point<ElementT>::value || std::is_same<half, ElementT>::value;
+    return (std::is_floating_point<ElementT>::value
+#ifdef OPENVDB_WITH_OPENEXR_HALF
+            || std::is_same<half, ElementT>::value
+#endif
+            );
 }
 
 
@@ -1388,7 +1394,11 @@ bool
 TypedAttributeArray<ValueType_, Codec_>::valueTypeIsClass() const
 {
     // half is not defined as a non-class type as expected, so explicitly exclude it
-    return std::is_class<ValueType>::value && !std::is_same<half, ValueType>::value;
+    return (std::is_class<ValueType>::value
+#ifdef OPENVDB_WITH_OPENEXR_HALF
+            && !std::is_same<half, ValueType>::value
+#endif
+            );
 }
 
 

--- a/openvdb/points/PointDataGrid.h
+++ b/openvdb/points/PointDataGrid.h
@@ -48,7 +48,7 @@ namespace io
 template<>
 inline void
 readCompressedValues(   std::istream& is, PointDataIndex32* destBuf, Index destCount,
-                        const util::NodeMask<3>& /*valueMask*/, bool /*fromHalf*/)
+                        const util::NodeMask<3>& /*valueMask*/, StoredAsHalf /*fromHalf*/)
 {
     using compression::bloscDecompress;
 
@@ -109,7 +109,7 @@ template<>
 inline void
 writeCompressedValues(  std::ostream& os, PointDataIndex32* srcBuf, Index srcCount,
                         const util::NodeMask<3>& /*valueMask*/,
-                        const util::NodeMask<3>& /*childMask*/, bool /*toHalf*/)
+                        const util::NodeMask<3>& /*childMask*/, StoredAsHalf /*toHalf*/)
 {
     using compression::bloscCompress;
 
@@ -493,14 +493,14 @@ public:
 
     // I/O methods
 
-    void readTopology(std::istream& is, bool fromHalf = false);
-    void writeTopology(std::ostream& os, bool toHalf = false) const;
+    void readTopology(std::istream& is, StoredAsHalf fromHalf = StoredAsHalf::no);
+    void writeTopology(std::ostream& os, StoredAsHalf toHalf = StoredAsHalf::no) const;
 
     Index buffers() const;
 
-    void readBuffers(std::istream& is, bool fromHalf = false);
-    void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
-    void writeBuffers(std::ostream& os, bool toHalf = false) const;
+    void readBuffers(std::istream& is, StoredAsHalf fromHalf = StoredAsHalf::no);
+    void readBuffers(std::istream& is, const CoordBBox&, StoredAsHalf fromHalf = StoredAsHalf::no);
+    void writeBuffers(std::ostream& os, StoredAsHalf toHalf = StoredAsHalf::no) const;
 
 
     Index64 memUsage() const;
@@ -1120,14 +1120,14 @@ PointDataLeafNode<T, Log2Dim>::setOffsetOnly(Index offset, const ValueType& val)
 
 template<typename T, Index Log2Dim>
 inline void
-PointDataLeafNode<T, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
+PointDataLeafNode<T, Log2Dim>::readTopology(std::istream& is, StoredAsHalf fromHalf)
 {
     BaseLeaf::readTopology(is, fromHalf);
 }
 
 template<typename T, Index Log2Dim>
 inline void
-PointDataLeafNode<T, Log2Dim>::writeTopology(std::ostream& os, bool toHalf) const
+PointDataLeafNode<T, Log2Dim>::writeTopology(std::ostream& os, StoredAsHalf toHalf) const
 {
     BaseLeaf::writeTopology(os, toHalf);
 }
@@ -1146,14 +1146,14 @@ PointDataLeafNode<T, Log2Dim>::buffers() const
 
 template<typename T, Index Log2Dim>
 inline void
-PointDataLeafNode<T, Log2Dim>::readBuffers(std::istream& is, bool fromHalf)
+PointDataLeafNode<T, Log2Dim>::readBuffers(std::istream& is, StoredAsHalf fromHalf)
 {
     this->readBuffers(is, CoordBBox::inf(), fromHalf);
 }
 
 template<typename T, Index Log2Dim>
 inline void
-PointDataLeafNode<T, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& /*bbox*/, bool fromHalf)
+PointDataLeafNode<T, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& /*bbox*/, StoredAsHalf fromHalf)
 {
     struct Local
     {
@@ -1329,7 +1329,7 @@ PointDataLeafNode<T, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& /*
 
 template<typename T, Index Log2Dim>
 inline void
-PointDataLeafNode<T, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
+PointDataLeafNode<T, Log2Dim>::writeBuffers(std::ostream& os, StoredAsHalf toHalf) const
 {
     struct Local
     {

--- a/openvdb/points/points.cc
+++ b/openvdb/points/points.cc
@@ -38,8 +38,10 @@ internal::initialize()
     TypedAttributeArray<math::Quat<double>>::registerType();
 
     // Register attribute arrays with truncate compression
+#ifdef OPENVDB_WITH_OPENEXR_HALF
     TypedAttributeArray<float, TruncateCodec>::registerType();
     TypedAttributeArray<math::Vec3<float>, TruncateCodec>::registerType();
+#endif
 
     // Register attribute arrays with fixed point compression
     TypedAttributeArray<math::Vec3<float>, FixedPointCodec<true>>::registerType();

--- a/openvdb/tools/PointIndexGrid.h
+++ b/openvdb/tools/PointIndexGrid.h
@@ -1481,9 +1481,9 @@ public:
 
     // I/O methods
 
-    void readBuffers(std::istream& is, bool fromHalf = false);
-    void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
-    void writeBuffers(std::ostream& os, bool toHalf = false) const;
+    void readBuffers(std::istream& is, StoredAsHalf fromHalf = StoredAsHalf::no);
+    void readBuffers(std::istream& is, const CoordBBox&, StoredAsHalf fromHalf = StoredAsHalf::no);
+    void writeBuffers(std::ostream& os, StoredAsHalf toHalf = StoredAsHalf::no) const;
 
 
     Index64 memUsage() const;
@@ -1714,7 +1714,7 @@ PointIndexLeafNode<T, Log2Dim>::isEmpty(const CoordBBox& bbox) const
 
 template<typename T, Index Log2Dim>
 inline void
-PointIndexLeafNode<T, Log2Dim>::readBuffers(std::istream& is, bool fromHalf)
+PointIndexLeafNode<T, Log2Dim>::readBuffers(std::istream& is, StoredAsHalf fromHalf)
 {
     BaseLeaf::readBuffers(is, fromHalf);
 
@@ -1728,7 +1728,7 @@ PointIndexLeafNode<T, Log2Dim>::readBuffers(std::istream& is, bool fromHalf)
 
 template<typename T, Index Log2Dim>
 inline void
-PointIndexLeafNode<T, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& bbox, bool fromHalf)
+PointIndexLeafNode<T, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& bbox, StoredAsHalf fromHalf)
 {
     // Read and clip voxel values.
     BaseLeaf::readBuffers(is, bbox, fromHalf);
@@ -1763,7 +1763,7 @@ PointIndexLeafNode<T, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& b
 
 template<typename T, Index Log2Dim>
 inline void
-PointIndexLeafNode<T, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
+PointIndexLeafNode<T, Log2Dim>::writeBuffers(std::ostream& os, StoredAsHalf toHalf) const
 {
     BaseLeaf::writeBuffers(os, toHalf);
 

--- a/openvdb/tree/InternalNode.h
+++ b/openvdb/tree/InternalNode.h
@@ -448,11 +448,11 @@ public:
     //
     // I/O
     //
-    void writeTopology(std::ostream&, bool toHalf = false) const;
-    void readTopology(std::istream&, bool fromHalf = false);
-    void writeBuffers(std::ostream&, bool toHalf = false) const;
-    void readBuffers(std::istream&, bool fromHalf = false);
-    void readBuffers(std::istream&, const CoordBBox&, bool fromHalf = false);
+    void writeTopology(std::ostream&, StoredAsHalf toHalf = StoredAsHalf::no) const;
+    void readTopology(std::istream&, StoredAsHalf fromHalf = StoredAsHalf::no);
+    void writeBuffers(std::ostream&, StoredAsHalf toHalf = StoredAsHalf::no) const;
+    void readBuffers(std::istream&, StoredAsHalf fromHalf = StoredAsHalf::no);
+    void readBuffers(std::istream&, const CoordBBox&, StoredAsHalf fromHalf = StoredAsHalf::no);
 
 
     //
@@ -2182,7 +2182,7 @@ InternalNode<ChildT, Log2Dim>::copyToDense(const CoordBBox& bbox, DenseT& dense)
 
 template<typename ChildT, Index Log2Dim>
 inline void
-InternalNode<ChildT, Log2Dim>::writeTopology(std::ostream& os, bool toHalf) const
+InternalNode<ChildT, Log2Dim>::writeTopology(std::ostream& os, StoredAsHalf toHalf) const
 {
     mChildMask.save(os);
     mValueMask.save(os);
@@ -2207,7 +2207,7 @@ InternalNode<ChildT, Log2Dim>::writeTopology(std::ostream& os, bool toHalf) cons
 
 template<typename ChildT, Index Log2Dim>
 inline void
-InternalNode<ChildT, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
+InternalNode<ChildT, Log2Dim>::readTopology(std::istream& is, StoredAsHalf fromHalf)
 {
     const ValueType background = (!io::getGridBackgroundValuePtr(is) ? zeroVal<ValueType>()
         : *static_cast<const ValueType*>(io::getGridBackgroundValuePtr(is)));
@@ -3021,7 +3021,7 @@ InternalNode<ChildT, Log2Dim>::doVisit2(NodeT& self, OtherChildAllIterT& otherIt
 
 template<typename ChildT, Index Log2Dim>
 inline void
-InternalNode<ChildT, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
+InternalNode<ChildT, Log2Dim>::writeBuffers(std::ostream& os, StoredAsHalf toHalf) const
 {
     for (ChildOnCIter iter = this->cbeginChildOn(); iter; ++iter) {
         iter->writeBuffers(os, toHalf);
@@ -3031,7 +3031,7 @@ InternalNode<ChildT, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
 
 template<typename ChildT, Index Log2Dim>
 inline void
-InternalNode<ChildT, Log2Dim>::readBuffers(std::istream& is, bool fromHalf)
+InternalNode<ChildT, Log2Dim>::readBuffers(std::istream& is, StoredAsHalf fromHalf)
 {
     for (ChildOnIter iter = this->beginChildOn(); iter; ++iter) {
         iter->readBuffers(is, fromHalf);
@@ -3042,7 +3042,7 @@ InternalNode<ChildT, Log2Dim>::readBuffers(std::istream& is, bool fromHalf)
 template<typename ChildT, Index Log2Dim>
 inline void
 InternalNode<ChildT, Log2Dim>::readBuffers(std::istream& is,
-    const CoordBBox& clipBBox, bool fromHalf)
+    const CoordBBox& clipBBox, StoredAsHalf fromHalf)
 {
     for (ChildOnIter iter = this->beginChildOn(); iter; ++iter) {
         // Stream in the branch rooted at this child.

--- a/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/tree/LeafNodeBool.h
@@ -189,15 +189,15 @@ public:
     // I/O methods
     //
     /// Read in just the topology.
-    void readTopology(std::istream&, bool fromHalf = false);
+    void readTopology(std::istream&, StoredAsHalf fromHalf = StoredAsHalf::no);
     /// Write out just the topology.
-    void writeTopology(std::ostream&, bool toHalf = false) const;
+    void writeTopology(std::ostream&, StoredAsHalf toHalf = StoredAsHalf::no) const;
 
     /// Read in the topology and the origin.
-    void readBuffers(std::istream&, bool fromHalf = false);
-    void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
+    void readBuffers(std::istream&, StoredAsHalf fromHalf = StoredAsHalf::no);
+    void readBuffers(std::istream& is, const CoordBBox&, StoredAsHalf fromHalf = StoredAsHalf::no);
     /// Write out the topology and the origin.
-    void writeBuffers(std::ostream&, bool toHalf = false) const;
+    void writeBuffers(std::ostream&, StoredAsHalf toHalf = StoredAsHalf::no) const;
 
     //
     // Accessor methods
@@ -949,7 +949,7 @@ LeafNode<bool, Log2Dim>::offsetToGlobalCoord(Index n) const
 
 template<Index Log2Dim>
 inline void
-LeafNode<bool, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
+LeafNode<bool, Log2Dim>::readTopology(std::istream& is, StoredAsHalf /*fromHalf*/)
 {
     mValueMask.load(is);
 }
@@ -957,7 +957,7 @@ LeafNode<bool, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
 
 template<Index Log2Dim>
 inline void
-LeafNode<bool, Log2Dim>::writeTopology(std::ostream& os, bool /*toHalf*/) const
+LeafNode<bool, Log2Dim>::writeTopology(std::ostream& os, StoredAsHalf /*toHalf*/) const
 {
     mValueMask.save(os);
 }
@@ -965,7 +965,7 @@ LeafNode<bool, Log2Dim>::writeTopology(std::ostream& os, bool /*toHalf*/) const
 
 template<Index Log2Dim>
 inline void
-LeafNode<bool, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& clipBBox, bool fromHalf)
+LeafNode<bool, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& clipBBox, StoredAsHalf fromHalf)
 {
     // Boolean LeafNodes don't currently implement lazy loading.
     // Instead, load the full buffer, then clip it.
@@ -983,7 +983,7 @@ LeafNode<bool, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& clipBBox
 
 template<Index Log2Dim>
 inline void
-LeafNode<bool, Log2Dim>::readBuffers(std::istream& is, bool /*fromHalf*/)
+LeafNode<bool, Log2Dim>::readBuffers(std::istream& is, StoredAsHalf /*fromHalf*/)
 {
     // Read in the value mask.
     mValueMask.load(is);
@@ -1024,7 +1024,7 @@ LeafNode<bool, Log2Dim>::readBuffers(std::istream& is, bool /*fromHalf*/)
 
 template<Index Log2Dim>
 inline void
-LeafNode<bool, Log2Dim>::writeBuffers(std::ostream& os, bool /*toHalf*/) const
+LeafNode<bool, Log2Dim>::writeBuffers(std::ostream& os, StoredAsHalf /*toHalf*/) const
 {
     // Write out the value mask.
     mValueMask.save(os);

--- a/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/tree/LeafNodeMask.h
@@ -193,15 +193,15 @@ public:
     // I/O methods
     //
     /// Read in just the topology.
-    void readTopology(std::istream&, bool fromHalf = false);
+    void readTopology(std::istream&, StoredAsHalf fromHalf = StoredAsHalf::no);
     /// Write out just the topology.
-    void writeTopology(std::ostream&, bool toHalf = false) const;
+    void writeTopology(std::ostream&, StoredAsHalf toHalf = StoredAsHalf::no) const;
 
     /// Read in the topology and the origin.
-    void readBuffers(std::istream&, bool fromHalf = false);
-    void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
+    void readBuffers(std::istream&, StoredAsHalf fromHalf = StoredAsHalf::no);
+    void readBuffers(std::istream& is, const CoordBBox&, StoredAsHalf fromHalf = StoredAsHalf::no);
     /// Write out the topology and the origin.
-    void writeBuffers(std::ostream&, bool toHalf = false) const;
+    void writeBuffers(std::ostream&, StoredAsHalf toHalf = StoredAsHalf::no) const;
 
     //
     // Accessor methods
@@ -945,7 +945,7 @@ LeafNode<ValueMask, Log2Dim>::offsetToGlobalCoord(Index n) const
 
 template<Index Log2Dim>
 inline void
-LeafNode<ValueMask, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
+LeafNode<ValueMask, Log2Dim>::readTopology(std::istream& is, StoredAsHalf /*fromHalf*/)
 {
     mBuffer.mData.load(is);
 }
@@ -953,7 +953,7 @@ LeafNode<ValueMask, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
 
 template<Index Log2Dim>
 inline void
-LeafNode<ValueMask, Log2Dim>::writeTopology(std::ostream& os, bool /*toHalf*/) const
+LeafNode<ValueMask, Log2Dim>::writeTopology(std::ostream& os, StoredAsHalf /*toHalf*/) const
 {
     mBuffer.mData.save(os);
 }
@@ -961,7 +961,7 @@ LeafNode<ValueMask, Log2Dim>::writeTopology(std::ostream& os, bool /*toHalf*/) c
 
 template<Index Log2Dim>
 inline void
-LeafNode<ValueMask, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& clipBBox, bool fromHalf)
+LeafNode<ValueMask, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& clipBBox, StoredAsHalf fromHalf)
 {
     // Boolean LeafNodes don't currently implement lazy loading.
     // Instead, load the full buffer, then clip it.
@@ -979,7 +979,7 @@ LeafNode<ValueMask, Log2Dim>::readBuffers(std::istream& is, const CoordBBox& cli
 
 template<Index Log2Dim>
 inline void
-LeafNode<ValueMask, Log2Dim>::readBuffers(std::istream& is, bool /*fromHalf*/)
+LeafNode<ValueMask, Log2Dim>::readBuffers(std::istream& is, StoredAsHalf /*fromHalf*/)
 {
     // Read in the value mask = buffer.
     mBuffer.mData.load(is);
@@ -990,7 +990,7 @@ LeafNode<ValueMask, Log2Dim>::readBuffers(std::istream& is, bool /*fromHalf*/)
 
 template<Index Log2Dim>
 inline void
-LeafNode<ValueMask, Log2Dim>::writeBuffers(std::ostream& os, bool /*toHalf*/) const
+LeafNode<ValueMask, Log2Dim>::writeBuffers(std::ostream& os, StoredAsHalf /*toHalf*/) const
 {
     // Write out the value mask = buffer.
     mBuffer.mData.save(os);

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -139,16 +139,16 @@ public:
     /// @brief Read the tree topology from a stream.
     ///
     /// This will read the tree structure and tile values, but not voxel data.
-    virtual void readTopology(std::istream&, bool saveFloatAsHalf = false);
+    virtual void readTopology(std::istream&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no);
     /// @brief Write the tree topology to a stream.
     ///
     /// This will write the tree structure and tile values, but not voxel data.
-    virtual void writeTopology(std::ostream&, bool saveFloatAsHalf = false) const;
+    virtual void writeTopology(std::ostream&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no) const;
 
     /// Read all data buffers for this tree.
-    virtual void readBuffers(std::istream&, bool saveFloatAsHalf = false) = 0;
+    virtual void readBuffers(std::istream&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no) = 0;
     /// Read all of this tree's data buffers that intersect the given bounding box.
-    virtual void readBuffers(std::istream&, const CoordBBox&, bool saveFloatAsHalf = false) = 0;
+    virtual void readBuffers(std::istream&, const CoordBBox&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no) = 0;
     /// @brief Read all of this tree's data buffers that are not yet resident in memory
     /// (because delayed loading is in effect).
     /// @details If this tree was read from a memory-mapped file, this operation
@@ -156,7 +156,7 @@ public:
     /// @sa clipUnallocatedNodes, io::File::open, io::MappedFile
     virtual void readNonresidentBuffers() const = 0;
     /// Write out all the data buffers for this tree.
-    virtual void writeBuffers(std::ostream&, bool saveFloatAsHalf = false) const = 0;
+    virtual void writeBuffers(std::ostream&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no) const = 0;
 
     /// @brief Print statistics, memory usage and other information about this tree.
     /// @param os            a stream to which to write textual information
@@ -307,15 +307,15 @@ public:
     /// @brief Read the tree topology from a stream.
     ///
     /// This will read the tree structure and tile values, but not voxel data.
-    void readTopology(std::istream&, bool saveFloatAsHalf = false) override;
+    void readTopology(std::istream&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no) override;
     /// @brief Write the tree topology to a stream.
     ///
     /// This will write the tree structure and tile values, but not voxel data.
-    void writeTopology(std::ostream&, bool saveFloatAsHalf = false) const override;
+    void writeTopology(std::ostream&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no) const override;
     /// Read all data buffers for this tree.
-    void readBuffers(std::istream&, bool saveFloatAsHalf = false) override;
+    void readBuffers(std::istream&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no) override;
     /// Read all of this tree's data buffers that intersect the given bounding box.
-    void readBuffers(std::istream&, const CoordBBox&, bool saveFloatAsHalf = false) override;
+    void readBuffers(std::istream&, const CoordBBox&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no) override;
     /// @brief Read all of this tree's data buffers that are not yet resident in memory
     /// (because delayed loading is in effect).
     /// @details If this tree was read from a memory-mapped file, this operation
@@ -323,7 +323,7 @@ public:
     /// @sa clipUnallocatedNodes, io::File::open, io::MappedFile
     void readNonresidentBuffers() const override;
     /// Write out all data buffers for this tree.
-    void writeBuffers(std::ostream&, bool saveFloatAsHalf = false) const override;
+    void writeBuffers(std::ostream&, StoredAsHalf saveFloatAsHalf = StoredAsHalf::no) const override;
 
     void print(std::ostream& os = std::cout, int verboseLevel = 1) const override;
 
@@ -1260,7 +1260,7 @@ struct Tree5 {
 
 
 inline void
-TreeBase::readTopology(std::istream& is, bool /*saveFloatAsHalf*/)
+TreeBase::readTopology(std::istream& is, StoredAsHalf /*saveFloatAsHalf*/)
 {
     int32_t bufferCount;
     is.read(reinterpret_cast<char*>(&bufferCount), sizeof(int32_t));
@@ -1269,7 +1269,7 @@ TreeBase::readTopology(std::istream& is, bool /*saveFloatAsHalf*/)
 
 
 inline void
-TreeBase::writeTopology(std::ostream& os, bool /*saveFloatAsHalf*/) const
+TreeBase::writeTopology(std::ostream& os, StoredAsHalf /*saveFloatAsHalf*/) const
 {
     int32_t bufferCount = 1;
     os.write(reinterpret_cast<char*>(&bufferCount), sizeof(int32_t));
@@ -1399,7 +1399,7 @@ Tree<RootNodeType>::cbegin() const
 
 template<typename RootNodeType>
 void
-Tree<RootNodeType>::readTopology(std::istream& is, bool saveFloatAsHalf)
+Tree<RootNodeType>::readTopology(std::istream& is, StoredAsHalf saveFloatAsHalf)
 {
     this->clearAllAccessors();
     TreeBase::readTopology(is, saveFloatAsHalf);
@@ -1409,7 +1409,7 @@ Tree<RootNodeType>::readTopology(std::istream& is, bool saveFloatAsHalf)
 
 template<typename RootNodeType>
 void
-Tree<RootNodeType>::writeTopology(std::ostream& os, bool saveFloatAsHalf) const
+Tree<RootNodeType>::writeTopology(std::ostream& os, StoredAsHalf saveFloatAsHalf) const
 {
     TreeBase::writeTopology(os, saveFloatAsHalf);
     mRoot.writeTopology(os, saveFloatAsHalf);
@@ -1418,7 +1418,7 @@ Tree<RootNodeType>::writeTopology(std::ostream& os, bool saveFloatAsHalf) const
 
 template<typename RootNodeType>
 inline void
-Tree<RootNodeType>::readBuffers(std::istream &is, bool saveFloatAsHalf)
+Tree<RootNodeType>::readBuffers(std::istream &is, StoredAsHalf saveFloatAsHalf)
 {
     this->clearAllAccessors();
     mRoot.readBuffers(is, saveFloatAsHalf);
@@ -1427,7 +1427,7 @@ Tree<RootNodeType>::readBuffers(std::istream &is, bool saveFloatAsHalf)
 
 template<typename RootNodeType>
 inline void
-Tree<RootNodeType>::readBuffers(std::istream &is, const CoordBBox& bbox, bool saveFloatAsHalf)
+Tree<RootNodeType>::readBuffers(std::istream &is, const CoordBBox& bbox, StoredAsHalf saveFloatAsHalf)
 {
     this->clearAllAccessors();
     mRoot.readBuffers(is, bbox, saveFloatAsHalf);
@@ -1447,7 +1447,7 @@ Tree<RootNodeType>::readNonresidentBuffers() const
 
 template<typename RootNodeType>
 inline void
-Tree<RootNodeType>::writeBuffers(std::ostream &os, bool saveFloatAsHalf) const
+Tree<RootNodeType>::writeBuffers(std::ostream &os, StoredAsHalf saveFloatAsHalf) const
 {
     mRoot.writeBuffers(os, saveFloatAsHalf);
 }


### PR DESCRIPTION
Proof of concept for https://github.com/AcademySoftwareFoundation/openvdb/issues/638

The idea here is that I added an enum, `StoredAsHalf`, which, if you compile with half, is
`enum class StoredAsHalf { no, yes };`
but if you aren't, it's just 
`enum class StoredAsHalf { no };`
which is to say if you aren't compiling with it, there's no way to request things to be stored as half, so it's typesafe like that.

Additionally, when building without half, `StoredAsHalf` arguments that are typically not defaulted are defaulted to `StoredAsHalf::no`.

Right now it throws an exception when it reads a file that is stored as half but it doesn't know how to read it.

Even if you are compiling with half, this has the advantage of adding type safety to the stored-as-half arguments.