### PR TITLE
Improved test_install CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
       run: ./ci/build.sh clang++ Release 6 ON None -DOPENVDB_CXX_STRICT=ON
     - name: test
       run: ./ci/test.sh
+    - name: test_install
+      run: ./ci/test_install.sh
 
   testabi5:
     runs-on: ubuntu-16.04
@@ -54,6 +56,8 @@ jobs:
       run: ./ci/build.sh clang++ Release 5 ON None -DOPENVDB_CXX_STRICT=ON
     - name: test
       run: ./ci/test.sh
+    - name: test_install
+      run: ./ci/test_install.sh
 
   testhou180:
     runs-on: ubuntu-16.04

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,25 +3,29 @@
 set -ex
 
 COMPILER="$1"; shift
-RELEASE="$1"; shift
+BUILD_TYPE="$1"; shift
 ABI="$1"; shift
 BLOSC="$1"; shift
 SIMD="$1"; shift
 CMAKE_EXTRA="$@"
 
+# github actions runners have 2 threads
+# https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
+export CMAKE_BUILD_PARALLEL_LEVEL=2
+
 # DebugNoInfo is a custom CMAKE_BUILD_TYPE - no optimizations, no symbols, asserts enabled
 
-mkdir -p $HOME/install
 mkdir build
 cd build
 
-# print version
+# print versions
+bash --version
 cmake --version
 
 cmake \
     -DCMAKE_CXX_FLAGS_DebugNoInfo="" \
     -DCMAKE_CXX_COMPILER=${COMPILER} \
-    -DCMAKE_BUILD_TYPE=${RELEASE} \
+    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
     -DOPENVDB_ABI_VERSION_NUMBER=${ABI} \
     -DOPENVDB_USE_DEPRECATED_ABI_5=ON \
     -DUSE_BLOSC=${BLOSC} \
@@ -33,8 +37,7 @@ cmake \
     -DOPENVDB_BUILD_VDB_RENDER=ON \
     -DOPENVDB_BUILD_VDB_VIEW=ON \
     -DOPENVDB_SIMD=${SIMD} \
-    -DCMAKE_INSTALL_PREFIX=$HOME/install \
     ${CMAKE_EXTRA} \
     ..
-make -j2
-make install
+
+cmake --build . --config $BUILD_TYPE --target install

--- a/ci/test_install.sh
+++ b/ci/test_install.sh
@@ -10,12 +10,12 @@ set -e
 cmakelists="
 cmake_minimum_required(VERSION 3.3)
 project(TestInstall LANGUAGES CXX)
-find_package(OpenVDB REQUIRED openvdb)
+find_package(OpenVDB REQUIRED COMPONENTS openvdb)
 add_executable(test_vdb_print \"../openvdb/cmd/openvdb_print.cc\")
 target_link_libraries(test_vdb_print OpenVDB::openvdb)
 "
 mkdir tmp
 cd tmp
 echo -e "$cmakelists" > CMakeLists.txt
-cmake -DCMAKE_MODULE_PATH=$HOME/install/lib64/cmake/OpenVDB/ .
-make -j2
+cmake -DCMAKE_MODULE_PATH=/usr/local/lib64/cmake/OpenVDB/ .
+cmake --build . --config Release --target test_vdb_print


### PR DESCRIPTION
Main change here is to leave the install directory to the system default so that the vdb install automatically ends up on the system path. Added this test to other ABI images and I'm looking to add this to the mac/windows CI asap too.

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>