### PR TITLE
Various improvements to CMake find modules

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -79,6 +79,13 @@ Version 7.1.0 - In Development
       Houdini shared library.
     - Added a USE_PKGCONFIG option to CMake to optionally disable use of
       pkg-config. [Contributed by Kartik Shrivastava]
+    - Standardized the dependency search paths in FindPackage modules using
+      GNU install paths.
+    - Added better library type detection of dependencies through FindPackage
+      modules on UNIX.
+    - Added missing TBB, OpenEXR and IlmBase defines for static builds on
+      Windows through the relevant FindPackage modules.
+    - Improved the logic in FindOpenVDB for static builds.
 
 Version 7.0.0 - December 6, 2019
 

--- a/cmake/FindCppUnit.cmake
+++ b/cmake/FindCppUnit.cmake
@@ -71,6 +71,7 @@ may be provided to tell this module where to look.
 #]=======================================================================]
 
 cmake_minimum_required(VERSION 3.3)
+include(GNUInstallDirs)
 
 # Monitoring <PackageName>_ROOT variables
 if(POLICY CMP0074)
@@ -125,7 +126,7 @@ list(APPEND _CPPUNIT_INCLUDE_SEARCH_DIRS
 find_path(CppUnit_INCLUDE_DIR cppunit/Portability.h
   ${_FIND_CPPUNIT_ADDITIONAL_OPTIONS}
   PATHS ${_CPPUNIT_INCLUDE_SEARCH_DIRS}
-  PATH_SUFFIXES include
+  PATH_SUFFIXES ${CMAKE_INSTALL_INCLUDEDIR} include
 )
 
 if(EXISTS "${CppUnit_INCLUDE_DIR}/cppunit/Portability.h")
@@ -156,28 +157,23 @@ list(APPEND _CPPUNIT_LIBRARYDIR_SEARCH_DIRS
 set(_CPPUNIT_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
 if(WIN32)
-  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
-    "_dll.lib"
-  )
-elseif(UNIX)
   if(CPPUNIT_USE_STATIC_LIBS)
-    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
-      ".a"
-    )
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+  else()
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES "_dll.lib")
+  endif()
+else()
+  if(CPPUNIT_USE_STATIC_LIBS)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   endif()
 endif()
 
 # Build suffix directories
 
-set(CPPUNIT_PATH_SUFFIXES
-  lib64
-  lib
-)
-
 find_library(CppUnit_LIBRARY cppunit
   ${_FIND_CPPUNIT_ADDITIONAL_OPTIONS}
   PATHS ${_CPPUNIT_LIBRARYDIR_SEARCH_DIRS}
-  PATH_SUFFIXES ${CPPUNIT_PATH_SUFFIXES}
+  PATH_SUFFIXES ${CMAKE_INSTALL_LIBDIR} lib64 lib
 )
 
 # Reset library suffix
@@ -199,17 +195,32 @@ find_package_handle_standard_args(CppUnit
 )
 
 if(CppUnit_FOUND)
+  # Configure lib type. If XXX_USE_STATIC_LIBS, we always assume a static
+  # lib is in use. If win32, we can't mark the import .libs as shared, so
+  # these are always marked as UNKNOWN. Otherwise, infer from extension.
+  set(CPPUNIT_LIB_TYPE UNKNOWN)
+  if(CPPUNIT_USE_STATIC_LIBS)
+    set(CPPUNIT_LIB_TYPE STATIC)
+  elseif(UNIX)
+    get_filename_component(_CPPUNIT_EXT ${CppUnit_LIBRARY} EXT)
+    if(_CPPUNIT_EXT STREQUAL ".a")
+      set(CPPUNIT_LIB_TYPE STATIC)
+    elseif(_CPPUNIT_EXT STREQUAL ".so" OR
+           _CPPUNIT_EXT STREQUAL ".dylib")
+      set(CPPUNIT_LIB_TYPE SHARED)
+    endif()
+  endif()
+
   set(CppUnit_LIBRARIES ${CppUnit_LIBRARY})
   set(CppUnit_INCLUDE_DIRS ${CppUnit_INCLUDE_DIR})
-  set(CppUnit_DEFINITIONS ${PC_CppUnit_CFLAGS_OTHER})
 
   get_filename_component(CppUnit_LIBRARY_DIRS ${CppUnit_LIBRARY} DIRECTORY)
 
   if(NOT TARGET CppUnit::cppunit)
-    add_library(CppUnit::cppunit UNKNOWN IMPORTED)
+    add_library(CppUnit::cppunit ${CPPUNIT_LIB_TYPE} IMPORTED)
     set_target_properties(CppUnit::cppunit PROPERTIES
       IMPORTED_LOCATION "${CppUnit_LIBRARIES}"
-      INTERFACE_COMPILE_DEFINITIONS "${CppUnit_DEFINITIONS}"
+      INTERFACE_COMPILE_OPTIONS "${PC_CppUnit_CFLAGS_OTHER}"
       INTERFACE_INCLUDE_DIRECTORIES "${CppUnit_INCLUDE_DIRS}"
     )
   endif()

--- a/cmake/FindIlmBase.cmake
+++ b/cmake/FindIlmBase.cmake
@@ -58,8 +58,6 @@ The following cache variables may also be set:
   The directory containing ``IlmBase/config-auto.h``.
 ``IlmBase_{COMPONENT}_LIBRARY``
   Individual component libraries for IlmBase
-``IlmBase_{COMPONENT}_DLL``
-  Individual component dlls for IlmBase on Windows.
 
 Hints
 ^^^^^
@@ -83,6 +81,7 @@ may be provided to tell this module where to look.
 #]=======================================================================]
 
 cmake_minimum_required(VERSION 3.3)
+include(GNUInstallDirs)
 
 # Monitoring <PackageName>_ROOT variables
 if(POLICY CMP0074)
@@ -166,7 +165,7 @@ list(APPEND _ILMBASE_INCLUDE_SEARCH_DIRS
 find_path(IlmBase_INCLUDE_DIR IlmBaseConfig.h
   ${_FIND_ILMBASE_ADDITIONAL_OPTIONS}
   PATHS ${_ILMBASE_INCLUDE_SEARCH_DIRS}
-  PATH_SUFFIXES include/OpenEXR OpenEXR
+  PATH_SUFFIXES ${CMAKE_INSTALL_INCLUDEDIR}/OpenEXR include/OpenEXR OpenEXR
 )
 
 if(EXISTS "${IlmBase_INCLUDE_DIR}/IlmBaseConfig.h")
@@ -208,41 +207,30 @@ list(APPEND _ILMBASE_LIBRARYDIR_SEARCH_DIRS
   ${SYSTEM_LIBRARY_PATHS}
 )
 
-# Build suffix directories
-
-set(ILMBASE_PATH_SUFFIXES
-  lib64
-  lib
-)
-
-if(UNIX)
-  list(INSERT ILMBASE_PATH_SUFFIXES 0 lib/x86_64-linux-gnu)
-endif()
+# Library suffix handling
 
 set(_ILMBASE_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+set(_IlmBase_Version_Suffix "-${IlmBase_VERSION_MAJOR}_${IlmBase_VERSION_MINOR}")
 
-# library suffix handling
 if(WIN32)
-  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
-    "-${IlmBase_VERSION_MAJOR}_${IlmBase_VERSION_MINOR}.lib"
-  )
+  if(ILMBASE_USE_STATIC_LIBS)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+  endif()
+  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES "${_IlmBase_Version_Suffix}.lib")
 else()
   if(ILMBASE_USE_STATIC_LIBS)
-    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
-      "-${IlmBase_VERSION_MAJOR}_${IlmBase_VERSION_MINOR}.a"
-    )
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   else()
     if(APPLE)
-      list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
-        "-${IlmBase_VERSION_MAJOR}_${IlmBase_VERSION_MINOR}.dylib"
-      )
+      list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES "${_IlmBase_Version_Suffix}.dylib")
     else()
-      list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
-        "-${IlmBase_VERSION_MAJOR}_${IlmBase_VERSION_MINOR}.so"
-      )
+      list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES "${_IlmBase_Version_Suffix}.so")
     endif()
   endif()
+  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES "${_IlmBase_Version_Suffix}.a")
 endif()
+
+unset(_IlmBase_Version_Suffix)
 
 set(IlmBase_LIB_COMPONENTS "")
 
@@ -250,21 +238,9 @@ foreach(COMPONENT ${IlmBase_FIND_COMPONENTS})
   find_library(IlmBase_${COMPONENT}_LIBRARY ${COMPONENT}
     ${_FIND_ILMBASE_ADDITIONAL_OPTIONS}
     PATHS ${_ILMBASE_LIBRARYDIR_SEARCH_DIRS}
-    PATH_SUFFIXES ${ILMBASE_PATH_SUFFIXES}
+    PATH_SUFFIXES ${CMAKE_INSTALL_LIBDIR} lib64 lib
   )
   list(APPEND IlmBase_LIB_COMPONENTS ${IlmBase_${COMPONENT}_LIBRARY})
-
-  if(WIN32 AND NOT ILMBASE_USE_STATIC_LIBS)
-    set(_ILMBASE_TMP ${CMAKE_FIND_LIBRARY_SUFFIXES})
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
-    find_library(IlmBase_${COMPONENT}_DLL ${COMPONENT}
-      ${_FIND_ILMBASE_ADDITIONAL_OPTIONS}
-      PATHS ${_ILMBASE_LIBRARYDIR_SEARCH_DIRS}
-      PATH_SUFFIXES bin
-    )
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${_ILMBASE_TMP})
-    unset(_ILMBASE_TMP)
-  endif()
 
   if(IlmBase_${COMPONENT}_LIBRARY)
     set(IlmBase_${COMPONENT}_FOUND TRUE)
@@ -273,7 +249,7 @@ foreach(COMPONENT ${IlmBase_FIND_COMPONENTS})
   endif()
 endforeach()
 
-# reset lib suffix
+# Reset library suffix
 
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${_ILMBASE_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
 unset(_ILMBASE_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
@@ -316,7 +292,6 @@ if(IlmBase_FOUND)
     ${IlmBase_INCLUDE_DIR}
   )
   unset(_IlmBase_Parent_Dir)
-  set(IlmBase_DEFINITIONS ${PC_IlmBase_CFLAGS_OTHER})
 
   set(IlmBase_LIBRARY_DIRS "")
   foreach(LIB ${IlmBase_LIB_COMPONENTS})
@@ -328,11 +303,37 @@ if(IlmBase_FOUND)
   # Configure imported targets
 
   foreach(COMPONENT ${IlmBase_FIND_COMPONENTS})
+    # Configure lib type. If XXX_USE_STATIC_LIBS, we always assume a static
+    # lib is in use. If win32, we can't mark the import .libs as shared, so
+    # these are always marked as UNKNOWN. Otherwise, infer from extension.
+    set(ILMBASE_${COMPONENT}_LIB_TYPE UNKNOWN)
+    if(ILMBASE_USE_STATIC_LIBS)
+      set(ILMBASE_${COMPONENT}_LIB_TYPE STATIC)
+    elseif(UNIX)
+      get_filename_component(_ILMBASE_${COMPONENT}_EXT ${IlmBase_${COMPONENT}_LIBRARY} EXT)
+      if(${_ILMBASE_${COMPONENT}_EXT} STREQUAL ".a")
+        set(ILMBASE_${COMPONENT}_LIB_TYPE STATIC)
+      elseif(${_ILMBASE_${COMPONENT}_EXT} STREQUAL ".so" OR
+             ${_ILMBASE_${COMPONENT}_EXT} STREQUAL ".dylib")
+        set(ILMBASE_${COMPONENT}_LIB_TYPE SHARED)
+      endif()
+    endif()
+
+    set(IlmBase_${COMPONENT}_DEFINITIONS)
+
+    # Add the OPENEXR_DLL define if the library is not static on WIN32
+    if(WIN32)
+      if(NOT ILMBASE_${COMPONENT}_LIB_TYPE STREQUAL STATIC)
+        list(APPEND IlmBase_${COMPONENT}_DEFINITIONS -DOPENEXR_DLL)
+      endif()
+    endif()
+
     if(NOT TARGET IlmBase::${COMPONENT})
-      add_library(IlmBase::${COMPONENT} UNKNOWN IMPORTED)
+      add_library(IlmBase::${COMPONENT} ${ILMBASE_${COMPONENT}_LIB_TYPE} IMPORTED)
       set_target_properties(IlmBase::${COMPONENT} PROPERTIES
         IMPORTED_LOCATION "${IlmBase_${COMPONENT}_LIBRARY}"
-        INTERFACE_COMPILE_OPTIONS "${IlmBase_DEFINITIONS}"
+        INTERFACE_COMPILE_OPTIONS "${PC_IlmBase_CFLAGS_OTHER}"
+        INTERFACE_COMPILE_DEFINITIONS "${IlmBase_${COMPONENT}_DEFINITIONS}"
         INTERFACE_INCLUDE_DIRECTORIES "${IlmBase_INCLUDE_DIRS}"
       )
     endif()

--- a/cmake/FindJemalloc.cmake
+++ b/cmake/FindJemalloc.cmake
@@ -65,6 +65,7 @@ may be provided to tell this module where to look.
 #]=======================================================================]
 
 cmake_minimum_required(VERSION 3.3)
+include(GNUInstallDirs)
 
 # Monitoring <PackageName>_ROOT variables
 if(POLICY CMP0074)
@@ -118,29 +119,24 @@ list(APPEND _JEMALLOC_LIBRARYDIR_SEARCH_DIRS
 set(_JEMALLOC_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
 if(WIN32)
-  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
-    "_dll.lib"
-  )
-elseif(UNIX)
   if(JEMALLOC_USE_STATIC_LIBS)
-    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES
-      ".a"
-    )
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+  else()
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES "_dll.lib")
+  endif()
+else()
+  if(JEMALLOC_USE_STATIC_LIBS)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   endif()
 endif()
 
 # Build suffix directories
 
 set(JEMALLOC_PATH_SUFFIXES
+  ${CMAKE_INSTALL_LIBDIR}
   lib64
   lib
 )
-
-# platform branching
-
-if(UNIX)
-  list(INSERT JEMALLOC_PATH_SUFFIXES 0 lib/x86_64-linux-gnu)
-endif()
 
 find_library(Jemalloc_LIBRARY jemalloc
   ${_FIND_JEMALLOC_ADDITIONAL_OPTIONS}
@@ -166,16 +162,31 @@ find_package_handle_standard_args(Jemalloc
 )
 
 if(Jemalloc_FOUND)
+  # Configure lib type. If XXX_USE_STATIC_LIBS, we always assume a static
+  # lib is in use. If win32, we can't mark the import .libs as shared, so
+  # these are always marked as UNKNOWN. Otherwise, infer from extension.
+  set(JEMALLOC_LIB_TYPE UNKNOWN)
+  if(JEMALLOC_USE_STATIC_LIBS)
+    set(JEMALLOC_LIB_TYPE STATIC)
+  elseif(UNIX)
+    get_filename_component(_JEMALLOC_EXT ${Jemalloc_LIBRARY} EXT)
+    if(_JEMALLOC_EXT STREQUAL ".a")
+      set(JEMALLOC_LIB_TYPE STATIC)
+    elseif(_JEMALLOC_EXT STREQUAL ".so" OR
+           _JEMALLOC_EXT STREQUAL ".dylib")
+      set(JEMALLOC_LIB_TYPE SHARED)
+    endif()
+  endif()
+
   set(Jemalloc_LIBRARIES ${Jemalloc_LIBRARY})
-  set(Jemalloc_DEFINITIONS ${PC_Jemalloc_CFLAGS_OTHER})
 
   get_filename_component(Jemalloc_LIBRARY_DIRS ${Jemalloc_LIBRARY} DIRECTORY)
 
   if(NOT TARGET Jemalloc::jemalloc)
-    add_library(Jemalloc::jemalloc UNKNOWN IMPORTED)
+    add_library(Jemalloc::jemalloc ${JEMALLOC_LIB_TYPE} IMPORTED)
     set_target_properties(Jemalloc::jemalloc PROPERTIES
       IMPORTED_LOCATION "${Jemalloc_LIBRARIES}"
-      INTERFACE_COMPILE_DEFINITIONS "${Jemalloc_DEFINITIONS}"
+      INTERFACE_COMPILE_OPTIONS "${PC_Jemalloc_CFLAGS_OTHER}"
     )
   endif()
 elseif(Jemalloc_FIND_REQUIRED)

--- a/cmake/FindLog4cplus.cmake
+++ b/cmake/FindLog4cplus.cmake
@@ -71,6 +71,7 @@ may be provided to tell this module where to look.
 #]=======================================================================]
 
 cmake_minimum_required(VERSION 3.3)
+include(GNUInstallDirs)
 
 # Monitoring <PackageName>_ROOT variables
 if(POLICY CMP0074)
@@ -125,7 +126,7 @@ list(APPEND _LOG4CPLUS_INCLUDE_SEARCH_DIRS
 find_path(Log4cplus_INCLUDE_DIR log4cplus/version.h
   ${_FIND_LOG4CPLUS_ADDITIONAL_OPTIONS}
   PATHS ${_LOG4CPLUS_INCLUDE_SEARCH_DIRS}
-  PATH_SUFFIXES include
+  PATH_SUFFIXES ${CMAKE_INSTALL_INCLUDEDIR} include
 )
 
 if(EXISTS "${Log4cplus_INCLUDE_DIR}/log4cplus/version.h")
@@ -161,29 +162,30 @@ list(APPEND _LOG4CPLUS_LIBRARYDIR_SEARCH_DIRS
   ${SYSTEM_LIBRARY_PATHS}
 )
 
+# Library suffix handling
 
-if(UNIX AND LOG4CPLUS_USE_STATIC_LIBS)
-  set(_LOG4CPLUS_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+set(_LOG4CPLUS_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+
+if(WIN32)
+  if(LOG4CPLUS_USE_STATIC_LIBS)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+  endif()
+else()
+  if(LOG4CPLUS_USE_STATIC_LIBS)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+  endif()
 endif()
-
-# Build suffix directories
-
-set(LOG4CPLUS_PATH_SUFFIXES
-  lib64
-  lib
-)
 
 find_library(Log4cplus_LIBRARY log4cplus
   ${_FIND_LOG4CPLUS_ADDITIONAL_OPTIONS}
   PATHS ${_LOG4CPLUS_LIBRARYDIR_SEARCH_DIRS}
-  PATH_SUFFIXES ${LOG4CPLUS_PATH_SUFFIXES}
+  PATH_SUFFIXES ${CMAKE_INSTALL_LIBDIR} lib64 lib
 )
 
-if(UNIX AND LOG4CPLUS_USE_STATIC_LIBS)
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_LOG4CPLUS_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
-  unset(_LOG4CPLUS_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
-endif()
+# Reset library suffix
+
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_LOG4CPLUS_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+unset(_LOG4CPLUS_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
 
 # ------------------------------------------------------------------------
 #  Cache and set Log4cplus_FOUND
@@ -199,17 +201,32 @@ find_package_handle_standard_args(Log4cplus
 )
 
 if(Log4cplus_FOUND)
+  # Configure lib type. If XXX_USE_STATIC_LIBS, we always assume a static
+  # lib is in use. If win32, we can't mark the import .libs as shared, so
+  # these are always marked as UNKNOWN. Otherwise, infer from extension.
+  set(LOG4CPLUS_LIB_TYPE UNKNOWN)
+  if(LOG4CPLUS_USE_STATIC_LIBS)
+    set(LOG4CPLUS_LIB_TYPE STATIC)
+  elseif(UNIX)
+    get_filename_component(_LOG4CPLUS_EXT ${Log4cplus_LIBRARY} EXT)
+    if(_LOG4CPLUS_EXT STREQUAL ".a")
+      set(LOG4CPLUS_LIB_TYPE STATIC)
+    elseif(_LOG4CPLUS_EXT STREQUAL ".so" OR
+           _LOG4CPLUS_EXT STREQUAL ".dylib")
+      set(LOG4CPLUS_LIB_TYPE SHARED)
+    endif()
+  endif()
+
   set(Log4cplus_LIBRARIES ${Log4cplus_LIBRARY})
   set(Log4cplus_INCLUDE_DIRS ${Log4cplus_INCLUDE_DIR})
-  set(Log4cplus_DEFINITIONS ${PC_Log4cplus_CFLAGS_OTHER})
 
   get_filename_component(Log4cplus_LIBRARY_DIRS ${Log4cplus_LIBRARY} DIRECTORY)
 
   if(NOT TARGET Log4cplus::log4cplus)
-    add_library(Log4cplus::log4cplus UNKNOWN IMPORTED)
+    add_library(Log4cplus::log4cplus ${LOG4CPLUS_LIB_TYPE} IMPORTED)
     set_target_properties(Log4cplus::log4cplus PROPERTIES
       IMPORTED_LOCATION "${Log4cplus_LIBRARIES}"
-      INTERFACE_COMPILE_DEFINITIONS "${Log4cplus_DEFINITIONS}"
+      INTERFACE_COMPILE_OPTIONS "${PC_Log4cplus_CFLAGS_OTHER}"
       INTERFACE_INCLUDE_DIRECTORIES "${Log4cplus_INCLUDE_DIRS}"
     )
   endif()

--- a/cmake/FindOpenVDB.cmake
+++ b/cmake/FindOpenVDB.cmake
@@ -84,6 +84,7 @@ may be provided to tell this module where to look.
 #]=======================================================================]
 
 cmake_minimum_required(VERSION 3.3)
+include(GNUInstallDirs)
 
 # Monitoring <PackageName>_ROOT variables
 if(POLICY CMP0074)
@@ -194,7 +195,7 @@ list(APPEND _OPENVDB_INCLUDE_SEARCH_DIRS
 find_path(OpenVDB_INCLUDE_DIR openvdb/version.h
   ${_FIND_OPENVDB_ADDITIONAL_OPTIONS}
   PATHS ${_OPENVDB_INCLUDE_SEARCH_DIRS}
-  PATH_SUFFIXES include
+  PATH_SUFFIXES ${CMAKE_INSTALL_INCLUDEDIR} include
 )
 
 OPENVDB_VERSION_FROM_HEADER("${OpenVDB_INCLUDE_DIR}/openvdb/version.h"
@@ -219,17 +220,18 @@ list(APPEND _OPENVDB_LIBRARYDIR_SEARCH_DIRS
   ${SYSTEM_LIBRARY_PATHS}
 )
 
-# Build suffix directories
+# Library suffix handling
 
-set(OPENVDB_PATH_SUFFIXES
-  lib64
-  lib
-)
+set(_OPENVDB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
-# Static library setup
-if(UNIX AND OPENVDB_USE_STATIC_LIBS)
-  set(_OPENVDB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+if(WIN32)
+  if(OPENVDB_USE_STATIC_LIBS)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+  endif()
+else()
+  if(OPENVDB_USE_STATIC_LIBS)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+  endif()
 endif()
 
 set(OpenVDB_LIB_COMPONENTS "")
@@ -239,7 +241,7 @@ foreach(COMPONENT ${OpenVDB_FIND_COMPONENTS})
   find_library(OpenVDB_${COMPONENT}_LIBRARY ${LIB_NAME}
     ${_FIND_OPENVDB_ADDITIONAL_OPTIONS}
     PATHS ${_OPENVDB_LIBRARYDIR_SEARCH_DIRS}
-    PATH_SUFFIXES ${OPENVDB_PATH_SUFFIXES}
+    PATH_SUFFIXES ${CMAKE_INSTALL_LIBDIR} lib64 lib
   )
   list(APPEND OpenVDB_LIB_COMPONENTS ${OpenVDB_${COMPONENT}_LIBRARY})
 
@@ -250,10 +252,10 @@ foreach(COMPONENT ${OpenVDB_FIND_COMPONENTS})
   endif()
 endforeach()
 
-if(UNIX AND OPENVDB_USE_STATIC_LIBS)
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_OPENVDB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
-  unset(_OPENVDB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
-endif()
+# Reset library suffix
+
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_OPENVDB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+unset(_OPENVDB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
 
 # ------------------------------------------------------------------------
 #  Cache and set OPENVDB_FOUND
@@ -301,7 +303,7 @@ if(NOT OpenVDB_FIND_QUIET)
 endif()
 
 # ------------------------------------------------------------------------
-#  Handle OpenVDB dependencies
+#  Handle OpenVDB dependencies and interface settings
 # ------------------------------------------------------------------------
 
 # Add standard dependencies
@@ -310,7 +312,7 @@ find_package(IlmBase REQUIRED COMPONENTS Half)
 find_package(TBB REQUIRED COMPONENTS tbb)
 find_package(ZLIB REQUIRED)
 
-if(NOT OPENVDB_USE_STATIC_LIBS)
+if(NOT OPENVDB_USE_STATIC_LIBS AND NOT Boost_USE_STATIC_LIBS)
   # @note  Both of these must be set for Boost 1.70 (VFX2020) to link against
   #        boost shared libraries (more specifically libraries built with -fPIC).
   #        http://boost.2283326.n4.nabble.com/CMake-config-scripts-broken-in-1-70-td4708957.html
@@ -321,60 +323,68 @@ endif()
 
 find_package(Boost REQUIRED COMPONENTS iostreams system)
 
-# Use GetPrerequisites to see which libraries this OpenVDB lib has linked to
-# which we can query for optional deps. This basically runs ldd/otoll/objdump
-# etc to track deps. We could use a vdb_config binary tools here to improve
-# this process
-
-include(GetPrerequisites)
-
-set(_EXCLUDE_SYSTEM_PREREQUISITES 1)
-set(_RECURSE_PREREQUISITES 0)
-set(_OPENVDB_PREREQUISITE_LIST)
-
-get_prerequisites(${OpenVDB_openvdb_LIBRARY}
-  _OPENVDB_PREREQUISITE_LIST
-  ${_EXCLUDE_SYSTEM_PREREQUISITES}
-  ${_RECURSE_PREREQUISITES}
-  ""
-  "${SYSTEM_LIBRARY_PATHS}"
-)
-
-unset(_EXCLUDE_SYSTEM_PREREQUISITES)
-unset(_RECURSE_PREREQUISITES)
-
 # As the way we resolve optional libraries relies on library file names, use
 # the configuration options from the main CMakeLists.txt to allow users
 # to manually identify the requirements of OpenVDB builds if they know them.
-
 set(OpenVDB_USES_BLOSC ${USE_BLOSC})
 set(OpenVDB_USES_LOG4CPLUS ${USE_LOG4CPLUS})
 set(OpenVDB_USES_EXR ${USE_EXR})
+set(OpenVDB_DEFINITIONS)
 
-# Search for optional dependencies
+if(WIN32)
+  list(APPEND OpenVDB_DEFINITIONS -D_WIN32 -DNOMINMAX)
+endif()
 
-foreach(PREREQUISITE ${_OPENVDB_PREREQUISITE_LIST})
-  set(_HAS_DEP)
-  get_filename_component(PREREQUISITE ${PREREQUISITE} NAME)
-
-  string(FIND ${PREREQUISITE} "blosc" _HAS_DEP)
-  if(NOT ${_HAS_DEP} EQUAL -1)
-    set(OpenVDB_USES_BLOSC ON)
+if(NOT OPENVDB_USE_STATIC_LIBS)
+  if(WIN32)
+    list(APPEND OpenVDB_DEFINITIONS -DOPENVDB_DLL)
   endif()
 
-  string(FIND ${PREREQUISITE} "log4cplus" _HAS_DEP)
-  if(NOT ${_HAS_DEP} EQUAL -1)
-    set(OpenVDB_USES_LOG4CPLUS ON)
-  endif()
+  # Use GetPrerequisites to see which libraries this OpenVDB lib has linked to
+  # which we can query for optional deps. This basically runs ldd/otoll/objdump
+  # etc to track deps. We could use a vdb_config binary tools here to improve
+  # this process
+  include(GetPrerequisites)
 
-  string(FIND ${PREREQUISITE} "IlmImf" _HAS_DEP)
-  if(NOT ${_HAS_DEP} EQUAL -1)
-    set(OpenVDB_USES_EXR ON)
-  endif()
-endforeach()
+  set(_EXCLUDE_SYSTEM_PREREQUISITES 1)
+  set(_RECURSE_PREREQUISITES 0)
+  set(_OPENVDB_PREREQUISITE_LIST)
 
-unset(_OPENVDB_PREREQUISITE_LIST)
-unset(_HAS_DEP)
+  get_prerequisites(${OpenVDB_openvdb_LIBRARY}
+    _OPENVDB_PREREQUISITE_LIST
+    ${_EXCLUDE_SYSTEM_PREREQUISITES}
+    ${_RECURSE_PREREQUISITES}
+    ""
+    "${SYSTEM_LIBRARY_PATHS}"
+  )
+
+  unset(_EXCLUDE_SYSTEM_PREREQUISITES)
+  unset(_RECURSE_PREREQUISITES)
+
+  # Search for optional dependencies
+  foreach(PREREQUISITE ${_OPENVDB_PREREQUISITE_LIST})
+    set(_HAS_DEP)
+    get_filename_component(PREREQUISITE ${PREREQUISITE} NAME)
+
+    string(FIND ${PREREQUISITE} "blosc" _HAS_DEP)
+    if(NOT ${_HAS_DEP} EQUAL -1)
+      set(OpenVDB_USES_BLOSC ON)
+    endif()
+
+    string(FIND ${PREREQUISITE} "log4cplus" _HAS_DEP)
+    if(NOT ${_HAS_DEP} EQUAL -1)
+      set(OpenVDB_USES_LOG4CPLUS ON)
+    endif()
+
+    string(FIND ${PREREQUISITE} "IlmImf" _HAS_DEP)
+    if(NOT ${_HAS_DEP} EQUAL -1)
+      set(OpenVDB_USES_EXR ON)
+    endif()
+  endforeach()
+
+  unset(_OPENVDB_PREREQUISITE_LIST)
+  unset(_HAS_DEP)
+endif()
 
 if(OpenVDB_USES_BLOSC)
   find_package(Blosc REQUIRED)
@@ -393,6 +403,16 @@ if(UNIX)
   find_package(Threads REQUIRED)
 endif()
 
+if(WIN32)
+  # @note OPENVDB_OPENEXR_STATICLIB is old functionality from the makefiles
+  #       used in PlatformConfig.h to configure EXR exports. Once this file
+  #       is completely removed, this define can be too
+  get_target_property(ILMBASE_LIB_TYPE IlmBase::Half TYPE)
+  if(OPENEXR_USE_STATIC_LIBS OR (${ILMBASE_LIB_TYPE} STREQUAL STATIC_LIBRARY))
+    list(APPEND OpenVDB_DEFINITIONS -DOPENVDB_OPENEXR_STATICLIB)
+  endif()
+endif()
+
 # Set deps. Note that the order here is important. If we're building against
 # Houdini 17.5 we must include OpenEXR and IlmBase deps first to ensure the
 # users chosen namespaced headers are correctly prioritized. Otherwise other
@@ -405,9 +425,8 @@ set(_OPENVDB_VISIBLE_DEPENDENCIES
   IlmBase::Half
 )
 
-set(_OPENVDB_DEFINITIONS)
 if(OpenVDB_ABI)
-  list(APPEND _OPENVDB_DEFINITIONS "-DOPENVDB_ABI_VERSION_NUMBER=${OpenVDB_ABI}")
+  list(APPEND OpenVDB_DEFINITIONS "-DOPENVDB_ABI_VERSION_NUMBER=${OpenVDB_ABI}")
 endif()
 
 if(OpenVDB_USES_EXR)
@@ -417,12 +436,12 @@ if(OpenVDB_USES_EXR)
     IlmBase::Imath
     OpenEXR::IlmImf
   )
-  list(APPEND _OPENVDB_DEFINITIONS "-DOPENVDB_TOOLS_RAYTRACER_USE_EXR")
+  list(APPEND OpenVDB_DEFINITIONS "-DOPENVDB_TOOLS_RAYTRACER_USE_EXR")
 endif()
 
 if(OpenVDB_USES_LOG4CPLUS)
   list(APPEND _OPENVDB_VISIBLE_DEPENDENCIES Log4cplus::log4cplus)
-  list(APPEND _OPENVDB_DEFINITIONS "-DOPENVDB_USE_LOG4CPLUS")
+  list(APPEND OpenVDB_DEFINITIONS "-DOPENVDB_USE_LOG4CPLUS")
 endif()
 
 list(APPEND _OPENVDB_VISIBLE_DEPENDENCIES
@@ -436,25 +455,20 @@ endif()
 
 set(_OPENVDB_HIDDEN_DEPENDENCIES)
 
-if(OpenVDB_USES_BLOSC)
-  list(APPEND _OPENVDB_HIDDEN_DEPENDENCIES Blosc::blosc)
-endif()
+if(NOT OPENVDB_USE_STATIC_LIBS)
+  if(OpenVDB_USES_BLOSC)
+    list(APPEND _OPENVDB_HIDDEN_DEPENDENCIES Blosc::blosc)
+  endif()
 
-list(APPEND _OPENVDB_HIDDEN_DEPENDENCIES ZLIB::ZLIB)
+  list(APPEND _OPENVDB_HIDDEN_DEPENDENCIES ZLIB::ZLIB)
+endif()
 
 # ------------------------------------------------------------------------
 #  Configure imported target
 # ------------------------------------------------------------------------
 
-set(OpenVDB_LIBRARIES
-  ${OpenVDB_LIB_COMPONENTS}
-)
+set(OpenVDB_LIBRARIES ${OpenVDB_LIB_COMPONENTS})
 set(OpenVDB_INCLUDE_DIRS ${OpenVDB_INCLUDE_DIR})
-
-set(OpenVDB_DEFINITIONS)
-list(APPEND OpenVDB_DEFINITIONS "${PC_OpenVDB_CFLAGS_OTHER}")
-list(APPEND OpenVDB_DEFINITIONS "${_OPENVDB_DEFINITIONS}")
-list(REMOVE_DUPLICATES OpenVDB_DEFINITIONS)
 
 set(OpenVDB_LIBRARY_DIRS "")
 foreach(LIB ${OpenVDB_LIB_COMPONENTS})
@@ -464,11 +478,29 @@ endforeach()
 list(REMOVE_DUPLICATES OpenVDB_LIBRARY_DIRS)
 
 foreach(COMPONENT ${OpenVDB_FIND_COMPONENTS})
+  # Configure lib type. If XXX_USE_STATIC_LIBS, we always assume a static
+  # lib is in use. If win32, we can't mark the import .libs as shared, so
+  # these are always marked as UNKNOWN. Otherwise, infer from extension.
+  set(OPENVDB_${COMPONENT}_LIB_TYPE UNKNOWN)
+  if(OPENVDB_USE_STATIC_LIBS)
+    set(OPENVDB_${COMPONENT}_LIB_TYPE STATIC)
+  elseif(UNIX)
+    get_filename_component(_OPENVDB_${COMPONENT}_EXT
+      ${OpenVDB_${COMPONENT}_LIBRARY} EXT)
+    if(_OPENVDB_${COMPONENT}_EXT STREQUAL ".a")
+      set(OPENVDB_${COMPONENT}_LIB_TYPE STATIC)
+    elseif(_OPENVDB_${COMPONENT}_EXT STREQUAL ".so" OR
+           _OPENVDB_${COMPONENT}_EXT STREQUAL ".dylib")
+      set(OPENVDB_${COMPONENT}_LIB_TYPE SHARED)
+    endif()
+  endif()
+
   if(NOT TARGET OpenVDB::${COMPONENT})
-    add_library(OpenVDB::${COMPONENT} UNKNOWN IMPORTED)
+    add_library(OpenVDB::${COMPONENT} ${OPENVDB_${COMPONENT}_LIB_TYPE} IMPORTED)
     set_target_properties(OpenVDB::${COMPONENT} PROPERTIES
       IMPORTED_LOCATION "${OpenVDB_${COMPONENT}_LIBRARY}"
-      INTERFACE_COMPILE_OPTIONS "${OpenVDB_DEFINITIONS}"
+      INTERFACE_COMPILE_OPTIONS "${PC_OpenVDB_CFLAGS_OTHER}"
+      INTERFACE_COMPILE_DEFINITIONS "${OpenVDB_DEFINITIONS}"
       INTERFACE_INCLUDE_DIRECTORIES "${OpenVDB_INCLUDE_DIR}"
       IMPORTED_LINK_DEPENDENT_LIBRARIES "${_OPENVDB_HIDDEN_DEPENDENCIES}" # non visible deps
       INTERFACE_LINK_LIBRARIES "${_OPENVDB_VISIBLE_DEPENDENCIES}" # visible deps (headers)
@@ -477,6 +509,5 @@ foreach(COMPONENT ${OpenVDB_FIND_COMPONENTS})
   endif()
 endforeach()
 
-unset(_OPENVDB_DEFINITIONS)
 unset(_OPENVDB_VISIBLE_DEPENDENCIES)
 unset(_OPENVDB_HIDDEN_DEPENDENCIES)

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -101,6 +101,13 @@ Build:
   Houdini shared library.
 - Added a USE_PKGCONFIG option to CMake to optionally disable use of pkg-config.
   <I>[Contributed&nbsp;by&nbsp;Kartik&nbsp;Shrivastava]</I>
+- Standardized the dependency search paths in FindPackage modules using
+  GNU install paths.
+- Added better library type detection of dependencies through FindPackage
+  modules on UNIX.
+- Added missing TBB, OpenEXR and IlmBase defines for static builds on
+  Windows through the relevant FindPackage modules.
+- Improved the logic in FindOpenVDB for static builds.
 
 
 @htmlonly <a name="v7_0_0_changes"></a>@endhtmlonly


### PR DESCRIPTION
This PR is a partial implementation of #654 

 - Removing unnecessary DLL methods
 - Adding better lib type detection on UNIX
 - Added GNU path support
 - Added required defines for static TBB on Windows
 - Added required defines for static IlmBase and OpenEXR on Windows
 - Improved handling of finding static builds of OpenVDB

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>