### PR TITLE
Bump Actions cache to v2

### DIFF
--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -24,7 +24,7 @@ jobs:
     - name: build
       run: ./ci/build_houdini.sh clang++ Release ON
     - name: write_houdini_cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: hou
         key: vdb1-houdini18_0-${{ hashFiles('hou/hou.tar.gz') }}


### PR DESCRIPTION
The scheduled action ran as expected today and succeeded, however GitHub Actions cache v1 does not support reading or writing caches when using a "schedule" trigger. Bumping to v2 which does support this.