### PR TITLE
Use the single-character search rather than string search.

### DIFF
--- a/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
+++ b/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
@@ -46,7 +46,7 @@ evalAttrType(const UT_String& attrStr, UT_String& attrName, int& attrClass)
 {
     std::string str = attrStr.toStdString();
 
-    const size_t idx = str.find_first_of(".");
+    const size_t idx = str.find_first_of('.');
     if (idx == std::string::npos) return false;
 
     attrName = str.substr(idx + 1, str.size() - 1);


### PR DESCRIPTION
The findfirstof can take a single char, which will be better than using a string of one character.