### PR TITLE
CMake 3.19 fix for find_package_handle_standard_args

### DIFF
--- a/cmake/OpenVDBGLFW3Setup.cmake
+++ b/cmake/OpenVDBGLFW3Setup.cmake
@@ -109,11 +109,17 @@ endif()
 set(glfw3_FIND_VERSION ${MINIMUM_GLFW_VERSION})
 find_package(glfw3 ${MINIMUM_GLFW_VERSION} REQUIRED)
 
-find_package(PackageHandleStandardArgs)
-find_package_handle_standard_args(glfw3
-  REQUIRED_VARS glfw3_DIR glfw3_FOUND
-  VERSION_VAR glfw3_VERSION
-)
+# We only use find_package_handle_standard_args to verify and print
+# appropriate messages. This now explicitly errors in 3.19...
+# @todo Improve this entire GLFW3 search
+#  https://gitlab.kitware.com/cmake/cmake/-/issues/21505
+if(${CMAKE_VERSION} VERSION_LESS 3.19)
+  find_package(PackageHandleStandardArgs)
+  find_package_handle_standard_args(glfw3
+    REQUIRED_VARS glfw3_DIR glfw3_FOUND
+    VERSION_VAR glfw3_VERSION
+  )
+endif()
 
 unset(glfw3_FIND_VERSION)
 


### PR DESCRIPTION
Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>

Fixes: https://github.com/AcademySoftwareFoundation/openvdb/actions/runs/398576400
I don't know why this explicit error was added