### PR TITLE
Fix AttributeArray Default Value Bug

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,9 @@ Version 7.1.0 - In Development
       [Contributed by Michael Tao]
     - Fixed a bug in the unit test for util::CpuTimer on Windows by using a
       more accurate sleep implementation.
+    - Fixed a bug where the requested uniform value of an AttributeArray was
+      not being applied on attribute creation if the default attribute value
+      was not the default value for that value type.
 
     API changes:
     - Removed a number of deprecated point methods.

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -55,6 +55,10 @@ Bug fixes:
   <I>[Contributed&nbsp;by&nbsp;Michael&nbsp;Tao]</I>
 - Fixed a bug in the unit test for util::CpuTimer on Windows by using a more
   accurate sleep implementation.
+- Fixed a bug where the requested uniform value of an
+  @vdblink::points::AttributeArray AttributeArray@endlink was not being applied
+  on attribute creation if the default attribute value was not the default
+  value for that value type.
 
 @par
 API changes:

--- a/openvdb/points/PointAttribute.h
+++ b/openvdb/points/PointAttribute.h
@@ -321,7 +321,13 @@ inline void appendAttribute(PointDataTreeT& tree,
     appendAttribute(tree, name, AttributeTypeConversion<ValueType, CodecType>::type(),
         strideOrTotalSize, constantStride, defaultValue, hidden, transient);
 
-    if (!defaultValue || !math::isExactlyEqual(uniformValue, defaultValue->value())) {
+    // if the uniform value is equal to either the default value provided
+    // through the metadata argument or the default value for this value type,
+    // it is not necessary to perform the collapse
+
+    const bool uniformIsDefault = math::isExactlyEqual(uniformValue,
+            bool(defaultValue) ? defaultValue->value() : Default<ValueType>::value());
+    if (!uniformIsDefault) {
         MetadataStorage<PointDataTreeT, ValueType>::add(tree, uniformValue);
         collapseAttribute<ValueType>(tree, name, uniformValue);
     }

--- a/openvdb/points/PointAttribute.h
+++ b/openvdb/points/PointAttribute.h
@@ -321,7 +321,7 @@ inline void appendAttribute(PointDataTreeT& tree,
     appendAttribute(tree, name, AttributeTypeConversion<ValueType, CodecType>::type(),
         strideOrTotalSize, constantStride, defaultValue, hidden, transient);
 
-    if (!math::isExactlyEqual(uniformValue, Default<ValueType>::value())) {
+    if (!defaultValue || !math::isExactlyEqual(uniformValue, defaultValue->value())) {
         MetadataStorage<PointDataTreeT, ValueType>::add(tree, uniformValue);
         collapseAttribute<ValueType>(tree, name, uniformValue);
     }

--- a/openvdb/unittest/TestPointAttribute.cc
+++ b/openvdb/unittest/TestPointAttribute.cc
@@ -135,6 +135,12 @@ TestPointAttribute::testAppendDrop()
         CPPUNIT_ASSERT(&attributeSet.descriptor() == &attributeSet4.descriptor());
 
         CPPUNIT_ASSERT(attributeSet.descriptor().getMetadata()["default:id"]);
+
+        AttributeArray& array = tree.beginLeaf()->attributeArray("id");
+        CPPUNIT_ASSERT(array.isUniform());
+
+        AttributeHandle<int> handle(array);
+        CPPUNIT_ASSERT_EQUAL(0, handle.get(0));
     }
 
     { // append three attributes, check ordering is consistent with insertion


### PR DESCRIPTION
This is bug that's been in the codebase for some time - setting the uniform value in a new AttributeArray was skipped if it was equal to the default value (to save doing this redundant operation), however it should have been checking against the default value for this AttributeArray instance _not_ the generic default value for this value type.

This didn't show up until recently because default metadata wasn't being supported properly but that was resolved in #590. Thanks to Nick for reporting this one.