### PR TITLE
Avoid a dereference of an attribute that we know to be null.

### DIFF
--- a/openvdb_houdini/openvdb_houdini/PointUtils.cc
+++ b/openvdb_houdini/openvdb_houdini/PointUtils.cc
@@ -494,7 +494,7 @@ convertAttributeFromHoudini(PointDataTree& tree, const tools::PointIndexTree& in
     using HoudiniStringAttribute = HoudiniReadAttribute<Name>;
 
     if (!attribute) {
-        std::stringstream ss; ss << "Invalid attribute - " << attribute->getName();
+        std::stringstream ss; ss << "Invalid attribute - " << name;
         throw std::runtime_error(ss.str());
     }
 


### PR DESCRIPTION
I think this was already checked on parent caller, so wouldn't show
up in the wild, but is clearly wrong.
