### PR TITLE
Level Set CSG Union Merging

### DIFF
--- a/openvdb/CMakeLists.txt
+++ b/openvdb/CMakeLists.txt
@@ -312,6 +312,7 @@ set(OPENVDB_LIBRARY_TOOLS_INCLUDE_FILES
   tools/LevelSetTracker.h
   tools/LevelSetUtil.h
   tools/Mask.h
+  tools/Merge.h
   tools/MeshToVolume.h
   tools/Morphology.h
   tools/MultiResGrid.h

--- a/openvdb/tools/Composite.h
+++ b/openvdb/tools/Composite.h
@@ -15,6 +15,7 @@
 #include <openvdb/Types.h>
 #include <openvdb/Grid.h>
 #include <openvdb/math/Math.h> // for isExactlyEqual()
+#include "Merge.h"
 #include "ValueTransformer.h" // for transformValues()
 #include "Prune.h"// for prune
 #include "SignedFloodFill.h" // for signedFloodFill()
@@ -722,6 +723,27 @@ struct CopyOp
 };
 /// @endcond
 
+template <typename TreeT>
+inline void validateLevelSet(const TreeT& tree, const std::string& gridName = std::string(""))
+{
+    using ValueT = typename TreeT::ValueType;
+    const ValueT zero = zeroVal<ValueT>();
+    if (!(tree.background() > zero)) {
+        std::stringstream ss;
+        ss << "expected grid ";
+        if (!gridName.empty()) ss << gridName << " ";
+        ss << "outside value > 0, got " << tree.background();
+        OPENVDB_THROW(ValueError, ss.str());
+    }
+    if (!(-tree.background() < zero)) {
+        std::stringstream ss;
+        ss << "expected grid ";
+        if (!gridName.empty()) ss << gridName << " ";
+        ss << "inside value < 0, got " << -tree.background();
+        OPENVDB_THROW(ValueError, ss.str());
+    }
+}
+
 } // namespace composite
 
 
@@ -891,7 +913,7 @@ public:
         }
         if (!(mBInside < zero)) {
             OPENVDB_THROW(ValueError,
-                "expected grid B outside value < 0, got " << mBOutside);
+                "expected grid B inside value < 0, got " << mBInside);
         }
     }
 
@@ -1129,8 +1151,11 @@ csgUnion(GridOrTreeT& a, GridOrTreeT& b, bool prune)
     using Adapter = TreeAdapter<GridOrTreeT>;
     using TreeT = typename Adapter::TreeType;
     TreeT &aTree = Adapter::tree(a), &bTree = Adapter::tree(b);
-    CsgUnionVisitor<TreeT> visitor(aTree, bTree);
-    aTree.visit2(bTree, visitor);
+    composite::validateLevelSet(aTree, "A");
+    composite::validateLevelSet(bTree, "B");
+    CsgUnionMergeOp<TreeT> op{&bTree};
+    tree::DynamicNodeManager<TreeT> nodeManager(aTree);
+    nodeManager.foreachTopDown(op);
     if (prune) tools::pruneLevelSet(aTree);
 }
 

--- a/openvdb/tools/Merge.h
+++ b/openvdb/tools/Merge.h
@@ -1,0 +1,416 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+//
+/// @file Merge.h
+///
+/// @brief Functions to efficiently merge grids
+///
+/// @author Dan Bailey
+
+#ifndef OPENVDB_TOOLS_MERGE_HAS_BEEN_INCLUDED
+#define OPENVDB_TOOLS_MERGE_HAS_BEEN_INCLUDED
+
+#include <openvdb/Platform.h>
+#include <openvdb/Exceptions.h>
+#include <openvdb/Types.h>
+#include <openvdb/Grid.h>
+#include <openvdb/tree/NodeManager.h>
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace tools {
+
+
+/// @brief Convenience class that contains a pointer to a const or non-const tree
+/// and a subset of methods to retrieve data from the tree.
+///
+/// @details This class has methods to extract data from the tree that will either
+/// result in stealing the data or deep-copying it depending on whether the tree
+/// is mutable or not.
+template <typename TreeT>
+struct TreeToMerge
+{
+    using TreeType = std::remove_const_t<TreeT>;
+    using RootNodeType = typename TreeType::RootNodeType;
+    using ValueType = typename TreeType::ValueType;
+
+    TreeToMerge() = delete;
+
+    /// @brief Non-const tree constructor.
+    explicit TreeToMerge(TreeType* tree) : mTree(tree) { }
+    /// @brief Const tree constructor. As the tree is not mutable and thus cannot be pruned, a lightweight
+    /// mask tree with the same topology is created that can be pruned to use as a reference.
+    explicit TreeToMerge(const TreeType* constTree) : mConstTree(constTree)
+    {
+        if (mConstTree)    this->initializeMask();
+    }
+
+    /// @brief Retrieve a const pointer to the root node.
+    const RootNodeType* rootPtr() const;
+
+    /// @brief Return a pointer to the node of type @c NodeT that contains
+    /// voxel (x, y, z).  If no such node exists, return @c nullptr.
+    template<typename NodeT>
+    const NodeT* probeConstNode(const Coord& ijk) const;
+
+    /// @brief Return a pointer to the node of type @c NodeT that contains voxel (x, y, z).
+    /// If the tree is non-const, steal the node and replace it with an inactive
+    /// background-value tile.
+    /// If the tree is const, deep-copy the node and modify the mask tree to prune the node.
+    template <typename NodeT>
+    std::unique_ptr<NodeT> stealOrDeepCopyNode(const Coord& ijk);
+
+    /// @brief Add a tile containing voxel (x, y, z) at the level of NodeT,
+    /// deleting the existing branch if necessary.
+    template <typename NodeT>
+    void addTile(const Coord& ijk, const ValueType& value, bool active);
+
+private:
+    // build the mask using a topology union of the const tree
+    void initializeMask();
+
+    TreeType* const mTree = nullptr;
+    const TreeType* const mConstTree = nullptr;
+    MaskTree mMaskTree;
+}; // struct TreeToMerge
+
+
+////////////////////////////////////////
+
+
+/// @brief NodeManager operator to merge multiple trees using a CSG union.
+/// @note This class modifies the topology of the tree so is designed to be used
+/// from DynamicNodeManager::foreachTopDown().
+template<typename TreeT>
+struct CsgUnionMergeOp
+{
+    using ValueT = typename TreeT::ValueType;
+    using RootT = typename TreeT::RootNodeType;
+    using LeafT = typename TreeT::LeafNodeType;
+
+    /// @brief Templated constructor. This can be used to pass in a container of trees
+    /// such as vector<TreeT*> or vector<const TreeT*>. However it will also accept a
+    /// container of mixed const/non-const trees by wrapping them in TreeToMerge objects
+    /// such as vector<TreeToMerge<TreeT>>. Merge order is preserved in this case.
+    template <typename TreesT>
+    CsgUnionMergeOp(const TreesT& trees)
+        : mTreesToMerge(trees.cbegin(), trees.cend()) { }
+
+    /// @brief Initializer list constructor. This is convenient for small numbers of
+    /// trees that are all const or all non-const.
+    CsgUnionMergeOp(std::initializer_list<TreeT*> init)
+        : mTreesToMerge(init.begin(), init.end()) { }
+
+    /// @brief Return the number of trees being merged
+    size_t size() const { return mTreesToMerge.size(); }
+
+    // Processes the root node. Required by the NodeManager
+    void operator()(RootT& root) const;
+
+    // Processes the internal nodes. Required by the NodeManager
+    template<typename NodeT>
+    void operator()(NodeT& node) const;
+
+    // Processes the leaf nodes. Required by the NodeManager
+    void operator()(LeafT& leaf) const;
+
+private:
+    // on processing the root node, the background value is stored, retrieve it
+    // and check that the root node has already been processed
+    const ValueT& background() const;
+
+    // note that this vector is copied in NodeTransformer every time a foreach call is made,
+    // however in typical use cases this cost will be dwarfed by the actual merge algorithm
+    mutable std::vector<TreeToMerge<TreeT>> mTreesToMerge;
+    mutable const ValueT* mBackground = nullptr;
+}; // struct CsgUnionMergeOp
+
+
+////////////////////////////////////////
+
+
+template<typename TreeT>
+void TreeToMerge<TreeT>::initializeMask()
+{
+    mMaskTree.topologyUnion(*mConstTree);
+}
+
+template<typename TreeT>
+const typename TreeToMerge<TreeT>::RootNodeType*
+TreeToMerge<TreeT>::rootPtr() const
+{
+    if (mTree)               return &mTree->root();
+    else if (mConstTree)     return &mConstTree->root();
+    return nullptr;
+}
+
+template<typename TreeT>
+template<typename NodeT>
+const NodeT*
+TreeToMerge<TreeT>::probeConstNode(const Coord& ijk) const
+{
+    if (mTree)               return mTree->template probeConstNode<NodeT>(ijk);
+    else if (mConstTree) {
+        // test mutable mask first, node may have already been pruned
+        using MaskNodeT = typename NodeT::template ValueConverter<ValueMask>::Type;
+        if (!mMaskTree.probeConstNode<MaskNodeT>(ijk))    return nullptr;
+        return mConstTree->template probeConstNode<NodeT>(ijk);
+    }
+    return nullptr;
+}
+
+template<typename TreeT>
+template<typename NodeT>
+std::unique_ptr<NodeT>
+TreeToMerge<TreeT>::stealOrDeepCopyNode(const Coord& ijk)
+{
+    if (mTree) {
+        return std::unique_ptr<NodeT>(
+            mTree->root().template stealNode<NodeT>(ijk, mTree->root().background(), false)
+        );
+    } else if (auto* child = this->probeConstNode<NodeT>(ijk)) {
+        auto result = std::make_unique<NodeT>(*child);
+        // prune mask tree
+        mMaskTree.addTile(NodeT::LEVEL, ijk, false, false);
+        return result;
+    }
+    return std::unique_ptr<NodeT>();
+}
+
+template<typename TreeT>
+template<typename NodeT>
+void
+TreeToMerge<TreeT>::addTile(const Coord& ijk, const ValueType& value, bool active)
+{
+    if (mTree) {
+        auto* node = mTree->template probeNode<NodeT>(ijk);
+        const Index pos = NodeT::coordToOffset(ijk);
+        node->addTile(pos, value, active);
+    } else {
+        // prune mask tree
+        mMaskTree.addTile(NodeT::LEVEL, ijk, false, false);
+    }
+}
+
+
+////////////////////////////////////////
+
+
+template <typename TreeT>
+void CsgUnionMergeOp<TreeT>::operator()(RootT& root) const
+{
+    if (mTreesToMerge.empty())     return;
+
+    // store the background value
+    if (!mBackground)   mBackground = &root.background();
+
+    // find all tile values in this root and track inside/outside and active state
+    // note that level sets should never contain active tiles, but we handle them anyway
+
+    constexpr uint8_t ACTIVE_TILE = 0x1;
+    constexpr uint8_t INSIDE_TILE = 0x2;
+    constexpr uint8_t OUTSIDE_TILE = 0x4;
+
+    auto getTileFlag = [](auto valueIter) -> uint8_t
+    {
+        uint8_t flag(0);
+        const ValueT& value = valueIter.getValue();
+        if (value < zeroVal<ValueT>())          flag |= INSIDE_TILE;
+        else if (value > zeroVal<ValueT>())     flag |= OUTSIDE_TILE;
+        if (valueIter.isValueOn())              flag |= ACTIVE_TILE;
+        return flag;
+    };
+
+    std::unordered_map<Coord, /*flags*/uint8_t> tiles;
+
+    if (root.getTableSize() > 0) {
+        for (auto valueIter = root.cbeginValueAll(); valueIter; ++valueIter) {
+            const Coord& key = valueIter.getCoord();
+            tiles.insert({key, getTileFlag(valueIter)});
+        }
+    }
+
+    // find all tiles values in other roots and replace outside tiles with inside tiles
+
+    for (TreeToMerge<TreeT>& mergeTree : mTreesToMerge) {
+        const auto* mergeRoot = mergeTree.rootPtr();
+        if (!mergeRoot)     continue;
+        for (auto valueIter = mergeRoot->cbeginValueAll(); valueIter; ++valueIter) {
+            const Coord& key = valueIter.getCoord();
+            auto it = tiles.find(key);
+            if (it == tiles.end()) {
+                // if no tile with this key, insert it
+                tiles.insert({key, getTileFlag(valueIter)});
+            } else {
+                // replace an outside tile with an inside tile
+                const uint8_t flag = it->second;
+                if (flag & OUTSIDE_TILE) {
+                    const uint8_t newFlag = getTileFlag(valueIter);
+                    if (newFlag & INSIDE_TILE) {
+                        it->second = newFlag;
+                    }
+                }
+            }
+        }
+    }
+
+    // insert all inside tiles
+
+    for (auto it : tiles) {
+        const uint8_t flag = it.second;
+        if (flag & INSIDE_TILE) {
+            const Coord& key = it.first;
+            const bool state = flag & ACTIVE_TILE;
+            root.addTile(key, -this->background(), state);
+        }
+    }
+
+    std::unordered_set<Coord> children;
+
+    if (root.getTableSize() > 0) {
+        for (auto childIter = root.cbeginChildOn(); childIter; ++childIter) {
+            const Coord& key = childIter.getCoord();
+            children.insert(key);
+        }
+    }
+
+    // find all children in other roots and insert them if a child or tile with this key
+    // does not already exist or if the child will replace an outside tile
+
+    for (TreeToMerge<TreeT>& mergeTree : mTreesToMerge) {
+        const auto* mergeRoot = mergeTree.rootPtr();
+        if (!mergeRoot)     continue;
+        for (auto childIter = mergeRoot->cbeginChildOn(); childIter; ++childIter) {
+            const Coord& key = childIter.getCoord();
+
+            // if child already exists, do nothing
+            if (children.count(key))    continue;
+
+            // if an inside tile exists, do nothing
+            auto it = tiles.find(key);
+            if (it != tiles.end() && it->second == INSIDE_TILE)     continue;
+
+            auto childPtr = mergeTree.template stealOrDeepCopyNode<typename RootT::ChildNodeType>(key);
+            if (childPtr)   root.addChild(childPtr.release());
+
+            children.insert(key);
+        }
+    }
+
+    // insert all outside tiles that don't replace an inside tile or a child node
+
+    for (auto it : tiles) {
+        const uint8_t flag = it.second;
+        if (flag & OUTSIDE_TILE) {
+            const Coord& key = it.first;
+            if (!children.count(key)) {
+                const bool state = flag & ACTIVE_TILE;
+                root.addTile(key, this->background(), state);
+            }
+        }
+    }
+}
+
+template<typename TreeT>
+template<typename NodeT>
+void CsgUnionMergeOp<TreeT>::operator()(NodeT& node) const
+{
+    using NonConstNodeT = typename std::remove_const<NodeT>::type;
+
+    if (mTreesToMerge.empty())     return;
+
+    const ValueT outsideBackground = this->background();
+    const ValueT insideBackground = -outsideBackground;
+
+    using NodeMaskT = typename NodeT::NodeMaskType;
+
+    // store temporary masks to track inside and outside tile states
+    NodeMaskT insideTile;
+    NodeMaskT outsideTile;
+
+    for (auto iter = node.beginChildOff(); iter; ++iter) {
+        if (iter.getValue() < zeroVal<ValueT>()) {
+            insideTile.setOn(iter.pos());
+        } else if (iter.getValue() > zeroVal<ValueT>()) {
+            outsideTile.setOn(iter.pos());
+        }
+    }
+
+    for (TreeToMerge<TreeT>& mergeTree : mTreesToMerge) {
+
+        auto* mergeNode = mergeTree.template probeConstNode<NonConstNodeT>(node.origin());
+
+        if (!mergeNode)     continue;
+
+        // iterate over all tiles
+
+        for (auto iter = mergeNode->cbeginChildOff(); iter; ++iter) {
+            Index pos = iter.pos();
+            // source node contains an inside tile, so ignore
+            if (insideTile.isOn(pos))   continue;
+            // this node contains an inside tile, so turn into an inside tile
+            if (iter.getValue() < zeroVal<ValueT>()) {
+                node.addTile(pos, insideBackground, iter.isValueOn());
+                insideTile.setOn(pos);
+            }
+        }
+
+        // iterate over all child nodes
+
+        for (auto iter = mergeNode->cbeginChildOn(); iter; ++iter) {
+            Index pos = iter.pos();
+            const Coord& ijk = iter.getCoord();
+            // source node contains an inside tile, so ensure other node has no child
+            if (insideTile.isOn(pos)) {
+                mergeTree.template addTile<NonConstNodeT>(ijk, outsideBackground, false);
+            } else if (outsideTile.isOn(pos)) {
+                auto childPtr = mergeTree.template stealOrDeepCopyNode<typename NodeT::ChildNodeType>(ijk);
+                if (childPtr)   node.addChild(childPtr.release());
+                outsideTile.setOff(pos);
+            }
+        }
+    }
+}
+
+template <typename TreeT>
+void CsgUnionMergeOp<TreeT>::operator()(LeafT& leaf) const
+{
+    if (mTreesToMerge.empty())     return;
+
+    if (!leaf.allocate())   return;
+
+    for (TreeToMerge<TreeT>& mergeTree : mTreesToMerge) {
+        const LeafT* mergeLeaf = mergeTree.template probeConstNode<LeafT>(leaf.origin());
+        if (!mergeLeaf)     continue;
+
+        for (Index i = 0 ; i < LeafT::SIZE; i++) {
+            const ValueT& newValue = mergeLeaf->getValue(i);
+            if (newValue < leaf.getValue(i)) {
+                leaf.setValueOnly(i, newValue);
+                leaf.setActiveState(i, mergeLeaf->isValueOn(i));
+            }
+        }
+    }
+}
+
+template <typename TreeT>
+const typename CsgUnionMergeOp<TreeT>::ValueT&
+CsgUnionMergeOp<TreeT>::background() const
+{
+    if (!mBackground) {
+        OPENVDB_THROW(RuntimeError, "Background value not set. "
+            "This operator is only intended to be used with foreachTopDown().");
+    }
+    return *mBackground;
+}
+
+
+} // namespace tools
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif // OPENVDB_TOOLS_MERGE_HAS_BEEN_INCLUDED

--- a/openvdb/tree/NodeManager.h
+++ b/openvdb/tree/NodeManager.h
@@ -30,6 +30,11 @@ namespace tree {
 template<typename TreeOrLeafManagerT, Index LEVELS = TreeOrLeafManagerT::RootNodeType::LEVEL>
 class NodeManager;
 
+// Produce linear arrays of all tree nodes lazily, to facilitate efficient threading
+// of topology-changing workflows.
+template<typename TreeOrLeafManagerT, Index LEVELS = TreeOrLeafManagerT::RootNodeType::LEVEL>
+class DynamicNodeManager;
+
 
 ////////////////////////////////////////
 
@@ -259,6 +264,14 @@ public:
         mNext.foreachTopDown(op, threaded, grainSize);
     }
 
+    template<typename NodeOp, typename ParentT>
+    void foreachTopDown(NodeOp& op, ParentT& parent, bool threaded, size_t grainSize)
+    {
+        this->rebuildList(parent);
+        mList.foreach(op, threaded, grainSize);
+        mNext.foreachTopDown(op, parent, threaded, grainSize);
+    }
+
     template<typename NodeOp>
     void reduceBottomUp(NodeOp& op, bool threaded, size_t grainSize)
     {
@@ -271,6 +284,14 @@ public:
     {
         mList.reduce(op, threaded, grainSize);
         mNext.reduceTopDown(op, threaded, grainSize);
+    }
+
+    template<typename NodeOp, typename ParentT>
+    void reduceTopDown(NodeOp& op, ParentT& parent, bool threaded, size_t grainSize)
+    {
+        this->rebuildList(parent);
+        mList.reduce(op, threaded, grainSize);
+        mNext.reduceTopDown(op, parent, threaded, grainSize);
     }
 
 private:
@@ -323,6 +344,13 @@ public:
         mList.foreach(op, threaded, grainSize);
     }
 
+    template<typename NodeOp, typename ParentT>
+    void foreachTopDown(NodeOp& op, ParentT& parent, bool threaded, size_t grainSize)
+    {
+        this->rebuild(parent);
+        mList.foreach(op, threaded, grainSize);
+    }
+
     template<typename NodeOp>
     void reduceBottomUp(NodeOp& op, bool threaded, size_t grainSize)
     {
@@ -332,6 +360,13 @@ public:
     template<typename NodeOp>
     void reduceTopDown(NodeOp& op, bool threaded, size_t grainSize)
     {
+        mList.reduce(op, threaded, grainSize);
+    }
+
+    template<typename NodeOp, typename ParentT>
+    void reduceTopDown(NodeOp& op, ParentT& parent, bool threaded, size_t grainSize)
+    {
+        this->rebuild(parent);
         mList.reduce(op, threaded, grainSize);
     }
 
@@ -549,6 +584,66 @@ protected:
 private:
     NodeManager(const NodeManager&) {}//disallow copy-construction
 };// NodeManager class
+
+
+////////////////////////////////////////////
+
+
+/// @brief To facilitate threading over the nodes of a tree, cache
+/// node pointers lazily in linear arrays, one for each level of the tree.
+///
+/// @details For a top-down operation, this implementation caches the nodes of
+/// the tree for each level of the tree just prior to performing the parallel
+/// for or parallel reduce operation on that level of the tree. This is mainly
+/// designed to be used in cases where an operation modifies the tree below the
+/// current level of execution.
+///
+/// For a bottom-up operation, this implementation caches the nodes of the tree
+/// just prior to performing the parallel for or parallel reduce operation on
+/// the whole tree. This is mainly provided for consistency and only represents
+/// a minor convenience to avoid having to explicitly rebuild the nodes of the
+/// tree after each bottom-up operation when performing topology-changing
+/// modifications to the tree in-between.
+///
+/// This implementation works with trees of any depth, but optimized
+/// specializations are provided for the most typical tree depths.
+template<typename TreeOrLeafManagerT, Index _LEVELS>
+class DynamicNodeManager : public NodeManager<TreeOrLeafManagerT, _LEVELS>
+{
+public:
+    using NodeManagerT = NodeManager<TreeOrLeafManagerT, _LEVELS>;
+
+    DynamicNodeManager(TreeOrLeafManagerT& tree)
+        : NodeManagerT(tree, /*initialize=*/false) { }
+
+    template<typename NodeOp>
+    void foreachBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        NodeManagerT::foreachBottomUp(op, threaded, grainSize);
+    }
+
+    template<typename NodeOp>
+    void foreachTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mChain.foreachTopDown(op, this->mRoot, threaded, grainSize);
+    }
+
+    template<typename NodeOp>
+    void reduceBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        NodeManagerT::reduceBottomUp(op, threaded, grainSize);
+    }
+
+    template<typename NodeOp>
+    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mChain.reduceTopDown(op, this->mRoot, threaded, grainSize);
+    }
+};
 
 
 ////////////////////////////////////////////
@@ -1051,6 +1146,256 @@ protected:
 private:
     NodeManager(const NodeManager&) {} // disallow copy-construction
 }; // NodeManager<4>
+
+
+/// @private
+/// Template specialization of the DynamicNodeManager with no caching of nodes
+template<typename TreeOrLeafManagerT>
+class DynamicNodeManager<TreeOrLeafManagerT, 0> : public NodeManager<TreeOrLeafManagerT, 0>
+{
+public:
+    using NodeManagerT = NodeManager<TreeOrLeafManagerT, 0>;
+
+    DynamicNodeManager(TreeOrLeafManagerT& tree)
+        : NodeManagerT(tree, /*initialize=*/false) { }
+}; // DynamicNodeManager<0>
+
+
+/// @private
+/// Template specialization of the DynamicNodeManager with one level of nodes
+template<typename TreeOrLeafManagerT>
+class DynamicNodeManager<TreeOrLeafManagerT, 1> : public NodeManager<TreeOrLeafManagerT, 1>
+{
+public:
+    using NodeManagerT = NodeManager<TreeOrLeafManagerT, 1>;
+
+    DynamicNodeManager(TreeOrLeafManagerT& tree)
+        : NodeManagerT(tree, /*initialize=*/false) { }
+
+    template<typename NodeOp>
+    void foreachBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        this->mList0.foreach(op, threaded, grainSize);
+        op(this->mRoot);
+    }
+
+    template<typename NodeOp>
+    void foreachTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mList0.clear();
+        this->mRoot.getNodes(this->mList0);
+        this->mList0.foreach(op, threaded, grainSize);
+    }
+
+    template<typename NodeOp>
+    void reduceBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        this->mList0.reduce(op, threaded, grainSize);
+        op(this->mRoot);
+    }
+
+    template<typename NodeOp>
+    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mList0.clear();
+        this->mRoot.getNodes(this->mList0);
+        this->mList0.reduce(op, threaded, grainSize);
+    }
+}; // DynamicNodeManager<1>
+
+
+/// @private
+/// Template specialization of the DynamicNodeManager with two levels of nodes
+template<typename TreeOrLeafManagerT>
+class DynamicNodeManager<TreeOrLeafManagerT, 2> : public NodeManager<TreeOrLeafManagerT, 2>
+{
+public:
+    using NodeManagerT = NodeManager<TreeOrLeafManagerT, 2>;
+
+    DynamicNodeManager(TreeOrLeafManagerT& tree)
+        : NodeManagerT(tree, /*initialize=*/false) { }
+
+    template<typename NodeOp>
+    void foreachBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        this->mList0.foreach(op, threaded, grainSize);
+        this->mList1.foreach(op, threaded, grainSize);
+        op(this->mRoot);
+    }
+
+    template<typename NodeOp>
+    void foreachTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mList1.clear();
+        this->mRoot.getNodes(this->mList1);
+        this->mList1.foreach(op, threaded, grainSize);
+        this->mList0.clear();
+        this->mRoot.getNodes(this->mList0);
+        this->mList0.foreach(op, threaded, grainSize);
+    }
+
+    template<typename NodeOp>
+    void reduceBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        this->mList0.reduce(op, threaded, grainSize);
+        this->mList1.reduce(op, threaded, grainSize);
+        op(this->mRoot);
+    }
+
+    template<typename NodeOp>
+    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mList1.clear();
+        this->mRoot.getNodes(this->mList1);
+        this->mList1.reduce(op, threaded, grainSize);
+        this->mList0.clear();
+        this->mRoot.getNodes(this->mList0);
+        this->mList0.reduce(op, threaded, grainSize);
+    }
+};  // DynamicNodeManager<2>
+
+
+/// @private
+/// Template specialization of the DynamicNodeManager with three levels of nodes
+template<typename TreeOrLeafManagerT>
+class DynamicNodeManager<TreeOrLeafManagerT, 3> : public NodeManager<TreeOrLeafManagerT, 3>
+{
+public:
+    using NodeManagerT = NodeManager<TreeOrLeafManagerT, 3>;
+
+    DynamicNodeManager(TreeOrLeafManagerT& tree)
+        : NodeManagerT(tree, /*initialize=*/false) { }
+
+    template<typename NodeOp>
+    void foreachBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        this->mList0.foreach(op, threaded, grainSize);
+        this->mList1.foreach(op, threaded, grainSize);
+        this->mList2.foreach(op, threaded, grainSize);
+        op(this->mRoot);
+    }
+
+    template<typename NodeOp>
+    void foreachTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mList2.clear();
+        this->mRoot.getNodes(this->mList2);
+        this->mList2.foreach(op, threaded, grainSize);
+        this->mList1.clear();
+        this->mRoot.getNodes(this->mList1);
+        this->mList1.foreach(op, threaded, grainSize);
+        this->mList0.clear();
+        this->mRoot.getNodes(this->mList0);
+        this->mList0.foreach(op, threaded, grainSize);
+    }
+
+    template<typename NodeOp>
+    void reduceBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        this->mList0.reduce(op, threaded, grainSize);
+        this->mList1.reduce(op, threaded, grainSize);
+        this->mList2.reduce(op, threaded, grainSize);
+        op(this->mRoot);
+    }
+
+    template<typename NodeOp>
+    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mList2.clear();
+        this->mRoot.getNodes(this->mList2);
+        this->mList2.reduce(op, threaded, grainSize);
+        this->mList1.clear();
+        this->mRoot.getNodes(this->mList1);
+        this->mList1.reduce(op, threaded, grainSize);
+        this->mList0.clear();
+        this->mRoot.getNodes(this->mList0);
+        this->mList0.reduce(op, threaded, grainSize);
+    }
+};  // DynamicNodeManager<3>
+
+
+/// @private
+/// Template specialization of the DynamicNodeManager with four levels of nodes
+template<typename TreeOrLeafManagerT>
+class DynamicNodeManager<TreeOrLeafManagerT, 4> : public NodeManager<TreeOrLeafManagerT, 4>
+{
+public:
+    using NodeManagerT = NodeManager<TreeOrLeafManagerT, 4>;
+
+    DynamicNodeManager(TreeOrLeafManagerT& tree)
+        : NodeManagerT(tree, /*initialize=*/false) { }
+
+    template<typename NodeOp>
+    void foreachBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        this->mList0.foreach(op, threaded, grainSize);
+        this->mList1.foreach(op, threaded, grainSize);
+        this->mList2.foreach(op, threaded, grainSize);
+        this->mList3.foreach(op, threaded, grainSize);
+        op(this->mRoot);
+    }
+
+    template<typename NodeOp>
+    void foreachTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mList3.clear();
+        this->mRoot.getNodes(this->mList3);
+        this->mList3.foreach(op, threaded, grainSize);
+        this->mList2.clear();
+        this->mRoot.getNodes(this->mList2);
+        this->mList2.foreach(op, threaded, grainSize);
+        this->mList1.clear();
+        this->mRoot.getNodes(this->mList1);
+        this->mList1.foreach(op, threaded, grainSize);
+        this->mList0.clear();
+        this->mRoot.getNodes(this->mList0);
+        this->mList0.foreach(op, threaded, grainSize);
+    }
+
+    template<typename NodeOp>
+    void reduceBottomUp(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        this->rebuild();
+        this->mList0.reduce(op, threaded, grainSize);
+        this->mList1.reduce(op, threaded, grainSize);
+        this->mList2.reduce(op, threaded, grainSize);
+        this->mList3.reduce(op, threaded, grainSize);
+        op(this->mRoot);
+    }
+
+    template<typename NodeOp>
+    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    {
+        op(this->mRoot);
+        this->mList3.clear();
+        this->mRoot.getNodes(this->mList3);
+        this->mList3.reduce(op, threaded, grainSize);
+        this->mList2.clear();
+        this->mRoot.getNodes(this->mList2);
+        this->mList2.reduce(op, threaded, grainSize);
+        this->mList1.clear();
+        this->mRoot.getNodes(this->mList1);
+        this->mList1.reduce(op, threaded, grainSize);
+        this->mList0.clear();
+        this->mRoot.getNodes(this->mList0);
+        this->mList0.reduce(op, threaded, grainSize);
+    }
+}; // DynamicNodeManager<4>
+
 
 } // namespace tree
 } // namespace OPENVDB_VERSION_NAME

--- a/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/unittest/CMakeLists.txt
@@ -101,6 +101,7 @@ set(UNITTEST_SOURCE_FILES
   TestMat4Metadata.cc
   TestMath.cc
   TestMeanCurvature.cc
+  TestMerge.cc
   TestMeshToVolume.cc
   TestMetadata.cc
   TestMetadataIO.cc

--- a/openvdb/unittest/TestMerge.cc
+++ b/openvdb/unittest/TestMerge.cc
@@ -1,0 +1,586 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <openvdb/openvdb.h>
+
+#include <openvdb/tools/Merge.h>
+
+using namespace openvdb;
+
+class TestMerge: public CppUnit::TestCase
+{
+public:
+    CPPUNIT_TEST_SUITE(TestMerge);
+    CPPUNIT_TEST(testCsgUnion);
+    CPPUNIT_TEST_SUITE_END();
+
+    void testCsgUnion();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestMerge);
+
+namespace
+{
+
+auto getTileCount = [](const auto& root) -> Index
+{
+    Index sum = 0;
+    for (auto iter = root.cbeginValueAll(); iter; ++iter)   sum++;
+    return sum;
+};
+
+auto getActiveTileCount = [](const auto& root) -> Index
+{
+    Index sum = 0;
+    for (auto iter = root.cbeginValueOn(); iter; ++iter)   sum++;
+    return sum;
+};
+
+auto getInactiveTileCount = [](const auto& root) -> Index
+{
+    Index sum = 0;
+    for (auto iter = root.cbeginValueOff(); iter; ++iter)   sum++;
+    return sum;
+};
+
+auto getInsideTileCount = [](const auto& root) -> Index
+{
+    using ValueT = typename std::remove_reference<decltype(root)>::type::ValueType;
+    Index sum = 0;
+    for (auto iter = root.cbeginValueAll(); iter; ++iter) {
+        if (iter.getValue() < zeroVal<ValueT>())     sum++;
+    }
+    return sum;
+};
+
+auto getOutsideTileCount = [](const auto& root) -> Index
+{
+    using ValueT = typename std::remove_reference<decltype(root)>::type::ValueType;
+    Index sum = 0;
+    for (auto iter = root.cbeginValueAll(); iter; ++iter) {
+        if (iter.getValue() > zeroVal<ValueT>())     sum++;
+    }
+    return sum;
+};
+
+auto getChildCount = [](const auto& root) -> Index
+{
+    Index sum = 0;
+    for (auto iter = root.cbeginChildOn(); iter; ++iter)   sum++;
+    return sum;
+};
+
+} // namespace
+
+void
+TestMerge::testCsgUnion()
+{
+    std::cerr << std::endl;
+
+    { // construction
+        FloatTree tree1;
+        FloatTree tree2;
+        const FloatTree tree3;
+
+        // empty
+        tools::CsgUnionMergeOp<FloatTree> mergeOp1{};
+        CPPUNIT_ASSERT_EQUAL(size_t(0), mergeOp1.size());
+        // one item, initializer list
+        tools::CsgUnionMergeOp<FloatTree> mergeOp2{&tree1};
+        CPPUNIT_ASSERT_EQUAL(size_t(1), mergeOp2.size());
+        // two items, initializer list
+        tools::CsgUnionMergeOp<FloatTree> mergeOp3{&tree1, &tree2};
+        CPPUNIT_ASSERT_EQUAL(size_t(2), mergeOp3.size());
+        // vector of tree pointers
+        std::vector<FloatTree*> trees4{&tree1, &tree2};
+        tools::CsgUnionMergeOp<FloatTree> mergeOp4(trees4);
+        CPPUNIT_ASSERT_EQUAL(size_t(2), mergeOp4.size());
+        // deque of tree pointers
+        std::deque<FloatTree*> trees5{&tree1, &tree2};
+        tools::CsgUnionMergeOp<FloatTree> mergeOp5(trees5);
+        CPPUNIT_ASSERT_EQUAL(size_t(2), mergeOp5.size());
+        // vector of TreesToMerge (to mix const and non-const trees)
+        std::vector<tools::TreeToMerge<FloatTree>> trees6;
+        trees6.emplace_back(&tree1);
+        trees6.emplace_back(&tree3); // const tree
+        trees6.emplace_back(&tree2);
+        tools::CsgUnionMergeOp<FloatTree> mergeOp6(trees6);
+        CPPUNIT_ASSERT_EQUAL(size_t(3), mergeOp6.size());
+        // implicit copy constructor
+        tools::CsgUnionMergeOp<FloatTree> mergeOp7(mergeOp3);
+        CPPUNIT_ASSERT_EQUAL(size_t(2), mergeOp7.size());
+        // implicit assignment operator
+        tools::CsgUnionMergeOp<FloatTree> mergeOp8 = mergeOp3;
+        CPPUNIT_ASSERT_EQUAL(size_t(2), mergeOp8.size());
+    }
+
+    { // empty merge trees
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{};
+
+        CPPUNIT_ASSERT_EQUAL(size_t(0), mergeOp.size());
+
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(0), root.getTableSize());
+    }
+
+    { // merge two different outside root tiles from one grid into an empty grid
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        root2.addTile(Coord(0, 0, 0), grid->background(), false);
+        root2.addTile(Coord(8192, 0, 0), grid->background(), true);
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), root2.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(2), getTileCount(root2));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getActiveTileCount(root2));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInactiveTileCount(root2));
+
+        // test container constructor here
+        std::vector<FloatTree*> treesToMerge{&grid2->tree()};
+        tools::CsgUnionMergeOp<FloatTree> mergeOp(treesToMerge);
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(2), getTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getActiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInactiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(0), getInsideTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getOutsideTileCount(root));
+    }
+
+    { // merge two different outside root tiles from two grids into an empty grid
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        FloatGrid::Ptr grid3 = createLevelSet<FloatGrid>();
+        auto& root3 = grid3->tree().root();
+        root2.addTile(Coord(0, 0, 0), /*background=*/123.0f, false);
+        root3.addTile(Coord(8192, 0, 0), /*background=*/0.1f, true);
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree(), &grid3->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(2), getTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getActiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInactiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(0), getInsideTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getOutsideTileCount(root));
+
+        // background values of merge trees should be ignored, only important
+        // that the values are greater than zero and thus an outside tile
+        for (auto iter = root.cbeginValueAll(); iter; ++iter) {
+            CPPUNIT_ASSERT_EQUAL(grid->background(), iter.getValue());
+        }
+    }
+
+    { // merge the same outside root tiles from two grids into an empty grid
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        FloatGrid::Ptr grid3 = createLevelSet<FloatGrid>();
+        auto& root3 = grid3->tree().root();
+        root2.addTile(Coord(0, 0, 0), grid->background(), true);
+        root3.addTile(Coord(0, 0, 0), grid->background(), false);
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree(), &grid3->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(1), getTileCount(root));
+        // merge order is important - tile should be active
+        CPPUNIT_ASSERT_EQUAL(Index(1), getActiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(0), getInactiveTileCount(root));
+
+        root.clear();
+        // reverse tree order
+        tools::CsgUnionMergeOp<FloatTree> mergeOp2{&grid3->tree(), &grid2->tree()};
+        nodeManager.foreachTopDown(mergeOp2);
+        // merge order is important - tile should now be inactive
+        CPPUNIT_ASSERT_EQUAL(Index(0), getActiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInactiveTileCount(root));
+    }
+
+    { // merge an outside root tile to a grid which already has this tile
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        root.addTile(Coord(0, 0, 0), grid->background(), false);
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        root2.addTile(Coord(0, 0, 0), grid->background(), true);
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(1), getTileCount(root));
+        // tile in merge grid should not replace existing tile - tile should remain inactive
+        CPPUNIT_ASSERT_EQUAL(Index(0), getActiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInactiveTileCount(root));
+    }
+
+    { // merge an inside root tile to a grid which has an outside tile, inside takes precedence
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        root.addTile(Coord(0, 0, 0), grid->background(), false);
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        root2.addTile(Coord(0, 0, 0), -123.0f, true);
+
+        CPPUNIT_ASSERT_EQUAL(Index(0), getInsideTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getOutsideTileCount(root));
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp, true);
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(1), getTileCount(root));
+        // tile in merge grid replace existing tile - tile should now be active and inside
+        CPPUNIT_ASSERT_EQUAL(Index(1), getActiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(0), getInactiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInsideTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(0), getOutsideTileCount(root));
+    }
+
+    { // merge two grids with an outside and an inside tile, inside takes precedence
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        root2.addTile(Coord(0, 0, 0), grid->background(), true);
+        FloatGrid::Ptr grid3 = createLevelSet<FloatGrid>();
+        auto& root3 = grid3->tree().root();
+        root3.addTile(Coord(0, 0, 0), /*inside*/-0.1f, false);
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree(), &grid3->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(1), getTileCount(root));
+        // tile in merge grid should not replace existing tile - tile should remain inactive
+        CPPUNIT_ASSERT_EQUAL(Index(0), getActiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInactiveTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInsideTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(0), getOutsideTileCount(root));
+    }
+
+    { // merge two child nodes into an empty grid
+        using RootChildType = FloatTree::RootNodeType::ChildNodeType;
+
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        root2.addChild(new RootChildType(Coord(0, 0, 0), 1.0f, false));
+        root2.addChild(new RootChildType(Coord(8192, 0, 0), -123.0f, true));
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), root2.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(0), getTileCount(root2));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getChildCount(root2));
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(0), getTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getChildCount(root));
+    }
+
+    { // merge a child node into a grid with an outside tile
+        using RootChildType = FloatTree::RootNodeType::ChildNodeType;
+
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        root.addTile(Coord(0, 0, 0), 123.0f, true);
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        root2.addChild(new RootChildType(Coord(0, 0, 0), 1.0f, false));
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), getTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getChildCount(root2));
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(1), getChildCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(0), getTileCount(root));
+    }
+
+    { // merge a child node into a grid with an existing child node
+        using RootChildType = FloatTree::RootNodeType::ChildNodeType;
+
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        root.addChild(new RootChildType(Coord(0, 0, 0), 123.0f, false));
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        root2.addChild(new RootChildType(Coord(8192, 0, 0), 1.9f, false));
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), getChildCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getChildCount(root2));
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(2), getChildCount(root));
+        CPPUNIT_ASSERT(root.cbeginChildOn()->cbeginValueAll());
+        CPPUNIT_ASSERT_EQUAL(123.0f, root.cbeginChildOn()->cbeginValueAll().getItem(0));
+        CPPUNIT_ASSERT_EQUAL(1.9f, (++root.cbeginChildOn())->cbeginValueAll().getItem(0));
+    }
+
+    { // merge an inside tile and an outside tile into a grid with two child nodes
+        using RootChildType = FloatTree::RootNodeType::ChildNodeType;
+
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        root.addChild(new RootChildType(Coord(0, 0, 0), 123.0f, false));
+        root.addChild(new RootChildType(Coord(8192, 0, 0), 1.9f, false));
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        root2.addTile(Coord(0, 0, 0), 15.0f, false); // should not replace child
+        root2.addTile(Coord(8192, 0, 0), -25.0f, false); // should replace child
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), getChildCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getTileCount(root2));
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(1), getChildCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getTileCount(root));
+        CPPUNIT_ASSERT(root.cbeginChildAll().isChildNode());
+        CPPUNIT_ASSERT(!(++root.cbeginChildAll()).isChildNode());
+        CPPUNIT_ASSERT_EQUAL(123.0f, root.cbeginChildOn()->getFirstValue());
+        // inside tile value replaced with negative background
+        CPPUNIT_ASSERT_EQUAL(-grid->background(), root.cbeginValueAll().getValue());
+    }
+
+    { // merge two child nodes into a grid with an inside tile and an outside tile
+        using RootChildType = FloatTree::RootNodeType::ChildNodeType;
+
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        root.addTile(Coord(0, 0, 0), 15.0f, false); // should be replaced by child
+        root.addTile(Coord(8192, 0, 0), -25.0f, false); // should not be replaced by child
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        root2.addChild(new RootChildType(Coord(0, 0, 0), 123.0f, false));
+        root2.addChild(new RootChildType(Coord(8192, 0, 0), 1.9f, false));
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), getTileCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getChildCount(root2));
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(Index(1), getChildCount(root));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getTileCount(root));
+        CPPUNIT_ASSERT(root.cbeginChildAll().isChildNode());
+        CPPUNIT_ASSERT(!(++root.cbeginChildAll()).isChildNode());
+        CPPUNIT_ASSERT_EQUAL(123.0f, root.cbeginChildOn()->getFirstValue());
+        CPPUNIT_ASSERT_EQUAL(-grid->background(), root.cbeginValueAll().getValue());
+    }
+
+    { // merge two internal nodes into a grid with an inside tile and an outside tile
+        using RootChildType = FloatTree::RootNodeType::ChildNodeType;
+        using LeafParentType = RootChildType::ChildNodeType;
+
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        auto rootChild = std::make_unique<RootChildType>(Coord(0, 0, 0), 123.0f, false);
+        rootChild->addTile(1, -14.0f, false);
+        root.addChild(rootChild.release());
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        auto rootChild2 = std::make_unique<RootChildType>(Coord(0, 0, 0), 55.0f, false);
+
+        rootChild2->addChild(new LeafParentType(Coord(0, 0, 0), 29.0f, false));
+        rootChild2->addChild(new LeafParentType(Coord(0, 0, 128), 31.0f, false));
+        rootChild2->addTile(2, 17.0f, true);
+        rootChild2->addTile(9, -19.0f, true);
+        root2.addChild(rootChild2.release());
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInsideTileCount(*root.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(0), getActiveTileCount(*root.cbeginChildOn()));
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), getChildCount(*root2.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInsideTileCount(*root2.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getActiveTileCount(*root2.cbeginChildOn()));
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), getChildCount(*root.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getInsideTileCount(*root.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getActiveTileCount(*root.cbeginChildOn()));
+        CPPUNIT_ASSERT(root.cbeginChildOn()->isChildMaskOn(0));
+        CPPUNIT_ASSERT(!root.cbeginChildOn()->isChildMaskOn(1));
+        CPPUNIT_ASSERT_EQUAL(29.0f, root.cbeginChildOn()->cbeginChildOn()->getFirstValue());
+        CPPUNIT_ASSERT_EQUAL(-14.0f, root.cbeginChildOn()->cbeginValueAll().getValue());
+
+        CPPUNIT_ASSERT_EQUAL(Index(0), getChildCount(*root2.cbeginChildOn()));
+    }
+
+    { // merge two internal nodes into a grid with an inside tile and an outside tile
+        using RootChildType = FloatTree::RootNodeType::ChildNodeType;
+        using LeafParentType = RootChildType::ChildNodeType;
+
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        auto& root = grid->tree().root();
+        auto rootChild = std::make_unique<RootChildType>(Coord(0, 0, 0), 123.0f, false);
+        rootChild->addTile(1, -14.0f, false);
+        root.addChild(rootChild.release());
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        auto& root2 = grid2->tree().root();
+        auto rootChild2 = std::make_unique<RootChildType>(Coord(0, 0, 0), 55.0f, false);
+
+        rootChild2->addChild(new LeafParentType(Coord(0, 0, 0), 29.0f, false));
+        rootChild2->addChild(new LeafParentType(Coord(0, 0, 128), 31.0f, false));
+        rootChild2->addTile(2, 17.0f, true);
+        rootChild2->addTile(9, -19.0f, true);
+        root2.addChild(rootChild2.release());
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInsideTileCount(*root.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(0), getActiveTileCount(*root.cbeginChildOn()));
+
+        CPPUNIT_ASSERT_EQUAL(Index(2), getChildCount(*root2.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getInsideTileCount(*root2.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getActiveTileCount(*root2.cbeginChildOn()));
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index(1), getChildCount(*root.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(2), getInsideTileCount(*root.cbeginChildOn()));
+        CPPUNIT_ASSERT_EQUAL(Index(1), getActiveTileCount(*root.cbeginChildOn()));
+        CPPUNIT_ASSERT(root.cbeginChildOn()->isChildMaskOn(0));
+        CPPUNIT_ASSERT(!root.cbeginChildOn()->isChildMaskOn(1));
+        CPPUNIT_ASSERT_EQUAL(29.0f, root.cbeginChildOn()->cbeginChildOn()->getFirstValue());
+        CPPUNIT_ASSERT_EQUAL(-14.0f, root.cbeginChildOn()->cbeginValueAll().getValue());
+
+        CPPUNIT_ASSERT_EQUAL(Index(0), getChildCount(*root2.cbeginChildOn()));
+    }
+
+    { // merge a leaf node into an empty grid
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+
+        grid2->tree().touchLeaf(Coord(0, 0, 0));
+
+        CPPUNIT_ASSERT_EQUAL(Index32(0), grid->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index32(1), grid2->tree().leafCount());
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index32(1), grid->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index32(0), grid2->tree().leafCount());
+    }
+
+    { // merge a leaf node into a grid with a partially constructed leaf node
+        using LeafT = FloatTree::LeafNodeType;
+
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+
+        grid->tree().addLeaf(new LeafT(PartialCreate(), Coord(0, 0, 0)));
+        auto* leaf = grid2->tree().touchLeaf(Coord(0, 0, 0));
+        leaf->setValueOnly(10, -2.3f);
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        const auto* testLeaf = grid->tree().probeConstLeaf(Coord(0, 0, 0));
+        CPPUNIT_ASSERT_EQUAL(-2.3f, testLeaf->getValue(10));
+    }
+
+    { // merge three leaf nodes from different grids
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+        FloatGrid::Ptr grid3 = createLevelSet<FloatGrid>();
+
+        auto* leaf = grid->tree().touchLeaf(Coord(0, 0, 0));
+        auto* leaf2 = grid2->tree().touchLeaf(Coord(0, 0, 0));
+        auto* leaf3 = grid3->tree().touchLeaf(Coord(0, 0, 0));
+
+        // active state from the voxel with the minimum value preserved
+
+        leaf->setValueOnly(5, 4.0f);
+        leaf2->setValueOnly(5, 2.0f);
+        leaf2->setValueOn(5);
+        leaf3->setValueOnly(5, 3.0f);
+
+        leaf->setValueOnly(7, 2.0f);
+        leaf->setValueOn(7);
+        leaf2->setValueOnly(7, 3.0f);
+        leaf3->setValueOnly(7, 4.0f);
+
+        leaf->setValueOnly(9, 4.0f);
+        leaf->setValueOn(9);
+        leaf2->setValueOnly(9, 3.0f);
+        leaf3->setValueOnly(9, 2.0f);
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp{&grid2->tree(), &grid3->tree()};
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        const auto* testLeaf = grid->tree().probeConstLeaf(Coord(0, 0, 0));
+        CPPUNIT_ASSERT_EQUAL(2.0f, testLeaf->getValue(5));
+        CPPUNIT_ASSERT(testLeaf->isValueOn(5));
+        CPPUNIT_ASSERT_EQUAL(2.0f, testLeaf->getValue(7));
+        CPPUNIT_ASSERT(testLeaf->isValueOn(7));
+        CPPUNIT_ASSERT_EQUAL(2.0f, testLeaf->getValue(9));
+        CPPUNIT_ASSERT(!testLeaf->isValueOn(9));
+    }
+
+    { // merge a leaf node into an empty grid from a const grid
+        FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+
+        grid2->tree().touchLeaf(Coord(0, 0, 0));
+
+        CPPUNIT_ASSERT_EQUAL(Index32(0), grid->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index32(1), grid2->tree().leafCount());
+
+        // merge from a const tree
+
+        std::vector<tools::TreeToMerge<FloatTree>> trees;
+        trees.emplace_back(&grid2->constTree());
+
+        tools::CsgUnionMergeOp<FloatTree> mergeOp(trees);
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
+        nodeManager.foreachTopDown(mergeOp);
+
+        CPPUNIT_ASSERT_EQUAL(Index32(1), grid->tree().leafCount());
+        // leaf has been deep copied not stolen
+        CPPUNIT_ASSERT_EQUAL(Index32(1), grid2->tree().leafCount());
+    }
+}


### PR DESCRIPTION
Draft PR to give an idea of where this merging work is heading. This includes:

* NodeManager.h - a new DynamicNodeManager that caches the nodes while traversing to allow topology-changing operations
* Merge.h - a CsgUnionMergeOp designed to work with the new DynamicNodeManager with accompanying unit test
* Composite.h - manipulating tools::csgUnion() to call the new NodeManager-based functionality

Benchmarking two 1.4 billion voxel spheres merging under different configurations:

* Overlapping (Old Method): 13.0s
* Overlapping (New Method): 0.71s
* Disjoint (Old Method): 0.05ms
* Disjoint (New Method): 282ms

This is marked as draft because filtering needs to be added to the DynamicNodeManager workflow to address the performance regression in merging disjoint level sets. Questions welcome at this stage of development!