### PR TITLE
Always set the vector UI to visible if we fail to get the input mesh.

### DIFF
--- a/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
+++ b/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
@@ -684,7 +684,7 @@ SOP_OpenVDB_From_Polygons::updateParmsFlags()
     GA_ROAttributeRef attrRef;
     int attrClass = POINT_ATTR;
     const GU_Detail* meshGdp = this->getInputLastGeo(0, time);
-    for (int i = 1, N = evalInt("numattrib", 0, time); i <= N; ++i) {
+    for (int i = 1, N = static_cast<int>(evalInt("numattrib", 0, time)); i <= N; ++i) {
         bool isVector = true;
         if (meshGdp) {
             isVector = false;

--- a/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
+++ b/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
@@ -684,11 +684,11 @@ SOP_OpenVDB_From_Polygons::updateParmsFlags()
     GA_ROAttributeRef attrRef;
     int attrClass = POINT_ATTR;
     const GU_Detail* meshGdp = this->getInputLastGeo(0, time);
-    if (meshGdp) {
-        for (int i = 1, N = static_cast<int>(evalInt("attrList", 0, time)); i <= N; ++i) {
-
+    for (int i = 1, N = evalInt("numattrib", 0, time); i <= N; ++i) {
+        bool isVector = true;
+        if (meshGdp) {
+            isVector = false;
             evalStringInst("attribute#", &i, attrStr, 0, time);
-            bool isVector = false;
 
             if (attrStr.length() != 0 && evalAttrType(attrStr, attrName, attrClass)) {
 
@@ -716,10 +716,10 @@ SOP_OpenVDB_From_Polygons::updateParmsFlags()
                     }
                 }
             }
-
-            changed |= enableParmInst("vecType#", &i, isVector);
-            changed |= setVisibleStateInst("vecType#", &i, isVector);
         }
+
+        changed |= enableParmInst("vectype#", &i, isVector);
+        changed |= setVisibleStateInst("vectype#", &i, isVector);
     }
     return changed;
 }


### PR DESCRIPTION
If we fail to retrieve the input mesh, we want to make the vector UI visible as we don't know if it is needed or not.  Otherwise it maintains the last set values which may cause it to become stuck off even though it is affecting the output.