### PR TITLE
Add Houdini 18.5 to GitHub Actions Cache

### DIFF
--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -11,6 +11,26 @@ on:
 # succeeds, put it into the GitHub Actions cache
 
 jobs:
+  houdini18_5:
+    runs-on: ubuntu-16.04
+    container:
+      image: aswf/ci-base:2020
+    steps:
+    - uses: actions/checkout@v2
+    - name: download_houdini
+      run: ./ci/download_houdini.sh 18.5 ON ON ${{ secrets.HOUDINI_CLIENT_ID }} ${{ secrets.HOUDINI_SECRET_KEY }}
+    - name: install_houdini
+      run: ./ci/install_houdini.sh
+    - name: build
+      run: ./ci/build_houdini.sh clang++ Release ON
+    - name: test
+      run: ./ci/test.sh
+    - name: write_houdini_cache
+      uses: actions/cache@v2
+      with:
+        path: hou
+        key: vdb1-houdini18_5-${{ hashFiles('hou/hou.tar.gz') }}
+
   houdini18_0:
     runs-on: ubuntu-16.04
     container:

--- a/ci/download_houdini.sh
+++ b/ci/download_houdini.sh
@@ -45,6 +45,7 @@ cp -r dsolib/libbz2* ../hou/dsolib/.
 cp -r dsolib/libtbb* ../hou/dsolib/.
 cp -r dsolib/libHalf* ../hou/dsolib/.
 cp -r dsolib/libjemalloc* ../hou/dsolib/.
+cp -r dsolib/liblzma* ../hou/dsolib/.
 
 # needed for < H18.0 (due to sesitag)
 if [ "$HOUDINI_MAJOR" == "17.0" ] || [ "$HOUDINI_MAJOR" == "17.5" ]; then


### PR DESCRIPTION
Boost 1.72 also needed the lzma library from the shipped Houdini libs, so this is now included in the cache.

After this has run for the first time in our weekly build, I'll update the CI to add an H18.5 build. We'll be dropping support for Houdini 17.5 with the imminent release of OpenVDB 8.0.