### PR TITLE
Add childCount() to RootNode, InternalNode and LeafNode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,9 @@ Version 7.1.0 - In Development
       data.
     - Added AttributeSet::Descriptor::groupIndexCollision() for detecting
       group index collisions when attempting to merge two Descriptors.
+    - Added RootNode::childCount(), InternalNode::childCount() and
+      LeafNode::childCount() to count the number of immediate child nodes that
+      exist below the current node.
 
     Bug fixes:
     - Fixed a bug where grids with no active values might return true when the

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -59,6 +59,10 @@ New features:
   data.
 - Added AttributeSet::Descriptor::groupIndexCollision for detecting group index
   collisions when attempting to merge two Descriptors.
+- Added @vdblink{tree::RootNode::childCount,RootNode::childCount},
+  @vdblink{tree::InternalNode::childCount,InternalNode::childCount} and
+  @vdblink{tree::LeafNode::childCount,LeafNode::childCount} to count
+  the number of immediate child nodes that exist below the current node.
 
 @par
 Bug fixes:

--- a/openvdb/tree/InternalNode.h
+++ b/openvdb/tree/InternalNode.h
@@ -271,6 +271,7 @@ public:
     Index32 leafCount() const;
     void nodeCount(std::vector<Index32> &vec) const;
     Index32 nonLeafCount() const;
+    Index32 childCount() const;
     Index64 onVoxelCount() const;
     Index64 offVoxelCount() const;
     Index64 onLeafVoxelCount() const;
@@ -1039,6 +1040,14 @@ InternalNode<ChildT, Log2Dim>::nonLeafCount() const
         sum += iter->nonLeafCount();
     }
     return sum;
+}
+
+
+template<typename ChildT, Index Log2Dim>
+inline Index32
+InternalNode<ChildT, Log2Dim>::childCount() const
+{
+    return this->getChildMask().countOn();
 }
 
 

--- a/openvdb/tree/LeafNode.h
+++ b/openvdb/tree/LeafNode.h
@@ -133,6 +133,8 @@ public:
     void nodeCount(std::vector<Index32> &) const {}
     /// Return the non-leaf count for this node, which is zero.
     static Index32 nonLeafCount() { return 0; }
+    /// Return the child count for this node, which is zero.
+    static Index32 childCount() { return 0; }
 
     /// Return the number of voxels marked On.
     Index64 onVoxelCount() const { return mValueMask.countOn(); }

--- a/openvdb/tree/RootNode.h
+++ b/openvdb/tree/RootNode.h
@@ -479,6 +479,7 @@ public:
 
     Index32 leafCount() const;
     Index32 nonLeafCount() const;
+    Index32 childCount() const;
     Index64 onVoxelCount() const;
     Index64 offVoxelCount() const;
     Index64 onLeafVoxelCount() const;
@@ -1543,6 +1544,14 @@ RootNode<ChildT>::nonLeafCount() const
         }
     }
     return sum;
+}
+
+
+template<typename ChildT>
+inline Index32
+RootNode<ChildT>::childCount() const
+{
+    return this->getChildCount();
 }
 
 

--- a/openvdb/unittest/TestLeaf.cc
+++ b/openvdb/unittest/TestLeaf.cc
@@ -23,6 +23,7 @@ public:
     CPPUNIT_TEST(testIsConstant);
     CPPUNIT_TEST(testMedian);
     CPPUNIT_TEST(testFill);
+    CPPUNIT_TEST(testCount);
     CPPUNIT_TEST_SUITE_END();
 
     void testBuffer();
@@ -38,6 +39,7 @@ public:
     void testIsConstant();
     void testMedian();
     void testFill();
+    void testCount();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLeaf);
@@ -532,4 +534,27 @@ TestLeaf::testFill()
     auto clippedBBox = leaf.getNodeBoundingBox();
     clippedBBox.intersect(bbox);
     CPPUNIT_ASSERT_EQUAL(int(clippedBBox.volume()), int(leaf.onVoxelCount()));
+}
+
+void
+TestLeaf::testCount()
+{
+    using namespace openvdb;
+    const Coord origin(-9, -2, -8);
+    tree::LeafNode<float, 3> leaf(origin, 1.0f, false);
+
+    CPPUNIT_ASSERT_EQUAL(Index(3), leaf.log2dim());
+    CPPUNIT_ASSERT_EQUAL(Index(8), leaf.dim());
+    CPPUNIT_ASSERT_EQUAL(Index(512), leaf.size());
+    CPPUNIT_ASSERT_EQUAL(Index(512), leaf.numValues());
+    CPPUNIT_ASSERT_EQUAL(Index(0), leaf.getLevel());
+    CPPUNIT_ASSERT_EQUAL(Index(1), leaf.getChildDim());
+    CPPUNIT_ASSERT_EQUAL(Index(1), leaf.leafCount());
+    CPPUNIT_ASSERT_EQUAL(Index(0), leaf.nonLeafCount());
+    CPPUNIT_ASSERT_EQUAL(Index(0), leaf.childCount());
+
+    std::vector<Index> dims;
+    leaf.getNodeLog2Dims(dims);
+    CPPUNIT_ASSERT_EQUAL(size_t(1), dims.size());
+    CPPUNIT_ASSERT_EQUAL(Index(3), dims[0]);
 }

--- a/openvdb/unittest/TestTree.cc
+++ b/openvdb/unittest/TestTree.cc
@@ -3003,11 +3003,13 @@ TestTree::testRootNode()
     { // test inserting child nodes directly and indirectly
         RootNodeType root(0.0f);
         CPPUNIT_ASSERT(root.empty());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(0), root.childCount());
 
         // populate the tree by inserting the two leaf nodes containing c0 and c1
         root.touchLeaf(c0);
         root.touchLeaf(c1);
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(2), root.childCount());
         CPPUNIT_ASSERT(!root.hasActiveTiles());
 
         { // verify c0 and c1 are the root node coordinates
@@ -3030,6 +3032,7 @@ TestTree::testRootNode()
             root.addChild(child);
         }
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(2), root.childCount());
 
         { // verify the coordinates of the root node children
             auto rootIter = root.cbeginChildOn();
@@ -3050,6 +3053,7 @@ TestTree::testRootNode()
         root.addTile(c0, /*value=*/1.0f, /*state=*/true);
         root.addTile(c1, /*value=*/2.0f, /*state=*/true);
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(0), root.childCount());
         CPPUNIT_ASSERT(root.hasActiveTiles());
         ASSERT_DOUBLES_EXACTLY_EQUAL(1.0f, root.getValue(c0));
         ASSERT_DOUBLES_EXACTLY_EQUAL(2.0f, root.getValue(c1));
@@ -3063,6 +3067,7 @@ TestTree::testRootNode()
 
         // verify active tiles have been replaced by child nodes
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(2), root.getTableSize());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(2), root.childCount());
         CPPUNIT_ASSERT(!root.hasActiveTiles());
 
         { // verify the coordinates of the root node children
@@ -3093,6 +3098,7 @@ TestTree::testInternalNode()
         internalNode.touchLeaf(c3);
 
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(2), internalNode.leafCount());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(2), internalNode.childCount());
         CPPUNIT_ASSERT(!internalNode.hasActiveTiles());
 
         { // verify c0 and c1 are the root node coordinates
@@ -3109,12 +3115,14 @@ TestTree::testInternalNode()
         std::vector<ChildType*> children;
         internalNode.stealNodes(children, 0.0f, false);
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(0), internalNode.leafCount());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(0), internalNode.childCount());
 
         // insert the root node children directly
         for (ChildType* child : children) {
             internalNode.addChild(child);
         }
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(2), internalNode.leafCount());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(2), internalNode.childCount());
 
         { // verify the coordinates of the root node children
             auto childIter = internalNode.cbeginChildOn();
@@ -3128,16 +3136,19 @@ TestTree::testInternalNode()
         InternalNodeType internalNode(c1, 0.0f);
         CPPUNIT_ASSERT(!internalNode.hasActiveTiles());
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(0), internalNode.leafCount());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(0), internalNode.childCount());
 
         // add a tile
         internalNode.addTile(openvdb::Index(0), /*value=*/1.0f, /*state=*/true);
         CPPUNIT_ASSERT(internalNode.hasActiveTiles());
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(0), internalNode.leafCount());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(0), internalNode.childCount());
 
         // replace the tile with a child node
         CPPUNIT_ASSERT(internalNode.addChild(new ChildType(c1, 2.0f)));
         CPPUNIT_ASSERT(!internalNode.hasActiveTiles());
         CPPUNIT_ASSERT_EQUAL(openvdb::Index(1), internalNode.leafCount());
+        CPPUNIT_ASSERT_EQUAL(openvdb::Index32(1), internalNode.childCount());
         CPPUNIT_ASSERT_EQUAL(c1, internalNode.cbeginChildOn().getCoord());
         ASSERT_DOUBLES_EXACTLY_EQUAL(2.0f, internalNode.cbeginChildOn()->getValue(0));
 


### PR DESCRIPTION
This follows the convention of using leafCount() to count the number of leaf nodes and addChild() to add an immediate child node. I added a unit test to cover the statistics methods in the leaf node too.