### PR TITLE
Update trigger rules for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,23 +5,19 @@ on:
   push:
     branches:
       - '*'
-    paths:
-      - '.github/**'
-      - 'CMakeLists.txt'
-      - 'ci/**'
-      - 'cmake/**'
-      - 'openvdb/**'
-      - 'openvdb_houdini/**'
+    paths-ignore:
+      - 'CHANGES'
+      - 'openvdb/doc/**'
+      - 'openvdb_maya/**'
+      - '**/*.md'
   pull_request:
     branches:
       - '*'
-    paths:
-      - '.github/**'
-      - 'CMakeLists.txt'
-      - 'ci/**'
-      - 'cmake/**'
-      - 'openvdb/**'
-      - 'openvdb_houdini/**'
+    paths-ignore:
+      - 'CHANGES'
+      - 'openvdb/doc/**'
+      - 'openvdb_maya/**'
+      - '**/*.md'
 
 jobs:
   testabi7:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,23 +5,17 @@ on:
   push:
     branches:
       - '*'
-    paths:
-      - '.github/**'
-      - 'CMakeLists.txt'
-      - 'ci/**'
-      - 'doc/**'
-      - 'openvdb/**'
-      - 'openvdb_houdini/**'
+    paths-ignore:
+      - 'CHANGES'
+      - 'openvdb_maya/**'
+      - '**/*.md'
   pull_request:
     branches:
       - '*'
-    paths:
-      - '.github/**'
-      - 'CMakeLists.txt'
-      - 'ci/**'
-      - 'doc/**'
-      - 'openvdb/**'
-      - 'openvdb_houdini/**'
+    paths-ignore:
+      - 'CHANGES'
+      - 'openvdb_maya/**'
+      - '**/*.md'
 
 jobs:
   doxygen:


### PR DESCRIPTION
Flip the logic in build and doc workflows to exclude certain paths (this should also correctly trigger builds on the new ax feature branch).