### PR TITLE
resolves #613 : Added CMake option to disable pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ list will be searched.]=] OFF)
 option(OPENVDB_USE_DEPRECATED_ABI "Bypass minimum ABI requirement checks" OFF)
 option(OPENVDB_FUTURE_DEPRECATION "Generate messages for upcoming deprecation" OFF)
 option(USE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." OFF)
+option(USE_PKGCONFIG "Globally disable/enable the use of pkg-config" ON)
 
 set(SYSTEM_LIBRARY_PATHS "" CACHE STRING [=[
 A global list of library paths to additionally use into when searching for dependencies.]=])

--- a/cmake/FindBlosc.cmake
+++ b/cmake/FindBlosc.cmake
@@ -100,11 +100,12 @@ elseif(DEFINED ENV{BLOSC_ROOT})
 endif()
 
 # Additionally try and use pkconfig to find blosc
-
-if(NOT DEFINED PKG_CONFIG_FOUND)
-  find_package(PkgConfig)
+if(USE_PKGCONFIG)
+  if(NOT DEFINED PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+  endif()
+  pkg_check_modules(PC_Blosc QUIET blosc)
 endif()
-pkg_check_modules(PC_Blosc QUIET blosc)
 
 # ------------------------------------------------------------------------
 #  Search for blosc include DIR

--- a/cmake/FindCppUnit.cmake
+++ b/cmake/FindCppUnit.cmake
@@ -102,11 +102,12 @@ elseif(DEFINED ENV{CPPUNIT_ROOT})
 endif()
 
 # Additionally try and use pkconfig to find cppunit
-
-if(NOT DEFINED PKG_CONFIG_FOUND)
-  find_package(PkgConfig)
+if(USE_PKGCONFIG)
+  if(NOT DEFINED PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+  endif()
+  pkg_check_modules(PC_CppUnit QUIET cppunit)
 endif()
-pkg_check_modules(PC_CppUnit QUIET cppunit)
 
 # ------------------------------------------------------------------------
 #  Search for CppUnit include DIR

--- a/cmake/FindIlmBase.cmake
+++ b/cmake/FindIlmBase.cmake
@@ -143,11 +143,12 @@ elseif(DEFINED ENV{ILMBASE_ROOT})
 endif()
 
 # Additionally try and use pkconfig to find IlmBase
-
-if(NOT DEFINED PKG_CONFIG_FOUND)
-  find_package(PkgConfig)
+if(USE_PKGCONFIG)
+  if(NOT DEFINED PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+  endif()
+  pkg_check_modules(PC_IlmBase QUIET IlmBase)
 endif()
-pkg_check_modules(PC_IlmBase QUIET IlmBase)
 
 # ------------------------------------------------------------------------
 #  Search for IlmBase include DIR

--- a/cmake/FindLog4cplus.cmake
+++ b/cmake/FindLog4cplus.cmake
@@ -102,11 +102,12 @@ elseif(DEFINED ENV{LOG4CPLUS_ROOT})
 endif()
 
 # Additionally try and use pkconfig to find log4cplus
-
-if(NOT DEFINED PKG_CONFIG_FOUND)
-  find_package(PkgConfig)
+if(USE_PKGCONFIG)
+  if(NOT DEFINED PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+  endif()
+  pkg_check_modules(PC_Log4cplus QUIET log4cplus)
 endif()
-pkg_check_modules(PC_Log4cplus QUIET log4cplus)
 
 # ------------------------------------------------------------------------
 #  Search for Log4cplus include DIR

--- a/cmake/FindOpenEXR.cmake
+++ b/cmake/FindOpenEXR.cmake
@@ -136,11 +136,12 @@ elseif(DEFINED ENV{OPENEXR_ROOT})
 endif()
 
 # Additionally try and use pkconfig to find OpenEXR
-
-if(NOT DEFINED PKG_CONFIG_FOUND)
-  find_package(PkgConfig)
+if(USE_PKGCONFIG)
+  if(NOT DEFINED PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+  endif()
+  pkg_check_modules(PC_OpenEXR QUIET OpenEXR)
 endif()
-pkg_check_modules(PC_OpenEXR QUIET OpenEXR)
 
 # ------------------------------------------------------------------------
 #  Search for OpenEXR include DIR

--- a/cmake/FindOpenVDB.cmake
+++ b/cmake/FindOpenVDB.cmake
@@ -143,11 +143,12 @@ elseif(DEFINED ENV{OPENVDB_ROOT})
 endif()
 
 # Additionally try and use pkconfig to find OpenVDB
-
-if(NOT DEFINED PKG_CONFIG_FOUND)
-  find_package(PkgConfig)
+if(USE_PKGCONFIG)
+  if(NOT DEFINED PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+  endif()
+  pkg_check_modules(PC_OpenVDB QUIET OpenVDB)
 endif()
-pkg_check_modules(PC_OpenVDB QUIET OpenVDB)
 
 # This CMake module supports being called from external packages AND from
 # within the OpenVDB repository for building openvdb components with the

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -127,11 +127,12 @@ elseif(DEFINED ENV{TBB_ROOT})
 endif()
 
 # Additionally try and use pkconfig to find Tbb
-
-if(NOT DEFINED PKG_CONFIG_FOUND)
-  find_package(PkgConfig)
+if(USE_PKGCONFIG)
+  if(NOT DEFINED PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+  endif()
+  pkg_check_modules(PC_Tbb QUIET tbb)
 endif()
-pkg_check_modules(PC_Tbb QUIET tbb)
 
 # ------------------------------------------------------------------------
 #  Search for tbb include DIR

--- a/cmake/OpenVDBGLFW3Setup.cmake
+++ b/cmake/OpenVDBGLFW3Setup.cmake
@@ -68,10 +68,12 @@ endif()
 # Additionally try and use pkconfig to find glfw, though we only use
 # pkg-config to re-direct to the cmake. In other words, glfw's cmake is
 # expected to be installed
-if(NOT DEFINED PKG_CONFIG_FOUND)
-  find_package(PkgConfig)
+if(USE_PKGCONFIG)
+  if(NOT DEFINED PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+  endif()
+  pkg_check_modules(PC_glfw3 QUIET glfw3)
 endif()
-pkg_check_modules(PC_glfw3 QUIET glfw3)
 
 if(PC_glfw3_FOUND)
   foreach(DIR ${PC_glfw3_LIBRARY_DIRS})


### PR DESCRIPTION
Added CMake option `USE_PKGCONFIG` to the root level CMakeLists.txt, followed by checks inside `openvdb/cmake/*.cmake` files according to patch mentioned in #613 .

Signed-off-by: KartikShrivastava <shrivastavakartik19@gmail.com>