### PR TITLE
Add VFX 2021 CI Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,19 @@ on:
       - '**/*.md'
 
 jobs:
+  testvfx2021:
+    runs-on: ubuntu-16.04
+    container:
+      image: aswf/ci-openvdb:2021
+    steps:
+    - uses: actions/checkout@v1
+    - name: build
+      run: ./ci/build.sh clang++ Release 7 ON None -DOPENVDB_CXX_STRICT=ON
+    - name: test
+      run: ./ci/test.sh
+    - name: test_install
+      run: ./ci/test_install.sh
+
   testabi7:
     runs-on: ubuntu-16.04
     container:

--- a/openvdb/unittest/TestTree.cc
+++ b/openvdb/unittest/TestTree.cc
@@ -469,6 +469,7 @@ struct FloatThrowOnCopy
     explicit FloatThrowOnCopy(float _value): value(_value) { }
 
     FloatThrowOnCopy(const FloatThrowOnCopy&) { throw openvdb::RuntimeError("No Copy"); }
+    FloatThrowOnCopy& operator=(const FloatThrowOnCopy&) = default;
 
     T operator+(const float rhs) const { return T(value + rhs); }
     T operator-() const { return T(-value); }


### PR DESCRIPTION
This is mainly about switching on a CI build that uses GCC 9.3.1 which is the draft compiler for VFX Reference Platform 2021. In fact, there was only one build issue which was a missing default copy assignment operator in one of the unit tests (TestTree) that showed up as a compiler error with OPENVDB_CXX_STRICT set.

I haven't yet tried to enable C++17 or tried building the Houdini plugin, but it's a start.