### PR TITLE
Replace use of computeQuickBounds with getBBox.

### DIFF
--- a/openvdb_houdini/SOP_OpenVDB_Clip.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Clip.cc
@@ -576,7 +576,7 @@ SOP_OpenVDB_Clip::Cache::cookVDBSop(OP_Context& context)
                 }
             } else {
                 UT_BoundingBox box;
-                maskGeo->computeQuickBounds(box);
+                maskGeo->getBBox(&box);
 
                 clipBox.min()[0] = box.xmin();
                 clipBox.min()[1] = box.ymin();

--- a/openvdb_houdini/SOP_OpenVDB_Fill.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Fill.cc
@@ -364,7 +364,7 @@ SOP_OpenVDB_Fill::Cache::cookVDBSop(OP_Context& context)
                 openvdb::BBoxd bbox;
                 if (const GU_Detail* refGeo = inputGeo(1)) {
                     UT_BoundingBox b;
-                    refGeo->computeQuickBounds(b);
+                    refGeo->getBBox(&b);
                     if (!b.isValid()) {
                         throw std::runtime_error("no reference geometry found");
                     }

--- a/openvdb_houdini/SOP_OpenVDB_Points_Group.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Points_Group.cc
@@ -612,7 +612,7 @@ SOP_OpenVDB_Points_Group::Cache::evalGroupParms(
                 refGdp->enlargeBoundingBox(box, range);
             }
             else {
-                refGdp->computeQuickBounds(box);
+                refGdp->getBBox(&box);
             }
 
             parms.mBBox.min()[0] = box.xmin();

--- a/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
@@ -104,7 +104,7 @@ getMaskGeoBBox(const GU_Detail * geoPt)
 {
     if (geoPt) {
         UT_BoundingBox box;
-        geoPt->computeQuickBounds(box);
+        geoPt->getBBox(&box);
 
         UT_SharedPtr<openvdb::BBoxd> bbox(new openvdb::BBoxd());
         bbox->min()[0] = box.xmin();

--- a/openvdb_houdini/SOP_OpenVDB_Read.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Read.cc
@@ -349,7 +349,7 @@ SOP_OpenVDB_Read::cookVDBSop(OP_Context& context)
         if (clip) {
             if (const GU_Detail* clipGeo = inputGeo(0)) {
                 UT_BoundingBox box;
-                clipGeo->computeQuickBounds(box);
+                clipGeo->getBBox(&box);
                 clipBBox.min()[0] = box.xmin();
                 clipBBox.min()[1] = box.ymin();
                 clipBBox.min()[2] = box.zmin();

--- a/openvdb_houdini/SOP_OpenVDB_Remove_Divergence.cc
+++ b/openvdb_houdini/SOP_OpenVDB_Remove_Divergence.cc
@@ -872,7 +872,7 @@ SOP_OpenVDB_Remove_Divergence::Cache::cookVDBSop(
             if (colliderTypeStr == "bbox") {
                 // Use the bounding box of the reference geometry as a collider.
                 UT_BoundingBox box;
-                colliderGeo->computeQuickBounds(box);
+                colliderGeo->getBBox(&box);
                 parms.colliderBBox.min() = openvdb::Vec3d(box.xmin(), box.ymin(), box.zmin());
                 parms.colliderBBox.max() = openvdb::Vec3d(box.xmax(), box.ymax(), box.zmax());
                 parms.colliderType = CT_BBOX;


### PR DESCRIPTION
Addresses issue: Use GEO_Detail::getBBox Instead of GEO_Detail::computeQuickBounds #615
Signed-off-by: kubaroth <kubaroth@gmail.com>