### PR TITLE
Add a check that ensures that Houdini is available in the ASWF repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
         restore-keys: vdb1-houdini18_0-
     - name: validate_houdini
       if: github.repository_owner == 'AcademySoftwareFoundation'
-      run: ./ci/validate_houdini.sh
+      run: test -f "hou/hou.tar.gz"
     - name: houdini
       run: ./ci/install_houdini2.sh
     - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,9 @@ jobs:
         path: hou
         key: vdb1-houdini18_0-${{ hashFiles('hou/hou.tar.gz') }}
         restore-keys: vdb1-houdini18_0-
+    - name: validate_houdini
+      if: github.repository_owner == 'AcademySoftwareFoundation'
+      run: ./ci/validate_houdini.sh
     - name: houdini
       run: ./ci/install_houdini2.sh
     - name: build

--- a/ci/validate_houdini.sh
+++ b/ci/validate_houdini.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ ! -f "hou/hou.tar.gz" ]; then
+    echo "Could not find Houdini download"
+    exit 1
+fi

--- a/ci/validate_houdini.sh
+++ b/ci/validate_houdini.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-if [ ! -f "hou/hou.tar.gz" ]; then
-    echo "Could not find Houdini download"
-    exit 1
-fi


### PR DESCRIPTION
It should always have been downloaded from the GHA cache for the parent repo, but it is allowed to not exist on fork repos.