### PR TITLE
New NodeVisitor Tool

### DIFF
--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -319,6 +319,7 @@ set(OPENVDB_LIBRARY_TOOLS_INCLUDE_FILES
   tools/MeshToVolume.h
   tools/Morphology.h
   tools/MultiResGrid.h
+  tools/NodeVisitor.h
   tools/ParticleAtlas.h
   tools/ParticlesToLevelSet.h
   tools/PointAdvect.h

--- a/openvdb/openvdb/tools/NodeVisitor.h
+++ b/openvdb/openvdb/tools/NodeVisitor.h
@@ -120,13 +120,16 @@ struct DepthFirstNodeVisitor;
 template <typename NodeT, Index LEVEL>
 struct DepthFirstNodeVisitor
 {
+    using NonConstChildType = typename NodeT::ChildNodeType;
+    using ChildNodeType = typename CopyConstness<NodeT, NonConstChildType>::Type;
+
     template <typename OpT>
     static size_t visit(NodeT& node, OpT& op, size_t idx = 0)
     {
         size_t offset = 0;
         op(node, idx + offset++);
-        for (typename NodeT::ChildOnIter iter = node.beginChildOn(); iter; ++iter) {
-            offset += DepthFirstNodeVisitor<typename NodeT::ChildNodeType>::visit(
+        for (auto iter = node.beginChildOn(); iter; ++iter) {
+            offset += DepthFirstNodeVisitor<ChildNodeType>::visit(
                 *iter, op, idx + offset);
         }
         return offset;
@@ -150,8 +153,10 @@ struct DepthFirstNodeVisitor<NodeT, 0>
 template <typename TreeT, typename OpT>
 size_t visitNodesDepthFirst(TreeT& tree, OpT& op, size_t idx)
 {
-    return DepthFirstNodeVisitor<typename TreeT::RootNodeType>::visit(
-        tree.root(), op, idx);
+    using NonConstRootNodeType = typename TreeT::RootNodeType;
+    using RootNodeType = typename CopyConstness<TreeT, NonConstRootNodeType>::Type;
+
+    return DepthFirstNodeVisitor<RootNodeType>::visit(tree.root(), op, idx);
 }
 
 

--- a/openvdb/openvdb/tools/NodeVisitor.h
+++ b/openvdb/openvdb/tools/NodeVisitor.h
@@ -1,0 +1,161 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+//
+/// @file NodeVisitor.h
+///
+/// @author Dan Bailey
+///
+/// @brief  Implementation of a depth-first node visitor.
+///
+/// @note   This algorithm is single-threaded by design and intended for rare
+///         use cases where this is desirable.  It is highly recommended to use
+///         the NodeManager or DynamicNodeManager for much greater threaded
+///         performance.
+
+#ifndef OPENVDB_TOOLS_NODE_VISITOR_HAS_BEEN_INCLUDED
+#define OPENVDB_TOOLS_NODE_VISITOR_HAS_BEEN_INCLUDED
+
+#include <openvdb/version.h>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace tools {
+
+/// @brief Visit all nodes in the tree depth-first and apply a user-supplied
+///  functor to each node.
+///
+/// @param tree      tree to be visited.
+/// @param op        user-supplied functor, see examples for interface details.
+/// @param idx       optional offset to start sequential node indexing from a
+///                  non-zero index.
+///
+/// @warning This method is single-threaded. Use the NodeManager or
+///  DynamicNodeManager for much greater threaded performance.
+///
+/// @par Example:
+/// @code
+/// Functor to offset all the active values of a tree.
+/// struct OffsetOp
+/// {
+///     OffsetOp(float v): mOffset(v) { }
+///
+///     template<typename NodeT>
+///     void operator()(NodeT& node, size_t) const
+///     {
+///         for (auto iter = node.beginValueOn(); iter; ++iter) {
+///             iter.setValue(iter.getValue() + mOffset);
+///         }
+///     }
+/// private:
+///     const float mOffset;
+/// };
+///
+/// // usage:
+/// OffsetOp op(3.0f);
+/// visitNodesDepthFirst(tree, op);
+///
+/// // Functor to offset all the active values of a tree. Note
+/// // this implementation also illustrates how different
+/// // computation can be applied to the different node types.
+/// template<typename TreeT>
+/// struct OffsetByLevelOp
+/// {
+///     using ValueT = typename TreeT::ValueType;
+///     using RootT = typename TreeT::RootNodeType;
+///     using LeafT = typename TreeT::LeafNodeType;
+///     OffsetByLevelOp(const ValueT& v) : mOffset(v) {}
+///     // Processes the root node.
+///     void operator()(RootT& root, size_t) const
+///     {
+///         for (auto iter = root.beginValueOn(); iter; ++iter) {
+///             iter.setValue(iter.getValue() + mOffset);
+///         }
+///     }
+///     // Processes the leaf nodes.
+///     void operator()(LeafT& leaf, size_t) const
+///     {
+///         for (auto iter = leaf.beginValueOn(); iter; ++iter) {
+///             iter.setValue(iter.getValue() + mOffset);
+///         }
+///     }
+///     // Processes the internal nodes.
+///     template<typename NodeT>
+///     void operator()(NodeT& node, size_t) const
+///     {
+///         for (auto iter = node.beginValueOn(); iter; ++iter) {
+///             iter.setValue(iter.getValue() + mOffset);
+///         }
+///     }
+/// private:
+///     const ValueT mOffset;
+// };
+///
+/// // usage:
+/// OffsetByLevelOp<FloatTree> op(3.0f);
+/// visitNodesDepthFirst(tree, op);
+///
+/// @endcode
+template <typename TreeT, typename OpT>
+size_t visitNodesDepthFirst(TreeT& tree, OpT& op, size_t idx = 0);
+
+
+/// @brief Visit all nodes that are downstream of a specific node in
+///  depth-first order and apply a user-supplied functor to each node.
+///
+/// @note This uses the same operator interface as documented in
+///  visitNodesDepthFirst().
+///
+/// @note The LEVEL template argument can be used to reduce the traversal
+///  depth. For example, calling visit() with a RootNode and using
+///  NodeT::LEVEL-1 would not visit leaf nodes.
+template <typename NodeT, Index LEVEL = NodeT::LEVEL>
+struct DepthFirstNodeVisitor;
+
+
+////////////////////////////////////////
+
+
+template <typename NodeT, Index LEVEL>
+struct DepthFirstNodeVisitor
+{
+    template <typename OpT>
+    static size_t visit(NodeT& node, OpT& op, size_t idx = 0)
+    {
+        size_t offset = 0;
+        op(node, idx + offset++);
+        for (typename NodeT::ChildOnIter iter = node.beginChildOn(); iter; ++iter) {
+            offset += DepthFirstNodeVisitor<typename NodeT::ChildNodeType>::visit(
+                *iter, op, idx + offset);
+        }
+        return offset;
+    }
+};
+
+
+// terminate recursion
+template <typename NodeT>
+struct DepthFirstNodeVisitor<NodeT, 0>
+{
+    template <typename OpT>
+    static size_t visit(NodeT& node, OpT& op, size_t idx = 0)
+    {
+        op(node, idx);
+        return size_t(1);
+    }
+};
+
+
+template <typename TreeT, typename OpT>
+size_t visitNodesDepthFirst(TreeT& tree, OpT& op, size_t idx)
+{
+    return DepthFirstNodeVisitor<typename TreeT::RootNodeType>::visit(
+        tree.root(), op, idx);
+}
+
+
+} // namespace tools
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif // OPENVDB_TOOLS_NODE_VISITOR_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/tools/NodeVisitor.h
+++ b/openvdb/openvdb/tools/NodeVisitor.h
@@ -16,6 +16,7 @@
 #define OPENVDB_TOOLS_NODE_VISITOR_HAS_BEEN_INCLUDED
 
 #include <openvdb/version.h>
+#include <openvdb/Types.h>
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE

--- a/openvdb/openvdb/tree/Tree.h
+++ b/openvdb/openvdb/tree/Tree.h
@@ -933,35 +933,35 @@ public:
 #endif
 
     template<typename BBoxOp>
-    [[deprecated("Use DynamicNodeManager instead")]]
+    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
     void visitActiveBBox(BBoxOp& op) const { mRoot.visitActiveBBox(op); }
 
     template<typename VisitorOp>
-    [[deprecated("Use DynamicNodeManager instead")]]
+    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
     void visit(VisitorOp& op);
     template<typename VisitorOp>
-    [[deprecated("Use DynamicNodeManager instead")]]
+    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
     void visit(const VisitorOp& op);
 
     template<typename VisitorOp>
-    [[deprecated("Use DynamicNodeManager instead")]]
+    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
     void visit(VisitorOp& op) const;
     template<typename VisitorOp>
-    [[deprecated("Use DynamicNodeManager instead")]]
+    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
     void visit(const VisitorOp& op) const;
 
     template<typename OtherTreeType, typename VisitorOp>
-    [[deprecated("Use DynamicNodeManager instead")]]
+    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
     void visit2(OtherTreeType& other, VisitorOp& op);
     template<typename OtherTreeType, typename VisitorOp>
-    [[deprecated("Use DynamicNodeManager instead")]]
+    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
     void visit2(OtherTreeType& other, const VisitorOp& op);
 
     template<typename OtherTreeType, typename VisitorOp>
-    [[deprecated("Use DynamicNodeManager instead")]]
+    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
     void visit2(OtherTreeType& other, VisitorOp& op) const;
     template<typename OtherTreeType, typename VisitorOp>
-    [[deprecated("Use DynamicNodeManager instead")]]
+    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
     void visit2(OtherTreeType& other, const VisitorOp& op) const;
 
 

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -113,6 +113,7 @@ set(UNITTEST_SOURCE_FILES
   TestNodeIterator.cc
   TestNodeManager.cc
   TestNodeMask.cc
+  TestNodeVisitor.cc
   TestParticleAtlas.cc
   TestParticlesToLevelSet.cc
   TestPointAdvect.cc

--- a/openvdb/openvdb/unittest/TestNodeVisitor.cc
+++ b/openvdb/openvdb/unittest/TestNodeVisitor.cc
@@ -12,6 +12,7 @@ class TestNodeVisitor: public ::testing::Test
 };
 
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 7
 struct NodeCountOp
 {
     template <typename NodeT>
@@ -44,6 +45,7 @@ TEST_F(TestNodeVisitor, testNodeCount)
         EXPECT_EQ(nodeCount1[i], nodeCount2[i]);
     }
 }
+#endif // OPENVDB_ABI_VERSION_NUMBER >= 7
 
 
 template <typename TreeT>
@@ -103,6 +105,7 @@ TEST_F(TestNodeVisitor, testDepthFirst)
 }
 
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 7
 template <typename TreeT>
 struct StoreOriginsOp
 {
@@ -164,6 +167,8 @@ TEST_F(TestNodeVisitor, testOriginArray)
 
     EXPECT_EQ(idx, origins.size());
 }
+#endif // OPENVDB_ABI_VERSION_NUMBER >= 7
+
 
 template <typename TreeType>
 struct DeactivateOp

--- a/openvdb/openvdb/unittest/TestNodeVisitor.cc
+++ b/openvdb/openvdb/unittest/TestNodeVisitor.cc
@@ -40,7 +40,7 @@ TEST_F(TestNodeVisitor, testNodeCount)
 
     EXPECT_EQ(nodeCount1.size(), nodeCount2.size());
 
-    for (int i = 0; i < nodeCount1.size(); i++) {
+    for (size_t i = 0; i < nodeCount1.size(); i++) {
         EXPECT_EQ(nodeCount1[i], nodeCount2[i]);
     }
 }
@@ -111,7 +111,7 @@ struct StoreOriginsOp
     StoreOriginsOp(std::vector<openvdb::Coord>& _origins)
         : origins(_origins) { }
 
-    void operator()(const RootT& root, size_t idx)
+    void operator()(const RootT&, size_t idx)
     {
         // root node has no origin
         origins[idx] = openvdb::Coord::max();

--- a/openvdb/openvdb/unittest/TestNodeVisitor.cc
+++ b/openvdb/openvdb/unittest/TestNodeVisitor.cc
@@ -67,10 +67,19 @@ TEST_F(TestNodeVisitor, testLeafCount)
 
     FloatGrid::Ptr grid = tools::createLevelSetCube<FloatGrid>(/*scale=*/10.0f);
 
-    LeafCountOp<FloatTree> leafCountOp;
-    tools::visitNodesDepthFirst(grid->tree(), leafCountOp);
+    { // non-const tree
+        LeafCountOp<FloatTree> leafCountOp;
+        tools::visitNodesDepthFirst(grid->tree(), leafCountOp);
 
-    EXPECT_EQ(grid->tree().leafCount(), leafCountOp.count);
+        EXPECT_EQ(grid->tree().leafCount(), leafCountOp.count);
+    }
+
+    { // const tree
+        LeafCountOp<FloatTree> leafCountOp;
+        tools::visitNodesDepthFirst(grid->constTree(), leafCountOp);
+
+        EXPECT_EQ(grid->tree().leafCount(), leafCountOp.count);
+    }
 }
 
 

--- a/openvdb/openvdb/unittest/TestNodeVisitor.cc
+++ b/openvdb/openvdb/unittest/TestNodeVisitor.cc
@@ -1,0 +1,269 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#include <openvdb/openvdb.h>
+#include <openvdb/tools/LevelSetPlatonic.h>
+#include <openvdb/tools/NodeVisitor.h>
+#include <openvdb/tools/Prune.h>
+#include "gtest/gtest.h"
+
+class TestNodeVisitor: public ::testing::Test
+{
+};
+
+
+struct NodeCountOp
+{
+    template <typename NodeT>
+    void operator()(const NodeT&, size_t)
+    {
+        const openvdb::Index level = NodeT::LEVEL;
+        while (level >= counts.size())     counts.emplace_back(0);
+        counts[level]++;
+    }
+
+    std::vector<openvdb::Index32> counts;
+}; // struct NodeCountOp
+
+
+TEST_F(TestNodeVisitor, testNodeCount)
+{
+    using namespace openvdb;
+
+    auto grid = tools::createLevelSetCube<FloatGrid>(/*scale=*/10.0f);
+
+    NodeCountOp nodeCountOp;
+    tools::visitNodesDepthFirst(grid->tree(), nodeCountOp);
+
+    std::vector<Index32> nodeCount1 = nodeCountOp.counts;
+    std::vector<Index32> nodeCount2 = grid->tree().nodeCount();
+
+    EXPECT_EQ(nodeCount1.size(), nodeCount2.size());
+
+    for (int i = 0; i < nodeCount1.size(); i++) {
+        EXPECT_EQ(nodeCount1[i], nodeCount2[i]);
+    }
+}
+
+
+template <typename TreeT>
+struct LeafCountOp
+{
+    using LeafT = typename TreeT::LeafNodeType;
+
+    template <typename NodeT>
+    void operator()(const NodeT&, size_t) { }
+    void operator()(const LeafT&, size_t) { count++; }
+
+    openvdb::Index32 count{0};
+}; // struct LeafCountOp
+
+
+TEST_F(TestNodeVisitor, testLeafCount)
+{
+    using namespace openvdb;
+
+    FloatGrid::Ptr grid = tools::createLevelSetCube<FloatGrid>(/*scale=*/10.0f);
+
+    LeafCountOp<FloatTree> leafCountOp;
+    tools::visitNodesDepthFirst(grid->tree(), leafCountOp);
+
+    EXPECT_EQ(grid->tree().leafCount(), leafCountOp.count);
+}
+
+
+struct DescendOp
+{
+    template <typename NodeT>
+    void operator()(const NodeT&, size_t)
+    {
+        const openvdb::Index level = NodeT::LEVEL;
+        // count the number of times the operator descends
+        // from a higher-level node to a lower-level node
+        if (NodeT::LEVEL < previousLevel)   count++;
+        previousLevel = level;
+    }
+
+    openvdb::Index32 previousLevel{0};
+    openvdb::Index32 count{0};
+}; // struct DescendOp
+
+
+TEST_F(TestNodeVisitor, testDepthFirst)
+{
+    using namespace openvdb;
+
+    FloatGrid::Ptr grid = tools::createLevelSetCube<FloatGrid>(/*scale=*/10.0f);
+
+    DescendOp descendOp;
+    tools::visitNodesDepthFirst(grid->tree(), descendOp);
+
+    // this confirms that the visit pattern is depth-first
+    EXPECT_EQ(descendOp.count, grid->tree().nonLeafCount());
+}
+
+
+template <typename TreeT>
+struct StoreOriginsOp
+{
+    using RootT = typename TreeT::RootNodeType;
+
+    StoreOriginsOp(std::vector<openvdb::Coord>& _origins)
+        : origins(_origins) { }
+
+    void operator()(const RootT& root, size_t idx)
+    {
+        // root node has no origin
+        origins[idx] = openvdb::Coord::max();
+    }
+
+    template <typename NodeT>
+    void operator()(const NodeT& node, size_t idx)
+    {
+        origins[idx] = node.origin();
+    }
+
+    std::vector<openvdb::Coord>& origins;
+}; // struct StoreOriginsOp
+
+
+TEST_F(TestNodeVisitor, testOriginArray)
+{
+    using namespace openvdb;
+
+    FloatGrid::Ptr grid = tools::createLevelSetCube<FloatGrid>(/*scale=*/10.0f);
+
+    std::vector<Index32> nodeCount = grid->tree().nodeCount();
+    Index32 totalNodeCount(0);
+    for (Index32 count : nodeCount)     totalNodeCount += count;
+
+    // use an offset
+    size_t offset = 10;
+
+    std::vector<Coord> origins;
+    origins.resize(totalNodeCount + offset);
+
+    StoreOriginsOp<FloatTree> storeOriginsOp(origins);
+    tools::visitNodesDepthFirst(grid->tree(), storeOriginsOp, offset);
+
+    size_t idx = offset;
+
+    // root node
+    EXPECT_EQ(origins[idx++], Coord::max());
+
+    const auto& root = grid->tree().root();
+    for (auto internal1Iter = root.cbeginChildOn(); internal1Iter; ++internal1Iter) {
+        EXPECT_EQ(origins[idx++], internal1Iter->origin());
+        for (auto internal2Iter = internal1Iter->cbeginChildOn(); internal2Iter; ++internal2Iter) {
+            EXPECT_EQ(origins[idx++], internal2Iter->origin());
+            for (auto leafIter = internal2Iter->cbeginChildOn(); leafIter; ++leafIter) {
+                EXPECT_EQ(origins[idx++], leafIter->origin());
+            }
+        }
+    }
+
+    EXPECT_EQ(idx, origins.size());
+}
+
+template <typename TreeType>
+struct DeactivateOp
+{
+    using LeafT = typename TreeType::LeafNodeType;
+
+    template <typename NodeT>
+    void operator()(NodeT&, size_t) { }
+
+    void operator()(LeafT& leaf, size_t)
+    {
+        leaf.setValuesOff();
+    }
+}; // struct DeactivateOp
+
+
+TEST_F(TestNodeVisitor, testPartialDeactivate)
+{
+    using namespace openvdb;
+
+    FloatGrid::Ptr grid = tools::createLevelSetCube<FloatGrid>(/*scale=*/10.0f);
+
+    using NodeT = FloatTree::RootNodeType::ChildNodeType::ChildNodeType;
+
+    auto iter = grid->tree().root().beginChildOn()->beginChildOn();
+
+    DeactivateOp<FloatTree> deactivateOp;
+    tools::DepthFirstNodeVisitor<NodeT>::visit(*iter, deactivateOp);
+
+    EXPECT_EQ(Index32(1413), grid->tree().leafCount());
+
+    tools::pruneInactive(grid->tree());
+
+    // a subset of the leaf nodes have now been deactivated and removed
+    EXPECT_EQ(Index32(1195), grid->tree().leafCount());
+}
+
+
+// Functor to offset all the active values of a tree.
+struct OffsetOp
+{
+    OffsetOp(float v): mOffset(v) { }
+
+    template<typename NodeT>
+    void operator()(NodeT& node, size_t) const
+    {
+        for (auto iter = node.beginValueOn(); iter; ++iter) {
+            iter.setValue(iter.getValue() + mOffset);
+        }
+    }
+private:
+    const float mOffset;
+};
+
+// Functor to offset all the active values of a tree. Note
+// this implementation also illustrates how different
+// computation can be applied to the different node types.
+template<typename TreeT>
+struct OffsetByLevelOp
+{
+    using ValueT = typename TreeT::ValueType;
+    using RootT = typename TreeT::RootNodeType;
+    using LeafT = typename TreeT::LeafNodeType;
+    OffsetByLevelOp(const ValueT& v) : mOffset(v) {}
+    // Processes the root node.
+    void operator()(RootT& root, size_t) const
+    {
+        for (auto iter = root.beginValueOn(); iter; ++iter) {
+            iter.setValue(iter.getValue() + mOffset);
+        }
+    }
+    // Processes the leaf nodes.
+    void operator()(LeafT& leaf, size_t) const
+    {
+        for (auto iter = leaf.beginValueOn(); iter; ++iter) {
+            iter.setValue(iter.getValue() + mOffset);
+        }
+    }
+    // Processes the internal nodes.
+    template<typename NodeT>
+    void operator()(NodeT& node, size_t) const
+    {
+        for (auto iter = node.beginValueOn(); iter; ++iter) {
+            iter.setValue(iter.getValue() + mOffset);
+        }
+    }
+private:
+    const ValueT mOffset;
+};
+
+// this is the example from the documentation
+TEST_F(TestNodeVisitor, testOffset)
+{
+    using namespace openvdb;
+
+    FloatGrid::Ptr grid = tools::createLevelSetCube<FloatGrid>(/*scale=*/10.0f);
+
+    OffsetOp op(3.0f);
+    tools::visitNodesDepthFirst(grid->tree(), op);
+
+    OffsetByLevelOp<FloatTree> byLevelOp(3.0f);
+    tools::visitNodesDepthFirst(grid->tree(), byLevelOp);
+}

--- a/pendingchanges/node_visitor.txt
+++ b/pendingchanges/node_visitor.txt
@@ -1,0 +1,3 @@
+    New features:
+    - Added tools::visitNodesDepthFirst and tools::DepthFirstNodeVisitor which
+      visit nodes in a tree or sub-tree in single-threaded depth-first order.


### PR DESCRIPTION
As requested by @jmlait, this tool provides the ability to visit nodes in a single-threaded, depth-first order. It's the functionality that's currently missing to allow us to remove the Tree::visit() methods.

It's a pretty small amount of code, most of the changes here are documentation and unit tests.  In fact, I used the sub-tree functionality here in the upcoming density VDB merging and it was quite useful.