### PR TITLE
Disable Windows secure CRT warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,10 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   add_definitions(-DNOMINMAX)
   # Excludes APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets
   add_definitions(-DWIN32_LEAN_AND_MEAN)
+  # Disable non-secure CRT library function warnings
+  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/
+  #     compiler-warning-level-3-c4996?view=vs-2019#unsafe-crt-library-functions
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
   if(NOT OPENVDB_CXX_STRICT)
     message(STATUS "Suppressing some noisy MSVC CXX warnings, "
       "set OPENVDB_CXX_STRICT=ON to re-enable them.")

--- a/openvdb/io/Archive.cc
+++ b/openvdb/io/Archive.cc
@@ -1083,10 +1083,11 @@ bool
 Archive::isDelayedLoadingEnabled()
 {
 #if defined(_MSC_VER)
-    char* s;
-    _dupenv_s(&s, nullptr, "OPENVDB_DISABLE_DELAYED_LOAD");
-    std::unique_ptr<char, decltype(std::free)*> sptr { s, std::free };
-    return !static_cast<bool>(sptr);
+    char* value;
+    _dupenv_s(&value, nullptr, "OPENVDB_DISABLE_DELAYED_LOAD");
+    if (!value) return true;
+    free(value);
+    return false;
 #else
     return (nullptr == std::getenv("OPENVDB_DISABLE_DELAYED_LOAD"));
 #endif

--- a/openvdb/io/Archive.cc
+++ b/openvdb/io/Archive.cc
@@ -1082,15 +1082,7 @@ Archive::connectInstance(const GridDescriptor& gd, const NamedGridMap& grids) co
 bool
 Archive::isDelayedLoadingEnabled()
 {
-#if defined(_MSC_VER)
-    char* value;
-    _dupenv_s(&value, nullptr, "OPENVDB_DISABLE_DELAYED_LOAD");
-    if (!value) return true;
-    free(value);
-    return false;
-#else
     return (nullptr == std::getenv("OPENVDB_DISABLE_DELAYED_LOAD"));
-#endif
 }
 
 

--- a/openvdb/io/File.cc
+++ b/openvdb/io/File.cc
@@ -71,20 +71,10 @@ struct File::Impl
     static Index64 getDefaultCopyMaxBytes()
     {
         Index64 result = DEFAULT_COPY_MAX_BYTES;
-#if defined(_MSC_VER)
-        char* s;
-        _dupenv_s(&s, nullptr, "OPENVDB_DISABLE_DELAYED_LOAD");
-        if (s) {
-            char* endptr = nullptr;
-            result = std::strtoul(s, &endptr, /*base=*/10);
-            free(s);
-        }
-#else
         if (const char* s = std::getenv("OPENVDB_DELAYED_LOAD_COPY_MAX_BYTES")) {
             char* endptr = nullptr;
             result = std::strtoul(s, &endptr, /*base=*/10);
         }
-#endif
         return result;
     }
 

--- a/openvdb/io/File.cc
+++ b/openvdb/io/File.cc
@@ -72,16 +72,19 @@ struct File::Impl
     {
         Index64 result = DEFAULT_COPY_MAX_BYTES;
 #if defined(_MSC_VER)
-        char* s = nullptr;
-        _dupenv_s(&s, nullptr, "OPENVDB_DELAYED_LOAD_COPY_MAX_BYTES");
-        std::unique_ptr<char, decltype(std::free)*> sptr { s, std::free };
-#else
-        const char* s = std::getenv("OPENVDB_DELAYED_LOAD_COPY_MAX_BYTES");
-#endif
+        char* s;
+        _dupenv_s(&s, nullptr, "OPENVDB_DISABLE_DELAYED_LOAD");
         if (s) {
             char* endptr = nullptr;
             result = std::strtoul(s, &endptr, /*base=*/10);
+            free(s);
         }
+#else
+        if (const char* s = std::getenv("OPENVDB_DELAYED_LOAD_COPY_MAX_BYTES")) {
+            char* endptr = nullptr;
+            result = std::strtoul(s, &endptr, /*base=*/10);
+        }
+#endif
         return result;
     }
 

--- a/openvdb/io/TempFile.cc
+++ b/openvdb/io/TempFile.cc
@@ -15,8 +15,8 @@
 #include <unistd.h> // for access()
 #else
 #include <fstream> // for std::filebuf
+#include <cstdio> // for std::tmpnam_s(), L_tmpnam_s
 #endif
-#include <cstdio> // for tmpnam_s(), L_tmpnam_s, P_tmpdir
 #include <iostream>
 #include <sstream>
 #include <string>

--- a/openvdb/io/TempFile.cc
+++ b/openvdb/io/TempFile.cc
@@ -15,8 +15,8 @@
 #include <unistd.h> // for access()
 #else
 #include <fstream> // for std::filebuf
-#include <cstdio> // for std::tmpnam_s(), L_tmpnam_s
 #endif
+#include <cstdio> // for std::tmpnam(), L_tmpnam, P_tmpdir
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -90,22 +90,21 @@ struct TempFile::TempFileImpl
     BufferType mBuffer;
     int mFileDescr;
 #else // _MSC_VER
-    // Use Windows only methods (tmpnam_s); no POSIX.
+    // Use only standard library routines; no POSIX.
 
     TempFileImpl(std::ostream& os) { this->init(os); }
 
     void init(std::ostream& os)
     {
-        char fnbuf[L_tmpnam_s];
-        errno_t err = tmpnam_s(fnbuf, L_tmpnam_s);
-        if (err) {
+        char fnbuf[L_tmpnam];
+        const char* filename = std::tmpnam(fnbuf);
+        if (!filename) {
             OPENVDB_THROW(IoError, "failed to generate name for temporary file");
         }
-
         /// @todo This is not safe, since another process could open a file
         /// with this name before we do.  Unfortunately, there is no safe,
         /// portable way to create a temporary file.
-        mPath = fnbuf;
+        mPath = filename;
 
         const std::ios_base::openmode mode = (std::ios_base::out | std::ios_base::binary);
         os.rdbuf(mBuffer.open(mPath.c_str(), mode));


### PR DESCRIPTION
This PR reverts some of the MSVC branching made to silence compiler warnings in #644 and instead adds the `-D_CRT_SECURE_NO_WARNINGS` define. Note that this define is not the same as `_CRT_NONSTDC_NO_WARNINGS` which was bundled into PR #646.

Note that additional conversation regarding these warnings can be found on https://github.com/AcademySoftwareFoundation/openvdb/pull/646. Further information as follows:

- MS documentation on C4996: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=vs-2019#posix-function-names
- Original TR for "Bounds Checking" APIs: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1225.pdf
- Review and proposal for deprecation: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1967.htm
