### PR TITLE
Synchronize Name attribute for OpenVDB Convert

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Version 7.1.1 - In Development
       packed geometry were also being converted.
     - Fixed a bug where a Houdini SOP's verb would not be correctly associated
       with the corresponding node if the node's internal name was changed.
+    - Fixed bug where OpenVDB Convert SOP could revert the name attribute.
 
     Build:
     - Removed the Makefiles.

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -18,6 +18,7 @@ Houdini:
   packed geometry were also being converted.
 - Fixed a bug where a Houdini SOP's verb would not be correctly associated
   with the corresponding node if the node's internal name was changed.
+- Fixed bug where OpenVDB Convert SOP could revert the name attribute.
 
 @par
 Build:

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Convert.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Convert.cc
@@ -1017,8 +1017,12 @@ SOP_OpenVDB_Convert::Cache::convertVDBType(
     const UT_String& outPrecStr,
     hvdb::Interrupter& boss)
 {
+    GA_RWHandleS name_h(gdp, GA_ATTRIB_PRIMITIVE, "name");
     for (hvdb::VdbPrimIterator it(&dst, group); it; ++it) {
         if (boss.wasInterrupted()) return;
+
+        if (name_h.isValid())
+            it->getGrid().setName(static_cast<const char *> (name_h.get(it->getMapOffset())));
 
         const UT_VDBType inType = it->getStorageType();
         const UT_String inTypeName = getVDBTypeName(inType);


### PR DESCRIPTION
The OpenVDB Convert SOP would copy the meta data that might be out of date, so cause the name attribute to appear to revert to an earlier value.  This is similar to the fix done for the LOD SOP for a similar problem.