### PR TITLE
Add new GCC10 and Clang10 CI builds and fix size_t issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,40 @@ jobs:
     - name: test
       run: ./ci/test.sh
 
+  testabi8gcc10:
+    runs-on: ubuntu-20.04
+    env:
+      CXX: g++-10
+    steps:
+    - uses: actions/checkout@v1
+    - name: install_boost
+      run: sudo apt-get -q install -y libboost-dev libboost-system-dev libboost-iostreams-dev
+    - name: install_tbb
+      run: sudo apt-get -q install -y libtbb-dev
+    - name: install_gtest
+      run: sudo apt-get -q install -y libgtest-dev
+    - name: build
+      run: ./ci/build.sh Release 8 OFF None "core,test" -DUSE_ZLIB=OFF -DDISABLE_DEPENDENCY_VERSION_CHECKS=ON -DCMAKE_INSTALL_PREFIX=`pwd`
+    - name: test
+      run: ./ci/test.sh
+
+  testabi8clang10:
+    runs-on: ubuntu-20.04
+    env:
+      CXX: clang++-10
+    steps:
+    - uses: actions/checkout@v1
+    - name: install_boost
+      run: sudo apt-get -q install -y libboost-dev libboost-system-dev libboost-iostreams-dev
+    - name: install_tbb
+      run: sudo apt-get -q install -y libtbb-dev
+    - name: install_gtest
+      run: sudo apt-get -q install -y libgtest-dev
+    - name: build
+      run: ./ci/build.sh Release 8 OFF None "core,test" -DUSE_ZLIB=OFF -DDISABLE_DEPENDENCY_VERSION_CHECKS=ON -DCMAKE_INSTALL_PREFIX=`pwd`
+    - name: test
+      run: ./ci/test.sh
+
   testwindows2019md:
     runs-on: windows-2019
     env:

--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Version 8.0.0 - In development
     - As of this release, VFX Reference Platform 2018 is no longer supported.
       CMake now issues deprecation warnings for 2019 VFX Reference Platform
       version dependencies.
+    - Added a missing header include to resolve an undefined size_t build error
+      on GCC10.
 
 
 Version 7.2.0 - December 9, 2020

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -19,6 +19,8 @@ Build:
 - As of this release, VFX Reference Platform 2018 is no longer supported.
   CMake now issues deprecation warnings for 2019 VFX Reference Platform
   version dependencies.
+- Added a missing header include to resolve an undefined size_t build error
+  on GCC10.
 
 @htmlonly <a name="v7_2_0_changes"></a>@endhtmlonly
 @par

--- a/openvdb/openvdb/version.h
+++ b/openvdb/openvdb/version.h
@@ -43,6 +43,7 @@
 #define OPENVDB_VERSION_HAS_BEEN_INCLUDED
 
 #include "Platform.h"
+#include <cstddef> // size_t
 #include <cstdint> // uint32_t
 
 


### PR DESCRIPTION
This addresses #902 and uses the apt package manager with ubuntu 20.04 to verify GCC10 and Clang10 both of which are now part of the GitHub Actions environment.