### PR TITLE
Add bzip to houdini cache and evaluate unit tests

### DIFF
--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -23,6 +23,8 @@ jobs:
       run: ./ci/install_houdini2.sh
     - name: build
       run: ./ci/build_houdini.sh clang++ Release ON
+    - name: test
+      run: ./ci/test.sh
     - name: write_houdini_cache
       uses: actions/cache@v2
       with:

--- a/ci/download_houdini2.sh
+++ b/ci/download_houdini2.sh
@@ -41,6 +41,7 @@ cp -r dsolib/libopenvdb_sesi* ../hou/dsolib/.
 cp -r dsolib/libblosc* ../hou/dsolib/.
 cp -r dsolib/libhboost* ../hou/dsolib/.
 cp -r dsolib/libz* ../hou/dsolib/.
+cp -r dsolib/libbz2* ../hou/dsolib/.
 cp -r dsolib/libtbb* ../hou/dsolib/.
 cp -r dsolib/libHalf* ../hou/dsolib/.
 cp -r dsolib/libjemalloc* ../hou/dsolib/.


### PR DESCRIPTION
The Houdini ABI test fails when attempting to use the Houdini cache due to a missing bzip library. Add this to Houdini cache and enable unit test evaluation to Houdini workflow.