### PR TITLE
Bugfix for relative -isystem paths changing search order

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,9 @@ Version 7.1.0 - In Development
       tools::meshToVolume(). This could cause values to not be propagated across
       node boundaries, leading to voxels incorrectly being marked as inside the
       isosurface. [Contributed by Tristan Barback]
+    - Fixed a bug in the CMake FindIlmBase/OpenEXR modules which could cause
+      compilers on UNIX systems to fail to find stdlib.h if IlmBase/OpenEXR
+      headers were installed to /usr/include.
 
     API changes:
     - Removed a number of deprecated point methods.

--- a/cmake/FindIlmBase.cmake
+++ b/cmake/FindIlmBase.cmake
@@ -295,13 +295,26 @@ if(IlmBase_FOUND)
   set(IlmBase_LIBRARIES ${IlmBase_LIB_COMPONENTS})
 
   # We have to add both include and include/OpenEXR to the include
-  # path in case OpenEXR and IlmBase are installed separately
+  # path in case OpenEXR and IlmBase are installed separately.
+  #
+  # Make sure we get the absolute path to avoid issues where
+  # /usr/include/OpenEXR/../ is picked up and passed to gcc from cmake
+  # which won't correctly compute /usr/include as an implicit system
+  # dir if the path is relative:
+  #
+  # https://github.com/AcademySoftwareFoundation/openvdb/issues/632
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
+
+  set(_IlmBase_Parent_Dir "")
+  get_filename_component(_IlmBase_Parent_Dir
+    ${IlmBase_INCLUDE_DIR}/../ ABSOLUTE)
 
   set(IlmBase_INCLUDE_DIRS)
   list(APPEND IlmBase_INCLUDE_DIRS
-    ${IlmBase_INCLUDE_DIR}/../
+    ${_IlmBase_Parent_Dir}
     ${IlmBase_INCLUDE_DIR}
   )
+  unset(_IlmBase_Parent_Dir)
   set(IlmBase_DEFINITIONS ${PC_IlmBase_CFLAGS_OTHER})
 
   set(IlmBase_LIBRARY_DIRS "")

--- a/cmake/FindOpenEXR.cmake
+++ b/cmake/FindOpenEXR.cmake
@@ -288,13 +288,26 @@ if(OpenEXR_FOUND)
   set(OpenEXR_LIBRARIES ${OpenEXR_LIB_COMPONENTS})
 
   # We have to add both include and include/OpenEXR to the include
-  # path in case OpenEXR and IlmBase are installed separately
+  # path in case OpenEXR and IlmBase are installed separately.
+  #
+  # Make sure we get the absolute path to avoid issues where
+  # /usr/include/OpenEXR/../ is picked up and passed to gcc from cmake
+  # which won't correctly compute /usr/include as an implicit system
+  # dir if the path is relative:
+  #
+  # https://github.com/AcademySoftwareFoundation/openvdb/issues/632
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
+
+  set(_OpenEXR_Parent_Dir "")
+  get_filename_component(_OpenEXR_Parent_Dir
+    ${OpenEXR_INCLUDE_DIR}/../ ABSOLUTE)
 
   set(OpenEXR_INCLUDE_DIRS)
   list(APPEND OpenEXR_INCLUDE_DIRS
-    ${OpenEXR_INCLUDE_DIR}/../
+    ${_OpenEXR_Parent_Dir}
     ${OpenEXR_INCLUDE_DIR}
   )
+  unset(_OpenEXR_Parent_Dir)
   set(OpenEXR_DEFINITIONS ${PC_OpenEXR_CFLAGS_OTHER})
 
   set(OpenEXR_LIBRARY_DIRS "")

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -40,6 +40,9 @@ Bug fixes:
   node boundaries, leading to voxels incorrectly being marked as inside the
   isosurface.
   <I>[Contributed&nbsp;by&nbsp;Tristan&nbsp;Barback]</I>
+- Fixed a bug in the CMake FindIlmBase/OpenEXR modules which could cause
+  compilers on UNIX systems to fail to find stdlib.h if IlmBase/OpenEXR
+  headers were installed to /usr/include.
 
 @par
 API changes:


### PR DESCRIPTION
Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>

As far as I can tell this fixes the problem reported in the following issues:

https://github.com/AcademySoftwareFoundation/openvdb/issues/632
https://github.com/AcademySoftwareFoundation/openvdb/issues/144

and can be reproduced with the following CMake (un-comment `get_filename_component` for the fix)

```cmake
cmake_minimum_required(VERSION 3.1)
project(TEST LANGUAGES CXX)
add_executable(tmp main.cpp)
set(IPATH /usr/include/../include)
#get_filename_component(IPATH ${IPATH} ABSOLUTE)  
target_include_directories(tmp SYSTEM PUBLIC ${IPATH})
```

