### PR TITLE
Add DynamicNodeManager

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,8 @@ Version 7.1.0 - In Development
       data.
     - Added AttributeSet::Descriptor::groupIndexCollision() for detecting
       group index collisions when attempting to merge two Descriptors.
+    - Added a DynamicNodeManager class that can be used for efficient
+      multi-threading of topology-changing workflows.
 
     Bug fixes:
     - Fixed a bug where grids with no active values might return true when the

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -59,6 +59,9 @@ New features:
   data.
 - Added AttributeSet::Descriptor::groupIndexCollision for detecting group index
   collisions when attempting to merge two Descriptors.
+- Added a @vdblink::tree::DynamicNodeManager DynamicNodeManager@endlink class
+  that can be used for efficient multi-threading of topology-changing
+  workflows.
 
 @par
 Bug fixes:

--- a/openvdb/tree/NodeManager.h
+++ b/openvdb/tree/NodeManager.h
@@ -238,8 +238,7 @@ public:
     template<typename ParentT>
     void rebuild(ParentT& parent)
     {
-        mList.clear();
-        parent.getNodes(mList);
+        this->rebuildList(parent);
         for (size_t i=0, n=mList.nodeCount(); i<n; ++i) mNext.rebuild(mList(i));
     }
 
@@ -276,6 +275,14 @@ public:
     {
         mList.reduce(op, threaded, grainSize);
         mNext.reduceTopDown(op, threaded, grainSize);
+    }
+
+private:
+    template<typename ParentT>
+    void rebuildList(ParentT& parent)
+    {
+        mList.clear();
+        parent.getNodes(mList);
     }
 
 protected:
@@ -366,7 +373,8 @@ public:
     using RootNodeType = typename TreeOrLeafManagerT::RootNodeType;
     static_assert(RootNodeType::LEVEL >= LEVELS, "number of levels exceeds root node height");
 
-    NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root()) { mChain.init(mRoot, tree); }
+    NodeManager(TreeOrLeafManagerT& tree)
+        : NodeManager(tree, /*initialize=*/true) { }
 
     virtual ~NodeManager() {}
 
@@ -533,6 +541,12 @@ public:
     //@}
 
 protected:
+    NodeManager(TreeOrLeafManagerT& tree, bool initialize)
+        : mRoot(tree.root())
+    {
+        if (initialize)  mChain.init(mRoot, tree);
+    }
+
     RootNodeType& mRoot;
     NodeManagerLink<typename RootNodeType::ChildNodeType, LEVELS-1> mChain;
 
@@ -553,7 +567,8 @@ public:
     using RootNodeType = typename TreeOrLeafManagerT::RootNodeType;
     static const Index LEVELS = 0;
 
-    NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root()) {}
+    NodeManager(TreeOrLeafManagerT& tree)
+        : NodeManager(tree, /*initialize=*/true) { }
 
     virtual ~NodeManager() {}
 
@@ -585,6 +600,9 @@ public:
     void reduceTopDown(NodeOp& op, bool, size_t) { op(mRoot); }
 
 protected:
+    NodeManager(TreeOrLeafManagerT& tree, bool /*initialize*/)
+        : mRoot(tree.root()) { }
+
     RootNodeType& mRoot;
 
 private:
@@ -605,16 +623,8 @@ public:
     static_assert(RootNodeType::LEVEL > 0, "expected instantiation of template specialization");
     static const Index LEVELS = 1;
 
-    NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root())
-    {
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
-        if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
-            tree.getNodes(mList0);
-        } else {
-            mRoot.getNodes(mList0);
-        }
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
-    }
+    NodeManager(TreeOrLeafManagerT& tree)
+        : NodeManager(tree, /*initialize=*/true) { }
 
     virtual ~NodeManager() {}
 
@@ -664,6 +674,20 @@ public:
     }
 
 protected:
+    NodeManager(TreeOrLeafManagerT& tree, bool initialize)
+        : mRoot(tree.root())
+    {
+        if (initialize) {
+            OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
+            if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
+                tree.getNodes(mList0);
+            } else {
+                mRoot.getNodes(mList0);
+            }
+            OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+        }
+    }
+
     using NodeT1 = RootNodeType;
     using NodeT0 = typename NodeT1::ChildNodeType;
     using ListT0 = NodeList<NodeT0>;
@@ -689,18 +713,8 @@ public:
     static_assert(RootNodeType::LEVEL > 1, "expected instantiation of template specialization");
     static const Index LEVELS = 2;
 
-    NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root())
-    {
-        mRoot.getNodes(mList1);
-
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
-        if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
-            tree.getNodes(mList0);
-        } else {
-            for (size_t i=0, n=mList1.nodeCount(); i<n; ++i) mList1(i).getNodes(mList0);
-        }
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
-    }
+    NodeManager(TreeOrLeafManagerT& tree)
+        : NodeManager(tree, /*initialize=*/true) { }
 
     virtual ~NodeManager() {}
 
@@ -762,6 +776,22 @@ public:
     }
 
 protected:
+    NodeManager(TreeOrLeafManagerT& tree, bool initialize)
+        : mRoot(tree.root())
+    {
+        if (initialize) {
+            mRoot.getNodes(mList1);
+
+            OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
+            if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
+                tree.getNodes(mList0);
+            } else {
+                for (size_t i=0, n=mList1.nodeCount(); i<n; ++i) mList1(i).getNodes(mList0);
+            }
+            OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+        }
+    }
+
     using NodeT2 = RootNodeType;
     using NodeT1 = typename NodeT2::ChildNodeType; // upper level
     using NodeT0 = typename NodeT1::ChildNodeType; // lower level
@@ -791,19 +821,8 @@ public:
     static_assert(RootNodeType::LEVEL > 2, "expected instantiation of template specialization");
     static const Index LEVELS = 3;
 
-    NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root())
-    {
-        mRoot.getNodes(mList2);
-        for (size_t i=0, n=mList2.nodeCount(); i<n; ++i) mList2(i).getNodes(mList1);
-
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
-        if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
-            tree.getNodes(mList0);
-        } else {
-            for (size_t i=0, n=mList1.nodeCount(); i<n; ++i) mList1(i).getNodes(mList0);
-        }
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
-    }
+    NodeManager(TreeOrLeafManagerT& tree)
+        : NodeManager(tree, /*initialize=*/true) { }
 
     virtual ~NodeManager() {}
 
@@ -871,6 +890,23 @@ public:
     }
 
 protected:
+    NodeManager(TreeOrLeafManagerT& tree, bool initialize)
+        : mRoot(tree.root())
+    {
+        if (initialize) {
+            mRoot.getNodes(mList2);
+            for (size_t i=0, n=mList2.nodeCount(); i<n; ++i) mList2(i).getNodes(mList1);
+
+            OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
+            if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
+                tree.getNodes(mList0);
+            } else {
+                for (size_t i=0, n=mList1.nodeCount(); i<n; ++i) mList1(i).getNodes(mList0);
+            }
+            OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+        }
+    }
+
     using NodeT3 = RootNodeType;
     using NodeT2 = typename NodeT3::ChildNodeType; // upper level
     using NodeT1 = typename NodeT2::ChildNodeType; // mid level
@@ -903,20 +939,8 @@ public:
     static_assert(RootNodeType::LEVEL > 3, "expected instantiation of template specialization");
     static const Index LEVELS = 4;
 
-    NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root())
-    {
-        mRoot.getNodes(mList3);
-        for (size_t i=0, n=mList3.nodeCount(); i<n; ++i) mList3(i).getNodes(mList2);
-        for (size_t i=0, n=mList2.nodeCount(); i<n; ++i) mList2(i).getNodes(mList1);
-
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
-        if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
-            tree.getNodes(mList0);
-        } else {
-            for (size_t i=0, n=mList1.nodeCount(); i<n; ++i) mList1(i).getNodes(mList0);
-        }
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
-    }
+    NodeManager(TreeOrLeafManagerT& tree)
+        : NodeManager(tree, /*initialize=*/true) { }
 
     virtual ~NodeManager() {}
 
@@ -993,6 +1017,24 @@ public:
     }
 
 protected:
+    NodeManager(TreeOrLeafManagerT& tree, bool initialize)
+        : mRoot(tree.root())
+    {
+        if (initialize) {
+            mRoot.getNodes(mList3);
+            for (size_t i=0, n=mList3.nodeCount(); i<n; ++i) mList3(i).getNodes(mList2);
+            for (size_t i=0, n=mList2.nodeCount(); i<n; ++i) mList2(i).getNodes(mList1);
+
+            OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
+            if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
+                tree.getNodes(mList0);
+            } else {
+                for (size_t i=0, n=mList1.nodeCount(); i<n; ++i) mList1(i).getNodes(mList0);
+            }
+            OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+        }
+    }
+
     using NodeT4 = RootNodeType;
     using NodeT3 = typename NodeT4::ChildNodeType; // upper level
     using NodeT2 = typename NodeT3::ChildNodeType; // upper mid level

--- a/openvdb/tree/NodeManager.h
+++ b/openvdb/tree/NodeManager.h
@@ -139,7 +139,7 @@ public:
     }
 
     template<typename NodeOp>
-    void foreach(const NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void foreach(NodeOp& op, bool threaded = true, size_t grainSize=1)
     {
         NodeTransformer<NodeOp> transform(op);
         transform.run(this->nodeRange(grainSize), threaded);
@@ -158,18 +158,22 @@ private:
     template<typename NodeOp>
     struct NodeTransformer
     {
-        NodeTransformer(const NodeOp& nodeOp) : mNodeOp(nodeOp)
+        NodeTransformer(NodeOp& nodeOp) : mNodeOp(nodeOp)
         {
         }
         void run(const NodeRange& range, bool threaded = true)
         {
             threaded ? tbb::parallel_for(range, *this) : (*this)(range);
         }
+        void operator()(const NodeRange& range)
+        {
+            for (typename NodeRange::Iterator it = range.begin(); it; ++it) mNodeOp(*it);
+        }
         void operator()(const NodeRange& range) const
         {
             for (typename NodeRange::Iterator it = range.begin(); it; ++it) mNodeOp(*it);
         }
-        const NodeOp mNodeOp;
+        NodeOp mNodeOp;
     };// NodeList::NodeTransformer
 
     // Private struct of NodeList that performs parallel_reduce
@@ -247,14 +251,14 @@ public:
     }
 
     template<typename NodeOp>
-    void foreachBottomUp(const NodeOp& op, bool threaded, size_t grainSize)
+    void foreachBottomUp(NodeOp& op, bool threaded, size_t grainSize)
     {
         mNext.foreachBottomUp(op, threaded, grainSize);
         mList.foreach(op, threaded, grainSize);
     }
 
     template<typename NodeOp>
-    void foreachTopDown(const NodeOp& op, bool threaded, size_t grainSize)
+    void foreachTopDown(NodeOp& op, bool threaded, size_t grainSize)
     {
         mList.foreach(op, threaded, grainSize);
         mNext.foreachTopDown(op, threaded, grainSize);
@@ -305,13 +309,13 @@ public:
     Index64 nodeCount(Index) const { return mList.nodeCount(); }
 
     template<typename NodeOp>
-    void foreachBottomUp(const NodeOp& op, bool threaded, size_t grainSize)
+    void foreachBottomUp(NodeOp& op, bool threaded, size_t grainSize)
     {
         mList.foreach(op, threaded, grainSize);
     }
 
     template<typename NodeOp>
-    void foreachTopDown(const NodeOp& op, bool threaded, size_t grainSize)
+    void foreachTopDown(NodeOp& op, bool threaded, size_t grainSize)
     {
         mList.foreach(op, threaded, grainSize);
     }
@@ -440,14 +444,14 @@ public:
     ///
     /// @endcode
     template<typename NodeOp>
-    void foreachBottomUp(const NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void foreachBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
     {
         mChain.foreachBottomUp(op, threaded, grainSize);
         op(mRoot);
     }
 
     template<typename NodeOp>
-    void foreachTopDown(const NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void foreachTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
     {
         op(mRoot);
         mChain.foreachTopDown(op, threaded, grainSize);


### PR DESCRIPTION
This PR adds a new DynamicNodeManager that builds the node caches lazily. The main use case is for calling foreachTopDown() with an operation that modifies the tree (below the current level) as it is recursing down it.

There are a few small refactoring changes to the NodeManager to make this possible and you can now use a non-const operator in a foreach() just as you can in a reduce() operation.