### PR TITLE
AX Fixes

### DIFF
--- a/openvdb_ax/openvdb_ax/codegen/Utils.h
+++ b/openvdb_ax/openvdb_ax/codegen/Utils.h
@@ -767,8 +767,7 @@ scalarToMatrix(llvm::Value* scalar,
         insertStaticAlloca(builder,
             llvm::ArrayType::get(type, dim*dim));
 
-    llvm::Value* zero = llvm::ConstantFP::get(type, 0.0);
-
+    llvm::Value* zero = llvmConstant(0, type);
     for (size_t i = 0; i < dim*dim; ++i) {
         llvm::Value* m = ((i % (dim+1) == 0) ? scalar : zero);
         llvm::Value* element = builder.CreateConstGEP2_64(array, 0, i);

--- a/openvdb_ax/openvdb_ax/test/backend/TestComputeGeneratorFailures.cc
+++ b/openvdb_ax/openvdb_ax/test/backend/TestComputeGeneratorFailures.cc
@@ -69,6 +69,9 @@ static const std::vector<std::string> tests {
     "string a,b; a ^ b;",
     "string a,b; a | b;",
     "string a,b; a || b;",
+    "string a,b; a * b;",
+    "string a,b; a - b;",
+    "string a,b; a / b;",
     "vec2d a,b; a & b;",
     "vec2d a,b; a && b;",
     "vec2d a,b; a << b;",
@@ -187,6 +190,11 @@ static const std::vector<std::string> tests {
     "vec4i a; vec3i b; a=b;",
     "mat4f a; mat3f b; a=b;",
     "mat4d a; mat3d b; a=b;",
+    "vec2f a = {1,2,3};",
+    "vec3f a = {1,2};",
+    "vec4f a = {1,2};",
+    "mat3f a = {1,2};",
+    "mat4f a = {1,2};",
     /// string assignments
     "string a = 1;",
     "int a; string b; b=a;",
@@ -202,6 +210,15 @@ static const std::vector<std::string> tests {
     "vec3f a; a[1,1];",
     "mat3f a; vec3f b; a[b,1];",
     "mat3f a; vec3f b; a[1,b];",
+    /// array packs
+    "{1, {2,3}};",
+    "{{1,2}, 3};",
+    "{1, 2, \"a\"};",
+    "vec2f a; {1, 2, a};",
+    "vec3f a; {1, 2, a};",
+    "mat3f a; {1, 2, a};",
+    "mat4f a; {1, 2, a};",
+    "string a; {1, 2, a};",
     /// unsupported implicit casts/ops
     "vec2f a; vec3f b; a*b;",
     "vec3f a; vec4f b; a*b;",
@@ -210,9 +227,22 @@ static const std::vector<std::string> tests {
     "mat3f a; mat4f b; a*b;",
     "string a; mat4f b; a*b;",
     "int a; string b; a*b;",
-    "string a; string b; a*b;",
-    "string a; string b; a-b;",
-    "string a; string b; a/b;",
+    "{0,0,0,0,0,0,0,0,0} * 0;"
+    "0 * {0,0,0,0,0,0,0,0,0};"
+    "{0,0,0,0,0,0,0,0,0} + 0;"
+    "{0,0,0,0,0,0,0,0,0} - 0;"
+    "{0,0,0,0,0,0,0,0,0} / 0;"
+    "0 * {.0f,0,0,0,0,0,0,0,0};"
+    "{.0f,0,0,0,0,0,0,0,0} * 0;"
+    "{0.0,0,0,0,0,0,0,0,0} * 0;"
+    "{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0} * 0;"
+    "0 * {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};"
+    "{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0} + 0;"
+    "{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0} - 0;"
+    "{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0} / 0;"
+    "0 * {.0f,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};"
+    "{.0f,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0} * 0;"
+    "{0.0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0} * 0;"
     "~0.0f;",
     "vec3f a; ~a;"
     /// loops
@@ -330,6 +360,7 @@ TestComputeGeneratorFailures::testFailures()
         const openvdb::ax::ast::Tree::ConstPtr ast =
             openvdb::ax::ast::parse(code.c_str(), logger);
         CPPUNIT_ASSERT_MESSAGE(ERROR_MSG("Unable to parse", code), ast.get());
+        CPPUNIT_ASSERT(!logger.hasError());
 
         unittest_util::LLVMState state;
         openvdb::ax::codegen::codegen_internal::ComputeGenerator gen(state.module(), opts, reg, logger);

--- a/pendingchanges/ax_fixes.txt
+++ b/pendingchanges/ax_fixes.txt
@@ -1,0 +1,5 @@
+    Bug fixes:
+    - Fixed a crash in OpenVDB AX when declaring arrays with non-scalar elements (unsupported) i.e. {"foo", 1, 2}, {1, {1,2}, 3} etc.
+    - Fixed a bug in OpenVDB AX which would cause an error when multiplying a vec3 by a mat4.
+    - In OpenVDB AX, improved the error message produced when attempting to use a matrix literal (i.e. {1,2,3...}) in a binary expression (this is invalid but would previously print out bad IR).
+


### PR DESCRIPTION
    - Fixed a crash in OpenVDB AX when declaring arrays with non-scalar elements (unsupported) i.e. {"foo", 1, 2}, {1, {1,2}, 3} etc.
    - Fixed a bug in OpenVDB AX which would cause an error when multiplying a vec3 by a mat4.
    - In OpenVDB AX, improved the error message produced when attempting to use a matrix literal (i.e. {1,2,3...}) in a binary expression.