### PR TITLE
Use Debug Builds without Symbols to Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: build
-      run: ./ci/build.sh clang++ Debug 7 ON None -DOPENVDB_CXX_STRICT=ON
+      run: ./ci/build.sh clang++ DebugNoInfo 7 ON None -DOPENVDB_CXX_STRICT=ON
 
   testabi7sse:
     runs-on: ubuntu-16.04
@@ -147,7 +147,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: build
-      run: ./ci/build.sh clang++ Debug 7 ON SSE42 -DOPENVDB_CXX_STRICT=ON
+      run: ./ci/build.sh clang++ Release 7 ON SSE42 -DOPENVDB_CXX_STRICT=ON
     - name: test
       run: ./ci/test.sh
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -9,9 +9,12 @@ BLOSC="$1"; shift
 SIMD="$1"; shift
 CMAKE_EXTRA="$@"
 
+# DebugNoInfo is a custom CMAKE_BUILD_TYPE - no optimizations, no symbols, asserts enabled
+
 mkdir build
 cd build
 cmake \
+    -DCMAKE_CXX_FLAGS_DebugNoInfo="" \
     -DCMAKE_CXX_COMPILER=${COMPILER} \
     -DCMAKE_BUILD_TYPE=${RELEASE} \
     -DOPENVDB_ABI_VERSION_NUMBER=${ABI} \

--- a/ci/build_houdini.sh
+++ b/ci/build_houdini.sh
@@ -6,6 +6,8 @@ COMPILER="$1"
 RELEASE="$2"
 EXTRAS="$3"
 
+# DebugNoInfo is a custom CMAKE_BUILD_TYPE - no optimizations, no symbols, asserts enabled
+
 if [ -d "hou" ]; then
     cd hou
     source houdini_setup_bash
@@ -14,6 +16,7 @@ if [ -d "hou" ]; then
     mkdir build
     cd build
     cmake \
+        -DCMAKE_CXX_FLAGS_DebugNoInfo="" \
         -DCMAKE_CXX_COMPILER=${COMPILER} \
         -DCMAKE_BUILD_TYPE=${RELEASE} \
         -DOPENVDB_CXX_STRICT=ON \


### PR DESCRIPTION
Adds a new `DebugNoInfo` CMake build type which is kind of the opposite of `RelWithInfo`.

Switches the ABI7 debug build to use this build type (and switches the SSE42 build to release, not sure why it was ever set to debug).

I still can't switch on the Houdini debug build due to disk space issues. This can either be fixed in the short term by GitHub Actions resolving their current disk space issues (https://github.com/actions/virtual-environments/issues/709) or by stripping out some of the data in the Houdini install that we don't use (it is currently 4GB when uncompressed).