### PR TITLE
Include version.h rather than Platform.h.

### DIFF
--- a/openvdb_houdini/ParmFactory.h
+++ b/openvdb_houdini/ParmFactory.h
@@ -27,7 +27,7 @@
     #define OPENVDB_HOUDINI_API
   #endif
 #else
-  #include <openvdb/Platform.h>
+  #include <openvdb/version.h>
 #endif
 #include <exception>
 #include <functional>


### PR DESCRIPTION
Include version.h rather than Platform.h.  The former will setup the ABI properly, and we now rely on ABI set properly for our destructor virtualization.  Otherwise missing ABI becomes old-school version, and we violate ODR on linking.