### PR TITLE
Fix determinism bug in NodeManager

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,10 @@ Version 8.0.0 - In development
     - VDB to Spheres SOP doesn't reset the radius when in worldspace mode.
       VDB Write likewise should not reset the compression values.
 
+    Bug fixes:
+    - Fixed a determinism bug in NodeManager when using non-thread-safe
+      functor members.
+
 Version 7.2.0 - December 9, 2020
 
     New features:

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -57,6 +57,11 @@ Houdini:
 - VDB to Spheres SOP doesn't reset the radius when in worldspace mode.
   VDB Write SOP should likewise not reset the compression values.
 
+@par
+Bug fixes:
+- Fixed a determinism bug in @vdblink::tree::NodeManager NodeManager@endlink
+  when using non-thread-safe functor members.
+
 @htmlonly <a name="v7_2_0_changes"></a>@endhtmlonly
 @par
 <B>Version 7.2.0</B> - <I>December 9, 2020</I>

--- a/openvdb/openvdb/tree/NodeManager.h
+++ b/openvdb/openvdb/tree/NodeManager.h
@@ -329,7 +329,7 @@ private:
                 OpT::template eval(mNodeOp, it);
             }
         }
-        const NodeOp& mNodeOp;
+        const NodeOp mNodeOp;
     };// NodeList::NodeTransformer
 
     // Private struct of NodeList that performs parallel_reduce


### PR DESCRIPTION
This is a relatively rare issue accidentally introduced in #785 and picked up by @Idclip. It occurs when using non-thread-safe data members (such as a ValueAccessor) in a NodeManager foreach functor.