### PR TITLE
Added github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+### Environment
+**Operating System:** (e.g. Windows 2019, macOS-10.15, Linux CentOS 7.4)
+**Version / Commit SHA:** (e.g VDB 7.2, SHA: 1a2b3c4d5e...)
+**Other:** (e.g compiler, C++ standard etc.)
+
+### Describe the bug
+(A clear and concise description of what the bug is.)
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. Build with '...'
+2. Run function '....'
+3. See error
+
+### Expected behavior
+(A clear and concise description of what you expected to happen.)
+
+### Additional context
+(Add any other context about the problem here.)

--- a/.github/ISSUE_TEMPLATE/build---installation.md
+++ b/.github/ISSUE_TEMPLATE/build---installation.md
@@ -1,0 +1,27 @@
+---
+name: Build / Installation
+about: Describe a problem with installation
+title: "[BUILD]"
+labels: ''
+assignees: ''
+
+---
+
+### Environment
+**Operating System:** (e.g. Windows 2019, macOS-10.15, Linux CentOS 7.4)
+**Version / Commit SHA:** (e.g VDB 7.2, SHA: 1a2b3c4d5e...)
+**CMake Version:** (e.g. 3.18)
+**Compiler:** (e.g. gcc 10, msvc 2019)
+
+### Describe the problem
+(A clear and concise description of the encountered issue.)
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. Checkout repo '...'
+2. Run CMake '....'
+3. Build with '....'
+4. See error
+
+### Additional context
+(Add any other context about the problem here.)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[REQUEST]"
+labels: enhancement
+assignees: ''
+
+---
+
+### Is your feature request related to a problem? Please describe.
+(A clear and concise description of what the problem is)
+
+### Describe the solution you'd like
+(A clear and concise description of what you want to happen.)
+
+### Describe alternatives you've considered
+(A clear and concise description of any alternative solutions or features you've considered.)
+
+### Additional context
+(Add any other context or screenshots about the feature request here.)


### PR DESCRIPTION
Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>

I haven't modified these too much from the defaults github give you and haven't modified the "template chooser". You can see what these templates look like by creating an issue by clicking on "New Issue" in my fork: https://github.com/Idclip/openvdb/issues

More info:
https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository