### PR TITLE
Fix CpuTimer Unit Test

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,8 @@ Version 7.1.0 - In Development
       that caused it to fail to decompose some matrices.
     - Fixed a bug where math::Quat::inverse() was not marked as const.
       [Contributed by Michael Tao]
+    - Fixed a bug in the unit test for util::CpuTimer on Windows by using a
+      more accurate sleep implementation.
 
     API changes:
     - Removed a number of deprecated point methods.

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -53,6 +53,8 @@ Bug fixes:
 - Fixed a bug where @vdblink::math::Quat::inverse() Quat::inverse@endlink was
   not marked as const.
   <I>[Contributed&nbsp;by&nbsp;Michael&nbsp;Tao]</I>
+- Fixed a bug in the unit test for util::CpuTimer on Windows by using a more
+  accurate sleep implementation.
 
 @par
 API changes:

--- a/openvdb/unittest/TestUtil.cc
+++ b/openvdb/unittest/TestUtil.cc
@@ -3,7 +3,6 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
-#include <tbb/tbb_thread.h>
 #include <tbb/task_scheduler_init.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
@@ -14,6 +13,7 @@
 #include <openvdb/util/PagedArray.h>
 #include <openvdb/util/Formats.h>
 
+#include <chrono>
 #include <iostream>
 
 //#define BENCHMARK_PAGED_ARRAY
@@ -136,25 +136,37 @@ TestUtil::testFormats()
 void
 TestUtil::testCpuTimer()
 {
-    const int expected = 159, tolerance = 20;//milliseconds
-    const tbb::tick_count::interval_t sec(expected/1000.0);
+    // std::this_thread::sleep_for() only guarantees that the time slept is no less
+    // than the requested time, which can be inaccurate, particularly on Windows,
+    // so use this more accurate, but non-asynchronous implementation for unit testing
+    auto sleep_for = [&](int ms) -> void
     {
-      openvdb::util::CpuTimer timer;
-      tbb::this_tbb_thread::sleep(sec);
-      const int actual1 = static_cast<int>(timer.milliseconds());
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, actual1, tolerance);
-      tbb::this_tbb_thread::sleep(sec);
-      const int actual2 = static_cast<int>(timer.milliseconds());
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(2*expected, actual2, tolerance);
+        auto start = std::chrono::high_resolution_clock::now();
+        while (true) {
+            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::high_resolution_clock::now() - start);
+            if (duration.count() > ms)    return;
+        }
+    };
+
+    const int expected = 159, tolerance = 20;//milliseconds
+    {
+        openvdb::util::CpuTimer timer;
+        sleep_for(expected);
+        const int actual1 = static_cast<int>(timer.milliseconds());
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, actual1, tolerance);
+        sleep_for(expected);
+        const int actual2 = static_cast<int>(timer.milliseconds());
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(2*expected, actual2, tolerance);
     }
     {
-      openvdb::util::CpuTimer timer;
-      tbb::this_tbb_thread::sleep(sec);
-      auto t1 = timer.restart();
-      tbb::this_tbb_thread::sleep(sec);
-      tbb::this_tbb_thread::sleep(sec);
-      auto t2 = timer.restart();
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(2*t1, t2, tolerance);
+        openvdb::util::CpuTimer timer;
+        sleep_for(expected);
+        auto t1 = timer.restart();
+        sleep_for(expected);
+        sleep_for(expected);
+        auto t2 = timer.restart();
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(2*t1, t2, tolerance);
     }
 }
 


### PR DESCRIPTION
As discussed, this PR fixes the util::CpuTimer unit test on Windows by using a more accurate sleep implementation.

This does **not** include any changes to the util::CpuTimer class itself - those will remain for further discussion/investigation in #690.