### PR TITLE
Fixed macos CI with automatic python selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,19 +275,19 @@ jobs:
     - uses: actions/checkout@v2
     - name: install
       shell: bash
+      # brew boost-python3 installs a "Keg-only" version of python which is
+      # not installed to PATH. We must manually provide the location of the
+      # required python installation to CMake through a hint variable which
+      # is exported in install_macos.sh
       run: ./ci/install_macos.sh
     - name: install
       shell: bash
       run: ./ci/install_blosc.sh 1.5.0
     - name: build
       shell: bash
-      # brew boost-python installs a "Keg-only" version of python which is
-      # not insatlled to PATH. Until this becomes the default, we must
-      # manually provide the location of the require python installation
-      # See https://formulae.brew.sh/formula/python@3.8
       # Also need to disable compiler warnings for ABI 6 and above due to
       # the version of clang installed
-      run: ./ci/build.sh clang++ Release 7 ON SSE42 -DPython_ROOT_DIR=/usr/local/opt/python@3.8 -DOPENVDB_CXX_STRICT=OFF
+      run: ./ci/build.sh clang++ Release 7 ON SSE42 -DOPENVDB_CXX_STRICT=OFF
     - name: test
       shell: bash
       run: ./ci/test.sh

--- a/ci/install_macos.sh
+++ b/ci/install_macos.sh
@@ -12,3 +12,13 @@ brew install cppunit
 brew install tbb
 brew install zlib
 brew install glfw
+brew install jq # for trivial parsing of brew json
+
+# Alias python version installed by boost-python3 to path
+py_version=$(brew info boost-python3 --json | \
+    jq -cr '.[].dependencies[] | select(. | startswith("python"))')
+echo "Using python $py_version"
+# export for subsequent action steps (note, not exported for this env)
+echo "Python_ROOT_DIR=/usr/local/opt/$py_version" >> $GITHUB_ENV
+echo "/usr/local/opt/$py_version/bin" >> $GITHUB_PATH
+


### PR DESCRIPTION
boost python has been updated to use python 3.9, we were hard coding to 3.8

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>