### PR TITLE
Enable visit2 on const tree

### DIFF
--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -787,8 +787,7 @@ protected:
     template<typename NodeT, typename VisitorOp, typename ChildAllIterT>
     static inline void doVisit(NodeT&, VisitorOp&);
 
-    template<typename NodeT, typename OtherNodeT, typename VisitorOp,
-        typename ChildAllIterT, typename OtherChildAllIterT>
+    template<typename NodeT, typename OtherNodeT, typename VisitorOp>
     static inline void doVisit2Node(NodeT&, OtherNodeT&, VisitorOp&);
 
     template<typename NodeT, typename VisitorOp,
@@ -2916,8 +2915,7 @@ template<typename OtherNodeType, typename VisitorOp>
 inline void
 InternalNode<ChildT, Log2Dim>::visit2Node(OtherNodeType& other, VisitorOp& op)
 {
-    doVisit2Node<InternalNode, OtherNodeType, VisitorOp, ChildAllIter,
-        typename OtherNodeType::ChildAllIter>(*this, other, op);
+    doVisit2Node<InternalNode, OtherNodeType, VisitorOp>(*this, other, op);
 }
 
 
@@ -2926,8 +2924,7 @@ template<typename OtherNodeType, typename VisitorOp>
 inline void
 InternalNode<ChildT, Log2Dim>::visit2Node(OtherNodeType& other, VisitorOp& op) const
 {
-    doVisit2Node<const InternalNode, OtherNodeType, VisitorOp, ChildAllCIter,
-        typename OtherNodeType::ChildAllCIter>(*this, other, op);
+    doVisit2Node<const InternalNode, OtherNodeType, VisitorOp>(*this, other, op);
 }
 
 
@@ -2935,9 +2932,7 @@ template<typename ChildT, Index Log2Dim>
 template<
     typename NodeT,
     typename OtherNodeT,
-    typename VisitorOp,
-    typename ChildAllIterT,
-    typename OtherChildAllIterT>
+    typename VisitorOp>
 inline void
 InternalNode<ChildT, Log2Dim>::doVisit2Node(NodeT& self, OtherNodeT& other, VisitorOp& op)
 {
@@ -2950,8 +2945,11 @@ InternalNode<ChildT, Log2Dim>::doVisit2Node(NodeT& self, OtherNodeT& other, Visi
     typename NodeT::ValueType val;
     typename OtherNodeT::ValueType otherVal;
 
-    ChildAllIterT iter = self.beginChildAll();
-    OtherChildAllIterT otherIter = other.beginChildAll();
+    auto iter = self.beginChildAll();
+    using ChildAllIterT = decltype(iter);
+    auto otherIter = other.beginChildAll();
+    using OtherChildAllIterT = decltype(otherIter);
+
 
     for ( ; iter && otherIter; ++iter, ++otherIter)
     {

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -884,8 +884,7 @@ protected:
     template<typename NodeT, typename VisitorOp, typename ChildAllIterT>
     static inline void doVisit(NodeT&, VisitorOp&);
 
-    template<typename NodeT, typename OtherNodeT, typename VisitorOp,
-             typename ChildAllIterT, typename OtherChildAllIterT>
+    template<typename NodeT, typename OtherNodeT, typename VisitorOp>
     static inline void doVisit2Node(NodeT& self, OtherNodeT& other, VisitorOp&);
 
     template<typename NodeT, typename VisitorOp,
@@ -1869,8 +1868,7 @@ template<typename OtherLeafNodeType, typename VisitorOp>
 inline void
 LeafNode<T, Log2Dim>::visit2Node(OtherLeafNodeType& other, VisitorOp& op)
 {
-    doVisit2Node<LeafNode, OtherLeafNodeType, VisitorOp, ChildAllIter,
-        typename OtherLeafNodeType::ChildAllIter>(*this, other, op);
+    doVisit2Node<LeafNode, OtherLeafNodeType, VisitorOp>(*this, other, op);
 }
 
 
@@ -1879,8 +1877,7 @@ template<typename OtherLeafNodeType, typename VisitorOp>
 inline void
 LeafNode<T, Log2Dim>::visit2Node(OtherLeafNodeType& other, VisitorOp& op) const
 {
-    doVisit2Node<const LeafNode, OtherLeafNodeType, VisitorOp, ChildAllCIter,
-        typename OtherLeafNodeType::ChildAllCIter>(*this, other, op);
+    doVisit2Node<const LeafNode, OtherLeafNodeType, VisitorOp>(*this, other, op);
 }
 
 
@@ -1888,9 +1885,7 @@ template<typename T, Index Log2Dim>
 template<
     typename NodeT,
     typename OtherNodeT,
-    typename VisitorOp,
-    typename ChildAllIterT,
-    typename OtherChildAllIterT>
+    typename VisitorOp>
 inline void
 LeafNode<T, Log2Dim>::doVisit2Node(NodeT& self, OtherNodeT& other, VisitorOp& op)
 {
@@ -1900,8 +1895,8 @@ LeafNode<T, Log2Dim>::doVisit2Node(NodeT& self, OtherNodeT& other, VisitorOp& op
     static_assert(OtherNodeT::LEVEL == NodeT::LEVEL,
         "can't visit nodes at different tree levels simultaneously");
 
-    ChildAllIterT iter = self.beginChildAll();
-    OtherChildAllIterT otherIter = other.beginChildAll();
+    auto iter = self.beginChildAll();
+    auto otherIter = other.beginChildAll();
 
     for ( ; iter && otherIter; ++iter, ++otherIter) {
         op(iter, otherIter);

--- a/openvdb/openvdb/tree/Tree.h
+++ b/openvdb/openvdb/tree/Tree.h
@@ -1896,8 +1896,7 @@ inline void
 Tree<RootNodeType>::visit2(OtherTreeType& other, VisitorOp& op)
 {
     this->clearAllAccessors();
-    using OtherRootNodeType = typename OtherTreeType::RootNodeType;
-    mRoot.template visit2<OtherRootNodeType, VisitorOp>(other.root(), op);
+    mRoot.template visit2(other.root(), op);
 }
 
 
@@ -1906,8 +1905,7 @@ template<typename OtherTreeType, typename VisitorOp>
 inline void
 Tree<RootNodeType>::visit2(OtherTreeType& other, VisitorOp& op) const
 {
-    using OtherRootNodeType = typename OtherTreeType::RootNodeType;
-    mRoot.template visit2<OtherRootNodeType, VisitorOp>(other.root(), op);
+    mRoot.template visit2(other.root(), op);
 }
 
 

--- a/openvdb/openvdb/unittest/TestTreeVisitor.cc
+++ b/openvdb/openvdb/unittest/TestTreeVisitor.cc
@@ -300,6 +300,28 @@ TEST_F(TestTreeVisitor, testVisit2Trees)
 
     visitor.reset();
 
+    // Traverse const references to both trees
+    const TreeT& cTree = tree;
+    const Tree2T& cTree2 = tree2;
+    cTree.visit2(cTree2, visitor);
+
+    EXPECT_EQ(tree.leafCount(), visitor.aLeafCount());
+    EXPECT_EQ(tree2.leafCount(), visitor.bLeafCount());
+    EXPECT_EQ(tree.nonLeafCount(), visitor.aNonLeafCount());
+    EXPECT_EQ(tree2.nonLeafCount(), visitor.bNonLeafCount());
+
+    visitor.reset();
+
+    // Traverse non-const and const
+    tree.visit2(cTree2, visitor);
+    
+    EXPECT_EQ(tree.leafCount(), visitor.aLeafCount());
+    EXPECT_EQ(tree2.leafCount(), visitor.bLeafCount());
+    EXPECT_EQ(tree.nonLeafCount(), visitor.aNonLeafCount());
+    EXPECT_EQ(tree2.nonLeafCount(), visitor.bNonLeafCount());
+
+    visitor.reset();
+
     // Change the topology of the first tree.
     tree.setValue(openvdb::Coord(-200, -200, -200), openvdb::zeroVal<ValueT>());
 

--- a/openvdb/openvdb/unittest/TestTreeVisitor.cc
+++ b/openvdb/openvdb/unittest/TestTreeVisitor.cc
@@ -314,7 +314,7 @@ TEST_F(TestTreeVisitor, testVisit2Trees)
 
     // Traverse non-const and const
     tree.visit2(cTree2, visitor);
-    
+
     EXPECT_EQ(tree.leafCount(), visitor.aLeafCount());
     EXPECT_EQ(tree2.leafCount(), visitor.bLeafCount());
     EXPECT_EQ(tree.nonLeafCount(), visitor.aNonLeafCount());


### PR DESCRIPTION
There already was a const version of `Tree::visit2`, but this could not be called as it would end up at [RootNode.h#L3439-L3440](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/openvdb/openvdb/tree/RootNode.h#L3439-L3440) with `RootNodeT` const qualified.

The modified test tries to call `visit2` on a const tree and it fails to compile.

The changes allow the  const version of `Tree::visit2` to be used, and also allow mixing a const and a non-const tree (the corresponding iterators passed to visitor will be const iterators or not).