### PR TITLE
Add Houdini CI caching workflow

### DIFF
--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -1,0 +1,30 @@
+
+name: Houdini
+
+on:
+  schedule:
+    # run this workflow every wednesday at noon UTC
+    - cron:  '0 12 * * 3'
+
+# download the latest production version of Houdini, strip out headers,
+# libraries and binaries required for building OpenVDB and if the build
+# succeeds, put it into the GitHub Actions cache
+
+jobs:
+  houdini18_0:
+    runs-on: ubuntu-16.04
+    container:
+      image: aswf/ci-base:2019
+    steps:
+    - uses: actions/checkout@v2
+    - name: download_houdini
+      run: ./ci/download_houdini2.sh 18.0 ON ON ${{ secrets.HOUDINI_CLIENT_ID }} ${{ secrets.HOUDINI_SECRET_KEY }}
+    - name: install_houdini
+      run: ./ci/install_houdini2.sh
+    - name: build
+      run: ./ci/build_houdini.sh clang++ Release ON
+    - name: write_houdini_cache
+      uses: actions/cache@v1
+      with:
+        path: hou
+        key: vdb1-houdini18_0-${{ hashFiles('hou/hou.tar.gz') }}

--- a/ci/download_houdini2.py
+++ b/ci/download_houdini2.py
@@ -1,0 +1,169 @@
+#!/usr/local/bin/python
+#
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: MPL-2.0
+#
+# Python script to download the latest Houdini builds
+# using the SideFX download API:
+#
+# https://www.sidefx.com/docs/api/download/index.html
+#
+# Authors: Dan Bailey, SideFX
+
+import time
+import sys
+import re
+import shutil
+import json
+import base64
+import requests
+import hashlib
+
+# this argument is for the major.minor version of Houdini to download (such as 15.0, 15.5, 16.0)
+version = sys.argv[1]
+only_production = True if sys.argv[2] == 'ON' else False
+user_client_id = sys.argv[3]
+user_client_secret_key = sys.argv[4]
+
+if not re.match('[0-9][0-9]\.[0-9]$', version):
+    raise IOError('Invalid Houdini Version "%s", expecting in the form "major.minor" such as "16.0"' % version)
+
+
+# Code that provides convenient Python wrappers to call into the API:
+
+def service(
+        access_token_url, client_id, client_secret_key, endpoint_url,
+        access_token=None, access_token_expiry_time=None):
+    if (access_token is None or
+            access_token_expiry_time is None or
+            access_token_expiry_time < time.time()):
+        access_token, access_token_expiry_time = (
+            get_access_token_and_expiry_time(
+                access_token_url, client_id, client_secret_key))
+
+    return _Service(
+        endpoint_url, access_token, access_token_expiry_time)
+
+
+class _Service(object):
+    def __init__(
+            self, endpoint_url, access_token, access_token_expiry_time):
+        self.endpoint_url = endpoint_url
+        self.access_token = access_token
+        self.access_token_expiry_time = access_token_expiry_time
+
+    def __getattr__(self, attr_name):
+        return _APIFunction(attr_name, self)
+
+
+class _APIFunction(object):
+    def __init__(self, function_name, service):
+        self.function_name = function_name
+        self.service = service
+
+    def __getattr__(self, attr_name):
+        # This isn't actually an API function, but a family of them.  Append
+        # the requested function name to our name.
+        return _APIFunction(
+            "{0}.{1}".format(self.function_name, attr_name), self.service)
+
+    def __call__(self, *args, **kwargs):
+        return call_api_with_access_token(
+            self.service.endpoint_url, self.service.access_token,
+            self.function_name, args, kwargs)
+
+#---------------------------------------------------------------------------
+# Code that implements authentication and raw calls into the API:
+
+
+def get_access_token_and_expiry_time(
+        access_token_url, client_id, client_secret_key):
+    """Given an API client (id and secret key) that is allowed to make API
+    calls, return an access token that can be used to make calls.
+    """
+    response = requests.post(
+        access_token_url,
+        headers={
+            "Authorization": u"Basic {0}".format(
+                base64.b64encode(
+                    "{0}:{1}".format(
+                        client_id, client_secret_key
+                    ).encode()
+                ).decode('utf-8')
+            ),
+        })
+    if response.status_code != 200:
+        raise AuthorizationError(response.status_code, reponse.text)
+
+    response_json = response.json()
+    access_token_expiry_time = time.time() - 2 + response_json["expires_in"]
+    return response_json["access_token"], access_token_expiry_time
+
+
+class AuthorizationError(Exception):
+    """Raised from the client if the server generated an error while generating
+    an access token.
+    """
+    def __init__(self, http_code, message):
+        super(AuthorizationError, self).__init__(message)
+        self.http_code = http_code
+
+
+def call_api_with_access_token(
+        endpoint_url, access_token, function_name, args, kwargs):
+    """Call into the API using an access token that was returned by
+    get_access_token.
+    """
+    response = requests.post(
+        endpoint_url,
+        headers={
+            "Authorization": "Bearer " + access_token,
+        },
+        data=dict(
+            json=json.dumps([function_name, args, kwargs]),
+        ))
+    if response.status_code == 200:
+        return response.json()
+
+    raise APIError(response.status_code, response.text)
+
+
+class APIError(Exception):
+    """Raised from the client if the server generated an error while calling
+    into the API.
+    """
+    def __init__(self, http_code, message):
+        super(APIError, self).__init__(message)
+        self.http_code = http_code
+
+
+service = service(
+        access_token_url="https://www.sidefx.com/oauth2/application_token",
+        client_id=user_client_id,
+        client_secret_key=user_client_secret_key,
+        endpoint_url="https://www.sidefx.com/api/",
+    )
+
+releases_list = service.download.get_daily_builds_list(
+        product='houdini', version=version, platform='linux', only_production=only_production)
+
+latest_release = service.download.get_daily_build_download(
+        product='houdini', version=version, platform='linux', build=releases_list[0]['build'])
+
+# Download the file as hou.tar.gz
+local_filename = 'hou.tar.gz'
+response = requests.get(latest_release['download_url'], stream=True)
+if response.status_code == 200:
+    with open(local_filename, 'wb') as f:
+        response.raw.decode_content = True
+        shutil.copyfileobj(response.raw, f)
+else:
+    raise Exception('Error downloading file!')
+
+# Verify the file checksum is matching
+file_hash = hashlib.md5()
+with open(local_filename, 'rb') as f:
+    for chunk in iter(lambda: f.read(4096), b''):
+        file_hash.update(chunk)
+if file_hash.hexdigest() != latest_release['hash']:
+    raise Exception('Checksum does not match!')

--- a/ci/download_houdini2.sh
+++ b/ci/download_houdini2.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -e
+
+HOUDINI_MAJOR="$1"
+GOLD="$2"
+HOUDINI_CLIENT_ID="$4"
+HOUDINI_SECRET_KEY="$5"
+
+if [ "$HOUDINI_CLIENT_ID" == "" ]; then
+    echo "HOUDINI_CLIENT_ID GitHub Action Secret needs to be set to install Houdini builds"
+    exit 1
+fi
+if [ "$HOUDINI_SECRET_KEY" == "" ]; then
+    echo "HOUDINI_SECRET_KEY GitHub Action Secret needs to be set to install Houdini builds"
+    exit 1
+fi
+
+pip install --user requests
+
+python ci/download_houdini2.py $HOUDINI_MAJOR $GOLD $HOUDINI_CLIENT_ID $HOUDINI_SECRET_KEY
+
+# create dir hierarchy
+mkdir -p hou/bin
+mkdir -p hou/houdini
+mkdir -p hou/toolkit
+mkdir -p hou/dsolib
+
+# unpack hou.tar.gz and cleanup
+tar -xzf hou.tar.gz
+rm -rf hou.tar.gz
+cd houdini*
+tar -xzf houdini.tar.gz
+
+# copy required files into hou dir
+cp houdini_setup* ../hou/.
+cp -r toolkit/cmake ../hou/toolkit/.
+cp -r toolkit/include ../hou/toolkit/.
+cp -r dsolib/libHoudini* ../hou/dsolib/.
+cp -r dsolib/libopenvdb_sesi* ../hou/dsolib/.
+cp -r dsolib/libblosc* ../hou/dsolib/.
+cp -r dsolib/libhboost* ../hou/dsolib/.
+cp -r dsolib/libz* ../hou/dsolib/.
+cp -r dsolib/libtbb* ../hou/dsolib/.
+cp -r dsolib/libHalf* ../hou/dsolib/.
+cp -r dsolib/libjemalloc* ../hou/dsolib/.
+
+# needed for < H18.0 (due to sesitag)
+if [ "$HOUDINI_MAJOR" == "17.0" ] || [ "$HOUDINI_MAJOR" == "17.5" ]; then
+    cp -r bin/app_init* ../hou/bin/.
+    cp -r bin/sesitag* ../hou/bin/.
+    cp -r dsolib/lib* ../hou/dsolib/.
+fi
+
+# write hou into hou.tar.gz and cleanup
+cd ..
+tar -czvf hou.tar.gz hou
+
+# move hou.tar.gz into hou subdirectory
+rm -rf hou/*
+mv hou.tar.gz hou
+
+# inspect size of tarball
+ls -lart hou/hou.tar.gz

--- a/ci/install_houdini2.sh
+++ b/ci/install_houdini2.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+# move hou tarball into top-level and untar
+cp hou/hou.tar.gz .
+tar -xzf hou.tar.gz


### PR DESCRIPTION
This new Houdini GitHub Actions workflow runs once a week and does the following:

* Download the latest Houdini production build using the new SideFX download API and the stored secret keys
* Strip out the headers, libraries and binaries required for building the OpenVDB Houdini plugin
* Try and build the OpenVDB Houdini plugin
* If successful, insert it into the GitHub Actions cache

With this PR alone, nothing is actually using the cache - using it will come in a subsequent PR.

I set this up to run on Wednesdays prior to our TSC meetings in case issues come up that need discussing. The intention is to deprecate the old Houdini download and install scripts, but for the purposes of migration I've introduced new ones (ci/download_houdini2.py, etc). For now, I'm just adding Houdini 18.0.