### PR TITLE
Fix Performance Regression in DynamicNodeManager

### DIFF
--- a/openvdb/openvdb/tree/NodeManager.h
+++ b/openvdb/openvdb/tree/NodeManager.h
@@ -278,7 +278,8 @@ public:
         transform.run(this->nodeRange(grainSize), threaded);
     }
 
-    // identical to foreach except the operator() method has a node index
+    // identical to foreach except the operator() method has a node index and
+    // the operator is referenced instead of copied in NodeTransformer
     template<typename NodeOp>
     void foreachWithIndex(const NodeOp& op, bool threaded = true, size_t grainSize=1)
     {

--- a/pendingchanges/node_manager_ref.txt
+++ b/pendingchanges/node_manager_ref.txt
@@ -1,0 +1,3 @@
+    Bug fixes:
+    - Use copy-by-reference for the operator in a DynamicNodeManager to fix a
+      performance regression.


### PR DESCRIPTION
In #921, I reverted the change to the NodeManager foreach methods to use copy-by-value instead of copy-by-reference. As it turns out this has a significant performance cost for the DynamicNodeManager that would take a lot of extra complexity in the API to resolve. This now forks the implementation so that NodeManager foreach uses copy-by-value and DynamicNodeManager foreach uses copy-by-reference.

I had tried to keep these two structures as aligned as possible, but they have already diverged because the DynamicNodeManager passes an index to the operator() and returns a bool whereas the NodeManager does not. This is not ideal, but I think is probably the most pragmatic way of resolving this.