### PR TITLE
TypeList::Unique compiler fix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,10 @@ Version 7.1.1 - In Development
     - Fixed a bug where a Houdini SOP's verb would not be correctly associated
       with the corresponding node if the node's internal name was changed.
 
+    Bug fixes:
+    - Fixed a bug which could cause recursive compile time instantiations of
+      TypeList objects, manifesting in longer compile times.
+
     Build:
     - Removed the Makefiles.
     - Re-organised the repository layout such that each independent library

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -20,6 +20,11 @@ Houdini:
   with the corresponding node if the node's internal name was changed.
 
 @par
+Bug Fixes:
+- Fixed a bug which could cause recursive compile time instantiations of
+  TypeList objects, manifesting in longer compile times.
+
+@par
 Build:
 - Removed the Makefiles.
 - Re-organised the repository layout such that each independent library

--- a/openvdb/openvdb/Types.h
+++ b/openvdb/openvdb/Types.h
@@ -696,17 +696,19 @@ struct TypeList
     static constexpr int64_t Index = internal::TSHasTypeImpl<Self, T>::Index;
 
     /// @brief Remove any duplicate types from this TypeList by rotating the
-    /// next valid type left (maintains the order of other types).
+    /// next valid type left (maintains the order of other types). Optionally
+    /// combine the result with another TypeList.
     /// @details Example:
     /// @code
     /// {
     ///     using Types = openvdb::TypeList<Int16, Int32, Int16, float, float, Int64>;
     /// }
     /// {
-    ///     using UniqueTypes = Types::Unique; // <Int16, Int32, float, Int64>
+    ///     using UniqueTypes = Types::Unique<>; // <Int16, Int32, float, Int64>
     /// }
     /// @endcode
-    using Unique = typename internal::TSMakeUniqueImpl<TypeList<>, Ts...>::type;
+    template<typename ListT = TypeList<>>
+    using Unique = typename internal::TSMakeUniqueImpl<ListT, Ts...>::type;
 
     /// @brief Append types, or the members of another TypeList, to this list.
     /// @details Example:

--- a/openvdb/openvdb/unittest/TestTypes.cc
+++ b/openvdb/openvdb/unittest/TestTypes.cc
@@ -536,13 +536,13 @@ TestTypes::testTypeList()
     //
 
     // Test some methods on lists with duplicate types
-    using DulplicateIntTypes = TypeList<Int32, Int16, Int64, Int16>;
-    using DulplicateRealTypes = TypeList<float, float, float, float>;
-    static_assert(DulplicateIntTypes::Size == 4, "");
-    static_assert(DulplicateRealTypes::Size == 4, "");
-    static_assert(DulplicateIntTypes::Index<Int16> == 1, "");
-    static_assert(std::is_same<DulplicateIntTypes::Unique<>, TypeList<Int32, Int16, Int64>>::value, "");
-    static_assert(std::is_same<DulplicateRealTypes::Unique<>, TypeList<float>>::value, "");
+    using DuplicateIntTypes = TypeList<Int32, Int16, Int64, Int16>;
+    using DuplicateRealTypes = TypeList<float, float, float, float>;
+    static_assert(DuplicateIntTypes::Size == 4, "");
+    static_assert(DuplicateRealTypes::Size == 4, "");
+    static_assert(DuplicateIntTypes::Index<Int16> == 1, "");
+    static_assert(std::is_same<DuplicateIntTypes::Unique<>, TypeList<Int32, Int16, Int64>>::value, "");
+    static_assert(std::is_same<DuplicateRealTypes::Unique<>, TypeList<float>>::value, "");
 
     //
 

--- a/openvdb/openvdb/unittest/TestTypes.cc
+++ b/openvdb/openvdb/unittest/TestTypes.cc
@@ -497,8 +497,8 @@ TestTypes::testTypeList()
     static_assert(!std::is_same<IntTypes::Get<3>, void>::value, "");
 
     // Unique
-    static_assert(std::is_same<IntTypes::Unique, IntTypes>::value, "");
-    static_assert(std::is_same<EmptyList::Unique, EmptyList>::value, "");
+    static_assert(std::is_same<IntTypes::Unique<>, IntTypes>::value, "");
+    static_assert(std::is_same<EmptyList::Unique<>, EmptyList>::value, "");
 
     // Front/Back
     static_assert(std::is_same<IntTypes::Front, Int16>::value, "");
@@ -541,8 +541,8 @@ TestTypes::testTypeList()
     static_assert(DulplicateIntTypes::Size == 4, "");
     static_assert(DulplicateRealTypes::Size == 4, "");
     static_assert(DulplicateIntTypes::Index<Int16> == 1, "");
-    static_assert(std::is_same<DulplicateIntTypes::Unique, TypeList<Int32, Int16, Int64>>::value, "");
-    static_assert(std::is_same<DulplicateRealTypes::Unique, TypeList<float>>::value, "");
+    static_assert(std::is_same<DulplicateIntTypes::Unique<>, TypeList<Int32, Int16, Int64>>::value, "");
+    static_assert(std::is_same<DulplicateRealTypes::Unique<>, TypeList<float>>::value, "");
 
     //
 


### PR DESCRIPTION
Fixed an issue where `TypeList::Unique` would be instantiated continuously on every `TypeList`.

It seems that as soon as a `TypeList` of any kind is created, `TypeList::Unique` would also be instantiated. As this also creates a `TypeList` this causes the compiler to explode for larger lists. I tried changing the implementation of `TypeList::Unique` to use a different container but this doesn't help. Really the `Unique` typedef should be a separate template struct. However this fix stops automatic instantiation so it can continue to live on the `TypeList`.

See an example of the issue here:

https://github.com/Idclip/openvdb/runs/1101152129?check_suite_focus=true

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>