### PR TITLE
Half CMake Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,10 +97,11 @@ option(USE_LOG4CPLUS [=[
 Use log4cplus while building openvdb components. If OPENVDB_BUILD_CORE is OFF, CMake attempts to query the
 located openvdb build configuration to decide on log4cplus support. You may set this to on to force log4cplus
 to be used if you know it to be required.]=] OFF)
-option(USE_EXR [=[
-Use OpenEXR while building the core openvdb library. If OPENVDB_BUILD_CORE is OFF, CMake attempts to query the located
-openvdb build configuration to decide on OpenEXR support. You may set this to on to force OpenEXR to be used if you
-know it to be required.]=] OFF)
+option(USE_IMATH_HALF [=[
+Use the definiton of half floating point types from the Imath library. If OFF, the embedded definition provided
+by OpenVDB is used. If OPENVDB_BUILD_CORE is OFF, CMake attempts to query the located openvdb build configuration
+to select the correct half support. You may set this to on to force Imath half to be used if you know it to be
+required.]=] OFF)
 cmake_dependent_option(OPENVDB_DISABLE_BOOST_IMPLICIT_LINKING
   "Disable the implicit linking of Boost libraries on Windows" ON "WIN32" OFF)
 option(USE_CCACHE "Build using Ccache if found on the path" ON)
@@ -164,6 +165,10 @@ set(OPENVDB_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/openvdb")
 
 ###### Deprecated options
 
+if(USE_EXR)
+  message(FATAL_ERROR "The USE_EXR option has been removed. Use USE_IMATH_HALF to use the Half "
+    "implementation from IMath, or leave OFF to use the new embedded version of half floating point types.")
+endif()
 if(OPENVDB_BUILD_HOUDINI_SOPS)
   message(FATAL_ERROR "The OPENVDB_BUILD_HOUDINI_SOPS option has been removed. Use OPENVDB_BUILD_HOUDINI_PLUGIN.")
 endif()
@@ -179,6 +184,7 @@ mark_as_advanced(
   USE_HOUDINI
   USE_MAYA
   USE_LOG4CPLUS
+  USE_IMATH_HALF
   USE_CCACHE
   OPENVDB_BUILD_HOUDINI_ABITESTS
   DISABLE_DEPENDENCY_VERSION_CHECKS

--- a/README.md
+++ b/README.md
@@ -32,17 +32,15 @@ OpenVDB welcomes contributions to the OpenVDB project. Please refer to the [cont
 
 ### Developer Quick Start
 
-See the [build documentation](https://www.openvdb.org/documentation/doxygen/build.html) for help with installations.
+The following provides basic installation examples for the core OpenVDB library. Other components, such as the python module, OpenVDB AX and various executables, may require additional dependencies. See the [build documentation](https://www.openvdb.org/documentation/doxygen/build.html) for help with installations.
 
 #### Linux
-##### Installing Dependencies (Boost, TBB, OpenEXR, Blosc)
+##### Installing Dependencies (Boost, TBB, Blosc)
 
 ```
 apt-get install -y libboost-iostreams-dev
 apt-get install -y libboost-system-dev
 apt-get install -y libtbb-dev
-apt-get install -y libilmbase-dev
-apt-get install -y libopenexr-dev
 ```
 ```
 git clone git@github.com:Blosc/c-blosc.git
@@ -67,12 +65,10 @@ make -j4
 make install
 ```
 #### macOS
-##### Installing Dependencies (Boost, TBB, OpenEXR, Blosc)
+##### Installing Dependencies (Boost, TBB, Blosc)
 ```
 brew install boost
 brew install tbb
-brew install ilmbase
-brew install openexr
 ```
 ```
 git clone git@github.com:Blosc/c-blosc.git
@@ -96,7 +92,7 @@ make -j4
 make install
 ```
 #### Windows
-##### Installing Dependencies (Boost, TBB, OpenEXR, Blosc)
+##### Installing Dependencies (Boost, TBB, Blosc)
 
 Note that the following commands have only been tested for 64bit systems/libraries.
 It is recommended to set the `VCPKG_DEFAULT_TRIPLET` environment variable to
@@ -107,7 +103,6 @@ and [CMake](https://cmake.org/download/) to be installed.
 ```
 vcpkg install zlib:x64-windows
 vcpkg install blosc:x64-windows
-vcpkg install openexr:x64-windows
 vcpkg install tbb:x64-windows
 vcpkg install boost-iostreams:x64-windows
 vcpkg install boost-system:x64-windows

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -332,14 +332,14 @@ Package        | Description                                                    
 CMake          | Cross-platform family of tools designed to help build software    | All                              |
 C++14 Compiler | Matching Houdini compiler and version                             | All                              |
 Boost          | Components: system, iostreams, python, thread                     | All                              |
-IlmBase        | Used half precision floating points and EXR serialization support | All                              |
 ZLIB           | Compression library for disk serialization compression            | All                              |
 Blosc          | Recommended dependency for improved disk compression              | All*                             |
 GoogleTest     | A unit testing framework module for C++                           | Unit Tests                       |
 CppUnit        | A unit testing framework module for C++                           | Unit Tests (AX)                  |
 GLFW           | Simple API for OpenGL development                                 | OpenVDB View                     |
 Doxygen        | Documentation generation from C++                                 | Documentation                    |
-OpenEXR        | EXR serialization support                                         | Optional (Core) / OpenVDB Render |
+OpenEXR        | EXR serialization support                                         | OpenVDB Render                   |
+IlmBase        | Used half precision floating points and EXR serialization support | Optional (All)                   |
 Log4cplus      | An optional dependency for improved OpenVDB Logging               | Optional (All)                   |
 NumPy          | Scientific computing with Python                                  | Optional (Python)                |
 LLVM           | Target-independent code generation                                | OpenVDB AX                       |
@@ -347,9 +347,9 @@ LLVM           | Target-independent code generation                             
 
 * See [blosc support](@ref buildBloscSupport)
 
-At a minimum, boost, a matching C++14 compiler, IlmBase, ZLIB, blosc and CMake
-will be required. See the full [dependency list](@ref dependencies) for help
-with downloading and installing the above software.
+At a minimum, boost, a matching C++14 compiler, ZLIB, blosc and CMake will be
+required. See the full [dependency list](@ref dependencies) for help with
+downloading and installing the above software.
 
 With the necessary dependencies installed, create and enter a directory for
 cmake to write to. It's generally useful to create this in the location you've

--- a/doc/dependencies.txt
+++ b/doc/dependencies.txt
@@ -37,7 +37,7 @@ Reference Platform, but for those that do, their specified versions are
 
 Component               | Requirements                                                                         | Optional
 ----------------------- | ------------------------------------------------------------------------------------ | --------
-OpenVDB Core Library    | CMake, C++14 compiler, IlmBase::Half, TBB::tbb, Boost::system, Boost::iostream       | Blosc, ZLib, Log4cplus, OpenEXR::IlmImf
+OpenVDB Core Library    | CMake, C++14 compiler, TBB::tbb, Boost::system, Boost::iostream                      | Blosc, ZLib, Log4cplus, IlmBase::Half
 OpenVDB Print           | Core Library dependencies                                                            | -
 OpenVDB LOD             | Core Library dependencies                                                            | -
 OpenVDB Render          | Core Library dependencies, OpenEXR, IlmBase                                          | -

--- a/openvdb/openvdb/BuildConfig.h.in
+++ b/openvdb/openvdb/BuildConfig.h.in
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: MPL-2.0
 ///
 /// @file BuildConfig.h
+///
+/// @brief  Auto generated build config header from CMake
 
 #ifndef OPENVDB_BUILDCONFIG_HAS_BEEN_INCLUDED
 #define OPENVDB_BUILDCONFIG_HAS_BEEN_INCLUDED
 
-#cmakedefine OPENVDB_BUILDCONFIG_USE_EXR
+/// @brief  Denotes whether VDB was built with IMath Half support
+#cmakedefine OPENVDB_BUILDCONFIG_USE_IMATH_HALF
 
 #endif // OPENVDB_BUILDCONFIG_HAS_BEEN_INCLUDED
 

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -197,7 +197,7 @@ set(OPENVDB_LIBRARY_SOURCE_FILES
   io/Queue.cc
   io/Stream.cc
   io/TempFile.cc
-  math/half.cc
+  math/Half.cc
   math/Maps.cc
   math/Proximity.cc
   math/QuantizedUnitVec.cc
@@ -247,8 +247,8 @@ set(OPENVDB_LIBRARY_MATH_INCLUDE_FILES
   math/Coord.h
   math/DDA.h
   math/FiniteDifference.h
-  math/half.h
-  math/halfLimits.h
+  math/Half.h
+  math/HalfLimits.h
   math/LegacyFrustum.h
   math/Maps.h
   math/Mat.h

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -45,21 +45,13 @@ message(STATUS "----------------------------------------------------")
 
 # Collect and configure lib dependencies
 
-if(USE_EXR)
-  find_package(IlmBase ${MINIMUM_ILMBASE_VERSION} REQUIRED)
-  find_package(OpenEXR ${MINIMUM_OPENEXR_VERSION} REQUIRED)
-  if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_OPENEXR_VERSION)
-    if(${OpenEXR_VERSION} VERSION_LESS FUTURE_MINIMUM_OPENEXR_VERSION)
-      message(DEPRECATION "Support for OpenEXR versions < ${FUTURE_MINIMUM_OPENEXR_VERSION} "
+if(USE_IMATH_HALF)
+  find_package(IlmBase ${MINIMUM_ILMBASE_VERSION} REQUIRED COMPONENTS Half)
+  if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_ILMBASE_VERSION)
+    if(${IlmBase_VERSION} VERSION_LESS FUTURE_MINIMUM_ILMBASE_VERSION)
+      message(DEPRECATION "Support for IlmBase versions < ${FUTURE_MINIMUM_ILMBASE_VERSION} "
         "is deprecated and will be removed.")
     endif()
-  endif()
-endif()
-
-if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_ILMBASE_VERSION)
-  if(${IlmBase_VERSION} VERSION_LESS FUTURE_MINIMUM_ILMBASE_VERSION)
-    message(DEPRECATION "Support for IlmBase versions < ${FUTURE_MINIMUM_ILMBASE_VERSION} "
-      "is deprecated and will be removed.")
   endif()
 endif()
 
@@ -119,15 +111,20 @@ if(UNIX)
 endif()
 
 # Set deps. Note that the order here is important. If we're building against
-# Houdini 17.5 we must include OpenEXR and IlmBase deps first to ensure the
-# users chosen namespaced headers are correctly prioritized. Otherwise other
-# include paths from shared installs (including houdini) may pull in the wrong
-# headers
+# Houdini 17.5 we must include IlmBase deps first to ensure the users chosen
+# namespaced headers are correctly prioritized. Otherwise other include paths
+# from shared installs (including houdini) may pull in the wrong headers
 
 set(OPENVDB_CORE_DEPENDENT_LIBS
   Boost::iostreams
   Boost::system
 )
+
+if(USE_IMATH_HALF)
+  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
+    IlmBase::Half
+  )
+endif()
 
 if(WIN32)
   # Boost headers contain #pragma commands on Windows which causes Boost
@@ -140,12 +137,6 @@ if(WIN32)
         Boost::disable_autolinking  # add -DBOOST_ALL_NO_LIB
       )
   endif()
-endif()
-
-if(USE_EXR)
-  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
-    IlmBase::Half
-  )
 endif()
 
 if(USE_LOG4CPLUS)
@@ -186,12 +177,15 @@ endif()
 
 ##### Core library configuration
 
-option(OPENVDB_BUILDCONFIG_USE_EXR "Enable OpenEXR Half in Configuration File" OFF)
-if(USE_EXR)
-  set(OPENVDB_BUILDCONFIG_USE_EXR, 1)
+# Configure the BuildConfig header
+
+if(USE_IMATH_HALF)
+  set(OPENVDB_BUILDCONFIG_USE_IMATH_HALF 1)
 endif()
 
 configure_file(BuildConfig.h.in BuildConfig.h)
+
+##########################################################################
 
 set(OPENVDB_LIBRARY_SOURCE_FILES
   Grid.cc
@@ -417,8 +411,8 @@ if(WIN32)
   # @note OPENVDB_OPENEXR_STATICLIB is old functionality from the makefiles
   #       used in PlatformConfig.h to configure EXR exports. Once this file
   #       is completely removed, this define can be too
-  if(USE_EXR)
-    if(OPENEXR_USE_STATIC_LIBS OR (${ILMBASE_LIB_TYPE} STREQUAL STATIC_LIBRARY))
+  if(USE_IMATH_HALF)
+    if(ILMBASE_USE_STATIC_LIBS OR (${ILMBASE_LIB_TYPE} STREQUAL STATIC_LIBRARY))
       list(APPEND OPENVDB_CORE_PUBLIC_DEFINES -DOPENVDB_OPENEXR_STATICLIB)
     endif()
   endif()
@@ -485,7 +479,6 @@ if(OPENVDB_CORE_SHARED)
     list(APPEND RPATHS
       ${Boost_LIBRARY_DIRS}
       ${IlmBase_LIBRARY_DIRS}
-      ${OpenEXR_LIBRARY_DIRS}
       ${Log4cplus_LIBRARY_DIRS}
       ${Blosc_LIBRARY_DIRS}
       ${Tbb_LIBRARY_DIRS}

--- a/openvdb/openvdb/Types.h
+++ b/openvdb/openvdb/Types.h
@@ -18,7 +18,7 @@ namespace math {
 using half = half;
 }}}
 #else
-#include <openvdb/math/half.h>
+#include <openvdb/math/Half.h>
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {

--- a/openvdb/openvdb/Types.h
+++ b/openvdb/openvdb/Types.h
@@ -9,7 +9,7 @@
 #include "Platform.h"
 #include "TypeList.h" // backwards compat
 
-#ifdef OPENVDB_BUILDCONFIG_USE_EXR
+#ifdef OPENVDB_BUILDCONFIG_USE_IMATH_HALF
 #include <OpenEXR/half.h>
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE

--- a/openvdb/openvdb/math/Half.cc
+++ b/openvdb/openvdb/math/Half.cc
@@ -45,7 +45,7 @@
 //---------------------------------------------------------------------------
 
 #include <assert.h>
-#include "half.h"
+#include "Half.h"
 
 using namespace std;
 

--- a/openvdb/openvdb/math/Half.h
+++ b/openvdb/openvdb/math/Half.h
@@ -758,4 +758,4 @@ half::setBits (unsigned short bits)
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb
 
-#endif
+#endif // OPENVDB_MATH_HALF_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/math/HalfLimits.h
+++ b/openvdb/openvdb/math/HalfLimits.h
@@ -38,8 +38,8 @@
 //     Rod Bogart <rgb@ilm.com>
 
 
-#ifndef INCLUDED_HALF_LIMITS_H
-#define INCLUDED_HALF_LIMITS_H
+#ifndef OPENVDB_MATH_HALF_LIMITS_HAS_BEEN_INCLUDED
+#define OPENVDB_MATH_HALF_LIMITS_HAS_BEEN_INCLUDED
 
 
 //------------------------------------------------------------------------
@@ -49,7 +49,7 @@
 //------------------------------------------------------------------------
 
 #include <limits>
-#include "half.h"
+#include "Half.h"
 
 namespace std {
 
@@ -108,4 +108,4 @@ class numeric_limits <openvdb::OPENVDB_VERSION_NAME::math::half>
 
 } // namespace std
 
-#endif
+#endif // OPENVDB_MATH_HALF_LIMITS_HAS_BEEN_INCLUDED

--- a/openvdb_ax/openvdb_ax/CMakeLists.txt
+++ b/openvdb_ax/openvdb_ax/CMakeLists.txt
@@ -259,7 +259,6 @@ if(OPENVDB_AX_SHARED)
     list(APPEND RPATHS
       ${Boost_LIBRARY_DIRS}
       ${IlmBase_LIBRARY_DIRS}
-      ${OpenEXR_LIBRARY_DIRS}
       ${Log4cplus_LIBRARY_DIRS}
       ${Blosc_LIBRARY_DIRS}
       ${Tbb_LIBRARY_DIRS}


### PR DESCRIPTION
 - Removed `USE_EXR` and other variants in favour of `USE_IMATH_HALF`
 - Updated FindOpenVDB.cmake to work with new half requirement
 - Removed EXR RPATHS
 - Updated documentation
 - Capitalized headers in math/