### PR TITLE
Active tile count

### DIFF
--- a/openvdb/tree/InternalNode.h
+++ b/openvdb/tree/InternalNode.h
@@ -270,7 +270,7 @@ public:
 
     Index32 leafCount() const;
     void nodeCount(std::vector<Index32> &vec) const;
-    void activeTileCountByLevel(std::vector<Index32>& vec) const;
+    void activeTileCount(std::vector<Index32>& vec) const;
     Index32 nonLeafCount() const;
     Index32 childCount() const;
     Index64 onVoxelCount() const;
@@ -1032,13 +1032,13 @@ InternalNode<ChildT, Log2Dim>::nodeCount(std::vector<Index32> &vec) const
 
 template<typename ChildT, Index Log2Dim>
 inline void
-InternalNode<ChildT, Log2Dim>::activeTileCountByLevel(std::vector<Index32>& vec) const
+InternalNode<ChildT, Log2Dim>::activeTileCount(std::vector<Index32>& vec) const
 {
     assert(vec.size() > ChildNodeType::LEVEL);
     const auto countTile = mValueMask.countOn();
     const auto countChild = mChildMask.countOn();
     if (ChildNodeType::LEVEL > 0 && countChild > 0) {
-        for (auto iter = this->cbeginChildOn(); iter; ++iter) iter->activeTileCountByLevel(vec);
+        for (auto iter = this->cbeginChildOn(); iter; ++iter) iter->activeTileCount(vec);
     }
     vec[ChildNodeType::LEVEL] += countTile;
 }

--- a/openvdb/tree/InternalNode.h
+++ b/openvdb/tree/InternalNode.h
@@ -1030,6 +1030,18 @@ InternalNode<ChildT, Log2Dim>::nodeCount(std::vector<Index32> &vec) const
     vec[ChildNodeType::LEVEL] += count;
 }
 
+template<typename ChildT, Index Log2Dim>
+inline void
+InternalNode<ChildT, Log2Dim>::activeTileCountByLevel(std::vector<Index32>& vec) const
+{
+    assert(vec.size() > ChildNodeType::LEVEL);
+    const auto countTile = mValueMask.countOn();
+    const auto countChild = mChildMask.countOn();
+    if (ChildNodeType::LEVEL > 0 && countChild > 0) {
+        for (auto iter = this->cbeginChildOn(); iter; ++iter) iter->activeTileCountByLevel(vec);
+    }
+    vec[ChildNodeType::LEVEL] += countTile;
+}
 
 template<typename ChildT, Index Log2Dim>
 inline Index32

--- a/openvdb/tree/InternalNode.h
+++ b/openvdb/tree/InternalNode.h
@@ -270,6 +270,7 @@ public:
 
     Index32 leafCount() const;
     void nodeCount(std::vector<Index32> &vec) const;
+    void activeTileCountByLevel(std::vector<Index32>& vec) const;
     Index32 nonLeafCount() const;
     Index32 childCount() const;
     Index64 onVoxelCount() const;

--- a/openvdb/tree/LeafNode.h
+++ b/openvdb/tree/LeafNode.h
@@ -131,6 +131,8 @@ public:
     static Index32 leafCount() { return 1; }
     /// no-op
     void nodeCount(std::vector<Index32> &) const {}
+    /// no-op
+    void activeTileCountByLevel(std::vector<Index32>&) const {}
     /// Return the non-leaf count for this node, which is zero.
     static Index32 nonLeafCount() { return 0; }
     /// Return the child count for this node, which is zero.

--- a/openvdb/tree/LeafNode.h
+++ b/openvdb/tree/LeafNode.h
@@ -132,7 +132,7 @@ public:
     /// no-op
     void nodeCount(std::vector<Index32> &) const {}
     /// no-op
-    void activeTileCountByLevel(std::vector<Index32>&) const {}
+    void activeTileCount(std::vector<Index32>&) const {}
     /// Return the non-leaf count for this node, which is zero.
     static Index32 nonLeafCount() { return 0; }
     /// Return the child count for this node, which is zero.

--- a/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/tree/LeafNodeBool.h
@@ -111,6 +111,8 @@ public:
     static Index32 leafCount() { return 1; }
     /// no-op
     void nodeCount(std::vector<Index32> &) const {}
+    /// no-op
+    void activeTileCountByLevel(std::vector<Index32>&) const {}
     static Index32 nonLeafCount() { return 0; }
 
     /// Return the number of active voxels.

--- a/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/tree/LeafNodeBool.h
@@ -112,7 +112,7 @@ public:
     /// no-op
     void nodeCount(std::vector<Index32> &) const {}
     /// no-op
-    void activeTileCountByLevel(std::vector<Index32>&) const {}
+    void activeTileCount(std::vector<Index32>&) const {}
     static Index32 nonLeafCount() { return 0; }
 
     /// Return the number of active voxels.

--- a/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/tree/LeafNodeMask.h
@@ -114,6 +114,8 @@ public:
     static Index32 leafCount() { return 1; }
     /// no-op
     void nodeCount(std::vector<Index32> &) const {}
+    /// no-op
+    void activeTileCountByLevel(std::vector<Index32>&) const {}
     /// Return the non-leaf count for this node, which is zero.
     static Index32 nonLeafCount() { return 0; }
 

--- a/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/tree/LeafNodeMask.h
@@ -115,7 +115,7 @@ public:
     /// no-op
     void nodeCount(std::vector<Index32> &) const {}
     /// no-op
-    void activeTileCountByLevel(std::vector<Index32>&) const {}
+    void activeTileCount(std::vector<Index32>&) const {}
     /// Return the non-leaf count for this node, which is zero.
     static Index32 nonLeafCount() { return 0; }
 

--- a/openvdb/tree/RootNode.h
+++ b/openvdb/tree/RootNode.h
@@ -1642,6 +1642,20 @@ RootNode<ChildT>::nodeCount(std::vector<Index32> &vec) const
     vec[ChildNodeType::LEVEL] = sum;
 }
 
+template<typename ChildT>
+inline void
+RootNode<ChildT>::activeTileCountByLevel(std::vector<Index32>& vec) const
+{
+    assert(vec.size() > LEVEL);
+    Index32 sum = 0;
+    for (MapCIter i = mTable.begin(), e = mTable.end(); i != e; ++i) {
+        if (isChild(i)) {
+            getChild(i).activeTileCountByLevel(vec);
+        } else if (isTileOn(i)) ++sum;
+    }
+    vec[LEVEL] = 0;// zero tiles at root level
+    vec[ChildNodeType::LEVEL] = sum;
+}
 ////////////////////////////////////////
 
 

--- a/openvdb/tree/RootNode.h
+++ b/openvdb/tree/RootNode.h
@@ -486,7 +486,7 @@ public:
     Index64 offLeafVoxelCount() const;
     Index64 onTileCount() const;
     void nodeCount(std::vector<Index32> &vec) const;
-    void activeTileCountByLevel(std::vector<Index32>& vec) const;
+    void activeTileCount(std::vector<Index32>& vec) const;
 
     bool isValueOn(const Coord& xyz) const;
 
@@ -1644,13 +1644,13 @@ RootNode<ChildT>::nodeCount(std::vector<Index32> &vec) const
 
 template<typename ChildT>
 inline void
-RootNode<ChildT>::activeTileCountByLevel(std::vector<Index32>& vec) const
+RootNode<ChildT>::activeTileCount(std::vector<Index32>& vec) const
 {
     assert(vec.size() > LEVEL);
     Index32 sum = 0;
     for (MapCIter i = mTable.begin(), e = mTable.end(); i != e; ++i) {
         if (isChild(i)) {
-            getChild(i).activeTileCountByLevel(vec);
+            getChild(i).activeTileCount(vec);
         } else if (isTileOn(i)) ++sum;
     }
     vec[LEVEL] = 0;// zero tiles at root level

--- a/openvdb/tree/RootNode.h
+++ b/openvdb/tree/RootNode.h
@@ -486,6 +486,7 @@ public:
     Index64 offLeafVoxelCount() const;
     Index64 onTileCount() const;
     void nodeCount(std::vector<Index32> &vec) const;
+    void activeTileCountByLevel(std::vector<Index32>& vec) const;
 
     bool isValueOn(const Coord& xyz) const;
 

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -113,6 +113,10 @@ public:
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     virtual std::vector<Index32> nodeCount() const = 0;
+    /// Return a vector with tile counts. The number of tiles at level NodeType
+    /// is given as element NodeType::LEVEL in the return vector. Thus, the size
+    /// of this vector corresponds to the height (or depth) of this tree.
+    virtual std::vector<Index32> tileCount() const = 0;
 #endif
     /// Return the number of non-leaf nodes.
     virtual Index32 nonLeafCount() const = 0;

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -113,10 +113,10 @@ public:
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     virtual std::vector<Index32> nodeCount() const = 0;
-    /// Return a vector with tile counts. The number of tiles at level NodeType
+    /// Return a vector with active tile counts. The number of active tiles at level NodeType
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
-    virtual std::vector<Index32> tileCount() const = 0;
+    virtual std::vector<Index32> activeTileCount() const = 0;
 #endif
     /// Return the number of non-leaf nodes.
     virtual Index32 nonLeafCount() const = 0;

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -116,7 +116,7 @@ public:
     /// Return a vector with active tile counts. The number of active tiles at level NodeType
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
-    virtual std::vector<Index32> activeTileCount() const = 0;
+    virtual std::vector<Index32> activeTileCountByLevel() const = 0;
 #endif
     /// Return the number of non-leaf nodes.
     virtual Index32 nonLeafCount() const = 0;
@@ -352,10 +352,10 @@ public:
     /// Return a vector with active tile counts. The number of active tiles at level NodeType
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
-    std::vector<Index32> activeTileCount() const override
+    std::vector<Index32> activeTileCountByLevel() const override
     {
         std::vector<Index32> vec(DEPTH, 0);
-        mRoot.activeTileCount(vec);
+        mRoot.activeTileCountByLevel(vec);
         return vec;// Named Return Value Optimization
     }
 #endif

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -349,6 +349,15 @@ public:
         mRoot.nodeCount( vec );
         return vec;// Named Return Value Optimization
     }
+    /// Return a vector with active tile counts. The number of active tiles at level NodeType
+    /// is given as element NodeType::LEVEL in the return vector. Thus, the size
+    /// of this vector corresponds to the height (or depth) of this tree.
+    std::vector<Index32> activeTileCount() const override
+    {
+        std::vector<Index32> vec(DEPTH, 0);
+        mRoot.activeTileCount(vec);
+        return vec;// Named Return Value Optimization
+    }
 #endif
     /// Return the number of non-leaf nodes.
     Index32 nonLeafCount() const override { return mRoot.nonLeafCount(); }

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -113,6 +113,8 @@ public:
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     virtual std::vector<Index32> nodeCount() const = 0;
+#endif
+#if OPENVDB_ABI_VERSION_NUMBER >= 8
     /// Return in @a vec the active tile count for each level. The number of active tiles at level NodeType
     /// is given as element NodeType::LEVEL in the vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
@@ -352,6 +354,8 @@ public:
         mRoot.nodeCount( vec );
         return vec;// Named Return Value Optimization
     }
+#endif
+#if OPENVDB_ABI_VERSION_NUMBER >= 8
     /// Return in @a vec the active tile count for each level. The number of active tiles at level NodeType
     /// is given as element NodeType::LEVEL in the vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -113,13 +113,13 @@ public:
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     virtual std::vector<Index32> nodeCount() const = 0;
-    /// Return a vector with active tile counts. The number of active tiles at level NodeType
+    /// Return in @a vec the vector with active tile counts. The number of active tiles at level NodeType
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     /// @note While nodeCount() returns the number of allocated nodes at each level,
     /// regions of the tree may have data but not have nodes because
     /// they have activated constant regions.
-    virtual std::vector<Index32> activeTileCountByLevel() const = 0;
+    virtual void activeTileCount(std::vector<Index32>& vec) const = 0;
 #endif
     /// Return the number of non-leaf nodes.
     virtual Index32 nonLeafCount() const = 0;
@@ -352,17 +352,17 @@ public:
         mRoot.nodeCount( vec );
         return vec;// Named Return Value Optimization
     }
-    /// Return a vector with active tile counts. The number of active tiles at level NodeType
+    /// Return in @a vec the vector with active tile counts. The number of active tiles at level NodeType
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     /// @note While nodeCount() returns the number of allocated nodes at each level,
     /// regions of the tree may have data but not have nodes because
     /// they have activated constant regions.
-    std::vector<Index32> activeTileCountByLevel() const override
+    void activeTileCount(std::vector<Index32>& vec) const override
     {
-        std::vector<Index32> vec(DEPTH, 0);
-        mRoot.activeTileCountByLevel(vec);
-        return vec;// Named Return Value Optimization
+        vec.assign(DEPTH, 0);
+        vec.shrink_to_fit();
+        mRoot.activeTileCount(vec);
     }
 #endif
     /// Return the number of non-leaf nodes.

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -113,8 +113,8 @@ public:
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     virtual std::vector<Index32> nodeCount() const = 0;
-    /// Return in @a vec the vector with active tile counts. The number of active tiles at level NodeType
-    /// is given as element NodeType::LEVEL in the return vector. Thus, the size
+    /// Return in @a vec the active tile count for each level. The number of active tiles at level NodeType
+    /// is given as element NodeType::LEVEL in the vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     /// @note While nodeCount() returns the number of allocated nodes at each level,
     /// regions of the tree may have data but not have nodes because
@@ -352,8 +352,8 @@ public:
         mRoot.nodeCount( vec );
         return vec;// Named Return Value Optimization
     }
-    /// Return in @a vec the vector with active tile counts. The number of active tiles at level NodeType
-    /// is given as element NodeType::LEVEL in the return vector. Thus, the size
+    /// Return in @a vec the active tile count for each level. The number of active tiles at level NodeType
+    /// is given as element NodeType::LEVEL in the vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     /// @note While nodeCount() returns the number of allocated nodes at each level,
     /// regions of the tree may have data but not have nodes because

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -116,6 +116,9 @@ public:
     /// Return a vector with active tile counts. The number of active tiles at level NodeType
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
+    /// @note While nodeCount() returns the number of allocated nodes at each level,
+    /// regions of the tree may have data but not have nodes because
+    /// they have activated constant regions.
     virtual std::vector<Index32> activeTileCountByLevel() const = 0;
 #endif
     /// Return the number of non-leaf nodes.
@@ -352,6 +355,9 @@ public:
     /// Return a vector with active tile counts. The number of active tiles at level NodeType
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
+    /// @note While nodeCount() returns the number of allocated nodes at each level,
+    /// regions of the tree may have data but not have nodes because
+    /// they have activated constant regions.
     std::vector<Index32> activeTileCountByLevel() const override
     {
         std::vector<Index32> vec(DEPTH, 0);

--- a/openvdb/unittest/TestGrid.cc
+++ b/openvdb/unittest/TestGrid.cc
@@ -113,10 +113,7 @@ public:
 #if OPENVDB_ABI_VERSION_NUMBER >= 7
     std::vector<openvdb::Index32> nodeCount() const override
         { return std::vector<openvdb::Index32>(DEPTH, 0); }
-    std::vector<openvdb::Index32> activeTileCountByLevel() const override
-    {
-        return std::vector<openvdb::Index32>(DEPTH, 0);
-    }
+    void activeTileCount(std::vector<openvdb::Index32>&) const override {}
 #endif
     openvdb::Index nonLeafCount() const override { return 0; }
     openvdb::Index64 activeVoxelCount() const override { return 0UL; }

--- a/openvdb/unittest/TestGrid.cc
+++ b/openvdb/unittest/TestGrid.cc
@@ -113,6 +113,10 @@ public:
 #if OPENVDB_ABI_VERSION_NUMBER >= 7
     std::vector<openvdb::Index32> nodeCount() const override
         { return std::vector<openvdb::Index32>(DEPTH, 0); }
+    std::vector<openvdb::Index32> activeTileCountByLevel() const override
+    {
+        return std::vector<openvdb::Index32>(DEPTH, 0);
+    }
 #endif
     openvdb::Index nonLeafCount() const override { return 0; }
     openvdb::Index64 activeVoxelCount() const override { return 0UL; }

--- a/openvdb/unittest/TestGrid.cc
+++ b/openvdb/unittest/TestGrid.cc
@@ -113,6 +113,8 @@ public:
 #if OPENVDB_ABI_VERSION_NUMBER >= 7
     std::vector<openvdb::Index32> nodeCount() const override
         { return std::vector<openvdb::Index32>(DEPTH, 0); }
+#endif
+#if OPENVDB_ABI_VERSION_NUMBER >= 8
     void activeTileCount(std::vector<openvdb::Index32>&) const override {}
 #endif
     openvdb::Index nonLeafCount() const override { return 0; }

--- a/openvdb/unittest/TestTree.cc
+++ b/openvdb/unittest/TestTree.cc
@@ -110,6 +110,8 @@ public:
     void testStealNode();
 #if OPENVDB_ABI_VERSION_NUMBER >= 7
     void testNodeCount();
+#endif
+#if OPENVDB_ABI_VERSION_NUMBER >= 8
     void testActiveTileCount();
 #endif
     void testRootNode();

--- a/openvdb/unittest/TestTree.cc
+++ b/openvdb/unittest/TestTree.cc
@@ -71,7 +71,7 @@ public:
     CPPUNIT_TEST(testStealNode);
 #if OPENVDB_ABI_VERSION_NUMBER >= 7
     CPPUNIT_TEST(testNodeCount);
-    CPPUNIT_TEST(testActiveTileCountByLevel);
+    CPPUNIT_TEST(testActiveTileCount);
 #endif
     CPPUNIT_TEST(testRootNode);
     CPPUNIT_TEST(testInternalNode);
@@ -110,7 +110,7 @@ public:
     void testStealNode();
 #if OPENVDB_ABI_VERSION_NUMBER >= 7
     void testNodeCount();
-    void testActiveTileCountByLevel();
+    void testActiveTileCount();
 #endif
     void testRootNode();
     void testInternalNode();
@@ -2996,7 +2996,7 @@ TestTree::testNodeCount()
 }
 
 void
-TestTree::testActiveTileCountByLevel()
+TestTree::testActiveTileCount()
 {
     //openvdb::util::CpuTimer timer;// use for benchmark test
 
@@ -3017,7 +3017,8 @@ TestTree::testActiveTileCountByLevel()
     it.setMaxDepth(openvdb::FloatTree::ValueOnCIter::LEAF_DEPTH - 1);
     for (; it; ++it) ++(activeTileCount1[dims.size() - 1 - it.getDepth()]);
     //timer.restart("New technique");// use for benchmark test
-    const auto activeTileCount2 = tree.activeTileCountByLevel();
+    std::vector<openvdb::Index32> activeTileCount2;
+    tree.activeTileCount(activeTileCount2);
     //timer.stop();// use for benchmark test
     CPPUNIT_ASSERT_EQUAL(activeTileCount1.size(), activeTileCount2.size());
     //for (size_t i=0; i<activeTileCount2.size(); ++i) std::cerr << "activeTileCount1("<<i<<") OLD/NEW: " << activeTileCount1[i] << "/" << activeTileCount2[i] << std::endl;

--- a/openvdb/unittest/TestTree.cc
+++ b/openvdb/unittest/TestTree.cc
@@ -71,6 +71,8 @@ public:
     CPPUNIT_TEST(testStealNode);
 #if OPENVDB_ABI_VERSION_NUMBER >= 7
     CPPUNIT_TEST(testNodeCount);
+#endif
+#if OPENVDB_ABI_VERSION_NUMBER >= 8
     CPPUNIT_TEST(testActiveTileCount);
 #endif
     CPPUNIT_TEST(testRootNode);


### PR DESCRIPTION
### Goal

There are situations in which there is curiosity to know how many active tiles are at each tree level. Hence, a new method is developed to return a vector containing active tiles at each level. 

### Note

This new method is developed by using bitmask counting which is faster than old technique of tree-iterator.

### Unit and benchmark test

Unit test is developed by comparing this new method with the older tree-iterator method. Also, benchmark test can be done by using commented-out `timer` statements in unit test.

### Notice

This PR is developed by closely following PR #536 steps.
