### PR TITLE
Fix CSG intersection

### DIFF
--- a/openvdb/openvdb/tools/Merge.h
+++ b/openvdb/openvdb/tools/Merge.h
@@ -501,10 +501,63 @@ struct UnallocatedBuffer<BufferT, bool>
 template <typename TreeT, bool Union>
 bool CsgUnionOrIntersectionOp<TreeT, Union>::operator()(RootT& root, size_t) const
 {
+    const bool Intersect = !Union;
+
     if (this->empty())     return false;
 
     // store the background value
     if (!mBackground)   mBackground = &root.background();
+
+    // does the key exist in the root node?
+    auto keyExistsInRoot = [&](const Coord& key) -> bool
+    {
+        return root.getValueDepth(key) > -1;
+    };
+
+    // does the key exist in all merge tree root nodes?
+    auto keyExistsInAllTrees = [&](const Coord& key) -> bool
+    {
+        for (TreeToMerge<TreeT>& mergeTree : mTreesToMerge) {
+            const auto* mergeRoot = mergeTree.rootPtr();
+            if (!mergeRoot)                             return false;
+            if (mergeRoot->getValueDepth(key) == -1)    return false;
+        }
+        return true;
+    };
+
+    // for intersection, delete any root node keys that are not present in all trees
+    if (Intersect) {
+        // find all tile coordinates to delete
+        std::vector<Coord> toDelete;
+        for (auto valueIter = root.cbeginValueAll(); valueIter; ++valueIter) {
+            const Coord& key = valueIter.getCoord();
+            if (!keyExistsInAllTrees(key))   toDelete.push_back(key);
+        }
+        // find all child coordinates to delete
+        for (auto childIter = root.cbeginChildOn(); childIter; ++childIter) {
+            const Coord& key = childIter.getCoord();
+            if (!keyExistsInAllTrees(key))   toDelete.push_back(key);
+        }
+        // mark any background tiles as active to prevent them from being deleted
+        std::vector<Coord> toPreserve;
+        for (auto valueIter = root.beginValueAll(); valueIter; ++valueIter) {
+            const Coord& key = valueIter.getCoord();
+            // background tiles are always inactive
+            if (valueIter.isValueOff() &&
+                math::isApproxEqual(*valueIter, root.background())) {
+                toPreserve.push_back(key);
+                valueIter.setValueOn();
+            }
+        }
+        // only mechanism to delete elements in root node is to delete background tiles,
+        // so insert background tiles (which will replace any child nodes) and then delete
+        for (Coord& key : toDelete)     root.addTile(key, *mBackground, false);
+        root.eraseBackgroundTiles();
+        // now re-insert the background tiles
+        for (Coord& key : toPreserve) {
+            root.addTile(key, *mBackground, false);
+        }
+    }
 
     // find all tile values in this root and track inside/outside and active state
     // note that level sets should never contain active tiles, but we handle them anyway
@@ -569,7 +622,10 @@ bool CsgUnionOrIntersectionOp<TreeT, Union>::operator()(RootT& root, size_t) con
         if (flag & INSIDE_STATE) {
             const Coord& key = it.first;
             const bool state = flag & ACTIVE_TILE;
-            root.addTile(key, insideBackground, state);
+            // for intersection, only add the tile if the key already exists in the tree
+            if (Union || keyExistsInRoot(key)) {
+                root.addTile(key, insideBackground, state);
+            }
         }
     }
 
@@ -592,6 +648,9 @@ bool CsgUnionOrIntersectionOp<TreeT, Union>::operator()(RootT& root, size_t) con
         if (!mergeRoot)     continue;
         for (auto childIter = mergeRoot->cbeginChildOn(); childIter; ++childIter) {
             const Coord& key = childIter.getCoord();
+
+            // for intersection, only add child nodes if the key already exists in the tree
+            if (Intersect && !keyExistsInRoot(key))        continue;
 
             // if child already exists, merge recursion will need to continue to resolve conflict
             if (children.count(key)) {
@@ -618,7 +677,10 @@ bool CsgUnionOrIntersectionOp<TreeT, Union>::operator()(RootT& root, size_t) con
             const Coord& key = it.first;
             if (!children.count(key)) {
                 const bool state = flag & ACTIVE_TILE;
-                root.addTile(key, outsideBackground, state);
+                // for intersection, only add the tile if the key already exists in the tree
+                if (Union || keyExistsInRoot(key)) {
+                    root.addTile(key, outsideBackground, state);
+                }
             }
         }
     }

--- a/openvdb/openvdb/unittest/TestMerge.cc
+++ b/openvdb/openvdb/unittest/TestMerge.cc
@@ -838,6 +838,8 @@ TEST_F(TestMerge, testCsgIntersection)
     { // merge two different outside root tiles from one grid into an empty grid
         FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
         auto& root = grid->tree().root();
+        root.addTile(Coord(0, 0, 0), -grid->background(), false);
+        root.addTile(Coord(8192, 0, 0), -grid->background(), false);
         FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
         auto& root2 = grid2->tree().root();
         root2.addTile(Coord(0, 0, 0), grid->background(), false);
@@ -865,11 +867,15 @@ TEST_F(TestMerge, testCsgIntersection)
     { // merge two different outside root tiles from two grids into an empty grid
         FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
         auto& root = grid->tree().root();
+        root.addTile(Coord(0, 0, 0), /*background=*/-100.0f, false);
+        root.addTile(Coord(8192, 0, 0), /*background=*/-100.0f, false);
         FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
         auto& root2 = grid2->tree().root();
+        root2.addTile(Coord(0, 0, 0), /*background=*/123.0f, false);
+        root2.addTile(Coord(8192, 0, 0), /*background=*/-100.0f, false);
         FloatGrid::Ptr grid3 = createLevelSet<FloatGrid>();
         auto& root3 = grid3->tree().root();
-        root2.addTile(Coord(0, 0, 0), /*background=*/123.0f, false);
+        root3.addTile(Coord(0, 0, 0), /*background=*/-100.0f, false);
         root3.addTile(Coord(8192, 0, 0), /*background=*/0.1f, true);
 
         std::vector<FloatTree*> trees{&grid2->tree(), &grid3->tree()};
@@ -894,11 +900,12 @@ TEST_F(TestMerge, testCsgIntersection)
     { // merge the same outside root tiles from two grids into an empty grid
         FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
         auto& root = grid->tree().root();
+        root.addTile(Coord(0, 0, 0), -grid->background(), false);
         FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
         auto& root2 = grid2->tree().root();
+        root2.addTile(Coord(0, 0, 0), grid->background(), true);
         FloatGrid::Ptr grid3 = createLevelSet<FloatGrid>();
         auto& root3 = grid3->tree().root();
-        root2.addTile(Coord(0, 0, 0), grid->background(), true);
         root3.addTile(Coord(0, 0, 0), grid->background(), false);
 
         std::vector<FloatTree*> trees{&grid2->tree(), &grid3->tree()};
@@ -913,6 +920,7 @@ TEST_F(TestMerge, testCsgIntersection)
         EXPECT_EQ(Index(0), getInactiveTileCount(root));
 
         root.clear();
+        root.addTile(Coord(0, 0, 0), -grid->background(), false);
         // reverse tree order
         std::vector<FloatTree*> trees2{&grid3->tree(), &grid2->tree()};
         tools::CsgIntersectionOp<FloatTree> mergeOp2(trees2, Steal());
@@ -968,14 +976,12 @@ TEST_F(TestMerge, testCsgIntersection)
     { // merge two grids with an outside and an inside tile, outside takes precedence
         FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
         auto& root = grid->tree().root();
+        root.addTile(Coord(0, 0, 0), -grid->background(), true);
         FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
         auto& root2 = grid2->tree().root();
-        root2.addTile(Coord(0, 0, 0), -grid->background(), true);
-        FloatGrid::Ptr grid3 = createLevelSet<FloatGrid>();
-        auto& root3 = grid3->tree().root();
-        root3.addTile(Coord(0, 0, 0), /*outside*/0.1f, false);
+        root2.addTile(Coord(0, 0, 0), /*outside*/0.1f, false);
 
-        std::vector<FloatTree*> trees{&grid2->tree(), &grid3->tree()};
+        std::vector<FloatTree*> trees{&grid2->tree(), &grid2->tree()};
         tools::CsgIntersectionOp<FloatTree> mergeOp(trees, Steal());
         tree::DynamicNodeManager<FloatTree, 3> nodeManager(grid->tree());
         nodeManager.foreachTopDown(mergeOp);
@@ -994,6 +1000,8 @@ TEST_F(TestMerge, testCsgIntersection)
 
         FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
         auto& root = grid->tree().root();
+        root.addTile(Coord(0, 0, 0), -grid->background(), true);
+        root.addTile(Coord(8192, 0, 0), -grid->background(), true);
         FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
         auto& root2 = grid2->tree().root();
         root2.addChild(new RootChildType(Coord(0, 0, 0), 1.0f, false));
@@ -1040,8 +1048,10 @@ TEST_F(TestMerge, testCsgIntersection)
         FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
         auto& root = grid->tree().root();
         root.addChild(new RootChildType(Coord(0, 0, 0), 123.0f, false));
+        root.addTile(Coord(8192, 0, 0), -123.0f, true);
         FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
         auto& root2 = grid2->tree().root();
+        root2.addTile(Coord(0, 0, 0), -123.0f, true);
         root2.addChild(new RootChildType(Coord(8192, 0, 0), 1.9f, false));
 
         EXPECT_EQ(Index(1), getChildCount(root));
@@ -1159,8 +1169,8 @@ TEST_F(TestMerge, testCsgIntersection)
 
     { // merge a leaf node into an empty grid
         FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        grid->tree().root().addTile(Coord(0, 0, 0), -1.0f, false);
         FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
-
         grid2->tree().touchLeaf(Coord(0, 0, 0));
 
         EXPECT_EQ(Index32(0), grid->tree().leafCount());
@@ -1234,8 +1244,8 @@ TEST_F(TestMerge, testCsgIntersection)
 
     { // merge a leaf node into an empty grid from a const grid
         FloatGrid::Ptr grid = createLevelSet<FloatGrid>();
+        grid->tree().root().addTile(Coord(0, 0, 0), -1.0f, false);
         FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
-
         grid2->tree().touchLeaf(Coord(0, 0, 0));
 
         EXPECT_EQ(Index32(0), grid->tree().leafCount());

--- a/pendingchanges/fix_csg_intersection.txt
+++ b/pendingchanges/fix_csg_intersection.txt
@@ -1,0 +1,3 @@
+Bug fixes:
+    - Fixed a bug in the new CSG intersection merge algorithm where data
+      outside of the intersection region was not being removed.


### PR DESCRIPTION
This isn't for final review as it needs a bit more work, but it resolves the issue and demonstrates that it doesn't require changes to the DynamicNodeManager.

As you identified @jmlait, the issue is that for the root node in CSG intersection mode, if any trees being merged don't have a particular key, that element needs to be deleted from the resulting tree, meaning unlike CSG union and CSG difference, _absence_ of a root node child takes precedence over outside/inside tiles or child nodes. This doesn't apply to InternalNodes in CSG intersection mode as every element must be either a tile or a child.

I took a slightly different approach to yours here and first detect any keys that need deleting from the target tree, then delete them. Adding tiles or children in CSG intersection mode is then only permissible if they already exist in the root node. The root node has a pretty strict API so it's a bit of convoluted logic to even delete root node children - I found the easiest solution was to convert any elements I wanted to delete into background tiles and then call root.eraseBackgroundTiles(). There's definitely an argument for extending the RootNode API to make this kind of operation easier, but I don't think that should hold up this fix necessarily.

My next step is to modify the unit tests to run through the original CSG visitors to make sure I haven't baked in any other incorrect assumptions (as a test only - Merge.h should remain upstream of Composite.h). I also need a few additional unit tests to test the dropping of tiles and children in CSG Intersection mode.