### PR TITLE
Fetch Houdini from cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,14 @@ jobs:
       image: aswf/ci-base:2019
     steps:
     - uses: actions/checkout@v1
+    - name: fetch_houdini
+      uses: actions/cache@v2
+      with:
+        path: hou
+        key: vdb1-houdini18_0-${{ hashFiles('hou/hou.tar.gz') }}
+        restore-keys: vdb1-houdini18_0-
     - name: houdini
-      run: ./ci/install_houdini.sh 18.0 ${{ secrets.HOUPASS }}
+      run: ./ci/install_houdini2.sh
     - name: build
       run: ./ci/build_houdini.sh clang++ Release ON
     - name: test

--- a/ci/download_houdini2.sh
+++ b/ci/download_houdini2.sh
@@ -9,11 +9,11 @@ HOUDINI_SECRET_KEY="$5"
 
 if [ "$HOUDINI_CLIENT_ID" == "" ]; then
     echo "HOUDINI_CLIENT_ID GitHub Action Secret needs to be set to install Houdini builds"
-    exit 1
+    exit 0
 fi
 if [ "$HOUDINI_SECRET_KEY" == "" ]; then
     echo "HOUDINI_SECRET_KEY GitHub Action Secret needs to be set to install Houdini builds"
-    exit 1
+    exit 0
 fi
 
 pip install --user requests

--- a/ci/install_houdini2.sh
+++ b/ci/install_houdini2.sh
@@ -2,6 +2,8 @@
 
 set -e
 
-# move hou tarball into top-level and untar
-cp hou/hou.tar.gz .
-tar -xzf hou.tar.gz
+if [ -d "hou" ]; then
+    # move hou tarball into top-level and untar
+    cp hou/hou.tar.gz .
+    tar -xzf hou.tar.gz
+fi


### PR DESCRIPTION
This pulls the Houdini install from the GitHub Actions cache rather than attempting to download it directly. This side-steps all the issues with secret keys - once a week the Houdini install is updated in a regular scheduled job that _does_ have access to secret keys.

This is only for one job for now (the main Houdini 18.0 job). Once this has run successfully for a little while, I'll tidy up some of the old scripts, extend this to the other Houdini jobs and then finally deprecate Azure.