### PR TITLE
Make sIsInitialized (used by openvdb::initialize() and openvdb::unini…

### DIFF
--- a/openvdb/openvdb/openvdb.cc
+++ b/openvdb/openvdb/openvdb.cc
@@ -8,6 +8,7 @@
 //#endif
 #include "tools/PointIndexGrid.h"
 #include "util/logging.h"
+#include <tbb/atomic.h>
 #include <tbb/mutex.h>
 #ifdef OPENVDB_USE_BLOSC
 #include <blosc.h>
@@ -36,14 +37,15 @@ typedef Mutex::scoped_lock Lock;
 namespace {
 // Declare this at file scope to ensure thread-safe initialization.
 Mutex sInitMutex;
-bool sIsInitialized = false;
+tbb::atomic<bool> sIsInitialized{false};
 }
 
 void
 initialize()
 {
+    if (sIsInitialized.load<tbb::memory_semantics::acquire>()) return;
     Lock lock(sInitMutex);
-    if (sIsInitialized) return;
+    if (sIsInitialized.load<tbb::memory_semantics::acquire>()) return; // Double-checked lock
 
     logging::initialize();
 
@@ -118,7 +120,7 @@ initialize()
 __pragma(warning(disable:1711))
 #endif
 
-    sIsInitialized = true;
+    sIsInitialized.store<tbb::memory_semantics::release>(true);
 
 #ifdef __ICC
 __pragma(warning(default:1711))
@@ -130,14 +132,13 @@ void
 uninitialize()
 {
     Lock lock(sInitMutex);
-
 #ifdef __ICC
 // Disable ICC "assignment to statically allocated variable" warning.
 // This assignment is mutex-protected and therefore thread-safe.
 __pragma(warning(disable:1711))
 #endif
 
-    sIsInitialized = false;
+    sIsInitialized.store<tbb::memory_semantics::full_fence>(false); // What memory order? We can't have anything below reordered above this, right?
 
 #ifdef __ICC
 __pragma(warning(default:1711))


### PR DESCRIPTION
…tialize()) use double-checked locking so the hot path is just one atomic load

Closes https://github.com/AcademySoftwareFoundation/openvdb/issues/869