### PR TITLE
Run CI against VFX Ref 2018

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,8 @@ jobs:
     strategy:
       matrix:
         config:
+          # build against VFX Ref 2018 even though it's unsupported, just to make sure that we test Boost 1.61
+          - { cxx: clang++, image: '2018', hou: '18_0', build: 'Release', extras: 'ON' }
           - { cxx: clang++, image: '2019', hou: '18_0', build: 'Release', extras: 'ON' }
           - { cxx: clang++, image: '2020', hou: '18_5', build: 'Release', extras: 'ON' }
           - { cxx: clang++, image: '2020', hou: '18_5', build: 'Debug',   extras: 'OFF' }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,11 +65,11 @@ jobs:
       matrix:
         config:
           # build against VFX Ref 2018 even though it's unsupported, just to make sure that we test Boost 1.61
-          - { cxx: clang++, image: '2018', hou: '18_0', build: 'Release', extras: 'ON' }
-          - { cxx: clang++, image: '2019', hou: '18_0', build: 'Release', extras: 'ON' }
-          - { cxx: clang++, image: '2020', hou: '18_5', build: 'Release', extras: 'ON' }
-          - { cxx: clang++, image: '2020', hou: '18_5', build: 'Debug',   extras: 'OFF' }
-          - { cxx: g++,     image: '2020', hou: '18_5', build: 'Release', extras: 'OFF' }
+          - { cxx: clang++, image: '2018', hou: '18_0', build: 'Release', extras: 'ON', disable_checks: 'ON' }
+          - { cxx: clang++, image: '2019', hou: '18_0', build: 'Release', extras: 'ON', disable_checks: 'OFF' }
+          - { cxx: clang++, image: '2020', hou: '18_5', build: 'Release', extras: 'ON', disable_checks: 'OFF' }
+          - { cxx: clang++, image: '2020', hou: '18_5', build: 'Debug',   extras: 'OFF', disable_checks: 'OFF' }
+          - { cxx: g++,     image: '2020', hou: '18_5', build: 'Release', extras: 'OFF', disable_checks: 'OFF' }
       fail-fast: false
     steps:
     - uses: actions/checkout@v1
@@ -87,7 +87,7 @@ jobs:
     - name: houdini
       run: ./ci/install_houdini.sh
     - name: build
-      run: ./ci/build_houdini.sh ${{ matrix.config.build }} ${{ matrix.config.extras }}
+      run: ./ci/build_houdini.sh ${{ matrix.config.build }} ${{ matrix.config.extras }} -DDISABLE_DEPENDENCY_VERSION_CHECKS=${{ matrix.config.disable_checks }}
     - name: test
       run: ./ci/test.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v1
+    - name: install_cmake
+      run: ./ci/install_cmake.sh 3.12.0
     - name: install_gtest
       run: ./ci/install_gtest.sh 1.10.0
     - name: fetch_houdini


### PR DESCRIPTION
Although we don't officially support VFX Reference 2018, our codebase seems to still build against it, so I suggest we keep this test for the time being. When we deprecate support for Houdini 18.0 later this year, we can jump to VFX Reference 2020 as our minimum supported version - which will make Boost 1.70 our minimum version.