### PR TITLE
change std::unexpected() to std::terminate()

### DIFF
--- a/openvdb/cmd/openvdb_lod.cc
+++ b/openvdb/cmd/openvdb_lod.cc
@@ -351,7 +351,7 @@ main(int argc, char *argv[])
     }
     catch (...) {
         OPENVDB_LOG_FATAL("Exception caught (unexpected type)");
-        std::unexpected();
+        std::terminate();
     }
 
     return exitStatus;


### PR DESCRIPTION
Signed-off-by: Mark Sisson <5761292+marksisson@users.noreply.github.com>

Dynamic exception specification was deprecated in C++11, and removed in C++17.  This fixes compiler error when using C++17 compile feature by changing std::unexpected() to std::terminate().