### PR TITLE
A bad merge in PR747 grabbed the Houdini name for this parameter,

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -86,6 +86,8 @@ Version 7.1.0 - In Development
       point of the VDB when computing bounding box. SOPs affected include Clip,
       Fill, Points Group, Rasterize Points, Read, Remove Divergence.
       [Contributed by Kuba Roth]
+    - OpenVDB from Polygons SOP now always displays the vector UI, as otherwise
+      it might be stuck hidden if the input hasn't cooked.
 
     Build:
     - Improved the CMake build for the OpenVDB Houdini library on Windows.

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -110,6 +110,8 @@ Houdini:
   point of the VDB when computing bounding box. SOPs affected include Clip,
   Fill, Points Group, Rasterize Points, Read, Remove Divergence.
   <I>[Contributed&nbsp;by&nbsp;Kuba&nbsp;Roth]</I>
+- OpenVDB from Polygons SOP now always displays the vector UI, as otherwise
+  it might be stuck hidden if the input hasn't cooked.
 
 @par
 Build:

--- a/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
+++ b/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
@@ -684,7 +684,7 @@ SOP_OpenVDB_From_Polygons::updateParmsFlags()
     GA_ROAttributeRef attrRef;
     int attrClass = POINT_ATTR;
     const GU_Detail* meshGdp = this->getInputLastGeo(0, time);
-    for (int i = 1, N = static_cast<int>(evalInt("numattrib", 0, time)); i <= N; ++i) {
+    for (int i = 1, N = static_cast<int>(evalInt("attrList", 0, time)); i <= N; ++i) {
         bool isVector = true;
         if (meshGdp) {
             isVector = false;


### PR DESCRIPTION
Fixes the wrong parameter name being used.