### PR TITLE
VDB Combine in Flatten All mode shouldn't error with no second input

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,7 @@ Version 7.1.0 - In Development
     Houdini:
     - Platonic SOP is now verbified.
     - Extend all SOP references to support VDB Points.
+    - Combine SOP will not error in flatten-all mode if second has no grids.
 
 
 Version 7.0.0 - December 6, 2019

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -74,6 +74,7 @@ API changes:
 Houdini:
 - Platonic SOP is now verbified.
 - Extend all SOP references to support VDB Points.
+- Combine SOP will not error in flatten-all mode if second has no grids.
 
 
 @htmlonly <a name="v7_0_0_changes"></a>@endhtmlonly

--- a/openvdb_houdini/SOP_OpenVDB_Combine.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Combine.cc
@@ -682,8 +682,10 @@ SOP_OpenVDB_Combine::Cache::cookVDBSop(OP_Context& context)
                     }
                     break;
                 case COLL_FLATTEN_B_TO_A:
-                    aVdbVec.push_back(*aIt);
-                    bVdbVec.push_back(*bIt);
+                    if (*bIt) {
+                        aVdbVec.push_back(*aIt);
+                        bVdbVec.push_back(*bIt);
+                    }
                     for (++bIt; bIt; ++bIt) {
                         aVdbVec.push_back(nullptr);
                         bVdbVec.push_back(*bIt);


### PR DESCRIPTION
Before the collation re-write, the VDB Combine would silently do nothing if the second input was empty and Flatten All B into A was toggled. The new drop down menu, however, errors in this case. By testing the b iterator, we can avoid generating a pair in this case and restore the previous behaviour.

Bug: 103362