### PR TITLE
Fix move constructor compiler warning

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -91,6 +91,10 @@ Version 7.1.0 - In Development
     - Added missing TBB, OpenEXR and IlmBase defines for static builds on
       Windows through the relevant FindPackage modules.
     - Improved the logic in FindOpenVDB for static builds.
+    - Fixed a compiler warning on Apple Clang 11.0 where the AttributeArray
+      move constructor was being implicitly deleted despite being marked
+      default.
+
 
 Version 7.0.0 - December 6, 2019
 

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -113,6 +113,9 @@ Build:
 - Added missing TBB, OpenEXR and IlmBase defines for static builds on
   Windows through the relevant FindPackage modules.
 - Improved the logic in FindOpenVDB for static builds.
+- Fixed a compiler warning on Apple Clang 11.0 where the
+  @vdblink::points::AttributeArray AttributeArray@endlink move constructor was
+  being implicitly deleted despite being marked default.
 
 
 @htmlonly <a name="v7_0_0_changes"></a>@endhtmlonly

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -148,8 +148,8 @@ public:
     AttributeArray(const AttributeArray&) = default;
     AttributeArray& operator=(const AttributeArray&) = default;
 #endif
-    AttributeArray(AttributeArray&&) = default;
-    AttributeArray& operator=(AttributeArray&&) = default;
+    AttributeArray(AttributeArray&&) = delete;
+    AttributeArray& operator=(AttributeArray&&) = delete;
 
     /// Return a copy of this attribute.
     virtual AttributeArray::Ptr copy() const = 0;


### PR DESCRIPTION
A new Clang compiler warning is detecting that the AttributeArray move constructor is being implicitly deleted due to the member mutex, despite it being marked as default. This shows up when using Apple Clang 11.0 (based off LLVM 8.0) that was introduced with Mac Catalina, and errors when OPENVDB_CXX_STRICT is enabled. 