### PR TITLE
Fix Stream Compression Unit Test

### DIFF
--- a/openvdb/openvdb/unittest/TestStreamCompression.cc
+++ b/openvdb/openvdb/unittest/TestStreamCompression.cc
@@ -284,11 +284,15 @@ TEST_F(TestStreamCompression, testBlosc)
         std::vector<int> values;
         values.reserve(uncompressedCount); // 128 bytes
 
-        for (int i = 0; i < uncompressedCount; i++)     values.push_back(i*10000);
+        // insert a sequence of 32 integer values that cannot be compressed using Blosc
 
-        std::random_device rng;
-        std::mt19937 urng(rng());
-        std::shuffle(values.begin(), values.end(), urng);
+        for (int i = 0; i < uncompressedCount; i++) {
+            if ((i%2) == 0) {
+                values.push_back(i * 12340);
+            } else {
+                values.push_back(i * 56780);
+            }
+        }
 
         std::unique_ptr<int[]> uncompressedBuffer(new int[values.size()]);
 

--- a/pendingchanges/fix_stream_compression_test.txt
+++ b/pendingchanges/fix_stream_compression_test.txt
@@ -1,0 +1,2 @@
+    Bug fixes:
+    - Fixed a non-deterministic failure in the TestStreamCompression unit test.


### PR DESCRIPTION
This unit test is designed to pass a sequence of 32 integers to Blosc that cannot be compressed to test the failure case in our library, however the random shuffling wasn't being seeded correctly so it was generating a different sequence every time and sporadically failing.

I've replaced the random shuffle with a hard-coded deterministic sequence that always fails to compress instead.