### PR TITLE
Temporarily disable H18 debug build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,16 +111,16 @@ jobs:
     - name: test
       run: ./ci/test.sh
 
-  testhou180debug:
-    runs-on: ubuntu-16.04
-    container:
-      image: aswf/ci-base:2019
-    steps:
-    - uses: actions/checkout@v1
-    - name: houdini
-      run: ./ci/install_houdini.sh 18.0 ${{ secrets.HOUPASS }}
-    - name: build
-      run: ./ci/build_houdini.sh clang++ Debug OFF
+  # testhou180debug:
+  #   runs-on: ubuntu-16.04
+  #   container:
+  #     image: aswf/ci-base:2019
+  #   steps:
+  #   - uses: actions/checkout@v1
+  #   - name: houdini
+  #     run: ./ci/install_houdini.sh 18.0 ${{ secrets.HOUPASS }}
+  #   - name: build
+  #     run: ./ci/build_houdini.sh clang++ Debug OFF
 
   testabi7gcc:
     runs-on: ubuntu-16.04


### PR DESCRIPTION
This job has been sporadically failing on both Azure and Github Actions and is caused by running out of disk space on the virtual machine when building all the debug DSOs. Until recently, the VMs were generally providing more than their stated disk space, but that has been changed recently.

There are a few options to properly resolve this (which I hope we can discuss tomorrow), but for now, I think it's best to just disable this build.