### PR TITLE
Disable binaries and unit tests for Houdini build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,4 +11,4 @@ stages:
     condition: variables['HOUPASS']
     steps:
     - bash: ci/install_houdini_azure.sh 18.0 ${HOUPASS}
-    - bash: ci/build_houdini_azure.sh clang++ Release ON
+    - bash: ci/build_houdini_azure.sh clang++ Release OFF


### PR DESCRIPTION
As a result of changes in the hosted runners used in Azure Pipelines to more strictly enforce disk space limits, we're now hitting those limits even in release builds where we weren't before.

The Docker image is ~2.5GB and Houdini is ~4GB. For Azure Pipelines, we have access to just 10GB of disk space (GitHub Actions is 14GB) and I believe we're slightly over. This disables the unit tests and the command-line binaries for the Houdini build to reduce the disk footprint. Of course both of these components are still tested outside of the Houdini build. 

I'll look to re-enable these as we migrate the Houdini builds over to GitHub Actions with an improved mechanism, I just want to stabilise these builds for a little time first.