### PR TITLE
Thread LeafManager and NodeManager construction

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,7 @@ Version 7.1.0 - In Development
     - Changed the tree::NodeChain implementation to use an openvdb::TypeList
       rather than a boost::mpl::vector and updated all usage of tree::NodeChain
       accordingly.
+    - Threaded the construction of tree::LeafManager and tree::NodeManager.
 
     New features:
     - Added Grid::isTreeUnique() to tell if the tree is shared with another
@@ -77,6 +78,8 @@ Version 7.1.0 - In Development
     - Renamed AttributeSet::Descriptor::nextUnusedGroupOffset() to
       AttributeSet::Descriptor::unusedGroupOffset() to allow for providing an
       optional group offset hint.
+    - LeafManager::getNodes() is now deprecated as this is no longer used in
+      NodeManager construction.
 
     Houdini:
     - Platonic SOP is now verbified.

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -47,6 +47,9 @@ Improvements:
   to use an @vdblink::TypeList TypeList@endlink rather than a boost::mpl::vector
   and updated all usage of @vdblink::tree::NodeChain tree::NodeChain@endlink
   accordingly.
+- Threaded the construction of
+  @vdblink::tree::LeafManager tree::LeafManager@endlink and
+  @vdblink::tree::NodeManager tree::NodeManager@endlink.
 
 @par
 New features:
@@ -100,6 +103,8 @@ API changes:
 - Renamed AttributeSet::Descriptor::nextUnusedGroupOffset() to
   AttributeSet::Descriptor::unusedGroupOffset() to allow for providing an
   optional group offset hint.
+- LeafManager::getNodes() is now deprecated as this is no longer used in
+  NodeManager construction.
 
 @par
 Houdini:

--- a/openvdb/tree/LeafManager.h
+++ b/openvdb/tree/LeafManager.h
@@ -543,7 +543,7 @@ public:
     /// ArrayT::value_type. If the node type is a LeafNode the nodes
     /// are inserted from this LeafManager, else of the corresponding tree.
     template<typename ArrayT>
-    void getNodes(ArrayT& array)
+    OPENVDB_DEPRECATED void getNodes(ArrayT& array)
     {
         using T = typename ArrayT::value_type;
         static_assert(std::is_pointer<T>::value, "argument to getNodes() must be a pointer array");
@@ -565,7 +565,7 @@ public:
     /// ArrayT::value_type. If the node type is a LeafNode the nodes
     /// are inserted from this LeafManager, else of the corresponding tree.
     template<typename ArrayT>
-    void getNodes(ArrayT& array) const
+    OPENVDB_DEPRECATED void getNodes(ArrayT& array) const
     {
         using T = typename ArrayT::value_type;
         static_assert(std::is_pointer<T>::value, "argument to getNodes() must be a pointer array");

--- a/openvdb/tree/NodeManager.h
+++ b/openvdb/tree/NodeManager.h
@@ -224,11 +224,11 @@ public:
 
     void clear() { mList.clear(); mNext.clear(); }
 
-    template<typename ParentT, typename TreeOrLeafManagerT>
-    void init(ParentT& parent, TreeOrLeafManagerT& tree)
+    template<typename ParentT>
+    void init(ParentT& parent)
     {
         parent.getNodes(mList);
-        for (size_t i=0, n=mList.nodeCount(); i<n; ++i) mNext.init(mList(i), tree);
+        for (size_t i=0, n=mList.nodeCount(); i<n; ++i) mNext.init(mList(i));
     }
 
     template<typename ParentT>
@@ -298,7 +298,7 @@ public:
     void clear() { mList.clear(); }
 
     template<typename ParentT>
-    void rebuild(ParentT& parent) { mList.clear(); parent.getNodes(mList); }
+    void rebuild(ParentT& parent) { mList.clear(); this->init(parent); }
 
     Index64 nodeCount() const { return mList.nodeCount(); }
 
@@ -328,16 +328,10 @@ public:
         mList.reduce(op, threaded, grainSize);
     }
 
-    template<typename ParentT, typename TreeOrLeafManagerT>
-    void init(ParentT& parent, TreeOrLeafManagerT& tree)
+    template<typename ParentT>
+    void init(ParentT& parent)
     {
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
-        if (TreeOrLeafManagerT::DEPTH == 2 && NodeT::LEVEL == 0) {
-            tree.getNodes(mList);
-        } else {
-            parent.getNodes(mList);
-        }
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+        parent.getNodes(mList);
     }
 protected:
     NodeList<NodeT> mList;
@@ -362,7 +356,7 @@ public:
     using RootNodeType = typename TreeOrLeafManagerT::RootNodeType;
     static_assert(RootNodeType::LEVEL >= LEVELS, "number of levels exceeds root node height");
 
-    NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root()) { mChain.init(mRoot, tree); }
+    NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root()) { mChain.init(mRoot); }
 
     virtual ~NodeManager() {}
 
@@ -603,13 +597,7 @@ public:
 
     NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root())
     {
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
-        if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
-            tree.getNodes(mList0);
-        } else {
-            mRoot.getNodes(mList0);
-        }
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+        this->rebuild();
     }
 
     virtual ~NodeManager() {}
@@ -687,15 +675,7 @@ public:
 
     NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root())
     {
-        mRoot.getNodes(mList1);
-
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
-        if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
-            tree.getNodes(mList0);
-        } else {
-            for (size_t i=0, n=mList1.nodeCount(); i<n; ++i) mList1(i).getNodes(mList0);
-        }
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+        this->rebuild();
     }
 
     virtual ~NodeManager() {}
@@ -789,16 +769,7 @@ public:
 
     NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root())
     {
-        mRoot.getNodes(mList2);
-        for (size_t i=0, n=mList2.nodeCount(); i<n; ++i) mList2(i).getNodes(mList1);
-
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
-        if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
-            tree.getNodes(mList0);
-        } else {
-            for (size_t i=0, n=mList1.nodeCount(); i<n; ++i) mList1(i).getNodes(mList0);
-        }
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+        this->rebuild();
     }
 
     virtual ~NodeManager() {}
@@ -901,17 +872,7 @@ public:
 
     NodeManager(TreeOrLeafManagerT& tree) : mRoot(tree.root())
     {
-        mRoot.getNodes(mList3);
-        for (size_t i=0, n=mList3.nodeCount(); i<n; ++i) mList3(i).getNodes(mList2);
-        for (size_t i=0, n=mList2.nodeCount(); i<n; ++i) mList2(i).getNodes(mList1);
-
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN
-        if (TreeOrLeafManagerT::DEPTH == 2 && NodeT0::LEVEL == 0) {
-            tree.getNodes(mList0);
-        } else {
-            for (size_t i=0, n=mList1.nodeCount(); i<n; ++i) mList1(i).getNodes(mList0);
-        }
-        OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+        this->rebuild();
     }
 
     virtual ~NodeManager() {}

--- a/openvdb/tree/NodeManager.h
+++ b/openvdb/tree/NodeManager.h
@@ -176,14 +176,14 @@ private:
     template<typename NodeOp>
     struct NodeReducer
     {
-        NodeReducer(NodeOp& nodeOp) : mNodeOp(&nodeOp), mOwnsOp(false)
+        NodeReducer(NodeOp& nodeOp) : mNodeOp(&nodeOp)
         {
         }
-        NodeReducer(const NodeReducer& other, tbb::split) :
-            mNodeOp(new NodeOp(*(other.mNodeOp), tbb::split())), mOwnsOp(true)
+        NodeReducer(const NodeReducer& other, tbb::split)
+            : mNodeOpPtr(std::make_unique<NodeOp>(*(other.mNodeOp), tbb::split()))
+            , mNodeOp(mNodeOpPtr.get())
         {
         }
-        ~NodeReducer() { if (mOwnsOp) delete mNodeOp; }
         void run(const NodeRange& range, bool threaded = true)
         {
             threaded ? tbb::parallel_reduce(range, *this) : (*this)(range);
@@ -197,8 +197,8 @@ private:
         {
             mNodeOp->join(*(other.mNodeOp));
         }
-        NodeOp *mNodeOp;
-        const bool mOwnsOp;
+        std::unique_ptr<NodeOp> mNodeOpPtr;
+        NodeOp *mNodeOp = nullptr;
     };// NodeList::NodeReducer
 
 


### PR DESCRIPTION
The main motivation here was to eliminate the feature where the leaf nodes of the LeafManager could be used in the NodeManager construction to improve performance (as it was causing complexity in attempting to re-use the NodeList elsewhere). The simplest solution to achieving this was to just thread the construction of the LeafManager and the NodeManager. 

I also converted the NodeList and the LeafManager over to use unique ptr arrays instead of std::deque and raw ptr arrays (I expect these classes were written before C++11 features were available). Note that I've treated the NodeList as internal API due to it being described as such in the documentation, so made more invasive changes than I would otherwise do - it's non-trivial to try and also support backwards compatibility in this class. Finally, I've marked LeafManager::getNodes() methods as deprecated, they were only used in NodeManager construction to match the methods found in the tree hierarchy, so feels safe to mark them to be removed if we remove this code path. 

Here's construction times using the old implementation based on a 2.3 billion voxel sphere:

* LeafManager construction - 127ms
* NodeManager construction from Tree - 161ms
* NodeManager construction from LeafManager - 81ms

And this new threaded implementation:

* LeafManager construction - 18ms
* NodeManager construction from Tree - 19ms
* NodeManager construction from LeafManager - 20ms (now uses the same implementation as construction from Tree)

I also tested LeafManager construction using the data sets in the testActiveLeafVoxelCount to demonstrate scalability of this implementation down to cases with fewer leaf nodes and more unbalanced hierarchies. Old Method:

* Case 1 - 0.03ms
* Case 2 - 8.7ms
* Case 3 - 12.0ms
* Case 4 - 68.0ms

New Method:

* Case 1 - 0.04ms
* Case 2 - 3.7ms
* Case 3 - 2.8ms
* Case 4 - 12.8ms