### PR TITLE
Added the option to preserve active tiles during topology unions

### DIFF
--- a/openvdb/tree/InternalNode.h
+++ b/openvdb/tree/InternalNode.h
@@ -514,7 +514,7 @@ public:
     /// tiles or voxels that were inactive in this branch but active in the other branch
     /// are marked as active in this branch but left with their original values.
     template<typename OtherChildNodeType>
-    void topologyUnion(const InternalNode<OtherChildNodeType, Log2Dim>& other);
+    void topologyUnion(const InternalNode<OtherChildNodeType, Log2Dim>& other, const bool preserveTiles = false);
 
     /// @brief Intersects this tree's set of active values with the active values
     /// of the other tree, whose @c ValueType may be different.
@@ -2493,12 +2493,15 @@ struct InternalNode<ChildT, Log2Dim>::TopologyUnion
     struct A { inline void operator()(W &tV, const W& sV, const W& tC) const
         { tV = (tV | sV) & ~tC; }
     };
-    TopologyUnion(const OtherInternalNode* source, InternalNode* target) : s(source), t(target) {
+    TopologyUnion(const OtherInternalNode* source, InternalNode* target, const bool preserveTiles)
+        : s(source), t(target), mPreserveTiles(preserveTiles) {
         //(*this)(tbb::blocked_range<Index>(0, NUM_VALUES));//single thread for debugging
         tbb::parallel_for(tbb::blocked_range<Index>(0, NUM_VALUES), *this);
 
         // Bit processing is done in a single thread!
-        t->mChildMask |= s->mChildMask;//serial but very fast bitwise post-process
+        if (!mPreserveTiles) t->mChildMask |= s->mChildMask;//serial but very fast bitwise post-process
+        else                 t->mChildMask |= (s->mChildMask & !t->mValueMask);
+
         A op;
         t->mValueMask.foreach(s->mValueMask, t->mChildMask, op);
         assert((t->mValueMask & t->mChildMask).isOff());//no overlapping active tiles or child nodes
@@ -2508,11 +2511,13 @@ struct InternalNode<ChildT, Log2Dim>::TopologyUnion
             if (s->mChildMask.isOn(i)) {// Loop over other node's child nodes
                 const typename OtherInternalNode::ChildNodeType& other = *(s->mNodes[i].getChild());
                 if (t->mChildMask.isOn(i)) {//this has a child node
-                    t->mNodes[i].getChild()->topologyUnion(other);
+                    t->mNodes[i].getChild()->topologyUnion(other, mPreserveTiles);
                 } else {// this is a tile so replace it with a child branch with identical topology
-                    ChildT* child = new ChildT(other, t->mNodes[i].getValue(), TopologyCopy());
-                    if (t->mValueMask.isOn(i)) child->setValuesOn();//activate all values
-                    t->mNodes[i].setChild(child);
+                    if (!mPreserveTiles || t->mValueMask.isOff(i)) { // force child topology
+                        ChildT* child = new ChildT(other, t->mNodes[i].getValue(), TopologyCopy());
+                        if (t->mValueMask.isOn(i)) child->setValuesOn();//activate all values
+                        t->mNodes[i].setChild(child);
+                    }
                 }
             } else if (s->mValueMask.isOn(i) && t->mChildMask.isOn(i)) {
                 t->mNodes[i].getChild()->setValuesOn();
@@ -2521,14 +2526,15 @@ struct InternalNode<ChildT, Log2Dim>::TopologyUnion
     }
     const OtherInternalNode* s;
     InternalNode* t;
+    const bool mPreserveTiles;
 };// TopologyUnion
 
 template<typename ChildT, Index Log2Dim>
 template<typename OtherChildT>
 inline void
-InternalNode<ChildT, Log2Dim>::topologyUnion(const InternalNode<OtherChildT, Log2Dim>& other)
+InternalNode<ChildT, Log2Dim>::topologyUnion(const InternalNode<OtherChildT, Log2Dim>& other, const bool preserveTiles)
 {
-    TopologyUnion<InternalNode<OtherChildT, Log2Dim> > tmp(&other, this);
+    TopologyUnion<InternalNode<OtherChildT, Log2Dim> > tmp(&other, this, preserveTiles);
 }
 
 template<typename ChildT, Index Log2Dim>

--- a/openvdb/tree/LeafNode.h
+++ b/openvdb/tree/LeafNode.h
@@ -640,7 +640,7 @@ public:
     ///
     /// @note This operation modifies only active states, not values.
     template<typename OtherType>
-    void topologyUnion(const LeafNode<OtherType, Log2Dim>& other);
+    void topologyUnion(const LeafNode<OtherType, Log2Dim>& other, const bool preserveTiles = false);
 
     /// @brief Intersect this node's set of active values with the active values
     /// of the other node, whose @c ValueType may be different. So a
@@ -1676,7 +1676,7 @@ LeafNode<T, Log2Dim>::merge(const ValueType& tileValue, bool tileActive)
 template<typename T, Index Log2Dim>
 template<typename OtherType>
 inline void
-LeafNode<T, Log2Dim>::topologyUnion(const LeafNode<OtherType, Log2Dim>& other)
+LeafNode<T, Log2Dim>::topologyUnion(const LeafNode<OtherType, Log2Dim>& other, bool)
 {
     mValueMask |= other.valueMask();
 }

--- a/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/tree/LeafNodeBool.h
@@ -447,7 +447,7 @@ public:
     ///
     /// @note This operation modifies only active states, not values.
     template<typename OtherType>
-    void topologyUnion(const LeafNode<OtherType, Log2Dim>& other);
+    void topologyUnion(const LeafNode<OtherType, Log2Dim>& other, const bool preserveTiles = false);
 
     /// @brief Intersect this node's set of active values with the active values
     /// of the other node, whose @c ValueType may be different. So a
@@ -1307,7 +1307,7 @@ LeafNode<bool, Log2Dim>::merge(bool tileValue, bool tileActive)
 template<Index Log2Dim>
 template<typename OtherType>
 inline void
-LeafNode<bool, Log2Dim>::topologyUnion(const LeafNode<OtherType, Log2Dim>& other)
+LeafNode<bool, Log2Dim>::topologyUnion(const LeafNode<OtherType, Log2Dim>& other, bool)
 {
     mValueMask |= other.valueMask();
 }

--- a/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/tree/LeafNodeMask.h
@@ -455,7 +455,7 @@ public:
     ///
     /// @note This operation modifies only active states, not values.
     template<typename OtherType>
-    void topologyUnion(const LeafNode<OtherType, Log2Dim>& other);
+    void topologyUnion(const LeafNode<OtherType, Log2Dim>& other, const bool preserveTiles = false);
 
     /// @brief Intersect this node's set of active values with the active values
     /// of the other node, whose @c ValueType may be different. So a
@@ -1236,7 +1236,7 @@ LeafNode<ValueMask, Log2Dim>::merge(bool tileValue, bool)
 template<Index Log2Dim>
 template<typename OtherType>
 inline void
-LeafNode<ValueMask, Log2Dim>::topologyUnion(const LeafNode<OtherType, Log2Dim>& other)
+LeafNode<ValueMask, Log2Dim>::topologyUnion(const LeafNode<OtherType, Log2Dim>& other, bool)
 {
     mBuffer.mData |= other.valueMask();
 }

--- a/openvdb/tree/RootNode.h
+++ b/openvdb/tree/RootNode.h
@@ -832,8 +832,11 @@ public:
     /// Specifically, active tiles and voxels in this tree are not changed, and
     /// tiles or voxels that were inactive in this tree but active in the other tree
     /// are marked as active in this tree but left with their original values.
+    ///
+    /// @note If preserveTiles is true, any active tile in this topology
+    /// will not be densified by overlapping child topology.
     template<typename OtherChildType>
-    void topologyUnion(const RootNode<OtherChildType>& other);
+    void topologyUnion(const RootNode<OtherChildType>& other, const bool preserveTiles = false);
 
     /// @brief Intersects this tree's set of active values with the active values
     /// of the other tree, whose @c ValueType may be different.
@@ -3049,7 +3052,7 @@ RootNode<ChildT>::merge(RootNode& other)
 template<typename ChildT>
 template<typename OtherChildType>
 inline void
-RootNode<ChildT>::topologyUnion(const RootNode<OtherChildType>& other)
+RootNode<ChildT>::topologyUnion(const RootNode<OtherChildType>& other, const bool preserveTiles)
 {
     using OtherRootT = RootNode<OtherChildType>;
     using OtherCIterT = typename OtherRootT::MapCIter;
@@ -3063,12 +3066,14 @@ RootNode<ChildT>::topologyUnion(const RootNode<OtherChildType>& other)
                 mTable[i->first] = NodeStruct(
                     *(new ChildT(other.getChild(i), mBackground, TopologyCopy())));
             } else if (this->isChild(j)) { // union with child branch
-                this->getChild(j).topologyUnion(other.getChild(i));
+                this->getChild(j).topologyUnion(other.getChild(i), preserveTiles);
             } else {// this is a tile so replace it with a child branch with identical topology
-                ChildT* child = new ChildT(
-                    other.getChild(i), this->getTile(j).value, TopologyCopy());
-                if (this->isTileOn(j)) child->setValuesOn();//this is an active tile
-                this->setChild(j, *child);
+                if (!preserveTiles || this->isTileOff(j)) { // force child topology
+                    ChildT* child = new ChildT(
+                        other.getChild(i), this->getTile(j).value, TopologyCopy());
+                    if (this->isTileOn(j)) child->setValuesOn();//this is an active tile
+                    this->setChild(j, *child);
+                }
             }
         } else if (other.isTileOn(i)) { // other is an active tile
             if (j == mTable.end()) { // insert an active tile

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -684,8 +684,11 @@ public:
     /// Specifically, active tiles and voxels in this tree are not changed, and
     /// tiles or voxels that were inactive in this tree but active in the other tree
     /// are marked as active in this tree but left with their original values.
+    ///
+    /// @note If preserveTiles is true, any active tile in this topology
+    /// will not be densified by overlapping child topology.
     template<typename OtherRootNodeType>
-    void topologyUnion(const Tree<OtherRootNodeType>& other);
+    void topologyUnion(const Tree<OtherRootNodeType>& other, const bool preserveTiles = false);
 
     /// @brief Intersects this tree's set of active values with the active values
     /// of the other tree, whose @c ValueType may be different.
@@ -1841,10 +1844,10 @@ Tree<RootNodeType>::merge(Tree& other, MergePolicy policy)
 template<typename RootNodeType>
 template<typename OtherRootNodeType>
 inline void
-Tree<RootNodeType>::topologyUnion(const Tree<OtherRootNodeType>& other)
+Tree<RootNodeType>::topologyUnion(const Tree<OtherRootNodeType>& other, const bool preserveTiles)
 {
     this->clearAllAccessors();
-    mRoot.topologyUnion(other.root());
+    mRoot.topologyUnion(other.root(), preserveTiles);
 }
 
 template<typename RootNodeType>


### PR DESCRIPTION
This adds functionality to topology unions to preserve active tiles when the second tree contains active child topology which overlaps with a parent active tile in the first tree. Currently a leaf level tile in the first tree will be expanded to an allocated but constant (all active, all values the same) leaf node if the second tree contains a corresponding leaf node regardless of the leaf's activity. This is the current behaviour and is reflected in the function description.

As an example, I ran into an issue with this with the recent attempts to improve morphological dilations (and this is thus somewhat of a prerequisite for those upcoming improvements). The original unthreaded `dilateVoxels` ignores tiles. If a leaf neighbours an adjacent active tile and dilates into it, the tile remains unmodified. In the **current** implementation of `dilateActiveValues` the multithreaded implementation calls `topologyUnion` on subtrees. If a subtree happens to dilate into overlapping active tiles, these tiles are forcibly voxelized. If called with `IGNORE_TILES`, this seems incorrect. Ultimately, if you all you care about is an activity mask, this new behaviour is far more efficient.

I've opted for a new boolean flag on the `topologyUnion` call which defaults to the current behaviour, but perhaps this should really be a new `activityUnion` function. However this PR **only solves the preservation of active tiles**. The preservation of **inactive** tiles is unfortunately harder due to the complexity with updating the internal nodemasks (e.g. the case where an inactive tile is voxelized due to overlapping child topology, but all the child topology is inactive). You can avoid this with a pre `pruneInactive` on the second tree.


Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>