### PR TITLE
OVDB-101: Extended sharpening support to non-level-set volumes.

### DIFF
--- a/openvdb/openvdb/tools/Filter.h
+++ b/openvdb/openvdb/tools/Filter.h
@@ -147,6 +147,12 @@ public:
     /// @param mask Optional alpha mask.
     void median(int width = 1, int iterations = 1, const MaskType* mask = nullptr);
 
+    /// @brief Apply a sharpening filter to the grid.
+    /// @param width       the width of the sharpening filter is 2<i>width</i>+1 voxels
+    /// @param iterations  the number of times to apply the filter
+    /// @param mask        an optional alpha mask
+    void sharpen(int width = 1, int iterations = 1, const MaskType* mask = nullptr);
+
     /// Offsets (i.e. adds) a constant value to all active voxels.
     /// @param offset Offset in the same units as the grid.
     /// @param mask Optional alpha mask.
@@ -188,6 +194,7 @@ private:
     void doBoxY(const RangeType& r, Int32 w) { this->doBox<Avg<1> >(r,w); }
     void doBoxZ(const RangeType& r, Int32 w) { this->doBox<Avg<2> >(r,w); }
     void doMedian(const RangeType&, int);
+    void doSharpen(const RangeType&, const math::ConvolutionKernel<ValueType>&);
     void doOffset(const RangeType&, ValueType);
     /// @return true if the process was interrupted
     bool wasInterrupted();
@@ -663,6 +670,25 @@ Filter<GridT, MaskT, InterruptT>::median(int width, int iterations, const MaskTy
 
         this->cook(leafs);
     }
+    if (mInterrupter) mInterrupter->end();
+}
+
+
+template<typename GridT, typename MaskT, typename InterruptT>
+inline void
+Filter<GridT, MaskT, InterruptT>::sharpen(int width, int iterations, const MaskType* mask)
+{
+    if ((width == 0) || (iterations == 0)) return;
+
+    mMask = mask;
+    const auto kernel = math::sharpeningKernel<ValueType>(width);
+
+    if (mInterrupter) mInterrupter->start("Applying sharpening filter");
+
+    LeafManagerType leafMgr(mGrid->tree(), 1, mGrainSize == 0);
+
+    mTask = std::bind(&Filter::doSharpen, std::placeholders::_1, std::placeholders::_2, kernel);
+    for (int i = 0; i < iterations && !this->wasInterrupted(); ++i) this->cook(leafMgr);
 
     if (mInterrupter) mInterrupter->end();
 }
@@ -793,6 +819,42 @@ Filter<GridT, MaskT, InterruptT>::doMedian(const RangeType& range, int width)
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 stencil.moveTo(iter);
                 buffer.setValue(iter.pos(), stencil.median());
+            }
+        }
+    }
+}
+
+
+template<typename GridT, typename MaskT, typename InterruptT>
+inline void
+Filter<GridT, MaskT, InterruptT>::doSharpen(const RangeType& range,
+    const math::ConvolutionKernel<ValueType>& kernel)
+{
+    this->wasInterrupted();
+
+    math::ConvolutionStencil<GridType> stencil(*mGrid, kernel);
+
+    if (mMask) {
+        typename AlphaMaskT::FloatType a, b;
+        AlphaMaskT alpha(*mGrid, *mMask, mMinMask, mMaxMask, mInvertMask);
+        for (LeafIterT leafIter=range.begin(); leafIter; ++leafIter) {
+            BufferT& buffer = leafIter.buffer(1);
+            for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
+                if (alpha(iter.getCoord(), a, b)) {
+                    stencil.moveTo(iter);
+                    const ValueType phi0 = *iter, phi1 = stencil.convolve();
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+                    buffer.setValue(iter.pos(), b * phi0 + a * phi1);
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+                }
+            }
+        }
+    } else {
+        for (LeafIterT leafIter=range.begin(); leafIter; ++leafIter) {
+            BufferT& buffer = leafIter.buffer(1);
+            for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
+                stencil.moveTo(iter);
+                buffer.setValue(iter.pos(), stencil.convolve());
             }
         }
     }


### PR DESCRIPTION
Resubmission of Peter's sharpening work from #455. 

@Idclip - As noted below, this does unfortunately add a new boost dependency that wasn't there before, I couldn't see a trivial way of stripping this out. :(

- Added tools::Filter::sharpen().
- Moved sharpeningKernel() from LevelSetFilter.h to Stencils.h,
  for use by both Filter and LevelSetFilter.
- Changed BaseStencil::BufferType to boost::container::vector<T>
  to work around the absence of std::vector<bool>::data().
- Added a Sharpen option to the Filter SOP.
