### PR TITLE
Add stricter version warning for Blosc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,8 +215,9 @@ mark_as_advanced(
 # outside of the DISABLE_DEPENDENCY_VERSION_CHECKS catch
 
 # @note  Blosc version is currently treated as exception which must be adhered
-# to. The minimum version must be at least 1.5. Previous versions are incompatible.
-set(MINIMUM_BLOSC_VERSION 1.5)
+# to. The minimum version must be at least 1.5.0. Previous versions are incompatible.
+# Later versions (including 1.5.4), can be buggy on certain platforms.
+set(MINIMUM_BLOSC_VERSION 1.5.0)
 # @note  ABI always enforced so the correct deprecation messages are available.
 # OPENVDB_USE_DEPRECATED_ABI_<VERSION> should be used to circumvent this
 set(MINIMUM_OPENVDB_ABI_VERSION 5)

--- a/cmake/FindBlosc.cmake
+++ b/cmake/FindBlosc.cmake
@@ -147,10 +147,19 @@ if(EXISTS "${Blosc_INCLUDE_DIR}/blosc.h")
   )
   string(STRIP "${_blosc_version_minor_string}" Blosc_VERSION_MINOR)
 
+  file(STRINGS "${Blosc_INCLUDE_DIR}/blosc.h"
+     _blosc_version_release_string REGEX "#define BLOSC_VERSION_RELEASE +[0-9]+ "
+  )
+  string(REGEX REPLACE "#define BLOSC_VERSION_RELEASE +([0-9]+).*$" "\\1"
+    _blosc_version_release_string "${_blosc_version_release_string}"
+  )
+  string(STRIP "${_blosc_version_release_string}" Blosc_VERSION_RELEASE)
+
   unset(_blosc_version_major_string)
   unset(_blosc_version_minor_string)
+  unset(_blosc_version_release_string)
 
-  set(Blosc_VERSION ${Blosc_VERSION_MAJOR}.${Blosc_VERSION_MINOR})
+  set(Blosc_VERSION ${Blosc_VERSION_MAJOR}.${Blosc_VERSION_MINOR}.${Blosc_VERSION_RELEASE})
 endif()
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
Recently, we've discovered that Blosc 1.5.4 segfaults when saving OpenVDB files with LZ4 compression on Linux/GCC. The recommended version, Blosc 1.5.0, works correctly.

The current Blosc version warning in the build system only checks for differences in the major and minor version. Since we suspect that 1.5.4 has issues, I think it would be a good idea to extend the warning to check for differences in the patch version too.