### PR TITLE
Fix build of feature/nanovdb: explicit return type instead of auto

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -3303,19 +3303,19 @@ template<typename ValueT>
 using NanoGrid = Grid<NanoTree<ValueT>>;
 
 template <int CacheLevels = 3, typename ValueT = float>
-auto createAccessor(const NanoGrid<ValueT> &grid)
+ReadAccessor<NanoRoot<ValueT>, CacheLevels> createAccessor(const NanoGrid<ValueT> &grid)
 { 
     return ReadAccessor<NanoRoot<ValueT>, CacheLevels>(grid.tree().root());
 }
 
 template <int CacheLevels = 3, typename ValueT = float>
-auto createAccessor(const NanoTree<ValueT> &tree)
+ReadAccessor<NanoRoot<ValueT>, CacheLevels> createAccessor(const NanoTree<ValueT> &tree)
 { 
     return ReadAccessor<NanoRoot<ValueT>, CacheLevels>(tree.root());
 }
 
 template <int CacheLevels = 3, typename ValueT = float>
-auto createAccessor(const NanoRoot<ValueT> &root)
+ReadAccessor<NanoRoot<ValueT>, CacheLevels> createAccessor(const NanoRoot<ValueT> &root)
 { 
     return ReadAccessor<NanoRoot<ValueT>, CacheLevels>(root);
 }


### PR DESCRIPTION
auto is not a valid return type in C++11. We either have to use decltype(auto)
or the explicit return type.

> 'auto' return without trailing return type; deduced return types are a C++14 extension

Signed-off-by: Stephan Seitz <stephan.seitz@fau.de>