### PR TITLE
Issue 887/switch to std::atomic and std::mutex from deprecated tbb versions

### DIFF
--- a/doc/examplecode.txt
+++ b/doc/examplecode.txt
@@ -607,12 +607,12 @@ thread-safe counter.
 #include <openvdb/openvdb.h>
 #include <openvdb/tools/LevelSetSphere.h>
 #include <tbb/parallel_for.h>
-#include <tbb/atomic.h>
+#include <atomic>
 #include <cassert>
 #include <iostream>
 
 // Global active voxel counter, atomically updated from multiple threads
-tbb::atomic<openvdb::Index64> activeLeafVoxelCount;
+std::atomic<openvdb::Index64> activeLeafVoxelCount;
 
 // Functor for use with tbb::parallel_for() that operates on a grid's leaf nodes
 template<typename GridType>
@@ -632,7 +632,7 @@ struct LeafProcessor
             // Retrieve the leaf node to which the iterator is pointing.
             const LeafNode& leaf = *range.iterator();
             // Update the global counter.
-            activeLeafVoxelCount.fetch_and_add(leaf.onVoxelCount());
+            activeLeafVoxelCount.fetch_add(leaf.onVoxelCount());
         }
     }
 };

--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -29,7 +29,7 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
-#include <tbb/atomic.h>
+#include <atomic>
 
 #ifdef _MSC_VER
 #include <boost/interprocess/detail/os_file_functions.hpp> // open_existing_file(), close_file()
@@ -514,7 +514,7 @@ public:
     boost::interprocess::mapped_region mRegion;
     bool mAutoDelete;
     Notifier mNotifier;
-    mutable tbb::atomic<Index64> mLastWriteTime;
+    mutable std::atomic<Index64> mLastWriteTime;
 
 private:
     Impl(const Impl&); // not copyable

--- a/openvdb/openvdb/io/Queue.cc
+++ b/openvdb/openvdb/io/Queue.cc
@@ -11,7 +11,6 @@
 #include <openvdb/Exceptions.h>
 #include <openvdb/util/logging.h>
 #include <tbb/concurrent_hash_map.h>
-#include <tbb/mutex.h>
 #include <tbb/task.h>
 #include <tbb/tbb_thread.h> // for tbb::this_tbb_thread::sleep()
 #include <tbb/tick_count.h>
@@ -19,7 +18,7 @@
 #include <atomic>
 #include <iostream>
 #include <map>
-
+#include <mutex>
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
@@ -27,10 +26,6 @@ namespace OPENVDB_VERSION_NAME {
 namespace io {
 
 namespace {
-
-using Mutex = tbb::mutex;
-using Lock = Mutex::scoped_lock;
-
 
 // Abstract base class for queuable TBB tasks that adds a task completion callback
 class Task: public tbb::task
@@ -139,7 +134,7 @@ struct Queue::Impl
             // invokes a notifier method such as removeNotifier() on this queue,
             // the result will be a deadlock.
             /// @todo Is it worth trying to avoid such deadlocks?
-            Lock lock(mNotifierMutex);
+            std::lock_guard<std::mutex> lock(mNotifierMutex);
             if (!mNotifiers.empty()) {
                 didNotify = true;
                 for (NotifierMap::const_iterator it = mNotifiers.begin();
@@ -189,7 +184,7 @@ struct Queue::Impl
     StatusMap mStatus;
     NotifierMap mNotifiers;
     Index32 mNextNotifierId;
-    Mutex mNotifierMutex;
+    std::mutex mNotifierMutex;
 };
 
 
@@ -255,7 +250,7 @@ Queue::status(Id id) const
 Queue::Id
 Queue::addNotifier(Notifier notify)
 {
-    Lock lock(mImpl->mNotifierMutex);
+    std::lock_guard<std::mutex> lock(mImpl->mNotifierMutex);
     Queue::Id id = mImpl->mNextNotifierId++;
     mImpl->mNotifiers[id] = notify;
     return id;
@@ -265,7 +260,7 @@ Queue::addNotifier(Notifier notify)
 void
 Queue::removeNotifier(Id id)
 {
-    Lock lock(mImpl->mNotifierMutex);
+    std::lock_guard<std::mutex> lock(mImpl->mNotifierMutex);
     Impl::NotifierMap::iterator it = mImpl->mNotifiers.find(id);
     if (it != mImpl->mNotifiers.end()) {
         mImpl->mNotifiers.erase(it);
@@ -276,7 +271,7 @@ Queue::removeNotifier(Id id)
 void
 Queue::clearNotifiers()
 {
-    Lock lock(mImpl->mNotifierMutex);
+    std::lock_guard<std::mutex> lock(mImpl->mNotifierMutex);
     mImpl->mNotifiers.clear();
 }
 

--- a/openvdb/openvdb/io/Queue.cc
+++ b/openvdb/openvdb/io/Queue.cc
@@ -10,13 +10,13 @@
 #include "Stream.h"
 #include <openvdb/Exceptions.h>
 #include <openvdb/util/logging.h>
-#include <tbb/atomic.h>
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/mutex.h>
 #include <tbb/task.h>
 #include <tbb/tbb_thread.h> // for tbb::this_tbb_thread::sleep()
 #include <tbb/tick_count.h>
 #include <algorithm> // for std::max()
+#include <atomic>
 #include <iostream>
 #include <map>
 
@@ -184,7 +184,7 @@ struct Queue::Impl
 
     Index32 mTimeout;
     Index32 mCapacity;
-    tbb::atomic<Int32> mNumTasks;
+    std::atomic<Int32> mNumTasks;
     Index32 mNextId;
     StatusMap mStatus;
     NotifierMap mNotifiers;

--- a/openvdb/openvdb/math/Maps.cc
+++ b/openvdb/openvdb/math/Maps.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include "Maps.h"
-#include <tbb/mutex.h>
+#include <mutex>
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
@@ -11,13 +11,10 @@ namespace math {
 
 namespace {
 
-using Mutex = tbb::mutex;
-using Lock = Mutex::scoped_lock;
-
 // Declare this at file scope to ensure thread-safe initialization.
 // NOTE: Do *NOT* move this into Maps.h or else we will need to pull in
 //       Windows.h with things like 'rad2' defined!
-Mutex sInitMapRegistryMutex;
+std::mutex sInitMapRegistryMutex;
 
 } // unnamed namespace
 
@@ -37,7 +34,7 @@ MapRegistry::staticInstance()
 MapRegistry*
 MapRegistry::instance()
 {
-    Lock lock(sInitMapRegistryMutex);
+    std::lock_guard<std::mutex> lock(sInitMapRegistryMutex);
     return staticInstance();
 }
 
@@ -45,7 +42,7 @@ MapRegistry::instance()
 MapBase::Ptr
 MapRegistry::createMap(const Name& name)
 {
-    Lock lock(sInitMapRegistryMutex);
+    std::lock_guard<std::mutex> lock(sInitMapRegistryMutex);
     MapDictionary::const_iterator iter = staticInstance()->mMap.find(name);
 
     if (iter == staticInstance()->mMap.end()) {
@@ -59,7 +56,7 @@ MapRegistry::createMap(const Name& name)
 bool
 MapRegistry::isRegistered(const Name& name)
 {
-    Lock lock(sInitMapRegistryMutex);
+    std::lock_guard<std::mutex> lock(sInitMapRegistryMutex);
     return (staticInstance()->mMap.find(name) != staticInstance()->mMap.end());
 }
 
@@ -67,7 +64,7 @@ MapRegistry::isRegistered(const Name& name)
 void
 MapRegistry::registerMap(const Name& name, MapBase::MapFactory factory)
 {
-    Lock lock(sInitMapRegistryMutex);
+    std::lock_guard<std::mutex> lock(sInitMapRegistryMutex);
 
     if (staticInstance()->mMap.find(name) != staticInstance()->mMap.end()) {
         OPENVDB_THROW(KeyError, "Map type " << name << " is already registered");
@@ -80,7 +77,7 @@ MapRegistry::registerMap(const Name& name, MapBase::MapFactory factory)
 void
 MapRegistry::unregisterMap(const Name& name)
 {
-    Lock lock(sInitMapRegistryMutex);
+    std::lock_guard<std::mutex> lock(sInitMapRegistryMutex);
     staticInstance()->mMap.erase(name);
 }
 
@@ -88,7 +85,7 @@ MapRegistry::unregisterMap(const Name& name)
 void
 MapRegistry::clear()
 {
-    Lock lock(sInitMapRegistryMutex);
+    std::lock_guard<std::mutex> lock(sInitMapRegistryMutex);
     staticInstance()->mMap.clear();
 }
 

--- a/openvdb/openvdb/points/AttributeArray.cc
+++ b/openvdb/openvdb/points/AttributeArray.cc
@@ -65,7 +65,7 @@ AttributeArray::AttributeArray(const AttributeArray& rhs)
     : mIsUniform(rhs.mIsUniform)
     , mFlags(rhs.mFlags)
     , mUsePagedRead(rhs.mUsePagedRead)
-    , mOutOfCore(rhs.mOutOfCore)
+    , mOutOfCore(rhs.mOutOfCore.load())
     , mPageHandle()
 {
     if (mFlags & PARTIALREAD)       mCompressedBytes = rhs.mCompressedBytes;
@@ -82,7 +82,7 @@ AttributeArray::operator=(const AttributeArray& rhs)
     mIsUniform = rhs.mIsUniform;
     mFlags = rhs.mFlags;
     mUsePagedRead = rhs.mUsePagedRead;
-    mOutOfCore = rhs.mOutOfCore;
+    mOutOfCore.store(rhs.mOutOfCore);
     if (mFlags & PARTIALREAD)       mCompressedBytes = rhs.mCompressedBytes;
     else if (rhs.mPageHandle)       mPageHandle = rhs.mPageHandle->copy();
     else                            mPageHandle.reset();

--- a/openvdb/openvdb/points/AttributeArray.h
+++ b/openvdb/openvdb/points/AttributeArray.h
@@ -21,7 +21,7 @@
 #include "StreamCompression.h"
 
 #include <tbb/spin_mutex.h>
-#include <tbb/atomic.h>
+#include <atomic>
 
 #include <memory>
 #include <mutex>
@@ -382,7 +382,7 @@ protected:
     mutable tbb::spin_mutex mMutex;
     uint8_t mFlags = 0;
     uint8_t mUsePagedRead = 0;
-    tbb::atomic<Index32> mOutOfCore; // interpreted as bool
+    std::atomic<Index32> mOutOfCore; // interpreted as bool
     /// used for out-of-core, paged reading
     union {
         compression::PageHandle::Ptr mPageHandle;

--- a/openvdb/openvdb/python/pyutil.h
+++ b/openvdb/openvdb/python/pyutil.h
@@ -7,8 +7,8 @@
 #include "openvdb/openvdb.h"
 #include "openvdb/points/PointDataGrid.h"
 #include <boost/python.hpp>
-#include <tbb/mutex.h>
 #include <map> // for std::pair
+#include <mutex>
 #include <string>
 #include <sstream>
 
@@ -129,12 +129,12 @@ struct StringEnum
     /// Return the (key, value) map as a Python dict.
     static boost::python::dict items()
     {
-        static tbb::mutex sMutex;
+        static std::mutex sMutex;
         static boost::python::dict itemDict;
         if (!itemDict) {
             // The first time this function is called, populate
             // the static dict with (key, value) pairs.
-            tbb::mutex::scoped_lock lock(sMutex);
+            std::lock_guard<std::mutex> lock(sMutex);
             if (!itemDict) {
                 for (int i = 0; ; ++i) {
                     const CStringPair item = Descr::item(i);

--- a/openvdb/openvdb/python/pyutil.h
+++ b/openvdb/openvdb/python/pyutil.h
@@ -7,10 +7,10 @@
 #include "openvdb/openvdb.h"
 #include "openvdb/points/PointDataGrid.h"
 #include <boost/python.hpp>
-#include <map> // for std::pair
 #include <mutex>
-#include <string>
 #include <sstream>
+#include <string>
+#include <utility> // for std::pair
 
 
 namespace pyutil {

--- a/openvdb/openvdb/tools/FastSweeping.h
+++ b/openvdb/openvdb/tools/FastSweeping.h
@@ -574,7 +574,7 @@ void FastSweeping<SdfGridT, ExtValueT>::computeSweepMaskLeafOrigins()
     LeafManagerT leafManager(mSweepMask);
 
     mSweepMaskLeafOrigins.resize(leafManager.leafCount());
-    std::atomic<size_t> sweepingVoxelCount = 0;
+    std::atomic<size_t> sweepingVoxelCount{0};
     auto kernel = [&](const LeafT& leaf, size_t leafIdx) {
         mSweepMaskLeafOrigins[leafIdx] = leaf.origin();
         sweepingVoxelCount += leaf.onVoxelCount();

--- a/openvdb/openvdb/tools/FastSweeping.h
+++ b/openvdb/openvdb/tools/FastSweeping.h
@@ -574,7 +574,7 @@ void FastSweeping<SdfGridT, ExtValueT>::computeSweepMaskLeafOrigins()
     LeafManagerT leafManager(mSweepMask);
 
     mSweepMaskLeafOrigins.resize(leafManager.leafCount());
-    tbb::atomic<size_t> sweepingVoxelCount = 0;
+    std::atomic<size_t> sweepingVoxelCount = 0;
     auto kernel = [&](const LeafT& leaf, size_t leafIdx) {
         mSweepMaskLeafOrigins[leafIdx] = leaf.origin();
         sweepingVoxelCount += leaf.onVoxelCount();

--- a/openvdb/openvdb/tree/LeafBuffer.h
+++ b/openvdb/openvdb/tree/LeafBuffer.h
@@ -40,7 +40,7 @@ template<typename T>
 struct LeafBufferFlags
 {
     /// The type of LeafBuffer::mOutOfCore
-    using type = std::atomic<Index32>;
+    using type = std::atomic<Index32>; // FIXME: Can we make this change from tbb::atomic to std::atomic, or do we need an ABI bump for that?
     static constexpr bool IsAtomic = true;
 };
 

--- a/openvdb/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/openvdb/unittest/TestAttributeArray.cc
@@ -20,8 +20,8 @@
 #include <boost/interprocess/file_mapping.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 #include <tbb/tick_count.h>
-#include <tbb/atomic.h>
 
+#include <atomic>
 #include <cstdio> // for std::remove()
 #include <fstream>
 #include <sstream>

--- a/openvdb/openvdb/unittest/TestPointMove.cc
+++ b/openvdb/openvdb/unittest/TestPointMove.cc
@@ -10,8 +10,8 @@
 #include <openvdb/points/PointScatter.h>
 #include <openvdb/openvdb.h>
 #include <openvdb/Types.h>
-#include <tbb/atomic.h>
 #include <algorithm>
+#include <atomic>
 #include <map>
 #include <sstream>
 #include <string>
@@ -687,8 +687,8 @@ struct CustomDeformer
     using LeafT = PointDataGrid::TreeType::LeafNodeType;
 
     CustomDeformer(const openvdb::Vec3d& offset,
-                   tbb::atomic<int>& resetCalls,
-                   tbb::atomic<int>& applyCalls)
+                   std::atomic<int>& resetCalls,
+                   std::atomic<int>& applyCalls)
         : mOffset(offset)
         , mResetCalls(resetCalls)
         , mApplyCalls(applyCalls) { }
@@ -710,8 +710,8 @@ struct CustomDeformer
     }
 
     const openvdb::Vec3d mOffset;
-    tbb::atomic<int>& mResetCalls;
-    tbb::atomic<int>& mApplyCalls;
+    std::atomic<int>& mResetCalls;
+    std::atomic<int>& mApplyCalls;
 }; // struct CustomDeformer
 
 // Custom Deformer that always returns the position supplied in the constructor
@@ -755,7 +755,7 @@ TEST_F(TestPointMove, testCustomDeformer)
         const int leafCount = points->tree().leafCount();
         const int pointCount = int(positions.size());
 
-        tbb::atomic<int> resetCalls, applyCalls;
+        std::atomic<int> resetCalls, applyCalls;
         resetCalls = 0;
         applyCalls = 0;
 

--- a/openvdb/openvdb/unittest/TestStreamCompression.cc
+++ b/openvdb/openvdb/unittest/TestStreamCompression.cc
@@ -24,8 +24,6 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/version.hpp> // for BOOST_VERSION
 
-#include <tbb/atomic.h>
-
 #ifdef _MSC_VER
 #include <boost/interprocess/detail/os_file_functions.hpp> // open_existing_file(), close_file()
 // boost::interprocess::detail was renamed to boost::interprocess::ipcdetail in Boost 1.48.
@@ -38,6 +36,7 @@ namespace boost { namespace interprocess { namespace detail {} namespace ipcdeta
 #include <unistd.h> // for unlink()
 #endif
 
+#include <atomic>
 #include <fstream>
 #include <numeric> // for std::iota()
 
@@ -97,7 +96,7 @@ private:
         boost::interprocess::mapped_region mRegion;
         bool mAutoDelete = false;
         Notifier mNotifier;
-        mutable tbb::atomic<openvdb::Index64> mLastWriteTime;
+        mutable std::atomic<openvdb::Index64> mLastWriteTime;
     }; // class Impl
     std::unique_ptr<Impl> mImpl;
 }; // class ProxyMappedFile

--- a/openvdb/openvdb/unittest/TestTools.cc
+++ b/openvdb/openvdb/unittest/TestTools.cc
@@ -1600,14 +1600,15 @@ struct FloatToVec
     // Transform a scalar value into a vector value.
     static openvdb::Vec3s toVec(const ValueT& v) { return openvdb::Vec3s(v, v*2, v*3); }
 
-    FloatToVec() { numTiles = 0; }
+    FloatToVec() : numTiles{0} {}
+    FloatToVec(const FloatToVec& other) : numTiles{other.numTiles.load(std::memory_order_acquire)} {}
 
     void operator()(const InIterT& it, Accessor& acc)
     {
         if (it.isVoxelValue()) { // set a single voxel
             acc.setValue(it.getCoord(), toVec(*it));
         } else { // fill an entire tile
-            numTiles.fetch_and_increment();
+            numTiles.fetch_add(1);
             openvdb::CoordBBox bbox;
             it.getBoundingBox(bbox);
             acc.tree().fill(bbox, toVec(*it));

--- a/openvdb/openvdb/unittest/TestTools.cc
+++ b/openvdb/openvdb/unittest/TestTools.cc
@@ -28,8 +28,8 @@
 #include <openvdb/math/Stats.h>
 #include "util.h" // for unittest_util::makeSphere()
 #include "gtest/gtest.h"
-#include <tbb/atomic.h>
 #include <algorithm> // for std::sort
+#include <atomic>
 #include <random>
 #include <sstream>
 
@@ -1614,7 +1614,7 @@ struct FloatToVec
         }
     }
 
-    tbb::atomic<int> numTiles;
+    std::atomic<int> numTiles;
 };
 
 }

--- a/openvdb/openvdb/util/PagedArray.h
+++ b/openvdb/openvdb/util/PagedArray.h
@@ -197,7 +197,7 @@ public:
     /// @warning Not thread-safe and mostly intended for debugging!
     size_t push_back_unsafe(const ValueType& value)
     {
-        const size_t index = mSize.fetch_and_increment();
+        const size_t index = mSize.fetch_add(1);
         if (index >= mCapacity) {
             mPageTable.push_back( new Page() );
             mCapacity += Page::Size;

--- a/openvdb/openvdb/util/PagedArray.h
+++ b/openvdb/openvdb/util/PagedArray.h
@@ -21,7 +21,7 @@
 #include <cassert>
 #include <iostream>
 #include <algorithm>// std::swap
-#include <tbb/atomic.h>
+#include <atomic>
 #include <tbb/spin_mutex.h>
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_sort.h>
@@ -456,7 +456,7 @@ private:
         }
     }
     PageTableT mPageTable;//holds points to allocated pages
-    tbb::atomic<size_t> mSize;// current number of elements in array
+    std::atomic<size_t> mSize;// current number of elements in array
     size_t mCapacity;//capacity of array given the current page count
     tbb::spin_mutex mGrowthMutex;//Mutex-lock required to grow pages
 }; // Public class PagedArray

--- a/openvdb/openvdb/viewer/Viewer.cc
+++ b/openvdb/openvdb/viewer/Viewer.cc
@@ -12,8 +12,8 @@
 #include <openvdb/points/PointDataGrid.h>
 #include <openvdb/points/PointCount.h>
 #include <openvdb/version.h> // for OPENVDB_LIBRARY_MAJOR_VERSION, etc.
-#include <tbb/atomic.h>
 #include <tbb/mutex.h>
+#include <atomic>
 #include <cmath> // for fabs()
 #include <iomanip> // for std::setprecision()
 #include <iostream>
@@ -109,7 +109,7 @@ private:
     void doView();
     static void* doViewTask(void* arg);
 
-    tbb::atomic<bool> mRedisplay;
+    std::atomic<bool> mRedisplay;
     bool mClose, mHasThread;
     std::thread mThread;
     openvdb::GridCPtrVec mGrids;
@@ -328,7 +328,9 @@ ThreadManager::doView()
     // This function runs in its own thread.
     // The mClose and mRedisplay flags are set from the main thread.
     while (!mClose) {
-        if (mRedisplay.compare_and_swap(/*set to*/false, /*if*/true)) {
+        bool expected = true;
+        mRedisplay.compare_exchange_strong(expected, false);
+        if (expected) {
             if (sViewer) sViewer->view(mGrids);
         }
         sViewer->sleep(0.5/*sec*/);

--- a/openvdb/openvdb/viewer/Viewer.cc
+++ b/openvdb/openvdb/viewer/Viewer.cc
@@ -12,12 +12,12 @@
 #include <openvdb/points/PointDataGrid.h>
 #include <openvdb/points/PointCount.h>
 #include <openvdb/version.h> // for OPENVDB_LIBRARY_MAJOR_VERSION, etc.
-#include <tbb/mutex.h>
 #include <atomic>
 #include <cmath> // for fabs()
 #include <iomanip> // for std::setprecision()
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <vector>
 #include <limits>
@@ -123,7 +123,7 @@ namespace {
 
 ViewerImpl* sViewer = nullptr;
 ThreadManager* sThreadMgr = nullptr;
-tbb::mutex sLock;
+std::mutex sLock;
 
 
 void
@@ -177,7 +177,7 @@ Viewer
 init(const std::string& progName, bool background)
 {
     if (sViewer == nullptr) {
-        tbb::mutex::scoped_lock lock(sLock);
+        std::lock_guard<std::mutex> lock(sLock);
         if (sViewer == nullptr) {
             OPENVDB_START_THREADSAFE_STATIC_WRITE
             sViewer = new ViewerImpl;
@@ -188,7 +188,7 @@ init(const std::string& progName, bool background)
 
     if (background) {
         if (sThreadMgr == nullptr) {
-            tbb::mutex::scoped_lock lock(sLock);
+            std::lock_guard<std::mutex> lock(sLock);
             if (sThreadMgr == nullptr) {
                 OPENVDB_START_THREADSAFE_STATIC_WRITE
                 sThreadMgr = new ThreadManager;
@@ -197,7 +197,7 @@ init(const std::string& progName, bool background)
         }
     } else {
         if (sThreadMgr != nullptr) {
-            tbb::mutex::scoped_lock lock(sLock);
+            std::lock_guard<std::mutex> lock(sLock);
             delete sThreadMgr;
             OPENVDB_START_THREADSAFE_STATIC_WRITE
             sThreadMgr = nullptr;
@@ -328,9 +328,10 @@ ThreadManager::doView()
     // This function runs in its own thread.
     // The mClose and mRedisplay flags are set from the main thread.
     while (!mClose) {
+        // If mRedisplay was true, then set it to false
+        // and then, if sViewer, call view:
         bool expected = true;
-        mRedisplay.compare_exchange_strong(expected, false);
-        if (expected) {
+        if (mRedisplay.compare_exchange_strong(expected, false)) {
             if (sViewer) sViewer->view(mGrids);
         }
         sViewer->sleep(0.5/*sec*/);

--- a/openvdb_houdini/openvdb_houdini/GR_PrimVDBPoints.cc
+++ b/openvdb_houdini/openvdb_houdini/GR_PrimVDBPoints.cc
@@ -31,10 +31,9 @@
 #include <UT/UT_DSOVersion.h>
 #include <UT/UT_UniquePtr.h>
 
-#include <tbb/mutex.h>
-
 #include <iostream>
 #include <limits>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -58,7 +57,7 @@ namespace {
 /// @note The render hook guard should not be required..
 
 // Declare this at file scope to ensure thread-safe initialization.
-tbb::mutex sRenderHookRegistryMutex;
+std::mutex sRenderHookRegistryMutex;
 bool renderHookRegistered = false;
 
 } // anonymous namespace
@@ -174,7 +173,7 @@ private:
 void
 newRenderHook(DM_RenderTable* table)
 {
-    tbb::mutex::scoped_lock lock(sRenderHookRegistryMutex);
+    std::lock_guard<std::mutex> lock(sRenderHookRegistryMutex);
 
     if (!renderHookRegistered) {
 

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Rasterize_Points.cc
@@ -47,7 +47,6 @@
 #include <VOP/VOP_ExportedParmsManager.h>
 #include <VOP/VOP_LanguageContextTypeList.h>
 
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
@@ -59,6 +58,7 @@
 #include <hboost/algorithm/string/split.hpp>
 
 #include <algorithm> // std::sort
+#include <atomic>
 #include <cmath> // trigonometric functions
 #include <memory>
 #include <set>
@@ -1954,7 +1954,7 @@ private:
     UT_WorkArgs mVexArgs;
     const size_t mMaxArraySize;
     fpreal mTime, mTimeInc, mFrame;
-    tbb::atomic<int> mIsTimeDependant;
+    std::atomic<int> mIsTimeDependant;
     GU_VexGeoInputs mVexInputs;
 };
 

--- a/openvdb_maya/openvdb_maya/OpenVDBPlugin.cc
+++ b/openvdb_maya/openvdb_maya/OpenVDBPlugin.cc
@@ -23,8 +23,7 @@
 #include <maya/MPlug.h>
 #include <maya/MFnPluginData.h>
 
-#include <tbb/mutex.h>
-
+#include <mutex>
 #include <vector>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Should I keep the commit that removes these `using` declarations,
```
using Mutex = std::mutex;	
using Lock = std::lock_guard<Mutex>;	
```
in favor of directly using the std types? Or would you like to keep these `using` declarations?