### PR TITLE
OpenVDB Points -> Volume transfer framework & kernels

### DIFF
--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -449,9 +449,12 @@ set(OPENVDB_LIBRARY_POINTS_INCLUDE_FILES
   points/PointGroup.h
   points/PointMask.h
   points/PointMove.h
+  points/PointRasterizeSDF.h
+  points/PointRasterizeTrilinear.h
   points/PointSample.h
   points/PointScatter.h
   points/PointStatistics.h
+  points/PointTransfer.h
   points/StreamCompression.h
 )
 

--- a/openvdb/openvdb/points/PointCount.h
+++ b/openvdb/openvdb/points/PointCount.h
@@ -165,16 +165,20 @@ typename GridT::Ptr
 pointCountGrid( const PointDataGridT& points,
                 const FilterT& filter)
 {
-    static_assert(  std::is_integral<typename GridT::ValueType>::value ||
-                    std::is_floating_point<typename GridT::ValueType>::value,
+    static_assert(std::is_integral<typename GridT::ValueType>::value ||
+                  std::is_floating_point<typename GridT::ValueType>::value,
         "openvdb::points::pointCountGrid must return an integer or floating-point scalar grid");
 
-    // This is safe because the PointDataGrid can only be modified by the deformer
-    using AdapterT = TreeAdapter<typename PointDataGridT::TreeType>;
-    auto& nonConstPoints = const_cast<typename AdapterT::NonConstGridType&>(points);
+    using PointDataTreeT = typename PointDataGridT::TreeType;
+    using TreeT = typename GridT::TreeType;
 
-    return point_mask_internal::convertPointsToScalar<GridT>(
-        nonConstPoints, filter);
+    typename TreeT::Ptr tree =
+        point_mask_internal::convertPointsToScalar<TreeT, PointDataTreeT, FilterT>
+            (points.tree(), filter);
+
+    typename GridT::Ptr grid(new GridT(tree));
+    grid->setTransform(points.transform().copy());
+    return grid;
 }
 
 

--- a/openvdb/openvdb/points/PointRasterizeSDF.h
+++ b/openvdb/openvdb/points/PointRasterizeSDF.h
@@ -1,0 +1,1701 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+//
+/// @author Nick Avramoussis
+///
+/// @file PointRasterizeSDF.h
+///
+/// @brief Transfer schemes for rasterizing point positional and radius data to
+///  signed distance fields with optional closest point attribute transfers.
+///  All methods support arbitrary target linear transformations, fixed or
+///  varying point radius, filtering of point data and arbitrary types for
+///  attribute transferring.
+///
+/// @details There are two main transfer implementations; rasterizeSpheres and
+///  rasterizeSmoothSpheres. The prior performs trivial narrow band stamping
+///  of spheres for each point, where as the latter calculates an averaged
+///  position of influence per voxel as described in:
+///    [Animating Sand as a Fluid - Zhu Bridson 05].
+///
+///  rasterizeSpheres() is an extremely fast and efficient way to produce both a
+///  valid symmetrical narrow band level set and transfer attributes using
+///  closest point lookups.
+///
+///  rasterizeSmoothSpheres() produces smoother, more blended connections
+///  between points which is ideal for generating a more artistically pleasant
+///  surface directly from point distributions. It aims to avoid typical post
+///  filtering operations used to smooth surface volumes. Note however that
+///  rasterizeSmoothSpheres may not necessarily produce a *symmetrical* narrow
+///  band level set; the exterior band may be smaller than desired depending on
+///  the search radius. The surface can be rebuilt or resized if necessary.
+///  The same closet point algorithm is used to transfer attributes.
+///
+///  In general, it is recommended to consider post rebuilding/renormalizing the
+///  generated surface using either tools::levelSetRebuild() or
+///  tools::LevelSetTracker::normalize() tools::LevelSetTracker::resize().
+///
+/// @note These methods use the framework provided in PointTransfer.h
+///
+
+#ifndef OPENVEB_POINTS_RASTERIZE_SDF_HAS_BEEN_INCLUDED
+#define OPENVEB_POINTS_RASTERIZE_SDF_HAS_BEEN_INCLUDED
+
+#include "PointDataGrid.h"
+#include "PointTransfer.h"
+#include "PointStatistics.h"
+
+#include <openvdb/openvdb.h>
+#include <openvdb/Types.h>
+#include <openvdb/tools/Prune.h>
+#include <openvdb/tools/ValueTransformer.h>
+#include <openvdb/thread/Threading.h>
+#include <openvdb/util/NullInterrupter.h>
+
+#include <unordered_map>
+
+#include <tbb/task_group.h>
+#include <tbb/parallel_reduce.h>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+/// @brief Narrow band sphere stamping with a uniform radius.
+/// @details Rasterizes points into a level set using basic sphere stamping with
+///   a uniform radius. The radius parameter is given in world space units and
+///   is applied to every point to generate a fixed surface mask and consequent
+///   distance values.
+/// @param points       the point data grid to rasterize
+/// @param radius       the world space radius of every point
+/// @param halfband     the half band width
+/// @param transform    the target transform for the surface
+/// @param filter       a filter to apply to points
+/// @param interrupter  optional interrupter
+/// @return The signed distance field.
+template <typename PointDataGridT,
+    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+typename SdfT::Ptr
+rasterizeSpheres(const PointDataGridT& points,
+             const Real radius,
+             const Real halfband = LEVEL_SET_HALF_WIDTH,
+             math::Transform::Ptr transform = nullptr,
+             const FilterT& filter = NullFilter(),
+             InterrupterT* interrupter = nullptr);
+
+/// @brief Narrow band sphere stamping with a varying radius.
+/// @details Rasterizes points into a level set using basic sphere stamping with
+///   a variable radius. The radius string parameter expects a point attribute
+///   of type RadiusT to exist.
+/// @param points       the point data grid to rasterize
+/// @param radius       the name of the radius attribute
+/// @param scale        an optional scale to apply to each per point radius
+/// @param halfband     the half band width
+/// @param transform    the target transform for the surface
+/// @param filter       a filter to apply to points
+/// @param interrupter  optional interrupter
+/// @return The signed distance field.
+template <typename PointDataGridT,
+    typename RadiusT = float,
+    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+typename SdfT::Ptr
+rasterizeSpheres(const PointDataGridT& points,
+             const std::string& radius,
+             const Real scale = 1.0,
+             const Real halfband = LEVEL_SET_HALF_WIDTH,
+             math::Transform::Ptr transform = nullptr,
+             const FilterT& filter = NullFilter(),
+             InterrupterT* interrupter = nullptr);
+
+/// @brief Narrow band sphere stamping with a uniform radius and closest point
+///   attribute transfer.
+/// @details Rasterizes points into a level set using basic sphere stamping with
+///   a uniform radius. The radius parameter is given in world space units and
+///   is applied to every point to generate a fixed surface mask and consequent
+///   distance values. Every voxel's closest point is used to transfer each
+///   attribute in the attributes parameter to a new grid of matching topology.
+///   The destination types of these grids is equal to the ValueConverter result
+///   of the attribute type applied to the PointDataGridT.
+/// @note The AttributeTypes template parameter should be a TypeList of the
+///   required or possible attributes types. i.e. TypeList<int, float, double>.
+///   A runtime error will be thrown if no equivalent type for a given attribute
+////  is found in the AttributeTypes TypeList.
+/// @param points       the point data grid to rasterize
+/// @param radius       the world space radius of every point
+/// @param attributes   list of attributes to transfer
+/// @param halfband     the half band width
+/// @param transform    the target transform for the surface
+/// @param filter       a filter to apply to points
+/// @param interrupter  optional interrupter
+/// @return A vector of grids. The signed distance field is guaranteed to be
+///   first and at the type specified by SdfT. Successive grids are the closest
+///   point attribute grids. These grids are guaranteed to have a topology
+///   and transform equal to the surface.
+template <typename PointDataGridT,
+    typename AttributeTypes,
+    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+GridPtrVec
+rasterizeSpheres(const PointDataGridT& points,
+             const Real radius,
+             const std::vector<std::string>& attributes,
+             const Real halfband = LEVEL_SET_HALF_WIDTH,
+             math::Transform::Ptr transform = nullptr,
+             const FilterT& filter = NullFilter(),
+             InterrupterT* interrupter = nullptr);
+
+/// @brief Narrow band sphere stamping with a varying radius and closest point
+///   attribute transfer.
+/// @details Rasterizes points into a level set using basic sphere stamping with
+///   a variable radius. The radius string parameter expects a point attribute
+///   of type RadiusT to exist. Every voxel's closest point is used to transfer
+///   each attribute in the attributes parameter to a new grid of matching
+///   topology. The destination types of these grids is equal to the
+///   ValueConverter result of the attribute type applied to the PointDataGridT.
+/// @note The AttributeTypes template parameter should be a TypeList of the
+///   required or possible attributes types. i.e. TypeList<int, float, double>.
+///   A runtime error will be thrown if no equivalent type for a given attribute
+////  is found in the AttributeTypes TypeList.
+/// @param points       the point data grid to rasterize
+/// @param radius       the name of the radius attribute
+/// @param attributes   list of attributes to transfer
+/// @param scale        scale to apply to each per point radius
+/// @param halfband     the half band width
+/// @param transform    the target transform for the surface
+/// @param filter       a filter to apply to points
+/// @param interrupter  optional interrupter
+/// @return A vector of grids. The signed distance field is guaranteed to be
+///   first and at the type specified by SdfT. Successive grids are the closest
+///   point attribute grids. These grids are guaranteed to have a topology
+///   and transform equal to the surface.
+template <typename PointDataGridT,
+    typename AttributeTypes,
+    typename RadiusT = float,
+    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+GridPtrVec
+rasterizeSpheres(const PointDataGridT& points,
+             const std::string& radius,
+             const std::vector<std::string>& attributes,
+             const Real scale = 1.0,
+             const Real halfband = LEVEL_SET_HALF_WIDTH,
+             math::Transform::Ptr transform = nullptr,
+             const FilterT& filter = NullFilter(),
+             InterrupterT* interrupter = nullptr);
+
+/// @brief Smoothed point distribution based sphere stamping with a uniform radius.
+/// @details Rasterizes points into a level set using [Zhu Bridson 05] sphere
+///   stamping with a uniform radius. The radius and search radius parameters
+///   are given in world space units and are applied to every point to generate
+///   a fixed surface mask and consequent distance values. The search radius is
+///   each points points maximum contribution to the target level set. The search
+///   radius should always have a value equal to or larger than the point radius.
+/// @warning The width of the exterior half band *may* be smaller than the
+///   specified half band if the search radius is less than the equivalent
+///   world space halfband distance.
+/// @param points       the point data grid to rasterize
+/// @param radius       the world space radius of every point
+/// @param searchRadius the maximum search distance of every point
+/// @param halfband     the half band width
+/// @param transform    the target transform for the surface
+/// @param filter       a filter to apply to points
+/// @param interrupter  optional interrupter
+/// @return The signed distance field.
+template <typename PointDataGridT,
+    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+typename SdfT::Ptr
+rasterizeSmoothSpheres(const PointDataGridT& points,
+             const Real radius,
+             const Real searchRadius,
+             const Real halfband = LEVEL_SET_HALF_WIDTH,
+             math::Transform::Ptr transform = nullptr,
+             const FilterT& filter = NullFilter(),
+             InterrupterT* interrupter = nullptr);
+
+/// @brief Smoothed point distribution based sphere stamping with a varying radius.
+/// @details Rasterizes points into a level set using [Zhu Bridson 05] sphere
+///   stamping with a variable radius. The radius string parameter expects a
+///   point attribute of type RadiusT to exist. The radiusScale parameter is
+///   multiplier for radius values held on the radius attribute. The searchRadius
+///   parameter remains a fixed size value which represents each points points
+///   maximum contribution to the target level set. The radius scale and search
+///   radius parameters are given in world space units and are applied to every
+///   point to generate a fixed surface mask and consequent distance values. The
+///   search radius should always have a value equal to or larger than the point
+///   radii.
+/// @warning The width of the exterior half band *may* be smaller than the
+///   specified half band if the search radius is less than the equivalent
+///   world space halfband distance.
+/// @param points       the point data grid to rasterize
+/// @param radius       the attribute containing the world space radius
+/// @param radiusScale  the scale applied to every world space radius value
+/// @param searchRadius the maximum search distance of every point
+/// @param halfband     the half band width
+/// @param transform    the target transform for the surface
+/// @param filter       a filter to apply to points
+/// @param interrupter  optional interrupter
+/// @return The signed distance field.
+template <typename PointDataGridT,
+    typename RadiusT = float,
+    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+typename SdfT::Ptr
+rasterizeSmoothSpheres(const PointDataGridT& points,
+                 const std::string& radius,
+                 const Real radiusScale,
+                 const Real searchRadius,
+                 const Real halfband = LEVEL_SET_HALF_WIDTH,
+                 math::Transform::Ptr transform = nullptr,
+                 const FilterT& filter = NullFilter(),
+                 InterrupterT* interrupter = nullptr);
+
+/// @brief Smoothed point distribution based sphere stamping with a uniform
+///   radius and closest point attribute transfer.
+/// @details Rasterizes points into a level set using [Zhu Bridson 05] sphere
+///   stamping with a uniform radius. The radius and search radius parameters
+///   are given in world space units and are applied to every point to generate
+///   a fixed surface mask and consequent distance values. The search radius is
+///   each points points maximum contribution to the target level set. The
+///   search radius should always be larger than the point radius. Every voxel's
+///   closest point is used to transfer each attribute in the attributes
+///   parameter to a new grid of matching topology. The destination types of
+///   these grids is equal to the ValueConverter result of the attribute type
+///   applied to the PointDataGridT.
+/// @note The AttributeTypes template parameter should be a TypeList of the
+///   required or possible attributes types. i.e. TypeList<int, float, double>.
+///   A runtime error will be thrown if no equivalent type for a given attribute
+///  is found in the AttributeTypes TypeList.
+/// @warning The width of the exterior half band *may* be smaller than the
+///   specified half band if the search radius is less than the equivalent
+///   world space halfband distance.
+/// @param points       the point data grid to rasterize
+/// @param radius       the world space radius of every point
+/// @param searchRadius the maximum search distance of every point
+/// @param halfband     the half band width
+/// @param transform    the target transform for the surface
+/// @param filter       a filter to apply to points
+/// @param interrupter  optional interrupter
+/// @return A vector of grids. The signed distance field is guaranteed to be
+///   first and at the type specified by SdfT. Successive grids are the closest
+///   point attribute grids. These grids are guaranteed to have a topology
+///   and transform equal to the surface.
+template <typename PointDataGridT,
+    typename AttributeTypes,
+    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+GridPtrVec
+rasterizeSmoothSpheres(const PointDataGridT& points,
+                 const Real radius,
+                 const Real searchRadius,
+                 const std::vector<std::string>& attributes,
+                 const Real halfband = LEVEL_SET_HALF_WIDTH,
+                 math::Transform::Ptr transform = nullptr,
+                 const FilterT& filter = NullFilter(),
+                 InterrupterT* interrupter = nullptr);
+
+/// @brief Smoothed point distribution based sphere stamping with a varying
+///   radius and closest point attribute transfer.
+/// @details Rasterizes points into a level set using [Zhu Bridson 05] sphere
+///   stamping with a variable radius. The radius string parameter expects a
+///   point attribute of type RadiusT to exist. The radiusScale parameter is
+///   multiplier for radius values held on the radius attribute. The searchRadius
+///   parameter remains a fixed size value which represents each points points
+///   maximum contribution to the target level set. The radius scale and search
+///   radius parameters are given in world space units and are applied to every
+///   point to generate a fixed surface mask and consequent distance values. The
+///   search radius should always have a value equal to or larger than the point
+///   radii. Every voxel's closest point is used to transfer each attribute in
+///   the attributes parameter to a new grid of matching topology. The
+///   destination types of these grids is equal to the ValueConverter result of
+///   the attribute type applied to the PointDataGridT.
+/// @note The AttributeTypes template parameter should be a TypeList of the
+///   required or possible attributes types. i.e. TypeList<int, float, double>.
+///   A runtime error will be thrown if no equivalent type for a given attribute
+////  is found in the AttributeTypes TypeList.
+/// @warning The width of the exterior half band *may* be smaller than the
+///   specified half band if the search radius is less than the equivalent
+///   world space halfband distance.
+/// @param points       the point data grid to rasterize
+/// @param radius       the attribute containing the world space radius
+/// @param radiusScale  the scale applied to every world space radius value
+/// @param searchRadius the maximum search distance of every point
+/// @param halfband     the half band width
+/// @param transform    the target transform for the surface
+/// @param filter       a filter to apply to points
+/// @param interrupter  optional interrupter
+/// @return A vector of grids. The signed distance field is guaranteed to be
+///   first and at the type specified by SdfT. Successive grids are the closest
+///   point attribute grids. These grids are guaranteed to have a topology
+///   and transform equal to the surface.
+template <typename PointDataGridT,
+    typename AttributeTypes,
+    typename RadiusT = float,
+    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+GridPtrVec
+rasterizeSmoothSpheres(const PointDataGridT& points,
+                 const std::string& radius,
+                 const Real radiusScale,
+                 const Real searchRadius,
+                 const std::vector<std::string>& attributes,
+                 const Real halfband = LEVEL_SET_HALF_WIDTH,
+                 math::Transform::Ptr transform = nullptr,
+                 const FilterT& filter = NullFilter(),
+                 InterrupterT* interrupter = nullptr);
+
+///////////////////////////////////////////////////
+///////////////////////////////////////////////////
+
+namespace rasterize_sdf_internal
+{
+
+/// @brief  Define a fixed index space radius for point rasterization
+template <typename ValueT>
+struct FixedRadius
+{
+    FixedRadius(const ValueT ris) : mR(ris) {}
+    inline void reset(const PointDataTree::LeafNodeType&) const {}
+    inline const FixedRadius& eval(const Index) const { return *this; }
+    inline ValueT get() const { return mR; }
+private:
+    const ValueT mR;
+};
+
+/// @brief  Define a fixed narrow band radius for point rasterization
+/// @details  Pass in an index space radius (relative to a PointDataGrid voxel
+///   size) and the desired half band width of the target surface. The minimum
+///   radius of influence is clamped to zero.
+template <typename ValueT>
+struct FixedBandRadius : public FixedRadius<ValueT>
+{
+    FixedBandRadius(const ValueT ris, const ValueT hb)
+        : FixedRadius<ValueT>(ris)
+        , mMinSearchIS(math::Max(ValueT(0.0), ris - hb))
+        , mMaxSearchIS(ris + hb)
+        , mMinSearchSqIS(mMinSearchIS*mMinSearchIS)
+        , mMaxSearchSqIS(mMaxSearchIS*mMaxSearchIS) {}
+
+    inline void reset(const PointDataTree::LeafNodeType&) const {}
+    inline const FixedBandRadius& eval(const Index) const { return *this; }
+    inline ValueT min() const { return mMinSearchIS; }
+    inline ValueT minSq() const { return mMinSearchSqIS; }
+    inline ValueT max() const { return mMaxSearchIS; }
+    inline ValueT maxSq() const { return mMaxSearchSqIS; }
+private:
+    const ValueT mMinSearchIS, mMaxSearchIS;
+    const ValueT mMinSearchSqIS, mMaxSearchSqIS;
+};
+
+/// @brief  A varying per point radius with an optional scale
+template <typename ValueT, typename CodecT = UnknownCodec>
+struct VaryingRadius
+{
+    using RadiusHandleT = AttributeHandle<ValueT, CodecT>;
+    VaryingRadius(const size_t ridx, const ValueT scale = 1.0)
+        : mRIdx(ridx), mRHandle(), mScale(scale) {}
+    VaryingRadius(const VaryingRadius& other)
+        : mRIdx(other.mRIdx), mRHandle(), mScale(other.mScale) {}
+
+    inline void reset(const PointDataTree::LeafNodeType& leaf)
+    {
+        mRHandle.reset(new RadiusHandleT(leaf.constAttributeArray(mRIdx)));
+    }
+
+    /// @brief  Compute a fixed radius for a specific point
+    inline const FixedRadius<ValueT> eval(const Index id) const
+    {
+        assert(mRHandle);
+        return FixedRadius<ValueT>(mRHandle->get(id) * mScale);
+    }
+
+private:
+    const size_t mRIdx;
+    typename RadiusHandleT::UniquePtr mRHandle;
+    const ValueT mScale;
+};
+
+/// @brief  A varying per point narrow band radius with an optional scale
+template <typename ValueT, typename CodecT = UnknownCodec>
+struct VaryingBandRadius : public VaryingRadius<ValueT, CodecT>
+{
+    using BaseT = VaryingRadius<ValueT, CodecT>;
+    VaryingBandRadius(const size_t ridx, const ValueT halfband,
+        const ValueT scale = 1.0)
+        : BaseT(ridx, scale), mHalfBand(halfband) {}
+
+    inline const FixedBandRadius<ValueT> eval(const Index id) const
+    {
+        const auto r = this->BaseT::eval(id).get();
+        return FixedBandRadius<ValueT>(ValueT(r), mHalfBand);
+    }
+
+private:
+    const ValueT mHalfBand;
+};
+
+/// @brief  Base class for SDF transfers which consolidates member data and
+///  some required interface methods.
+/// @note   Derives from TransformTransfer for automatic transformation support
+///   and VolumeTransfer<...T> for automatic buffer setup
+template <typename SdfT,
+    typename PositionCodecT,
+    typename RadiusType,
+    bool CPG>
+struct SignedDistanceFieldTransfer :
+    public TransformTransfer,
+    public std::conditional<CPG,
+        VolumeTransfer<typename SdfT::TreeType, Int64Tree>,
+        VolumeTransfer<typename SdfT::TreeType>>::type
+{
+    using TreeT = typename SdfT::TreeType;
+    using ValueT = typename TreeT::ValueType;
+    static_assert(std::is_floating_point<ValueT>::value,
+        "Spherical transfer only supports floating point values.");
+    static_assert(!std::is_reference<RadiusType>::value && !std::is_pointer<RadiusType>::value,
+        "Templated radius type must not be a reference or pointer");
+
+    using VolumeTransferT = typename std::conditional<CPG,
+        VolumeTransfer<TreeT, Int64Tree>,
+        VolumeTransfer<TreeT>>::type;
+
+    using PositionHandleT = AttributeHandle<Vec3f, PositionCodecT>;
+
+    // typically the max radius of all points rounded up
+    inline Int32 range(const Coord&, size_t) const { return Int32(mMaxKernelWidth); }
+
+    inline bool startPointLeaf(const PointDataTree::LeafNodeType& leaf)
+    {
+        mPosition.reset(new PositionHandleT(leaf.constAttributeArray(mPIdx)));
+        mRadius.reset(leaf);
+        // if CPG, store leaf id in upper 32 bits of mask
+        if (CPG) mPLeafMask = (Index64(mIds->find(&leaf)->second) << 32);
+        return true;
+    }
+
+protected:
+    /// @brief Constructor to use when a closet point grid is not in use
+    template <bool EnableT = CPG>
+    SignedDistanceFieldTransfer(const size_t pidx,
+            const size_t width,
+            const RadiusType& rt,
+            const math::Transform& source,
+            SdfT& surface,
+            Int64Tree* cpg,
+            const std::unordered_map<const PointDataTree::LeafNodeType*, Index>* ids,
+            typename std::enable_if<EnableT>::type* = 0)
+        : TransformTransfer(source, surface.transform())
+        , VolumeTransferT(&(surface.tree()), cpg)
+        , mPIdx(pidx)
+        , mPosition()
+        , mMaxKernelWidth(width)
+        , mRadius(rt)
+        , mBackground(surface.background())
+        , mDx(surface.voxelSize()[0])
+        , mIds(ids)
+        , mPLeafMask(0) {
+            assert(cpg && ids);
+        }
+
+    /// @brief Constructor to use when a closet point grid is in use
+    template <bool EnableT = CPG>
+    SignedDistanceFieldTransfer(const size_t pidx,
+            const size_t width,
+            const RadiusType& rt,
+            const math::Transform& source,
+            SdfT& surface,
+            Int64Tree*,
+            const std::unordered_map<const PointDataTree::LeafNodeType*, Index>*,
+            typename std::enable_if<!EnableT>::type* = 0)
+        : TransformTransfer(source, surface.transform())
+        , VolumeTransferT(surface.tree())
+        , mPIdx(pidx)
+        , mPosition()
+        , mMaxKernelWidth(width)
+        , mRadius(rt)
+        , mBackground(surface.background())
+        , mDx(surface.voxelSize()[0])
+        , mIds(nullptr)
+        , mPLeafMask(0) {}
+
+    SignedDistanceFieldTransfer(const SignedDistanceFieldTransfer& other)
+        : TransformTransfer(other)
+        , VolumeTransferT(other)
+        , mPIdx(other.mPIdx)
+        , mPosition()
+        , mMaxKernelWidth(other.mMaxKernelWidth)
+        , mRadius(other.mRadius)
+        , mBackground(other.mBackground)
+        , mDx(other.mDx)
+        , mIds(other.mIds)
+        , mPLeafMask(0) {}
+
+protected:
+    const size_t mPIdx;
+    typename PositionHandleT::UniquePtr mPosition;
+    const size_t mMaxKernelWidth;
+    RadiusType mRadius;
+    const ValueT mBackground;
+    const double mDx;
+    const std::unordered_map<const PointDataTree::LeafNodeType*, Index>* mIds;
+    Index64 mPLeafMask;
+};
+
+/// @brief  The transfer implementation for spherical stamping of narrow band
+///   radius values.
+template <typename SdfT,
+    typename PositionCodecT,
+    typename RadiusType,
+    bool CPG>
+struct SphericalTransfer :
+    public SignedDistanceFieldTransfer<SdfT, PositionCodecT, RadiusType, CPG>
+{
+    using BaseT = SignedDistanceFieldTransfer<SdfT, PositionCodecT, RadiusType, CPG>;
+    using typename BaseT::TreeT;
+    using typename BaseT::ValueT;
+    static const Index DIM = TreeT::LeafNodeType::DIM;
+    static const Index LOG2DIM = TreeT::LeafNodeType::LOG2DIM;
+    // The precision of the kernel arithmetic
+    using RealT = double;
+
+    SphericalTransfer(const size_t pidx,
+            const size_t width,
+            const RadiusType& rt,
+            const math::Transform& source,
+            SdfT& surface,
+            Int64Tree* cpg = nullptr,
+            const std::unordered_map<const PointDataTree::LeafNodeType*, Index>* ids = nullptr)
+        : BaseT(pidx, width, rt, source, surface, cpg, ids) {}
+
+    /// @brief  For each point, stamp a sphere with a given radius by running
+    ///   over all intersecting voxels and calculating if this point is closer
+    ///   than the currently held distance value. Note that the default value
+    ///   of the surface buffer should be the background value of the surface.
+    inline void rasterizePoint(const Coord& ijk,
+                    const Index id,
+                    const CoordBBox& bounds)
+    {
+        // @note  GCC 6.3 warns here in optimised builds
+#if defined(__GNUC__)  && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+        Vec3d P = ijk.asVec3d() + Vec3d(this->mPosition->get(id));
+#if defined(__GNUC__)  && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+        P = this->transformSourceToTarget(P);
+
+        const auto& r = this->mRadius.eval(id);
+        const RealT max = r.max();
+
+        CoordBBox intersectBox(Coord::floor(P - max), Coord::ceil(P + max));
+        intersectBox.intersect(bounds);
+        if (intersectBox.empty()) return;
+
+        auto* const data = this->template buffer<0>();
+        auto* const cpg = CPG ? this->template buffer<CPG ? 1 : 0>() : nullptr;
+        auto& mask = *(this->template mask<0>());
+
+        // If min2 == 0.0, then the index space radius is equal to or less than
+        // the desired half band. In this case each sphere interior always needs
+        // to be filled with distance values as we won't ever reach the negative
+        // background value. If, however, a point overlaps a voxel coord exactly,
+        // x2y2z2 will be 0.0. Forcing min2 to be less than zero here avoids
+        // incorrectly setting these voxels to inactive -background values as
+        // x2y2z2 will never be < 0.0. We still want the lteq logic in the
+        // (x2y2z2 <= min2) check as this is valid when min2 > 0.0.
+        const RealT min2 = r.minSq() == 0.0 ? -1.0 : r.minSq();
+        const RealT max2 = r.maxSq();
+
+        const Coord& a(intersectBox.min());
+        const Coord& b(intersectBox.max());
+        for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+            const RealT x2 = static_cast<RealT>(math::Pow2(c.x() - P[0]));
+            const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
+            for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                const RealT x2y2 = static_cast<RealT>(x2 + math::Pow2(c.y() - P[1]));
+                const Index ij = i + ((c.y() & (DIM-1u)) << LOG2DIM);
+                for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                    const Index offset = ij + /*k*/(c.z() & (DIM-1u));
+                    if (!mask.isOn(offset)) continue; // inside existing level set or not in range
+
+                    const RealT x2y2z2 = static_cast<RealT>(x2y2 + math::Pow2(c.z() - P[2]));
+                    if (x2y2z2 >= max2) continue; //outside narrow band of particle in positive direction
+                    if (x2y2z2 <= min2) { //outside narrow band of the particle in negative direction. can disable this to fill interior
+                        data[offset] = -(this->mBackground);
+                        mask.setOff(offset);
+                        continue;
+                    }
+
+                    const ValueT d = ValueT(this->mDx * (math::Sqrt(x2y2z2) - r.get())); // back to world space
+                    ValueT& v = data[offset];
+                    if (d < v) {
+                        v = d;
+                        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+                        if (CPG) cpg[offset] = Int64(this->mPLeafMask | Index64(id));
+                        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+                        // transfer attributes - we can't use this here as the exposed
+                        // function signatures take vector of attributes (i.e. an unbounded
+                        // size). If we instead clamped the attribute transfer to a fixed
+                        // amount of attributes we could get rid of the closest point logic
+                        // entirely. @todo consider adding another signature for increased
+                        // performance
+                        // this->foreach([&](auto* buffer, const size_t idx) {
+                        //     using Type = typename std::remove_pointer<decltype(buffer)>::type;
+                        //     buffer[offset] = mAttributes.template get<Type>(idx);
+                        // })
+                    }
+                }
+            }
+        } // outer sdf voxel
+    } // point idx
+
+    /// @brief Allow early termination if all voxels in the surface have been
+    ///   deactivated (all interior)
+    inline bool endPointLeaf(const PointDataTree::LeafNodeType&)
+    {
+        // If the mask is off, terminate rasterization
+        return !(this->template mask<0>()->isOff());
+    }
+
+    inline bool finalize(const Coord&, const size_t)
+    {
+        // loop over voxels in the outer cube diagonals which won't have been
+        // hit by point rasterizations - these will be on because of the mask
+        // fill technique and need to be turned off.
+        auto& mask = *(this->template mask<0>());
+        auto* const data = this->template buffer<0>();
+        for (auto iter = mask.beginOn(); iter; ++iter) {
+            if (data[iter.pos()] == this->mBackground) mask.setOff(iter.pos());
+        }
+        // apply sdf mask to other grids
+        if (CPG) *(this->template mask<CPG ? 1 : 0>()) = mask;
+        return true;
+    }
+};
+
+/// @brief  The transfer implementation for averaging of positions followed by
+///   spherical stamping.
+template <typename SdfT,
+    typename PositionCodecT,
+    typename RadiusType,
+    bool CPG>
+struct AveragePositionTransfer :
+    public SignedDistanceFieldTransfer<SdfT, PositionCodecT, RadiusType, CPG>
+{
+    using BaseT = SignedDistanceFieldTransfer<SdfT, PositionCodecT, RadiusType, CPG>;
+    using typename BaseT::TreeT;
+    using typename BaseT::ValueT;
+
+    using VolumeTransferT = typename std::conditional<CPG,
+        VolumeTransfer<typename SdfT::TreeType, Int64Tree>,
+        VolumeTransfer<typename SdfT::TreeType>>::type;
+
+    static const Index DIM = TreeT::LeafNodeType::DIM;
+    static const Index LOG2DIM = TreeT::LeafNodeType::LOG2DIM;
+    static const Index NUM_VALUES = TreeT::LeafNodeType::NUM_VALUES;
+    // The precision of the kernel arithmetic
+    using RealT = double;
+
+    struct PosRadPair
+    {
+        template <typename S> inline void addP(const math::Vec3<S>& v) { P += v; }
+        template <typename S> inline void addR(const S r) { R += r; }
+        template <typename S> inline void multR(const S w) { R *= w; }
+        template <typename S> inline void multP(const S w) { P *= w; }
+        inline RealT length() const { return P.length() - R; }
+        math::Vec3<RealT> P = math::Vec3<RealT>(0.0);
+        RealT R = 0.0;
+    };
+
+    AveragePositionTransfer(const size_t pidx,
+            const size_t width,
+            const RadiusType& rt,
+            const RealT search,
+            const math::Transform& source,
+            SdfT& surface,
+            Int64Tree* cpg = nullptr,
+            const std::unordered_map<const PointDataTree::LeafNodeType*, Index>* ids = nullptr)
+        : BaseT(pidx, width, rt, source, surface, cpg, ids)
+        , mMaxSearchIS(search)
+        , mMaxSearchSqIS(search*search)
+        , mWeights()
+        , mDist() {}
+
+    AveragePositionTransfer(const AveragePositionTransfer& other)
+        : BaseT(other)
+        , mMaxSearchIS(other.mMaxSearchIS)
+        , mMaxSearchSqIS(other.mMaxSearchSqIS)
+        , mWeights()
+        , mDist() {}
+
+    inline void initialize(const Coord& origin, const size_t idx, const CoordBBox& bounds)
+    {
+        // init buffers
+        this->BaseT::initialize(origin, idx, bounds);
+        mWeights.assign(NUM_VALUES, PosRadPair());
+        if (CPG) mDist.assign(NUM_VALUES, std::numeric_limits<float>::max());
+        // We use the surface buffer to store the intermediate weights as
+        // defined by the sum of k(|x−xj|/R), where k(s) = max(0,(1−s^2)^3)
+        // and R is the maximum search distance. The active buffer currently
+        // holds background values. We could simply subtract the background away
+        // from the final result - however if the background value increases
+        // beyond 1, progressively larger floating point instabilities can be
+        // observed with the weight calculation. Instead, reset all active
+        // values to zero
+        // @todo The surface buffer may not be at RealT precision. Should we
+        //  enforce this by storing the weights in another vector?
+        auto* const data = this->template buffer<0>();
+        const auto& mask = *(this->template mask<0>());
+        for (auto iter = mask.beginOn(); iter; ++iter) {
+            data[iter.pos()] = ValueT(0);
+        }
+    }
+
+    inline void rasterizePoint(const Coord& ijk,
+                    const Index id,
+                    const CoordBBox& bounds)
+    {
+#if defined(__GNUC__)  && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+        const Vec3d PWS = this->sourceTransform().indexToWorld(ijk.asVec3d() + Vec3d(this->mPosition->get(id)));
+#if defined(__GNUC__)  && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+        const Vec3d P = this->targetTransform().worldToIndex(PWS);
+
+        CoordBBox intersectBox(Coord::floor(P - mMaxSearchIS),
+            Coord::ceil(P + mMaxSearchIS));
+        intersectBox.intersect(bounds);
+        if (intersectBox.empty()) return;
+
+        auto* const data = this->template buffer<0>();
+        auto* const cpg = CPG ? this->template buffer<CPG ? 1 : 0>() : nullptr;
+        const auto& mask = *(this->template mask<0>());
+
+        // index space radius
+        const auto& r = this->mRadius.eval(id);
+        const RealT rad = r.get();
+        const RealT invsq = 1.0 / mMaxSearchSqIS;
+
+        const Coord& a(intersectBox.min());
+        const Coord& b(intersectBox.max());
+        for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+            const RealT x2 = static_cast<RealT>(math::Pow2(c.x() - P[0]));
+            const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
+            for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                const RealT x2y2 = static_cast<RealT>(x2 + math::Pow2(c.y() - P[1]));
+                const Index ij = i + ((c.y() & (DIM-1u)) << LOG2DIM);
+                for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                    RealT x2y2z2 = static_cast<RealT>(x2y2 + math::Pow2(c.z() - P[2]));
+                    if (x2y2z2 >= mMaxSearchSqIS) continue; //outside search distance
+                    const Index offset = ij + /*k*/(c.z() & (DIM-1u));
+                    if (!mask.isOn(offset)) continue; // inside existing level set or not in range
+
+                    // @note this algorithm is unable to deactivate voxels within
+                    // a computed narrow band during rasterization as all points must
+                    // visit their affected voxels.
+
+                    if (CPG) {
+                        // CPG still computed directly with each individual point
+                        // @note  Because voxels can't be discarded, it may be faster to
+                        //  do this as a post process (and avoid the sqrt per lookup)
+                        // @note  No need to scale back to world space
+                        const float dist = static_cast<float>(math::Sqrt(x2y2z2) - r.get());
+                        auto& d = mDist[offset];
+                        if (dist < d) {
+                            d = dist;
+                            OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+                            cpg[offset] = Int64(this->mPLeafMask | Index64(id));
+                            OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+                        }
+                    }
+
+                    x2y2z2 *= invsq; // x2y2z2 = (x - xi) / R
+                    // k(s) = max(0,(1−s^2)^3). note that the max is unecessary
+                    // as we early terminate above with x2y2z2 >= mMaxSearchSqIS
+                    x2y2z2 = math::Pow3(1.0 - x2y2z2);
+                    assert(x2y2z2 >= 0.0);
+                    // @todo The surface buffer may not be at RealT precision. Should we
+                    //  enforce this by storing the weights in another vector?
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+                    data[offset] += x2y2z2;
+                    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+                    auto& wt = mWeights[offset];
+                    wt.addP(PWS * x2y2z2);
+                    wt.addR(rad * x2y2z2);
+                }
+            }
+        } // outer sdf voxel
+    } // point idx
+
+    inline bool endPointLeaf(const PointDataTree::LeafNodeType&) { return true; }
+
+    inline bool finalize(const Coord& origin, const size_t)
+    {
+        auto& mask = *(this->template mask<0>());
+        auto* const data = this->template buffer<0>();
+
+        for (auto iter = mask.beginOn(); iter; ++iter) {
+            const Index idx = iter.pos();
+            auto& w = data[idx];
+            // if background, voxel was out of range. Guaranteed to be outside as
+            // all interior voxels will have at least a single point contribution
+            if (w == 0.0f) {
+                mask.setOff(idx);
+                w = this->mBackground;
+            }
+            else {
+                const Coord ijk = origin + TreeT::LeafNodeType::offsetToLocalCoord(idx);
+                const Vec3d ws = this->targetTransform().indexToWorld(ijk);
+                const RealT wi = RealT(1.0) / RealT(w); // wi
+                auto& wt = mWeights[idx];
+                wt.multP(wi); // sum of weighted positions
+                wt.multR(wi * this->mDx); // sum of weighted radii (scale to ws)
+                wt.addP(-ws); // (x - xi) (instead doing (-x + xi))
+                w = static_cast<typename SdfT::ValueType>(wt.length()); // (x - xi) - r
+                // clamp active region and value range to requested narrow band
+                if (std::fabs(w) >= this->mBackground) {
+                    w = std::copysign(this->mBackground, w);
+                    mask.setOff(idx);
+                }
+            }
+        }
+
+        // apply sdf mask to other grids
+        if (CPG) *(this->template mask<CPG ? 1 : 0>()) = mask;
+        return true;
+    }
+
+private:
+    const RealT mMaxSearchIS, mMaxSearchSqIS;
+    std::vector<PosRadPair> mWeights;
+    std::vector<float> mDist;
+};
+
+/// @brief  Base class for surfacing mask initialization
+template <typename MaskTreeT = MaskTree,
+    typename InterrupterT = util::NullInterrupter>
+struct SurfaceMaskOp
+{
+    inline void join(SurfaceMaskOp& other)
+    {
+        if (mMask->leafCount() > other.mMask->leafCount()) {
+            mMask->topologyUnion(*other.mMask);
+            other.mMask.reset();
+        }
+        else {
+            other.mMask->topologyUnion(*mMask);
+            mMask.reset(other.mMask.release());
+        }
+
+        if (mMaskOff->leafCount() > other.mMaskOff->leafCount()) {
+            mMaskOff->topologyUnion(*other.mMaskOff);
+            other.mMaskOff.reset();
+        }
+        else {
+            other.mMaskOff->topologyUnion(*mMaskOff);
+            mMaskOff.reset(other.mMaskOff.release());
+        }
+    }
+
+    std::unique_ptr<MaskTreeT> mask() { return std::move(mMask); }
+    std::unique_ptr<MaskTreeT> maskoff() { return std::move(mMaskOff); }
+
+protected:
+    SurfaceMaskOp(const math::Transform& points,
+                  const math::Transform& surface,
+                  InterrupterT* interrupter = nullptr)
+        : mMask(new MaskTreeT)
+        , mMaskOff(new MaskTreeT)
+        , mPointsTransform(points)
+        , mSurfaceTransform(surface)
+        , mInterrupter(interrupter)
+        , mVoxelOffset(static_cast<int>(math::RoundUp(points.voxelSize()[0] /
+            surface.voxelSize()[0]))) {}
+
+    SurfaceMaskOp(const SurfaceMaskOp& other)
+        : mMask(new MaskTreeT)
+        , mMaskOff(new MaskTreeT)
+        , mPointsTransform(other.mPointsTransform)
+        , mSurfaceTransform(other.mSurfaceTransform)
+        , mInterrupter(other.mInterrupter)
+        , mVoxelOffset(other.mVoxelOffset) {}
+
+    // @brief  Sparse fill a tree with activated bounding boxes expanded from
+    //   each active voxel.
+    // @note  This method used to fill from each individual voxel. Whilst more
+    //   accurate, this was slower in comparison to using the active node bounds.
+    //   As the rasterization is so fast (discarding of voxels out of range)
+    //   this overzealous activation results in far superior performance here.
+    template <typename LeafT>
+    inline void fill(const LeafT& leaf, const int dist, const bool active)
+    {
+        auto doFill = [&](CoordBBox b) {
+            b = mSurfaceTransform.worldToIndexCellCentered(
+                    mPointsTransform.indexToWorld(b));
+            b.expand(dist);
+            if (active) mMask->sparseFill(b, true, true);
+            else        mMaskOff->sparseFill(b, true, true);
+        };
+
+        const auto& mask = leaf.getValueMask();
+        if (mask.isOn()) {
+            doFill(leaf.getNodeBoundingBox());
+        }
+        else {
+            CoordBBox bounds;
+            for (auto iter = mask.beginOn(); iter; ++iter) {
+                bounds.expand(leaf.offsetToLocalCoord(iter.pos()));
+            }
+            if (!bounds.empty()) {
+                bounds.translate(leaf.origin());
+                doFill(bounds);
+            }
+        }
+    }
+
+    inline bool interrupted()
+    {
+        if (util::wasInterrupted(mInterrupter)) {
+            thread::cancelGroupExecution();
+            return true;
+        }
+        return false;
+    }
+
+protected:
+    std::unique_ptr<MaskTreeT> mMask;
+    std::unique_ptr<MaskTreeT> mMaskOff;
+    const math::Transform& mPointsTransform;
+    const math::Transform& mSurfaceTransform;
+    InterrupterT* mInterrupter;
+    // add the size of a single points voxel at the surface resolution
+    // to the distance limits - this is becasue we don't query exact point
+    // positions in SurfaceMaskOp, which means we have to
+    // actviate the "worst case scenario" bounds. The closer the points
+    // voxel size is to the target sdf voxel size the better the topology
+    // estimate
+    const int mVoxelOffset;
+};
+
+/// @brief Initializes a fixed activity mask
+template <typename MaskTreeT,
+    typename InterrupterT = util::NullInterrupter>
+struct FixedSurfaceMaskOp
+    : public SurfaceMaskOp<MaskTreeT, InterrupterT>
+{
+    using BaseT = SurfaceMaskOp<MaskTreeT, InterrupterT>;
+    using LeafManagerT =
+        tree::LeafManager<const points::PointDataTree>;
+
+    FixedSurfaceMaskOp(const math::Transform& points,
+                   const math::Transform& surface,
+                   const double minBandRadius,
+                   const double maxBandRadius,
+                   InterrupterT* interrupter = nullptr)
+        : BaseT(points, surface, interrupter)
+        , mMin(), mMax() {
+            // calculate the min interior cube area of activity. this is the side
+            // of the largest possible cube that fits into the radius "min":
+            //   d = 2r -> 2r = 3x^2 -> x = 2r / sqrt(3)
+            // finally half it to the new radius
+            const Real min = ((2.0 * minBandRadius) / std::sqrt(3.0)) / 2.0;
+            const int d = static_cast<int>(math::RoundDown(min)) - this->mVoxelOffset;
+            mMin = math::Max(0, d);
+            mMax = static_cast<int>(math::RoundUp(maxBandRadius));
+            mMax += this->mVoxelOffset;
+        }
+
+    FixedSurfaceMaskOp(const FixedSurfaceMaskOp& other, tbb::split)
+        : BaseT(other), mMin(other.mMin), mMax(other.mMax) {}
+
+    void operator()(const typename LeafManagerT::LeafRange& range)
+    {
+        if (this->interrupted()) return;
+        for (auto leafIter = range.begin(); leafIter; ++leafIter) {
+            this->fill(*leafIter, mMax, true);
+        }
+        if (mMin <= 0) return;
+        for (auto leafIter = range.begin(); leafIter; ++leafIter) {
+            this->fill(*leafIter, mMin, false);
+        }
+    }
+
+private:
+    int mMin, mMax;
+};
+
+/// @brief Initializes a variable activity mask
+template <typename RadiusTreeT,
+    typename MaskTreeT,
+    typename InterrupterT = util::NullInterrupter>
+struct VariableSurfaceMaskOp
+    : public SurfaceMaskOp<MaskTreeT, InterrupterT>
+{
+    using BaseT = SurfaceMaskOp<MaskTreeT, InterrupterT>;
+    using LeafManagerT =
+        tree::LeafManager<const points::PointDataTree>;
+
+    VariableSurfaceMaskOp(const math::Transform& pointsTransform,
+                         const math::Transform& surfaceTransform,
+                         const RadiusTreeT& min,
+                         const RadiusTreeT& max,
+                         const Real scale,
+                         const Real halfband,
+                         InterrupterT* interrupter = nullptr)
+        : BaseT(pointsTransform, surfaceTransform, interrupter)
+        , mMin(min), mMax(max), mScale(scale), mHalfband(halfband) {}
+
+    VariableSurfaceMaskOp(const VariableSurfaceMaskOp& other, tbb::split)
+        : BaseT(other), mMin(other.mMin), mMax(other.mMax)
+        , mScale(other.mScale), mHalfband(other.mHalfband) {}
+
+    void operator()(const typename LeafManagerT::LeafRange& range)
+    {
+        if (this->interrupted()) return;
+        const tree::ValueAccessor<const RadiusTreeT> maxacc(mMax);
+        for (auto leafIter = range.begin(); leafIter; ++leafIter) {
+            const int max = this->maxDist(maxacc.getValue(leafIter->origin()));
+            this->fill(*leafIter, max, true);
+        }
+        const tree::ValueAccessor<const RadiusTreeT> minacc(mMin);
+        for (auto leafIter = range.begin(); leafIter; ++leafIter) {
+            const int min = this->minDist(minacc.getValue(leafIter->origin()));
+            if (min <= 0) continue;
+            this->fill(*leafIter, min, false);
+        }
+    }
+
+private:
+    inline int maxDist(const typename RadiusTreeT::ValueType& max) const
+    {
+        // max radius in index space
+        const Real v = (Real(max) * mScale) + mHalfband;
+        int d = int(math::RoundUp(v)); // next voxel
+        d += this->mVoxelOffset; // final offset
+        return d;
+    }
+
+    inline int minDist(const typename RadiusTreeT::ValueType& min) const
+    {
+        // min radius in index space
+        Real v = math::Max(0.0, (Real(min) * mScale) - mHalfband);
+        v = math::Max(0.0, Real(v - this->mVoxelOffset)); // final offset
+        // calculate the min interior cube area of activity. this is the side
+        // of the largest possible cube that fits into the radius "v":
+        //   d = 2r -> 2r = 3x^2 -> x = 2r / sqrt(3)
+        // finally half it to the new radius
+        v = ((2.0 * v) / std::sqrt(3.0)) / 2.0;
+        return static_cast<int>(v); // round down (v is always >= 0)
+    }
+
+private:
+    const RadiusTreeT& mMin;
+    const RadiusTreeT& mMax;
+    const Real mScale, mHalfband;
+};
+
+template <typename SdfT, typename InterrupterT, typename PointDataGridT>
+inline typename SdfT::Ptr
+initFixedSdf(const PointDataGridT& points,
+        math::Transform::Ptr transform,
+        const typename SdfT::ValueType bg,
+        const double minBandRadius,
+        const double maxBandRadius,
+        InterrupterT* interrupter)
+{
+    using LeafManagerT = tree::LeafManager<const typename PointDataGridT::TreeType>;
+    using MaskTreeT = typename SdfT::TreeType::template ValueConverter<ValueMask>::Type;
+
+    typename SdfT::Ptr surface = SdfT::create(bg);
+    surface->setTransform(transform);
+    surface->setGridClass(GRID_LEVEL_SET);
+
+    FixedSurfaceMaskOp<MaskTreeT, InterrupterT> op(points.transform(),
+       *transform, minBandRadius, maxBandRadius, interrupter);
+
+    if (interrupter) interrupter->start("Generating uniform surface topology");
+
+    LeafManagerT leafManager(points.tree());
+    tbb::parallel_reduce(leafManager.leafRange(), op);
+    auto mask = op.mask();
+
+    if (minBandRadius > 0.0) {
+        auto maskoff = op.maskoff();
+        mask->topologyDifference(*maskoff);
+        // union will copy empty nodes so prune them
+        tools::pruneInactive(*mask);
+        surface->tree().topologyUnion(*mask);
+        mask.reset();
+        // set maskoff values to -background
+        tree::ValueAccessor<const MaskTreeT> acc(*maskoff);
+        auto setOffOp = [acc](auto& iter) {
+            if (acc.isValueOn(iter.getCoord())) {
+                iter.modifyValue([](auto& v) { v = -v; });
+            }
+        };
+        tools::foreach(surface->beginValueOff(), setOffOp,
+            /*thread=*/true, /*shared=*/false);
+        maskoff.reset();
+    }
+    else {
+        surface->tree().topologyUnion(*mask);
+        mask.reset();
+    }
+
+    surface->tree().voxelizeActiveTiles();
+    if (interrupter) interrupter->end();
+    return surface;
+}
+
+template <typename SdfT,
+    typename InterrupterT,
+    typename PointDataGridT,
+    typename RadiusTreeT>
+inline typename SdfT::Ptr
+initVariableSdf(const PointDataGridT& points,
+        math::Transform::Ptr transform,
+        const typename SdfT::ValueType bg,
+        const RadiusTreeT& min,
+        const RadiusTreeT& max,
+        const Real scale,
+        const Real halfband,
+        InterrupterT* interrupter)
+{
+    using LeafManagerT = tree::LeafManager<const typename PointDataGridT::TreeType>;
+    using MaskTreeT = typename SdfT::TreeType::template ValueConverter<ValueMask>::Type;
+
+    typename SdfT::Ptr surface = SdfT::create(bg);
+    surface->setTransform(transform);
+    surface->setGridClass(GRID_LEVEL_SET);
+
+    VariableSurfaceMaskOp<RadiusTreeT, MaskTreeT, InterrupterT>
+        op(points.transform(), *transform, min, max, scale, halfband, interrupter);
+
+    if (interrupter) interrupter->start("Generating variable surface topology");
+
+    LeafManagerT leafManager(points.tree());
+    tbb::parallel_reduce(leafManager.leafRange(), op);
+    auto mask = op.mask();
+    auto maskoff = op.maskoff();
+
+    if (!maskoff->empty()) {
+        mask->topologyDifference(*maskoff);
+        // union will copy empty nodes so prune them
+        tools::pruneInactive(*mask);
+        surface->tree().topologyUnion(*mask);
+        // set maskoff values to -background
+        tree::ValueAccessor<const MaskTreeT> acc(*maskoff);
+        auto setOffOp = [acc](auto& iter) {
+            if (acc.isValueOn(iter.getCoord())) {
+                iter.modifyValue([](auto& v) { v = -v; });
+            }
+        };
+        tools::foreach(surface->beginValueOff(), setOffOp,
+            /*thread=*/true, /*shared=*/false);
+    }
+    else {
+        surface->tree().topologyUnion(*mask);
+    }
+
+    mask.reset();
+    maskoff.reset();
+    surface->tree().voxelizeActiveTiles();
+    if (interrupter) interrupter->end();
+    return surface;
+}
+
+template <typename PointDataTreeT,
+    typename AttributeTypes>
+inline GridPtrVec
+transferAttributes(const tree::LeafManager<const PointDataTreeT>& manager,
+                   const std::vector<std::string>& attributes,
+                   const Int64Tree& cpg,
+                   const math::Transform::Ptr transform)
+{
+    assert(manager.leafCount() != 0);
+    // masking uses upper 32 bits for leaf node id
+    // @note we can use a point list impl to support larger counts
+    // if necessary but this is far faster
+    assert(manager.leafCount() <
+        size_t(std::numeric_limits<Index>::max()));
+
+    // linearise cpg to avoid having to probe data
+    const tree::LeafManager<const Int64Tree> cpmanager(cpg);
+
+    auto transfer = [&](auto& tree, const size_t attrIdx) {
+        using TreeType = typename std::decay<decltype(tree)>::type;
+        using HandleT = AttributeHandle<typename TreeType::ValueType>;
+
+        // init topology
+        tree.topologyUnion(cpg);
+        tree::LeafManager<TreeType> lm(tree);
+
+        // init values
+        lm.foreach([&manager, &cpmanager, attrIdx]
+            (auto& leaf, const size_t idx)  {
+            auto voxel = leaf.beginValueOn();
+            if (!voxel) return;
+
+            auto* data = leaf.buffer().data();
+            const Int64* ids = cpmanager.leaf(idx).buffer().data();
+            Index prev = Index(ids[voxel.pos()] >> 32);
+            typename HandleT::UniquePtr handle(
+                new HandleT(manager.leaf(prev).constAttributeArray(attrIdx)));
+
+            for (; voxel; ++voxel) {
+                const Int64 hash = ids[voxel.pos()];
+                const Index lfid = Index(hash >> 32); // upper 32 bits to leaf id
+                const Index ptid = static_cast<Index>(hash); // lower
+                if (lfid != prev) {
+                    handle.reset(new HandleT(manager.leaf(lfid).constAttributeArray(attrIdx)));
+                    prev = lfid;
+                }
+                data[voxel.pos()] = handle->get(ptid);
+            }
+        });
+    };
+
+    GridPtrVec grids;
+    grids.reserve(attributes.size());
+    const auto& attrSet = manager.leaf(0).attributeSet();
+    tbb::task_group tasks;
+
+    for (const auto& name : attributes) {
+        const size_t attrIdx = attrSet.find(name);
+        if (attrIdx == points::AttributeSet::INVALID_POS) continue;
+        if (attrSet.get(attrIdx)->stride() != 1) {
+            OPENVDB_THROW(RuntimeError, "Transfer of attribute " + name +
+               " not supported since it is strided");
+        }
+
+        const std::string& type = attrSet.descriptor().valueType(attrIdx);
+        GridBase::Ptr grid = nullptr;
+        AttributeTypes::foreach([&](const auto& v) {
+            using ValueType = typename std::remove_const<typename std::decay<decltype(v)>::type>::type;
+            using TreeT = typename PointDataTreeT::template ValueConverter<ValueType>::Type;
+            if (!grid && typeNameAsString<ValueType>() == type) {
+                auto typed = Grid<TreeT>::create();
+                grid = typed;
+                typed->setName(name);
+                typed->setTransform(transform);
+                tasks.run([typed, attrIdx, transfer] { transfer(typed->tree(), attrIdx); });
+                grids.emplace_back(grid);
+            }
+        });
+
+        if (!grid) {
+            OPENVDB_THROW(RuntimeError, "No support for attribute type " + type +
+                " built during closest point surface transfer");
+        }
+    }
+
+    tasks.wait();
+    return grids;
+}
+
+template <typename SdfT,
+    template <typename, typename, typename, bool> class TransferInterfaceT,
+    typename AttributeTypes,
+    typename InterrupterT,
+    typename PointDataGridT,
+    typename FilterT,
+    typename ...Args>
+inline GridPtrVec
+rasterizeSurface(const PointDataGridT& points,
+    const std::vector<std::string>& attributes,
+    const FilterT& filter,
+    SdfT& surface,
+    InterrupterT* interrupter,
+    Args&&... args)
+{
+    using RadRefT = typename std::tuple_element<1, std::tuple<Args...>>::type;
+    using RadT = typename std::remove_reference<RadRefT>::type;
+
+    GridPtrVec grids;
+    auto leaf = points.constTree().cbeginLeaf();
+    if (!leaf) return grids;
+
+    const size_t pidx = leaf->attributeSet().find("P");
+    if (pidx == AttributeSet::INVALID_POS) {
+        OPENVDB_THROW(RuntimeError, "Failed to find position attribute");
+    }
+
+    // @note  Can't split this out into a generic lambda yet as there
+    // are compiler issues with capturing variadic arguments
+    const NamePair& ptype = leaf->attributeSet().descriptor().type(pidx);
+
+    if (attributes.empty()) {
+        if (ptype.second == NullCodec::name()) {
+            using TransferT = TransferInterfaceT<SdfT, NullCodec, RadT, false>;
+            TransferT transfer(pidx, args...);
+            rasterize<PointDataGridT, TransferT, FilterT, InterrupterT>
+                (points, transfer, filter, interrupter);
+        }
+        else {
+            using TransferT = TransferInterfaceT<SdfT, UnknownCodec, RadT, false>;
+            TransferT transfer(pidx, args...);
+            rasterize<PointDataGridT, TransferT, FilterT, InterrupterT>
+                (points, transfer, filter, interrupter);
+        }
+    }
+    else {
+        Int64Tree cpg;
+        cpg.topologyUnion(surface.tree());
+        tree::LeafManager<const PointDataTree> manager(points.tree());
+        // map point leaf nodes to their linear id
+        // @todo sorted vector of leaf ptr-> index pair then lookup with binary search?
+        std::unordered_map<const PointDataTree::LeafNodeType*, Index> ids;
+        manager.foreach([&](auto& leaf, size_t idx) { ids[&leaf] = Index(idx); }, false);
+
+        if (ptype.second == NullCodec::name()) {
+            using TransferT = TransferInterfaceT<SdfT, NullCodec, RadT, true>;
+            TransferT transfer(pidx, args..., &cpg, &ids);
+            rasterize<PointDataGridT, TransferT, FilterT, InterrupterT>
+                (points, transfer, filter, interrupter);
+        }
+        else {
+            using TransferT = TransferInterfaceT<SdfT, UnknownCodec, RadT, true>;
+            TransferT transfer(pidx, args..., &cpg, &ids);
+            rasterize<PointDataGridT, TransferT, FilterT, InterrupterT>
+                (points, transfer, filter, interrupter);
+        }
+
+        ids.clear();
+        tools::pruneInactive(cpg);
+        // Build attribute transfer grids
+        grids = transferAttributes
+            <typename PointDataGrid::TreeType, AttributeTypes>
+                (manager, attributes, cpg, surface.transformPtr());
+    }
+
+    return grids;
+}
+
+} // namespace rasterize_sdf_internal
+
+
+///////////////////////////////////////////////////
+///////////////////////////////////////////////////
+
+
+template <typename PointDataGridT,
+    typename SdfT,
+    typename FilterT,
+    typename InterrupterT>
+typename SdfT::Ptr
+rasterizeSpheres(const PointDataGridT& points,
+                 const Real radius,
+                 const Real halfband,
+                 math::Transform::Ptr transform,
+                 const FilterT& filter,
+                 InterrupterT* interrupter)
+{
+    auto grids =
+        rasterizeSpheres<PointDataGridT, TypeList<>, SdfT, FilterT, InterrupterT>
+            (points, radius, {}, halfband, transform, filter, interrupter);
+    return StaticPtrCast<SdfT>(grids.front());
+}
+
+template <typename PointDataGridT,
+    typename RadiusT,
+    typename SdfT,
+    typename FilterT,
+    typename InterrupterT>
+typename SdfT::Ptr
+rasterizeSpheres(const PointDataGridT& points,
+                 const std::string& radius,
+                 const Real scale,
+                 const Real halfband,
+                 math::Transform::Ptr transform,
+                 const FilterT& filter,
+                 InterrupterT* interrupter)
+{
+    auto grids =
+        rasterizeSpheres<PointDataGridT, TypeList<>, RadiusT, SdfT, FilterT, InterrupterT>
+            (points, radius, {}, scale, halfband, transform, filter, interrupter);
+    return StaticPtrCast<SdfT>(grids.front());
+}
+
+template <typename PointDataGridT,
+    typename AttributeTypes,
+    typename SdfT,
+    typename FilterT,
+    typename InterrupterT>
+GridPtrVec
+rasterizeSpheres(const PointDataGridT& points,
+                 const Real radius,
+                 const std::vector<std::string>& attributes,
+                 const Real halfband,
+                 math::Transform::Ptr transform,
+                 const FilterT& filter,
+                 InterrupterT* interrupter)
+{
+    using namespace rasterize_sdf_internal;
+
+    if (!transform) transform = points.transform().copy();
+    const Real vs = transform->voxelSize()[0];
+    const float background = static_cast<float>(vs * halfband);
+
+    // search distance at the SDF transform, including its half band
+    const Real radiusIndexSpace = radius / vs;
+    const FixedBandRadius<Real> rad(radiusIndexSpace, halfband);
+    const Real minBandRadius = rad.min();
+    const Real maxBandRadius = rad.max();
+    const size_t width = static_cast<size_t>(math::RoundUp(maxBandRadius));
+
+    typename SdfT::Ptr surface =
+        initFixedSdf<SdfT, InterrupterT>
+            (points, transform, background, minBandRadius, maxBandRadius, interrupter);
+
+    if (interrupter) interrupter->start("Rasterizing particles to level set using constant Spheres");
+
+    GridPtrVec grids =
+        rasterizeSurface<SdfT, SphericalTransfer, AttributeTypes, InterrupterT>
+            (points, attributes, filter, *surface, interrupter,
+                width, rad, points.transform(), *surface); // args
+
+    tools::pruneLevelSet(surface->tree());
+    if (interrupter) interrupter->end();
+    grids.insert(grids.begin(), surface);
+    return grids;
+}
+
+template <typename PointDataGridT,
+    typename AttributeTypes,
+    typename RadiusT,
+    typename SdfT,
+    typename FilterT,
+    typename InterrupterT>
+GridPtrVec
+rasterizeSpheres(const PointDataGridT& points,
+                 const std::string& radius,
+                 const std::vector<std::string>& attributes,
+                 const Real scale,
+                 const Real halfband,
+                 math::Transform::Ptr transform,
+                 const FilterT& filter,
+                 InterrupterT* interrupter)
+{
+    using namespace rasterize_sdf_internal;
+    using PointDataTreeT = typename PointDataGridT::TreeType;
+    using RadTreeT = typename PointDataTreeT::template ValueConverter<RadiusT>::Type;
+
+    if (!transform) transform = points.transform().copy();
+    const Real vs = transform->voxelSize()[0];
+    const float background = static_cast<float>(vs * halfband);
+
+    RadiusT min(0), max(0);
+    typename RadTreeT::Ptr mintree(new RadTreeT), maxtree(new RadTreeT);
+    points::evalMinMax<RadiusT, UnknownCodec>
+        (points.tree(), radius, min, max, filter, mintree.get(), maxtree.get());
+
+    // search distance at the SDF transform
+    const RadiusT indexSpaceScale = RadiusT(scale / vs);
+    typename SdfT::Ptr surface =
+        initVariableSdf<SdfT, InterrupterT>
+            (points, transform, background, *mintree, *maxtree,
+                indexSpaceScale, halfband, interrupter);
+    mintree.reset();
+    maxtree.reset();
+
+    auto leaf = points.constTree().cbeginLeaf();
+    if (!leaf) return GridPtrVec(1, surface);
+
+    // max possible index space radius
+    const size_t width = static_cast<size_t>
+        (math::RoundUp((Real(max) * indexSpaceScale) + Real(halfband)));
+
+    const size_t ridx = leaf->attributeSet().find(radius);
+    if (ridx == AttributeSet::INVALID_POS) {
+        OPENVDB_THROW(RuntimeError, "Failed to find radius attribute \"" + radius + "\"");
+    }
+
+    VaryingBandRadius<RadiusT> rad(ridx, RadiusT(halfband), indexSpaceScale);
+    if (interrupter) interrupter->start("Rasterizing particles to level set using variable Spheres");
+
+    GridPtrVec grids =
+        rasterizeSurface<SdfT, SphericalTransfer, AttributeTypes, InterrupterT>
+            (points, attributes, filter, *surface, interrupter,
+                width, rad, points.transform(), *surface); // args
+
+    if (interrupter) interrupter->end();
+    tools::pruneLevelSet(surface->tree());
+    grids.insert(grids.begin(), surface);
+    return grids;
+}
+
+///////////////////////////////////////////////////
+
+template <typename PointDataGridT,
+    typename SdfT,
+    typename FilterT,
+    typename InterrupterT>
+typename SdfT::Ptr
+rasterizeSmoothSpheres(const PointDataGridT& points,
+             const Real radius,
+             const Real searchRadius,
+             const Real halfband,
+             math::Transform::Ptr transform,
+             const FilterT& filter,
+             InterrupterT* interrupter)
+{
+    auto grids =
+        rasterizeSmoothSpheres<PointDataGridT, TypeList<>, SdfT, FilterT, InterrupterT>
+            (points, radius, searchRadius, {}, halfband, transform, filter, interrupter);
+    return StaticPtrCast<SdfT>(grids.front());
+}
+
+template <typename PointDataGridT,
+    typename RadiusT,
+    typename SdfT,
+    typename FilterT,
+    typename InterrupterT>
+typename SdfT::Ptr
+rasterizeSmoothSpheres(const PointDataGridT& points,
+                 const std::string& radius,
+                 const Real radiusScale,
+                 const Real searchRadius,
+                 const Real halfband,
+                 math::Transform::Ptr transform,
+                 const FilterT& filter,
+                 InterrupterT* interrupter)
+{
+    auto grids =
+        rasterizeSmoothSpheres<PointDataGridT, TypeList<>, RadiusT, SdfT, FilterT, InterrupterT>
+            (points, radius, radiusScale, searchRadius, {}, halfband, transform, filter, interrupter);
+    return StaticPtrCast<SdfT>(grids.front());
+}
+
+template <typename PointDataGridT,
+    typename AttributeTypes,
+    typename SdfT,
+    typename FilterT,
+    typename InterrupterT>
+GridPtrVec
+rasterizeSmoothSpheres(const PointDataGridT& points,
+                 const Real radius,
+                 const Real searchRadius,
+                 const std::vector<std::string>& attributes,
+                 const Real halfband,
+                 math::Transform::Ptr transform,
+                 const FilterT& filter,
+                 InterrupterT* interrupter)
+{
+    using namespace rasterize_sdf_internal;
+
+    if (!transform) transform = points.transform().copy();
+    const Real vs = transform->voxelSize()[0];
+    const float background = static_cast<float>(vs * halfband);
+    const Real indexSpaceSearch = searchRadius / vs;
+    const FixedBandRadius<Real> bands(radius / vs, halfband);
+    const Real max = bands.max();
+
+    typename SdfT::Ptr surface =
+        initFixedSdf<SdfT, InterrupterT>
+            (points, transform, background, /*min*/0.0, max, interrupter);
+
+    auto leaf = points.constTree().cbeginLeaf();
+    if (!leaf) return GridPtrVec(1, surface);
+
+    // max possible index space search radius
+    const size_t width = static_cast<size_t>(math::RoundUp(indexSpaceSearch));
+
+    const FixedRadius<Real> rad(radius / vs);
+    if (interrupter) interrupter->start("Rasterizing particles to level set using constant Zhu-Bridson");
+
+    GridPtrVec grids =
+        rasterizeSurface<SdfT, AveragePositionTransfer, AttributeTypes, InterrupterT>
+            (points, attributes, filter, *surface, interrupter,
+                width, rad, indexSpaceSearch, points.transform(), *surface); // args
+
+    tools::pruneInactive(surface->tree());
+    if (interrupter) interrupter->end();
+    grids.insert(grids.begin(), surface);
+    return grids;
+}
+
+template <typename PointDataGridT,
+    typename AttributeTypes,
+    typename RadiusT,
+    typename SdfT,
+    typename FilterT,
+    typename InterrupterT>
+GridPtrVec
+rasterizeSmoothSpheres(const PointDataGridT& points,
+                 const std::string& radius,
+                 const Real radiusScale,
+                 const Real searchRadius,
+                 const std::vector<std::string>& attributes,
+                 const Real halfband,
+                 math::Transform::Ptr transform,
+                 const FilterT& filter,
+                 InterrupterT* interrupter)
+{
+    using namespace rasterize_sdf_internal;
+    using PointDataTreeT = typename PointDataGridT::TreeType;
+    using RadTreeT = typename PointDataTreeT::template ValueConverter<RadiusT>::Type;
+
+    if (!transform) transform = points.transform().copy();
+    const Real vs = transform->voxelSize()[0];
+    const float background = static_cast<float>(vs * halfband);
+    const Real indexSpaceSearch = searchRadius / vs;
+
+    RadiusT min(0), max(0);
+    typename RadTreeT::Ptr mintree(new RadTreeT), maxtree(new RadTreeT);
+    points::evalMinMax<RadiusT, UnknownCodec>
+        (points.tree(), radius, min, max, filter, mintree.get(), maxtree.get());
+
+    // search distance at the SDF transform
+    const RadiusT indexSpaceScale = RadiusT(radiusScale / vs);
+    typename SdfT::Ptr surface =
+        initVariableSdf<SdfT, InterrupterT>
+            (points, transform, background, *mintree, *maxtree,
+                indexSpaceScale, halfband, interrupter);
+    mintree.reset();
+    maxtree.reset();
+
+    auto leaf = points.constTree().cbeginLeaf();
+    if (!leaf) return GridPtrVec(1, surface);
+
+    // max possible index space search radius
+    const size_t width = static_cast<size_t>(math::RoundUp(indexSpaceSearch));
+
+    const size_t ridx = leaf->attributeSet().find(radius);
+    if (ridx == AttributeSet::INVALID_POS) {
+        OPENVDB_THROW(RuntimeError, "Failed to find radius attribute");
+    }
+
+    VaryingRadius<RadiusT> rad(ridx, indexSpaceScale);
+    if (interrupter) interrupter->start("Rasterizing particles to level set using variable Zhu-Bridson");
+
+    GridPtrVec grids =
+        rasterizeSurface<SdfT, AveragePositionTransfer, AttributeTypes, InterrupterT>
+            (points, attributes, filter, *surface, interrupter,
+                width, rad, indexSpaceSearch, points.transform(), *surface); // args
+
+    tools::pruneInactive(surface->tree());
+    if (interrupter) interrupter->end();
+    grids.insert(grids.begin(), surface);
+    return grids;
+}
+
+} // namespace points
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif //OPENVEB_POINTS_RASTERIZE_SDF_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/points/PointRasterizeTrilinear.h
+++ b/openvdb/openvdb/points/PointRasterizeTrilinear.h
@@ -1,0 +1,430 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+//
+/// @author Nick Avramoussis
+///
+/// @file PointTransferSchemes.h
+///
+/// @brief Transfer schemes for rasterizing point data
+///
+
+#ifndef OPENVEB_POINTS_RASTERIZE_TRILINEAR_HAS_BEEN_INCLUDED
+#define OPENVEB_POINTS_RASTERIZE_TRILINEAR_HAS_BEEN_INCLUDED
+
+#include <openvdb/openvdb.h>
+#include <openvdb/Types.h>
+#include <openvdb/Grid.h>
+#include <openvdb/math/Math.h>
+#include <openvdb/math/Transform.h>
+#include <openvdb/tools/Morphology.h>
+#include <openvdb/tree/ValueAccessor.h>
+
+#include "PointDataGrid.h"
+#include "PointMask.h"
+#include "PointTransfer.h"
+
+#include <string>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+///
+template <typename ValueT, bool Staggered = true>
+struct TrilinearTraits
+{
+    using ResultT = typename std::conditional<
+        VecTraits<ValueT>::IsVec, ValueT, math::Vec3<ValueT>>::type;
+    template <typename PointDataTreeT>
+    using TreeT = typename PointDataTreeT::template ValueConverter<ResultT>::Type;
+};
+
+///
+template <typename ValueT>
+struct TrilinearTraits<ValueT, false>
+{
+    using ResultT = ValueT;
+    template <typename PointDataTreeT>
+    using TreeT = typename PointDataTreeT::template ValueConverter<ResultT>::Type;
+};
+
+/// @brief Threaded method to perform a weighted rasterization of all points within a voxel
+/// @details Accumulates values and weights according to a simple 0-1-0 weighted hat function.
+///          This algorithm is an exact inverse of a trilinear interpolation and thus a key method
+///          used in PIC/FLIP style simulations. Returns a grid of the same precision as the input
+///          source attribute.
+///
+/// @tparam Staggered whether to perform a staggered rasterization
+/// @param points     the PointDataGrid used to hold the point set to be rasterized
+/// @param attribute  the name of the source attribute to rasterize
+/// @param exclude    the group of names to exclude
+template <bool Staggered,
+    typename ValueT,
+    typename FilterT = NullFilter,
+    typename PointDataTreeT = PointDataTree>
+inline typename TrilinearTraits<ValueT, Staggered>::template
+    TreeT<PointDataTreeT>::Ptr
+rasterizeTrilinear(const PointDataTreeT& points,
+           const std::string& attribute,
+           const FilterT& filter = NullFilter());
+
+///////////////////////////////////////////////////
+///////////////////////////////////////////////////
+
+namespace rasterize_trilinear_internal {
+
+template <typename TreeType,
+          typename PositionCodecT,
+          typename SourceValueT,
+          typename SourceCodecT>
+struct TrilinearTransfer : public VolumeTransfer<TreeType>
+{
+    using BaseT = VolumeTransfer<TreeType>;
+    using WeightT = typename TreeType::ValueType;
+    using PositionHandleT = points::AttributeHandle<Vec3f, PositionCodecT>;
+    using SourceHandleT = points::AttributeHandle<SourceValueT, SourceCodecT>;
+
+    // precision of kernel arithmetic - aliased to the floating point
+    // element type of the source attribute.
+    using SourceElementT = typename ValueTraits<SourceValueT>::ElementType;
+    using RealT = SourceElementT;
+
+    static_assert(std::is_floating_point<SourceElementT>::value,
+        "Trilinear rasterization only supports floating point values.");
+
+    static const Index NUM_VALUES = TreeType::LeafNodeType::NUM_VALUES;
+
+    TrilinearTransfer(const size_t pidx,
+        const size_t sidx, TreeType& tree)
+        : BaseT(tree)
+        , mPIdx(pidx)
+        , mSIdx(sidx)
+        , mPHandle()
+        , mSHandle()
+        , mWeights() {}
+
+    TrilinearTransfer(const TrilinearTransfer& other)
+        : BaseT(other)
+        , mPIdx(other.mPIdx)
+        , mSIdx(other.mSIdx)
+        , mPHandle()
+        , mSHandle()
+        , mWeights() {}
+
+    //// @note Kernel value evaluator
+    static inline RealT value(const RealT x)
+    {
+        const RealT abs_x = std::fabs(x);
+        if (abs_x < RealT(1.0)) return RealT(1.0) - abs_x;
+        return RealT(0.0);
+    }
+
+    inline static Int32 range() { return 1; }
+    inline Int32 range(const Coord&, size_t) const { return this->range(); }
+
+    inline void initialize(const Coord& origin, const size_t idx, const CoordBBox& bounds)
+    {
+        this->BaseT::initialize(origin, idx, bounds);
+        mWeights.fill(openvdb::zeroVal<WeightT>());
+    }
+
+    inline bool startPointLeaf(const PointDataTree::LeafNodeType& leaf)
+    {
+        mPHandle.reset(new PositionHandleT(leaf.constAttributeArray(mPIdx)));
+        mSHandle.reset(new SourceHandleT(leaf.constAttributeArray(mSIdx)));
+        return true;
+    }
+
+    inline bool endPointLeaf(const PointDataTree::LeafNodeType&) { return true; }
+
+protected:
+    const size_t mPIdx;
+    const size_t mSIdx;
+    typename PositionHandleT::UniquePtr mPHandle;
+    typename SourceHandleT::UniquePtr mSHandle;
+    std::array<WeightT, NUM_VALUES> mWeights;
+};
+
+template <typename TreeType,
+          typename PositionCodecT,
+          typename SourceValueT,
+          typename SourceCodecT>
+struct StaggeredTransfer :
+    public TrilinearTransfer<TreeType, PositionCodecT, SourceValueT, SourceCodecT>
+{
+    using BaseT = TrilinearTransfer<TreeType, PositionCodecT, SourceValueT, SourceCodecT>;
+    using RealT = typename BaseT::RealT;
+    using BaseT::value;
+
+    static_assert(VecTraits<typename TreeType::ValueType>::IsVec,
+        "Target Tree must be a vector tree for staggered rasterization");
+
+    static const Index DIM = TreeType::LeafNodeType::DIM;
+    static const Index LOG2DIM = TreeType::LeafNodeType::LOG2DIM;
+
+    StaggeredTransfer(const size_t pidx,
+        const size_t sidx, TreeType& tree)
+        : BaseT(pidx, sidx, tree) {}
+
+    void rasterizePoint(const Coord& ijk,
+                    const Index id,
+                    const CoordBBox& bounds)
+    {
+        CoordBBox intersectBox(ijk.offsetBy(-1), ijk.offsetBy(1));
+        intersectBox.intersect(bounds);
+        if (intersectBox.empty()) return;
+
+        auto* const data = this->buffer();
+        const auto& mask = *(this->mask());
+
+        const math::Vec3<RealT> P(this->mPHandle->get(id));
+        const SourceValueT s(this->mSHandle->get(id));
+
+        math::Vec3<RealT> centerw, macw;
+
+        const Coord& a(intersectBox.min());
+        const Coord& b(intersectBox.max());
+        for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+            // @todo can probably simplify the double call to value() in some way
+            const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
+            const RealT x = static_cast<RealT>(c.x()-ijk.x()); // distance from ijk to c
+            centerw[0] = value(P.x() - x); // center dist
+            macw.x() = value(P.x() - (x-RealT(0.5))); // mac dist
+
+            for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                const Index ij = i + ((c.y() & (DIM-1u)) << LOG2DIM);
+                const RealT y = static_cast<RealT>(c.y()-ijk.y());
+                centerw[1] = value(P.y() - y);
+                macw.y() = value(P.y() - (y-RealT(0.5)));
+
+                for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                    assert(bounds.isInside(c));
+                    const Index offset = ij + /*k*/(c.z() & (DIM-1u));
+                    if (!mask.isOn(offset)) continue;
+                    const RealT z = static_cast<RealT>(c.z()-ijk.z());
+                    centerw[2] = value(P.z() - z);
+                    macw.z() = value(P.z() - (z-RealT(0.5)));
+
+                    const math::Vec3<RealT> r {
+                        (macw[0] * centerw[1] * centerw[2]),
+                        (macw[1] * centerw[0] * centerw[2]),
+                        (macw[2] * centerw[0] * centerw[1])
+                    };
+
+                    data[offset] += s * r;
+                    this->mWeights[offset] += r;
+                }
+            }
+        }
+    }
+
+    inline bool finalize(const Coord&, const size_t)
+    {
+        auto* const data = this->buffer();
+        const auto& mask = *(this->mask());
+
+        for (auto iter = mask.beginOn(); iter; ++iter) {
+            const Index offset = iter.pos();
+            const auto& w = this->mWeights[offset];
+            auto& v = data[offset];
+            if (!math::isZero(w[0])) v[0] /= w[0];
+            if (!math::isZero(w[1])) v[1] /= w[1];
+            if (!math::isZero(w[2])) v[2] /= w[2];
+        }
+
+        return true;
+    }
+};
+
+template <typename TreeType,
+          typename PositionCodecT,
+          typename SourceValueT,
+          typename SourceCodecT>
+struct CellCenteredTransfer :
+    public TrilinearTransfer<TreeType, PositionCodecT, SourceValueT, SourceCodecT>
+{
+    using BaseT = TrilinearTransfer<TreeType, PositionCodecT, SourceValueT, SourceCodecT>;
+    using RealT = typename BaseT::RealT;
+    using BaseT::value;
+
+    static const Index DIM = TreeType::LeafNodeType::DIM;
+    static const Index LOG2DIM = TreeType::LeafNodeType::LOG2DIM;
+
+    CellCenteredTransfer(const size_t pidx,
+        const size_t sidx, TreeType& tree)
+        : BaseT(pidx, sidx, tree) {}
+
+    void rasterizePoint(const Coord& ijk,
+                    const Index id,
+                    const CoordBBox& bounds)
+    {
+        const Vec3f P(this->mPHandle->get(id));
+
+        // build area of influence depending on point position
+        CoordBBox intersectBox(ijk, ijk);
+        if (P.x() < 0.0f) intersectBox.min().x() -= 1;
+        else              intersectBox.max().x() += 1;
+        if (P.y() < 0.0f) intersectBox.min().y() -= 1;
+        else              intersectBox.max().y() += 1;
+        if (P.z() < 0.0f) intersectBox.min().z() -= 1;
+        else              intersectBox.max().z() += 1;
+        assert(intersectBox.volume() == 8);
+
+        intersectBox.intersect(bounds);
+        if (intersectBox.empty()) return;
+
+        auto* const data = this->buffer();
+        const auto& mask = *(this->mask());
+
+        const SourceValueT s(this->mSHandle->get(id));
+        math::Vec3<RealT> centerw;
+
+        const Coord& a(intersectBox.min());
+        const Coord& b(intersectBox.max());
+        for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+            const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
+            const RealT x = static_cast<RealT>(c.x()-ijk.x()); // distance from ijk to c
+            centerw[0] = value(P.x() - x); // center dist
+
+            for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                const Index ij = i + ((c.y() & (DIM-1u)) << LOG2DIM);
+                const RealT y = static_cast<RealT>(c.y()-ijk.y());
+                centerw[1] = value(P.y() - y);
+
+                for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                    assert(bounds.isInside(c));
+                    const Index offset = ij + /*k*/(c.z() & (DIM-1u));
+                    if (!mask.isOn(offset)) continue;
+                    const RealT z = static_cast<RealT>(c.z()-ijk.z());
+                    centerw[2] = value(P.z() - z);
+
+                    assert(centerw[0] >= 0.0f && centerw[0] <= 1.0f);
+                    assert(centerw[1] >= 0.0f && centerw[1] <= 1.0f);
+                    assert(centerw[2] >= 0.0f && centerw[2] <= 1.0f);
+
+                    const RealT weight = centerw.product();
+                    data[offset] += s * weight;
+                    this->mWeights[offset] += weight;
+                }
+            }
+        }
+    }
+
+    inline bool finalize(const Coord&, const size_t)
+    {
+        auto* const data = this->buffer();
+        const auto& mask = *(this->mask());
+
+        for (auto iter = mask.beginOn(); iter; ++iter) {
+            const Index offset = iter.pos();
+            const auto& w = this->mWeights[offset];
+            auto& v = data[offset];
+            if (!math::isZero(w)) v /= w;
+        }
+        return true;
+    }
+};
+
+template <bool Staggered,
+    typename ValueT,
+    typename CodecT,
+    typename PositionCodecT,
+    typename FilterT,
+    typename PointDataTreeT>
+inline typename TrilinearTraits<ValueT, Staggered>::template
+    TreeT<PointDataTreeT>::Ptr
+rasterizeTrilinear(const PointDataTreeT& points,
+           const size_t pidx,
+           const size_t sidx,
+           const FilterT& filter)
+{
+    using TraitsT = TrilinearTraits<ValueT, Staggered>;
+    using TargetTreeT = typename TraitsT::template TreeT<PointDataTree>;
+    using TransferT = typename std::conditional<Staggered,
+            StaggeredTransfer<TargetTreeT, PositionCodecT, ValueT, CodecT>,
+            CellCenteredTransfer<TargetTreeT, PositionCodecT, ValueT, CodecT>
+        >::type;
+
+    typename TargetTreeT::Ptr tree(new TargetTreeT);
+    if (std::is_same<FilterT, NullFilter>::value) {
+        tree->topologyUnion(points);
+    }
+    else {
+        using MaskTreeT = typename PointDataTreeT::template ValueConverter<ValueMask>::Type;
+        auto mask = convertPointsToMask<PointDataTreeT, MaskTreeT>(points, filter);
+        tree->topologyUnion(*mask);
+    }
+
+    TransferT transfer(pidx, sidx, *tree);
+    tools::dilateActiveValues(*tree, transfer.range(),
+        tools::NN_FACE_EDGE_VERTEX, tools::EXPAND_TILES);
+
+    rasterize<PointDataTreeT, TransferT>(points, transfer, filter);
+    return tree;
+}
+
+} // namespace rasterize_trilinear_internal
+
+///////////////////////////////////////////////////
+
+template <bool Staggered,
+    typename ValueT,
+    typename FilterT,
+    typename PointDataTreeT>
+inline typename TrilinearTraits<ValueT, Staggered>::template
+    TreeT<PointDataTreeT>::Ptr
+rasterizeTrilinear(const PointDataTreeT& points,
+           const std::string& attribute,
+           const FilterT& filter)
+{
+    using TraitsT = TrilinearTraits<ValueT, Staggered>;
+    using TargetTreeT = typename TraitsT::template TreeT<PointDataTree>;
+
+    const auto iter = points.cbeginLeaf();
+    if (!iter) return typename TargetTreeT::Ptr(new TargetTreeT);
+
+    const AttributeSet::Descriptor& descriptor = iter->attributeSet().descriptor();
+    const size_t pidx = descriptor.find("P");
+    const size_t sidx = descriptor.find(attribute);
+    if (pidx == AttributeSet::INVALID_POS) {
+        OPENVDB_THROW(RuntimeError, "Failed to find position attribute");
+    }
+    if (sidx == AttributeSet::INVALID_POS) {
+        OPENVDB_THROW(RuntimeError, "Failed to find source attribute");
+    }
+
+    const NamePair& ptype = descriptor.type(pidx);
+    const NamePair& stype = descriptor.type(sidx);
+    if (ptype.second == NullCodec::name()) {
+        if (stype.second == NullCodec::name()) {
+            return rasterize_trilinear_internal::rasterizeTrilinear
+                <Staggered, ValueT, NullCodec, NullCodec>
+                    (points, pidx, sidx, filter);
+        }
+        else {
+            return rasterize_trilinear_internal::rasterizeTrilinear
+                <Staggered, ValueT, UnknownCodec, NullCodec>
+                    (points, pidx, sidx, filter);
+        }
+    }
+    else {
+        if (stype.second == NullCodec::name()) {
+            return rasterize_trilinear_internal::rasterizeTrilinear
+                <Staggered, ValueT, NullCodec, UnknownCodec>
+                    (points, pidx, sidx, filter);
+        }
+        else {
+            return rasterize_trilinear_internal::rasterizeTrilinear
+                <Staggered, ValueT, UnknownCodec, UnknownCodec>
+                    (points, pidx, sidx, filter);
+        }
+    }
+}
+
+
+} // namespace points
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif //OPENVEB_POINTS_RASTERIZE_TRILINEAR_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/points/PointTransfer.h
+++ b/openvdb/openvdb/points/PointTransfer.h
@@ -1,0 +1,582 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+//
+/// @author Nick Avramoussis
+///
+/// @file PointTransfer.h
+///
+/// @brief  Framework methods for rasterizing PointDataGrid data to Trees.
+///
+/// @details  Provides a generic inherited interface for deriving transfer
+///   schemes that represent how point data should be rasterized. The provided
+///   components together support the transfer of multiple attributes to
+///   arbitrary and multiple grid types. Target grids must have the same
+///   transform, but this transform can differ from the source PointDataGrid
+///   (multiple instantiations of rasterize() should instead be invoked to
+///   transfer to grids of different transforms). Arbitrary attributes can be
+///   accessed and transfered to arbitrary trees.
+///
+
+#ifndef OPENVEB_POINTS_TRANSFER_HAS_BEEN_INCLUDED
+#define OPENVEB_POINTS_TRANSFER_HAS_BEEN_INCLUDED
+
+#include <openvdb/openvdb.h>
+#include <openvdb/Types.h>
+#include <openvdb/Grid.h>
+#include <openvdb/math/Transform.h>
+#include <openvdb/util/NullInterrupter.h>
+#include <openvdb/thread/Threading.h>
+
+#include <type_traits>
+#include <tuple>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+/// @par A transfer scheme must be configured to call the provided
+///   rasterize methods. See below for an example or
+///   PointRasterizeSDF.h/PointRasterizeTrilinear.h for implementations.
+/// @code
+/// struct Transfer
+/// {
+///     /// @return Returns the tree topology to loop over. This can be different
+///     ///   from the destination tree i.e. This can act as a mask.
+///     inline auto& topology();
+///
+///     /// @brief  The maximum lookup range of this transfer scheme in index
+///     ///   space of the source points.
+///     /// @details The return value represent how far away from the destination
+///     ///   leaf node points should be accessed.
+///     /// @param origin  The leaf origin of the topology being accessed
+///     /// @param idx     The leaf index of the topology being accessed
+///     inline Int32 range(const Coord& origin, size_t idx) const;
+///
+///     /// @brief  The initialize function, called on each leaf which has valid
+///     ///   topology to write to.
+///     /// @param origin  The leaf origin of the topology being accessed
+///     /// @param idx     The leaf index of the topology being accessed
+///     /// @param bounds  The active voxel bounds of the leaf
+///     inline void initialize(const Coord& origin, size_t idx, const CoordBBox& bounds);
+///
+///     /// @brief  Run each time a point leaf is accessed. Typically this is
+///     ///  where attribute handles can be constructed
+///     /// @param leaf  The PointDataLeafNode which is being accessed.
+///     /// @return  Return true to continue rasterization, false to early exit
+///     ///   and skip the current leaf's contribution to the destination volume.
+///     inline bool startPointLeaf(const PointDataTree::LeafNodeType& leaf);
+///
+///     /// @brief  The point stamp function. Each point which contributes to
+///     ///  the current leaf will call this function exactly once.
+///     /// @param ijk  The current voxel containing the point being rasterized.
+///     ///   May be outside the destination leaf node depending on the range()
+///     /// @param id   The point index being rasterized
+///     /// @param bounds  The active bounds of the leaf node.
+///     void rasterizePoint(const Coord& ijk,
+///                     const Index id,
+///                     const CoordBBox& bounds);
+///
+///     /// @brief  Run each time a point leaf is finished with.
+///     /// @param leaf  The PointDataLeafNode which was being accessed.
+///     /// @return  Return true to continue rasterization, false to early exit
+///     ///   and stop rasterization to the destination leaf node.
+///     inline bool endPointLeaf(const PointDataTree::LeafNodeType& leaf);
+///
+///     /// @brief  The finalization function for the given destination tree(s).
+///     /// @param origin  The leaf origin of the topology being accessed
+///     /// @param idx     The leaf index of the topology being accessed
+///     /// @return  Return true to stop, false to recursively rasterize
+///     inline bool finalize(const Coord& origin, size_t idx);
+/// };
+/// @endcode
+///
+///
+/// Below is a full example using the native components.
+///
+/// @code
+/// /// @brief Sum point distances into a target float tree
+/// ///   Note: Using TransformTransfer to handle different index spaces, and
+/// ///   VolumeTransfer for automatic buffer setup
+/// struct MyTransfer :
+///     public TransformTransfer,
+///     public VolumeTransfer<FloatTree>
+/// {
+///     MyTransfer(FloatGrid& dest, const PointDataGrid& source)
+///         : TransformTransfer(source.transform(), dest.transform())
+///         , VolumeTransfer(dest.tree())
+///         , mHandle(nullptr) {}
+///
+///     MyTransfer(const MyTransfer& other)
+///         : TransformTransfer(other)
+///         , VolumeTransfer(other)
+///         , mHandle(nullptr) {}
+///
+///     /// @brief Range in index space of the source points
+///     Int32 range(const Coord&, size_t) const { return Int32(1); }
+///
+///     /// @brief Every time we start a new point leaf, init the position array.
+///     ///   Always return true as we don't skip any leaf nodes.
+///     bool startPointLeaf(const PointDataTree::LeafNodeType& leaf)
+///     {
+///         mHandle.reset(new AttributeHandle<Vec3f>(leaf.constAttributeArray("P"));
+///         return true;
+///     }
+///
+///     /// @brief  For each point, compute its relative index space position in
+///     ///   the destination tree and sum the length of its distance
+///     void rasterizePoint(const Coord& ijk, const Index id, const CoordBBox& bounds)
+///     {
+///         Vec3d P = ijk.asVec3d() + Vec3d(this->mHandle->get(id));
+///         P = this->transformSourceToTarget(P); // TransformTransfer::transformSourceToTarget
+///         // for each active voxel, accumulate distance
+///         const auto* mask = this->mask(); // VolumeTransfer::mask
+///         for (auto& coord : bounds) {
+///             const Index voxel = FloatTree::LeafNodeType::coordToOffset(coord);
+///             if (!mask->isOn(voxel)) continue;
+///             Vec3d dist = coord.asVec3d() - P;
+///             this->buffer()[voxel] += dist.length(); // VolumeTransfer::buffer
+///         }
+///     }
+///
+///     /// @brief Return true for endPointLeaf() to continue, false for finalize() so
+///     ///   we don't recurse.
+///     bool endPointLeaf(const PointDataTree::LeafNodeType&) { return true; }
+///     bool finalize(const Coord&, size_t) { return false; }
+///
+/// private:
+///     std::unique_ptr<AttributeHandle<Vec3f>> mHandle;
+/// };
+/// @endcode
+
+
+/// @brief Perform potentially complex rasterization from a user defined
+///  transfer scheme.
+/// @details The method works by looping over a single Tree topology, looking
+///   up point data at a position relative to that topology and passing that
+///   data to a transfer scheme TransferT.
+/// @note  Each thread receives a copy of the transfer scheme object.
+/// @param points       the point data grid to rasterize
+/// @param transfer     the transfer scheme
+/// @param filter       optional point filter
+/// @param threaded     whether to multithread
+/// @param interrupter  optional interrupter
+template <typename PointDataTreeOrGridT,
+    typename TransferT,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+inline void
+rasterize(const PointDataTreeOrGridT& points,
+          TransferT& transfer,
+          const FilterT& filter = NullFilter(),
+          const bool threaded = true,
+          InterrupterT* interrupter = nullptr);
+
+
+///////////////////////////////////////////////////
+
+/// @brief  The TransformTransfer module should be used if the source transform
+///   of the input points and the target transforms of the destination volumes
+///   differ. The default rasterizer will skip index to world (and vice versa)
+///   transformations unless a transfer scheme derives from a TransformTransfer.
+struct TransformTransfer
+{
+    TransformTransfer(const math::Transform& st,
+        const math::Transform& tt)
+        : mSourceTransform(st)
+        , mTargetTransform(tt) {}
+
+    template <typename T>
+    inline auto transformSourceToTarget(const T& value) const
+    {
+        const auto result = mSourceTransform.indexToWorld(value);
+        return mTargetTransform.worldToIndex(result);
+    }
+
+    template <typename T>
+    inline auto transformTargetToSource(const T& value) const
+    {
+        const auto result = mTargetTransform.indexToWorld(value);
+        return mSourceTransform.worldToIndex(result);
+    }
+
+    const math::Transform& sourceTransform() const { return mSourceTransform; }
+    const math::Transform& targetTransform() const { return mTargetTransform; }
+
+private:
+    const math::Transform& mSourceTransform;
+    const math::Transform& mTargetTransform;
+};
+
+/// @brief  The VolumeTransfer module provides methods to automatically setup
+///   and access destination buffers for multiple target volumes of arbitrary
+///   types. Deriving from a VolumeTransfer ensures that the available
+///   buffers correlate to the order of the provided tree arguments.
+template <typename ...TreeTypes>
+struct VolumeTransfer
+{
+    static const size_t Size = sizeof...(TreeTypes);
+    using TreeTupleT = std::tuple<TreeTypes*...>;
+
+    template <size_t Idx> using TreeType = typename std::tuple_element<Idx, std::tuple<TreeTypes...>>::type;
+    template <size_t Idx> using ValueType = typename TreeType<Idx>::ValueType;
+    template <typename T> struct TypeResolver { using Type = typename T::ValueType; };
+    using NodeMaskT = typename TreeType<0>::LeafNodeType::NodeMaskType;
+
+    VolumeTransfer(TreeTypes*... trees);
+
+    VolumeTransfer(TreeTypes&... trees)
+        : VolumeTransfer(&trees...) {}
+
+    VolumeTransfer(const VolumeTransfer& other)
+        : mTreeArray(other.mTreeArray)
+        , mBuffers()
+        , mMasks()
+    {
+        mBuffers.fill(nullptr);
+        mMasks.fill(nullptr);
+    }
+
+    inline TreeType<0>& topology() { return *(std::get<0>(mTreeArray)); }
+
+    inline void initialize(const Coord& origin, const size_t, const CoordBBox&);
+
+    template <size_t Idx>
+    inline ValueType<Idx>* buffer()
+    {
+        return static_cast<ValueType<Idx>*>(mBuffers[Idx]);
+    }
+
+    template <size_t Idx>
+    inline const ValueType<Idx>* buffer() const
+    {
+        return static_cast<ValueType<Idx>*>(mBuffers[Idx]);
+    }
+
+    template <size_t Idx>
+    inline NodeMaskT* mask() { return mMasks[Idx]; }
+    inline NodeMaskT* mask(const size_t idx) { return mMasks[idx]; }
+
+    template <size_t Idx>
+    inline const NodeMaskT* mask() const { return mMasks[Idx]; }
+    inline const NodeMaskT* mask(const size_t idx) const { return mMasks[idx]; }
+
+    template <typename FunctorT>
+    inline void foreach(const FunctorT& functor);
+
+private:
+    const TreeTupleT mTreeArray;
+    std::array<void*, Size> mBuffers;
+    std::array<NodeMaskT*, Size> mMasks;
+};
+
+/// @brief  VolumeTransfer specialization for a single target volume
+/// @todo this specialization should avoid the probe
+template <typename TreeT>
+struct VolumeTransfer<TreeT>
+{
+    using TreeType = TreeT;
+    using ValueType = typename TreeType::ValueType;
+    using NodeMaskT = typename TreeType::LeafNodeType::NodeMaskType;
+
+    static_assert(std::is_base_of<TreeBase, TreeType>::value,
+        "One or more template arguments to VolumeTransfer "
+        "are not a valid openvdb::Tree type.");
+
+    VolumeTransfer(TreeType* tree)
+        : mTree(tree)
+        , mBuffer(nullptr)
+        , mMask(nullptr) {
+        assert(tree);
+    }
+
+    VolumeTransfer(TreeType& tree)
+        : VolumeTransfer(&tree) {}
+
+    VolumeTransfer(const VolumeTransfer& other)
+        : mTree(other.mTree)
+        , mBuffer(nullptr)
+        , mMask(nullptr) {}
+
+    inline TreeType& topology() { return *mTree; }
+
+    inline void initialize(const Coord& origin, const size_t, const CoordBBox&)
+    {
+        assert(mTree);
+        if (auto leaf = mTree->probeLeaf(origin)) {
+            mBuffer = leaf->buffer().data();
+            mMask = &(leaf->getValueMask());
+        }
+        else {
+            mBuffer = nullptr;
+            mMask = nullptr;
+        }
+    }
+
+    inline ValueType* buffer() { return mBuffer; }
+    inline const ValueType* buffer() const { return mBuffer; }
+    inline NodeMaskT* mask() { return mMask; }
+    inline const NodeMaskT* mask() const { return mMask; }
+
+    // compatibility with multi tree containers
+    template <size_t> inline ValueType* buffer() { return this->buffer(); }
+    template <size_t> inline const ValueType* buffer() const { return this->buffer(); }
+    template <size_t> inline NodeMaskT* mask() { return this->mask(); }
+    template <size_t> inline const NodeMaskT* mask() const { return this->mask(); }
+
+private:
+    TreeType* const mTree;
+    ValueType* mBuffer;
+    NodeMaskT* mMask;
+};
+
+namespace transfer_internal
+{
+template<typename T, typename F, size_t... Is>
+void foreach(T&& t, const F& func, std::integer_sequence<size_t, Is...>)
+{
+    auto init = { (func(std::get<Is>(t), Is), 0)... };
+    (void)init;
+}
+
+template<typename T, typename F, size_t... Is>
+void foreach(void** buffers, const F& func, std::integer_sequence<size_t, Is...>)
+{
+    int init[sizeof...(Is)] = {
+        (func(static_cast<typename std::tuple_element<Is, T>::type*>
+            (*(buffers + Is)), Is), 0)...
+    };
+}
+
+template<typename T, template <typename> class R, typename F, size_t... Is>
+void foreach(void** buffers, const F& func, std::integer_sequence<size_t, Is...>)
+{
+    int init[sizeof...(Is)] = {
+        (func(static_cast<typename R<typename std::tuple_element<Is, T>::type>::Type*>
+           (*(buffers + Is)), Is), 0)...
+    };
+}
+}
+
+template <typename ...TreeTypes>
+VolumeTransfer<TreeTypes...>::VolumeTransfer(TreeTypes*... trees)
+    : mTreeArray({ trees... })
+    , mBuffers()
+    , mMasks()
+{
+    transfer_internal::foreach(mTreeArray, [](auto&& tree, const size_t) {
+        using TreeT = typename std::remove_pointer<typename std::decay<decltype(tree)>::type>::type;
+        static_assert(std::is_base_of<TreeBase, TreeT>::value,
+            "One or more template arguments to VolumeTransfer "
+            "are not a valid openvdb::Tree type.");
+        assert(tree);
+    }, std::make_integer_sequence<size_t, Size>());
+
+    mBuffers.fill(nullptr);
+    mMasks.fill(nullptr);
+}
+
+template <typename ...TreeTypes>
+inline void VolumeTransfer<TreeTypes...>::initialize(const Coord& origin, const size_t, const CoordBBox&)
+{
+    transfer_internal::foreach(mTreeArray,
+        [&](auto&& tree, const size_t i) {
+            assert(tree);
+            if (auto leaf = tree->probeLeaf(origin)) {
+                mBuffers[i] = static_cast<void*>(leaf->buffer().data());
+                mMasks[i] = &(leaf->getValueMask());
+            }
+            else {
+                mBuffers[i] = nullptr;
+                mMasks[i] = nullptr;
+            }
+        }, std::make_integer_sequence<size_t, Size>());
+}
+
+template <typename ...TreeTypes>
+template <typename FunctorT>
+inline void VolumeTransfer<TreeTypes...>::foreach(const FunctorT& functor)
+{
+    transfer_internal::foreach<TreeTupleT, TypeResolver>(mBuffers.data(), functor,
+        std::make_integer_sequence<size_t, Size>());
+}
+
+namespace transfer_internal
+{
+template <typename TransferT,
+          typename TopologyT,
+          typename PointFilterT = points::NullFilter,
+          typename InterrupterT = util::NullInterrupter>
+struct RasterizePoints
+{
+    using LeafManagerT = tree::LeafManager<TopologyT>;
+    using LeafNodeT = typename LeafManagerT::LeafNodeType;
+
+    static const Index DIM = TopologyT::LeafNodeType::DIM;
+    static const Int32 DIM32 = static_cast<Int32>(DIM);
+    static const Index LOG2DIM = TopologyT::LeafNodeType::LOG2DIM;
+
+    RasterizePoints(const points::PointDataTree& tree,
+                    const TransferT& transfer,
+                    const PointFilterT& filter = PointFilterT(),
+                    InterrupterT* interrupter = nullptr)
+        : mPointAccessor(tree)
+        , mTransfer(transfer)
+        , mFilter(filter)
+        , mInterrupter(interrupter) {}
+
+    void operator()(LeafNodeT& leaf, const size_t idx) const
+    {
+        if (util::wasInterrupted(mInterrupter)) {
+            thread::cancelGroupExecution();
+            return;
+        }
+
+        const Coord& origin = leaf.origin();
+        auto& mask = leaf.getValueMask();
+
+        CoordBBox bounds;
+
+        bool state;
+        if (mask.isConstant(state)) {
+            if (!state) return; // all inactive
+            else bounds = leaf.getNodeBoundingBox();
+        }
+        else {
+            // Use evalActiveBoundingBox over getNodeBoundingBox()
+            // to get a better approximation
+            leaf.evalActiveBoundingBox(bounds);
+            assert(!bounds.empty());
+        }
+
+        mTransfer.initialize(origin, idx, bounds);
+
+        CoordBBox search = bounds.expandBy(mTransfer.range(origin, idx));
+        this->transform<>(search);
+
+        // start the iteration from a leaf origin
+        const Coord min = (search.min() & ~(DIM-1));
+        const Coord& max = search.max();
+        PointFilterT localFilter(mFilter);
+
+        // loop over overlapping leaf nodes
+        Coord leafOrigin;
+        for (leafOrigin[0] = min[0]; leafOrigin[0] <= max[0]; leafOrigin[0]+=DIM32) {
+            for (leafOrigin[1] = min[1]; leafOrigin[1] <= max[1]; leafOrigin[1]+=DIM32) {
+                for (leafOrigin[2] = min[2]; leafOrigin[2] <= max[2]; leafOrigin[2]+=DIM32) {
+
+                    // if no overlap, continue
+                    CoordBBox pbox = CoordBBox::createCube(leafOrigin, DIM32);
+                    pbox.intersect(search);
+                    if (pbox.empty()) continue;
+
+                    // if no points, continue
+                    const auto* pointLeaf = mPointAccessor.probeConstLeaf(leafOrigin);
+                    if (!pointLeaf) continue;
+                    if (!mTransfer.startPointLeaf(*pointLeaf)) continue;
+                    localFilter.reset(*pointLeaf);
+
+                    // loop over point voxels which contribute to this leaf
+                    const Coord& pmin(pbox.min());
+                    const Coord& pmax(pbox.max());
+                    for (Coord ijk = pmin; ijk.x() <= pmax.x(); ++ijk.x()) {
+                        const Index i = ((ijk.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
+                        for (ijk.y() = pmin.y(); ijk.y() <= pmax.y(); ++ijk.y()) {
+                            const Index ij = i + ((ijk.y() & (DIM-1u)) << LOG2DIM);
+                            for (ijk.z() = pmin.z(); ijk.z() <= pmax.z(); ++ijk.z()) {
+                                // voxel should be in this points leaf
+                                assert((ijk & ~(DIM-1u)) == leafOrigin);
+                                const Index index = ij + /*k*/(ijk.z() & (DIM-1u));
+                                const Index end = pointLeaf->getValue(index);
+                                Index id = (index == 0) ? 0 : Index(pointLeaf->getValue(index - 1));
+                                for (; id < end; ++id) {
+                                    if (!localFilter.valid(&id)) continue;
+                                    mTransfer.rasterizePoint(ijk, id, bounds);
+                                } //point idx
+                            }
+                        }
+                    } // outer point voxel
+
+                    if (!mTransfer.endPointLeaf(*pointLeaf)) {
+                        // rescurse if necessary
+                        if (!mTransfer.finalize(origin, idx)) {
+                            this->operator()(leaf, idx);
+                        }
+                        return;
+                    }
+                }
+            }
+        } // outer leaf node
+
+        // rescurse if necessary
+        if (!mTransfer.finalize(origin, idx)) {
+            this->operator()(leaf, idx);
+        }
+    }
+
+    void operator()(const typename LeafManagerT::LeafRange& range) const
+    {
+        for (auto leaf = range.begin(); leaf; ++leaf) {
+            (*this)(*leaf, leaf.pos());
+        }
+    }
+
+private:
+
+    template <typename EnableT = TransferT>
+    typename std::enable_if<std::is_base_of<TransformTransfer, EnableT>::value>::type
+    transform(CoordBBox& bounds) const
+    {
+        const TransformTransfer* transform =
+            static_cast<TransformTransfer*>(&mTransfer);
+        const BBoxd bbox(bounds.min().asVec3d(), bounds.max().asVec3d());
+        bounds = transform->sourceTransform().worldToIndexCellCentered(
+            transform->targetTransform().indexToWorld(bbox));
+    }
+
+    template <typename EnableT = TransferT>
+    typename std::enable_if<!std::is_base_of<TransformTransfer, EnableT>::value>::type
+    transform(CoordBBox&) const {}
+
+private:
+    const PointDataGrid::ConstAccessor mPointAccessor;
+    mutable TransferT mTransfer;
+    const PointFilterT& mFilter;
+    InterrupterT* mInterrupter;
+};
+
+} // namespace transfer_internal
+
+///////////////////////////////////////////////////
+///////////////////////////////////////////////////
+
+template <typename PointDataTreeOrGridT,
+    typename TransferT,
+    typename FilterT,
+    typename InterrupterT>
+inline void
+rasterize(const PointDataTreeOrGridT& points,
+          TransferT& transfer,
+          const FilterT& filter,
+          const bool threaded,
+          InterrupterT* interrupter)
+{
+    using PointTreeT = typename TreeAdapter<PointDataTreeOrGridT>::TreeType;
+    static_assert(std::is_base_of<TreeBase, PointTreeT>::value,
+        "Provided points to rasterize is not a derived TreeBase type.");
+
+    const auto& tree = TreeAdapter<PointDataTreeOrGridT>::tree(points);
+
+    auto& topology = transfer.topology();
+    using TreeT = typename std::decay<decltype(topology)>::type;
+    tree::LeafManager<TreeT> manager(topology);
+    transfer_internal::RasterizePoints<TransferT, TreeT, FilterT, InterrupterT>
+        raster(tree, transfer, filter, interrupter);
+    manager.foreach(raster, threaded);
+}
+
+} // namespace points
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif //OPENVEB_POINTS_TRANSFER_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/points/PointTransfer.h
+++ b/openvdb/openvdb/points/PointTransfer.h
@@ -159,7 +159,6 @@ namespace points {
 /// @param points       the point data grid to rasterize
 /// @param transfer     the transfer scheme
 /// @param filter       optional point filter
-/// @param threaded     whether to multithread
 /// @param interrupter  optional interrupter
 template <typename PointDataTreeOrGridT,
     typename TransferT,
@@ -169,7 +168,6 @@ inline void
 rasterize(const PointDataTreeOrGridT& points,
           TransferT& transfer,
           const FilterT& filter = NullFilter(),
-          const bool threaded = true,
           InterrupterT* interrupter = nullptr);
 
 
@@ -558,7 +556,6 @@ inline void
 rasterize(const PointDataTreeOrGridT& points,
           TransferT& transfer,
           const FilterT& filter,
-          const bool threaded,
           InterrupterT* interrupter)
 {
     using PointTreeT = typename TreeAdapter<PointDataTreeOrGridT>::TreeType;
@@ -572,7 +569,7 @@ rasterize(const PointDataTreeOrGridT& points,
     tree::LeafManager<TreeT> manager(topology);
     transfer_internal::RasterizePoints<TransferT, TreeT, FilterT, InterrupterT>
         raster(tree, transfer, filter, interrupter);
-    manager.foreach(raster, threaded);
+    manager.foreach(raster);
 }
 
 } // namespace points

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -146,6 +146,8 @@ else()
     TestPointMask.cc
     TestPointMove.cc
     TestPointPartitioner.cc
+    TestPointRasterizeSDF.cc
+    TestPointRasterizeTrilinear.cc
     TestPointSample.cc
     TestPointScatter.cc
     TestPointStatistics.cc

--- a/openvdb/openvdb/unittest/TestPointMask.cc
+++ b/openvdb/openvdb/unittest/TestPointMask.cc
@@ -50,6 +50,11 @@ TEST_F(TestPointMask, testMask)
 
         EXPECT_EQ(points->tree().activeVoxelCount(), Index64(4));
         EXPECT_EQ(mask->tree().activeVoxelCount(), Index64(4));
+
+        // also test tree function signature
+        auto maskTree = convertPointsToMask(points->tree());
+        EXPECT_EQ(maskTree->activeVoxelCount(), Index64(4));
+        EXPECT_TRUE(maskTree->hasSameTopology(mask->tree()));
     }
 
     { // mask grid instead of bool grid

--- a/openvdb/openvdb/unittest/TestPointRasterizeSDF.cc
+++ b/openvdb/openvdb/unittest/TestPointRasterizeSDF.cc
@@ -1,11 +1,11 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: MPL-2.0
 
-#include <gtest/gtest.h>
-
 #include <openvdb/openvdb.h>
 #include <openvdb/points/PointRasterizeSDF.h>
 #include "PointBuilder.h"
+
+#include <gtest/gtest.h>
 
 using namespace openvdb;
 

--- a/openvdb/openvdb/unittest/TestPointRasterizeSDF.cc
+++ b/openvdb/openvdb/unittest/TestPointRasterizeSDF.cc
@@ -1,0 +1,1138 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+
+#include <openvdb/openvdb.h>
+#include <openvdb/points/PointRasterizeSDF.h>
+#include "PointBuilder.h"
+
+using namespace openvdb;
+
+class TestPointRasterizeSDF: public ::testing::Test
+{
+public:
+    void SetUp() override { openvdb::initialize(); }
+    void TearDown() override { openvdb::uninitialize(); }
+}; // class TestPointRasterizeSDF
+
+
+template <typename FilterT>
+struct FixedSpheres
+{
+    FixedSpheres(const FilterT& f = FilterT()) : filter(f) {}
+
+    FloatGrid::Ptr surface(const Real radius)
+    {
+        auto sdf = points::rasterizeSpheres(*points, radius, halfband, transform, filter);
+        sdf->setName("fixed");
+        return sdf;
+    }
+
+    template <typename AttList>
+    GridPtrVec surface(const Real radius, const std::vector<std::string>& attrs)
+    {
+        auto grids = points::rasterizeSpheres<points::PointDataGrid, AttList>
+            (*points, radius, attrs, halfband, transform, filter);
+        grids.front()->setName("fixed");
+        return grids;
+    }
+
+    FloatGrid::Ptr surfaceSmooth(const Real radius, const Real search)
+    {
+        auto sdf = points::rasterizeSmoothSpheres(*points, radius, search, halfband, transform, filter);
+        sdf->setName("fixed_avg");
+        return sdf;
+    }
+
+    template <typename AttList>
+    GridPtrVec surfaceSmooth(const Real radius, const Real search, const std::vector<std::string>& attrs)
+    {
+        auto grids = points::rasterizeSmoothSpheres<points::PointDataGrid, AttList>
+            (*points, radius, search, attrs, halfband, transform, filter);
+        grids.front()->setName("fixed_avg");
+        return grids;
+    }
+
+    FilterT filter;
+    double halfband = LEVEL_SET_HALF_WIDTH;
+    points::PointDataGrid::Ptr points = nullptr;
+    math::Transform::Ptr transform = nullptr;
+};
+
+template <typename FilterT>
+struct VariableSpheres : public FixedSpheres<FilterT>
+{
+    VariableSpheres(const FilterT& f = FilterT()) : FixedSpheres<FilterT>(f) {}
+
+    FloatGrid::Ptr surface(const Real scale = 1.0, const std::string& pscale = "pscale")
+    {
+        auto sdf = points::rasterizeSpheres(*(this->points), pscale, scale,
+            this->halfband, this->transform, this->filter);
+        sdf->setName("variable");
+        return sdf;
+    }
+
+    template <typename AttList>
+    GridPtrVec surface(const Real scale, const std::string& pscale, const std::vector<std::string>& attrs)
+    {
+        auto grids = points::rasterizeSpheres<points::PointDataGrid, AttList>
+            (*(this->points), pscale, attrs, scale, this->halfband, this->transform, this->filter);
+        grids.front()->setName("variable");
+        return grids;
+    }
+
+    FloatGrid::Ptr surfaceSmooth(const Real scale, const Real search, const std::string& pscale)
+    {
+        auto sdf = points::rasterizeSmoothSpheres(*(this->points), pscale, scale, search,
+                        this->halfband, this->transform, this->filter);
+        sdf->setName("variable_avg");
+        return sdf;
+    }
+
+    template <typename AttList>
+    GridPtrVec surfaceSmooth(const Real scale, const Real search, const std::string& pscale, const std::vector<std::string>& attrs)
+    {
+        auto grids = points::rasterizeSmoothSpheres<points::PointDataGrid, AttList>
+            (*(this->points), pscale, scale, search, attrs, this->halfband, this->transform, this->filter);
+        grids.front()->setName("variable_avg");
+        return grids;
+    }
+};
+
+
+TEST_F(TestPointRasterizeSDF, testRasterizeSpheres)
+{
+    // Test no points
+    {
+        float radius = 0.2f;
+        FixedSpheres<points::NullFilter> s;
+        s.halfband = 3;
+        s.points = PointBuilder({}).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surface(radius);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+    }
+
+    // Test single point
+    {
+        FixedSpheres<points::NullFilter> s;
+
+        // small radius, small voxel size
+        float radius = 0.2f;
+        s.halfband = 3;
+        s.points = PointBuilder({Vec3f(0)}).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surface(radius);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(8), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(485), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            float length = float(ws.length()); // dist to center
+            length -= radius; // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // should only have exterior background
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_EQ(sdf->background(), *iter);
+        }
+
+        // larger radius, larger voxel size
+        radius = 1.3f;
+        s.halfband = 3;
+        s.points = PointBuilder({Vec3f(0)}).voxelsize(0.5).get();
+        s.transform = nullptr;
+
+        sdf = s.surface(radius);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(8), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(739), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            float length = float(ws.length()); // dist to center
+            length -= radius; // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // should only have exterior background
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_EQ(sdf->background(), *iter);
+        }
+
+        // offset position, different transform, larger half band
+        Vec3f center(-1.2f, 3.4f,-5.6f);
+        radius = 2.0f;
+        s.halfband = 4;
+        s.points = PointBuilder({center}).voxelsize(0.1).get();
+        s.transform = math::Transform::createLinearTransform(0.3);
+
+        sdf = s.surface(radius);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == *s.transform);
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.transform->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(27), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(5005), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord()) - center;
+            float length = float(ws.length()); // dist to center
+            length -= radius; // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // check off values
+        size_t interiorOff = 0, exteriorOff = 0;
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord()) - center;
+            float length = float(ws.length()); // dist to center
+            // if length is <= the (rad - halfbandws), voxel is inside the surface
+            const bool interior = (length <= (radius - (s.halfband * s.transform->voxelSize()[0])));
+            if (interior) EXPECT_EQ(-sdf->background(), *iter);
+            else          EXPECT_EQ(sdf->background(), *iter);
+            interior ? ++interiorOff : ++exteriorOff;
+        }
+
+        EXPECT_EQ(size_t(80), interiorOff);
+        EXPECT_EQ(size_t(82438), exteriorOff);
+    }
+
+    // Test multiple points - 8 points at cube corner positions
+    {
+        FixedSpheres<points::NullFilter> s;
+        float radius = 0.2f;
+        auto positions = getBoxPoints(/*scale*/0.0f);
+
+        // test points overlapping all at 0,0,0 - should produce the same grid as first test
+        s.halfband = 3;
+        s.points = PointBuilder(positions).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surface(radius);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(8), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(485), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            float length = float(ws.length()); // dist to center
+            length -= radius; // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // should only have exterior background
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_EQ(sdf->background(), *iter);
+        }
+
+        // test points from a box with coords at 0.5
+        positions = getBoxPoints(/*scale*/0.5f);
+        radius = 0.2f;
+        s.halfband = 3;
+        s.points = PointBuilder(positions).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        sdf = s.surface(radius);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(38), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(485*8), sdf->tree().activeVoxelCount()); // 485 per sphere
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            // get closest dist from all points
+            float length = std::numeric_limits<float>::max();
+            for (auto& pos : positions) length = std::min(length, float((ws-pos).length()));
+            length -= radius; // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // should only have exterior background
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_EQ(sdf->background(), *iter);
+        }
+
+        // test points from a box with coords at 3, rad 10 so
+        // overlapping and rotated/scaled/translated transform
+
+        const double deg2rad = math::pi<double>() / 180.0;
+        Mat4R mat(Mat4R::identity()); // voxelsize = 1
+        mat.preRotate(math::Z_AXIS, deg2rad*99.0);
+        mat.preRotate(math::Y_AXIS, deg2rad*66.0);
+        mat.preRotate(math::X_AXIS, deg2rad*33.0);
+        mat.preScale(Vec3d(1.5));
+        mat.preTranslate(Vec3d(-1,2,-3));
+
+        positions = getBoxPoints(/*scale*/3.0f);
+        radius = 10.0f;
+        s.halfband = 3;
+        s.points = PointBuilder(positions).voxelsize(0.1).get();
+        s.transform = math::Transform::createLinearTransform(mat);
+
+        sdf = s.surface(radius);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == *s.transform);
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.transform->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(46), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(7198), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            // get closest dist from all points
+            float length = std::numeric_limits<float>::max();
+            for (auto& pos : positions) length = std::min(length, float((ws-pos).length()));
+            length -= radius; // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // check off values
+        size_t interiorOff = 0, exteriorOff = 0;
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            // get closest dist from all points
+            float length = std::numeric_limits<float>::max();
+            for (auto& pos : positions) length = std::min(length, float((ws-pos).length()));
+            // if length is <= the (rad - halfbandws), voxel is inside the surface
+            const bool interior = (length <= (radius - (s.halfband * s.transform->voxelSize()[0])));
+            if (interior) EXPECT_EQ(-sdf->background(), *iter);
+            else          EXPECT_EQ(sdf->background(), *iter);
+            interior ? ++interiorOff : ++exteriorOff;
+        }
+
+        EXPECT_EQ(size_t(1049), interiorOff);
+        EXPECT_EQ(size_t(310163), exteriorOff);
+    }
+
+    // Test point filter
+    {
+        // test alternativing points from a box with coords at 0.5
+        // spheres end up on a single face and don't overlap
+        std::vector<Vec3f> positions = getBoxPoints(/*scale*/0.5f);
+        float radius = 0.2f;
+        auto points = PointBuilder(positions)
+            .voxelsize(0.1)
+            .group({1,0,1,0,1,0,1,0}, "test")
+            .get();
+        points::GroupFilter filter("test", points->tree().cbeginLeaf()->attributeSet());
+        FixedSpheres<points::GroupFilter> s(filter);
+        s.halfband = 3;
+        s.points = points;
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surface(radius);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(17), sdf->tree().leafCount()); // less leaf nodes, active points are on a single face
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(485*4), sdf->tree().activeVoxelCount()); // 485 per sphere
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            // get closest dist from all points
+            float length = std::numeric_limits<float>::max();
+            for (auto& pos : positions) length = std::min(length, float((ws-pos).length()));
+            length -= radius; // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // should only have exterior background
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_EQ(sdf->background(), *iter);
+        }
+    }
+}
+
+
+TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
+{
+    // First few tests check that the results are fp equivalent to fixed spheres
+
+    // Test no points
+    {
+        VariableSpheres<points::NullFilter> s;
+        s.halfband = 3;
+        s.points = PointBuilder({}).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surface();
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+    }
+
+    // Test single point
+    {
+        VariableSpheres<points::NullFilter> s;
+        float radius = 0.2f;
+
+        // small radius, small voxel size
+        s.halfband = 3;
+        s.points = PointBuilder({ Vec3f(0) }).voxelsize(0.1).attribute(radius, "pscale").get();
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surface();
+        FloatGrid::Ptr comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(comp && comp->getName() == "fixed");
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+
+        // larger radius, larger voxel size
+        radius = 1.3f;
+        s.halfband = 3;
+        s.points = PointBuilder({ Vec3f(0) }).voxelsize(0.5).attribute(radius, "pscale").get();
+        s.transform = nullptr;
+
+        sdf = s.surface();
+        comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(comp && comp->getName() == "fixed");
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+
+        // offset position, different transform, larger half band
+        Vec3f center(-1.2f, 3.4f,-5.6f);
+        radius = 2.0f;
+        s.halfband = 4;
+        s.points =PointBuilder({ center }).voxelsize(0.1).attribute(radius, "pscale").get();
+        s.transform = math::Transform::createLinearTransform(0.3);
+
+        sdf = s.surface();
+        comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(comp && comp->getName() == "fixed");
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+    }
+
+    // Test multiple points - 8 points at cube corner positions
+    {
+        VariableSpheres<points::NullFilter> s;
+        float radius = 0.2f;
+        auto positions = getBoxPoints(/*scale*/0.0f);
+        // test points overlapping all at 0,0,0 - should produce the same grid as first test
+        s.halfband = 3;
+        s.points = PointBuilder(positions).voxelsize(0.1).attribute(radius, "pscale").get();
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surface();
+        FloatGrid::Ptr comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(comp && comp->getName() == "fixed");
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+
+        // test points from a box with coords at 0.5
+        radius = 0.2f;
+        positions = getBoxPoints(/*scale*/0.5f);
+        s.halfband = 3;
+        s.points = PointBuilder(positions).voxelsize(0.1).attribute(radius, "pscale").get();
+        s.transform = nullptr;
+
+        sdf = s.surface();
+        comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(comp && comp->getName() == "fixed");
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+
+        // test points from a box with coords at 3, rad 10 so
+        // overlapping and rotated/scaled/translated transform
+
+        const double deg2rad = math::pi<double>() / 180.0;
+        Mat4R mat(Mat4R::identity()); // voxelsize = 1
+        mat.preRotate(math::Z_AXIS, deg2rad*99.0);
+        mat.preRotate(math::Y_AXIS, deg2rad*66.0);
+        mat.preRotate(math::X_AXIS, deg2rad*33.0);
+        mat.preScale(Vec3d(1.5));
+        mat.preTranslate(Vec3d(-1,2,-3));
+
+        radius = 10.0f;
+        positions = getBoxPoints(/*scale*/3.0f);
+        s.halfband = 3;
+        s.points = PointBuilder(positions).voxelsize(0.1).attribute(radius, "pscale").get();
+        s.transform = math::Transform::createLinearTransform(mat);
+
+        sdf = s.surface();
+        comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(comp && comp->getName() == "fixed");
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+    }
+
+    // Test point filter
+    {
+        // test alternativing points from a box with coords at 0.5
+        // spheres end up on a single face and don't overlap
+        std::vector<Vec3f> positions = getBoxPoints(/*scale*/0.5f);
+        float radius = 0.2f;
+        auto points = PointBuilder(positions)
+            .voxelsize(0.1)
+            .group({1,0,1,0,1,0,1,0}, "test")
+            .attribute(radius, "pscale")
+            .get();
+        points::GroupFilter filter("test", points->tree().cbeginLeaf()->attributeSet());
+        VariableSpheres<points::GroupFilter> s(filter);
+        s.halfband = 3;
+        s.points = points;
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surface();
+        FloatGrid::Ptr comp = s.FixedSpheres<points::GroupFilter>::surface(radius);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(comp && comp->getName() == "fixed");
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+    }
+
+    // Test multiple points with different radius values
+    {
+        std::vector<Vec3f> positions = getBoxPoints(/*scale*/0.5f);
+        std::vector<float> rads = {1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f};
+        float radscale = 0.5f;
+
+        auto points = PointBuilder(positions)
+            .voxelsize(0.2)
+            .attribute(rads, "myrad")
+            .get();
+
+        VariableSpheres<points::NullFilter> s;
+        s.halfband = 1; // small half band
+        s.points = points;
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surface(radscale, "myrad");
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(8), sdf->tree().leafCount()); // less leaf nodes, active points are on a single face
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(1454), sdf->tree().activeVoxelCount()); // 485 per sphere
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            // get closest dist from all points including rad
+            float length = std::numeric_limits<float>::max();
+            for (size_t i = 0; i < positions.size(); ++i) {
+                length = std::min(length, float((ws-positions[i]).length()) - (rads[i] * radscale));
+            }
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // check off values
+        size_t interiorOff = 0, exteriorOff = 0;
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            // get closest dist from all points
+            float length = std::numeric_limits<float>::max();
+            for (size_t i = 0; i < positions.size(); ++i) {
+                length = std::min(length, float((ws-positions[i]).length()) - (rads[i] * radscale));
+            }
+            // if length is <= the (rad - halfbandws), voxel is inside the surface
+            const bool interior = (length <= (s.halfband * sdf->voxelSize()[0]));
+            if (interior) EXPECT_EQ(-sdf->background(), *iter);
+            else          EXPECT_EQ(sdf->background(), *iter);
+            interior ? ++interiorOff : ++exteriorOff;
+        }
+
+        EXPECT_EQ(size_t(664), interiorOff);
+        EXPECT_EQ(size_t(296874), exteriorOff);
+    }
+}
+
+
+TEST_F(TestPointRasterizeSDF, testRasterizeSmoothSpheres)
+{
+    // Test no points
+    {
+        float radius = 0.2f, search = 0.4f;
+        FixedSpheres<points::NullFilter> s;
+        s.halfband = 3;
+        s.points = PointBuilder({}).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surfaceSmooth(radius, search);
+        EXPECT_TRUE(sdf && sdf->getName() == "fixed_avg");
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+    }
+
+    // Test single point
+    {
+        FixedSpheres<points::NullFilter> s;
+        s.halfband = 3;
+        s.points = PointBuilder({ Vec3f(0) }).voxelsize(0.1).get();
+        s.transform = nullptr;
+        double radius = 0.2, search = 0.0; // 0.0 search = no result
+
+        FloatGrid::Ptr sdf = s.surfaceSmooth(radius, search);
+        EXPECT_TRUE(sdf && sdf->getName() == "fixed_avg");
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+
+        // result should be exactly the same as normal rasterizeSphere
+        s.halfband = 3; // half band equal to search radius to ensure same topology
+        s.transform = nullptr;
+        radius = 0.2, search = 0.6;
+
+        sdf = s.surfaceSmooth(radius, search);
+        FloatGrid::Ptr comp = s.surface(radius);
+        EXPECT_TRUE(sdf && sdf->getName() == "fixed_avg");
+        EXPECT_TRUE(comp && comp->getName() == "fixed");
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+
+        // Test exterior half band limit
+        s.halfband = 3;
+        s.transform = nullptr;
+        radius = 0.5, search = 5; // search of 5 allows for halfband size to up 10
+        sdf = s.surfaceSmooth(radius, search);
+        EXPECT_TRUE(sdf && sdf->getName() == "fixed_avg");
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            EXPECT_TRUE(*iter > -sdf->background());
+            EXPECT_TRUE(*iter < sdf->background());
+        }
+    }
+
+    // Test point filter
+    {
+        std::vector<Vec3f> positions = getBoxPoints(/*scale*/1.0f);
+        double radius = 0.6, search = 2.0;
+        auto points = PointBuilder(positions)
+            .voxelsize(0.1)
+            .group({1,0,0,0,0,0,0,0}, "test") // only first point
+            .get();
+        points::GroupFilter filter("test", points->tree().cbeginLeaf()->attributeSet());
+        FixedSpheres<points::GroupFilter> s(filter);
+        s.halfband = 3;
+        s.points = points;
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surfaceSmooth(radius, search);
+        EXPECT_TRUE(sdf && sdf->getName() == "fixed_avg");
+
+        // voxels values should be based on first position
+        Vec3f pos = positions.front();
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            float length = float((ws-pos).length() - radius); // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_TRUE(sdf->background() == *iter ||
+                -sdf->background() == *iter);
+        }
+    }
+
+    // Test multiple points - 8 points at cube corner positions
+    {
+        FixedSpheres<points::NullFilter> s;
+        // test points overlapping all at 0,0,0 - should produce the same grid as first test
+        auto positions = getBoxPoints(/*scale*/0.0f);
+        s.halfband = 3;
+        s.points = PointBuilder(positions).voxelsize(0.1).get();
+        s.transform = nullptr;
+        double radius = 0.2, search = 0.6; // radius * 3
+
+        FloatGrid::Ptr sdf = s.surfaceSmooth(radius, search);
+        FloatGrid::Ptr comp = s.surface(radius);
+        EXPECT_TRUE(sdf && sdf->getName() == "fixed_avg");
+        EXPECT_TRUE(comp && comp->getName() == "fixed");
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+
+        // test points from a box with coords at 0.5 and a search radius
+        // large enough to create a smoothed box
+        // @todo find a way to better test these values
+        positions = getBoxPoints(/*scale*/0.5f);
+        radius = 0.2, search = 1.2;
+        s.halfband = 3;
+        s.points = PointBuilder(positions).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        sdf = s.surfaceSmooth(radius, search);
+        EXPECT_TRUE(sdf && sdf->getName() == "fixed_avg");
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(44), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(6303), sdf->tree().activeVoxelCount());
+        const CoordBBox bounds(Coord(-7), Coord(7));
+        for (CoordBBox::XYZIterator iter(bounds); iter; ++iter) {
+            EXPECT_TRUE(sdf->tree().isValueOn(*iter));
+        }
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            EXPECT_TRUE(*iter > -sdf->background());
+            EXPECT_TRUE(*iter < sdf->background());
+        }
+        // should only have exterior background
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_EQ(sdf->background(), *iter);
+        }
+    }
+}
+
+
+TEST_F(TestPointRasterizeSDF, testRasterizeVariableSmoothSpheres)
+{
+    // Test no points
+    {
+        float radius = 0.2f, search = 0.4f;
+        VariableSpheres<points::NullFilter> s;
+        s.halfband = 3;
+        s.points = PointBuilder({}).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surfaceSmooth(radius, search, "pscale");
+        EXPECT_TRUE(sdf && sdf->getName() == "variable_avg");
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+    }
+
+    // Test single point
+    {
+        VariableSpheres<points::NullFilter> s;
+        s.halfband = 3;
+        s.points = PointBuilder({ Vec3f(0) }).voxelsize(0.1).attribute(0.2f, "rad").get();
+        s.transform = math::Transform::createLinearTransform(0.1);
+        double scale = 1.0, search = 0.0; // 0.0 search = no result
+
+        FloatGrid::Ptr sdf = s.surfaceSmooth(scale, search, "rad");
+        EXPECT_TRUE(sdf && sdf->getName() == "variable_avg");
+        EXPECT_TRUE(sdf->transform() == *s.transform);
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.transform->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+
+        // result should be exactly the same as normal rasterizeSphere
+        s.halfband = 3; // half band equal to search radius to ensure same topology
+        s.transform = math::Transform::createLinearTransform(0.1);
+        scale = 1.0;
+        search = 0.6;
+
+        sdf = s.surfaceSmooth(scale, search, "rad");
+        FloatGrid::Ptr comp = s.FixedSpheres<points::NullFilter>::surfaceSmooth(0.2, search);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable_avg");
+        EXPECT_TRUE(comp && comp->getName() == "fixed_avg");
+        EXPECT_TRUE(sdf->transform() == *s.transform);
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.transform->voxelSize()[0]), sdf->background());
+                EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+
+        // Test exterior half band limit and radius scale
+        s.halfband = 3;
+        s.points = PointBuilder({ Vec3f(0) }).voxelsize(0.1).attribute(0.4f, "rad").get();
+        s.transform = math::Transform::createLinearTransform(0.1);
+        scale = 0.5; // 0.4*0.5 = 0.2
+        search = 5; // search of 5 allows for halfband size to up 10
+        sdf = s.surfaceSmooth(scale, search, "rad");
+        comp = s.FixedSpheres<points::NullFilter>::surfaceSmooth(0.2, search);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable_avg");
+        EXPECT_TRUE(comp && comp->getName() == "fixed_avg");
+        EXPECT_TRUE(sdf->transform() == *s.transform);
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.transform->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
+        tools::foreach(sdf->cbeginValueAll(), [&comp](auto iter) {
+            auto val = comp->tree().getValue(iter.getCoord());
+            EXPECT_NEAR(val, *iter, 1e-6f);
+        });
+    }
+
+    // Test point filter
+    {
+        std::vector<Vec3f> positions = getBoxPoints(/*scale*/1.0f);
+        double radius = 1.0, scale = 0.6, search = 2.0;
+        auto points = PointBuilder(positions)
+            .voxelsize(0.1)
+            .group({1,0,0,0,0,0,0,0}, "test") // only first point
+            .attribute(float(radius), "pscale")
+            .get();
+        points::GroupFilter filter("test", points->tree().cbeginLeaf()->attributeSet());
+        VariableSpheres<points::GroupFilter> s(filter);
+        s.halfband = 3;
+        s.points = points;
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surfaceSmooth(scale, search, "pscale");
+        EXPECT_TRUE(sdf && sdf->getName() == "variable_avg");
+
+        // voxels values should be based on first position
+        Vec3f pos = positions.front();
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            float length = float((ws-pos).length() - (radius*scale)); // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_TRUE(sdf->background() == *iter ||
+                -sdf->background() == *iter);
+        }
+    }
+
+    // Test multiple points - 8 points at cube corner positions
+    {
+        // test points from a box with coords at 1.0 and a search radius
+        // large enough to create a smoothed box with each corner having
+        // a sphere of a different radius
+        // @todo find a way to better test these values
+        std::vector<Vec3f> positions = getBoxPoints(/*scale*/1.0f);
+        std::vector<float> rads = {1.1f, 1.3f, 1.5f, 1.7f, 2.1f, 2.3f, 2.5f, 2.7f};
+        double scale = 0.6, search = 2.0;
+
+        VariableSpheres<points::NullFilter> s;
+        s.halfband = 4; // large enough to fill interior of the cube
+        s.points = PointBuilder(positions).voxelsize(0.2).attribute(rads, "myrad").get();
+        s.transform = nullptr;
+
+        FloatGrid::Ptr sdf = s.surfaceSmooth(scale, search, "myrad");
+        EXPECT_TRUE(sdf && sdf->getName() == "variable_avg");
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_EQ(Index32(64), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(15011), sdf->tree().activeVoxelCount());
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            EXPECT_TRUE(*iter > -sdf->background());
+            EXPECT_TRUE(*iter < sdf->background());
+        }
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_TRUE(sdf->background() == *iter ||
+                -sdf->background() == *iter);
+        }
+    }
+}
+
+
+TEST_F(TestPointRasterizeSDF, testAttrTransfer)
+{
+    // Test no points
+    {
+        float radius = 0.2f, search = 0.4f;
+        FixedSpheres<points::NullFilter> s;
+        s.halfband = 3;
+        s.points = PointBuilder({}).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        GridPtrVec grids = s.surface<TypeList<>>(radius, {"test1", "test2"});
+        EXPECT_EQ(size_t(1), grids.size());
+        auto sdf = DynamicPtrCast<FloatGrid>(grids[0]);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+
+        grids = s.surfaceSmooth<TypeList<>>(radius, search, {"test1", "test2"});
+        EXPECT_EQ(size_t(1), grids.size());
+        sdf = DynamicPtrCast<FloatGrid>(grids[0]);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+    }
+
+    // Test 8 point attribute transfers for normal spheres and smooth spheres
+    {
+        FixedSpheres<points::NullFilter> s;
+
+        std::vector<Vec3f> positions = getBoxPoints(/*scale*/0.5f);
+        const std::vector<int64_t> test1data = {9,10,11,12,13,14,15,16};
+        const std::vector<double> test2data = {-1.1,-2.2,-3.3,-4.4,-5.5,-6.6,-7.7,-8.8};
+
+        // test cloest point transfer
+        float radius = 0.2f, search = 0.4f;
+        s.halfband = 1;
+        s.transform = nullptr;
+        s.points = PointBuilder(positions)
+            .voxelsize(0.1)
+            .attribute(test1data, "test1")
+            .attribute(test2data, "test2")
+            .get();
+
+        // check throw on invalid attr type list
+        EXPECT_THROW(s.surface<TypeList<>>(radius, {"test1", "test2"}), RuntimeError);
+        EXPECT_THROW(s.surface<TypeList<char>>(radius, {"test1", "test2"}), RuntimeError);
+        EXPECT_THROW(s.surfaceSmooth<TypeList<>>(radius, search, {"test1", "test2"}), RuntimeError);
+        EXPECT_THROW(s.surfaceSmooth<TypeList<char>>(radius, search, {"test1", "test2"}), RuntimeError);
+
+        // test both transfers
+        GridPtrVec grids1 = s.surface<TypeList<int64_t, double>>(radius, {"test1", "test2"});
+        GridPtrVec grids2 = s.surfaceSmooth<TypeList<int64_t, double>>(radius, search, {"test1", "test2"});
+        EXPECT_EQ(size_t(3), grids1.size());
+        EXPECT_EQ(size_t(3), grids2.size());
+
+        for (int i = 0; i < 2; ++ i) {
+            GridPtrVec grids = i == 0 ? grids1 : grids2;
+
+            auto sdf = DynamicPtrCast<FloatGrid>(grids[0]);
+            EXPECT_TRUE(sdf);
+            if (i == 0) EXPECT_TRUE(sdf->getName() == "fixed");
+            else        EXPECT_TRUE(sdf->getName() == "fixed_avg");
+            EXPECT_TRUE(sdf->transform() == s.points->transform());
+            EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+            EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+
+            if (i == 0) EXPECT_EQ(Index64(928), sdf->tree().activeVoxelCount());
+            else        EXPECT_EQ(Index64(856), sdf->tree().activeVoxelCount());
+
+            auto test1 = DynamicPtrCast<Int64Grid>(grids[1]);
+            EXPECT_TRUE(test1 && test1->getName() == "test1");
+            EXPECT_TRUE(sdf->transform() == test1->transform());
+            EXPECT_EQ(GRID_UNKNOWN, test1->getGridClass());
+            EXPECT_EQ(zeroVal<int64_t>(), test1->background());
+
+            auto test2 = DynamicPtrCast<DoubleGrid>(grids[2]);
+            EXPECT_TRUE(test2 && test2->getName() == "test2");
+            EXPECT_TRUE(sdf->transform() == test2->transform());
+            EXPECT_EQ(GRID_UNKNOWN, test2->getGridClass());
+            EXPECT_EQ(zeroVal<double>(), test2->background());
+
+            EXPECT_TRUE(sdf->tree().hasSameTopology(test1->tree()));
+            EXPECT_TRUE(sdf->tree().hasSameTopology(test2->tree()));
+
+            // check atributes that have been transfered are correct
+            for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+                const Coord ijk = iter.getCoord();
+                const Vec3d ws = sdf->transform().indexToWorld(ijk);
+                // get closest dist from all points including rad
+                float length = std::numeric_limits<float>::max();
+                size_t idx = 0;
+                for (size_t i = 0; i < positions.size(); ++i) {
+                    float min = float((ws-positions[i]).length()) - radius;
+                    if (min < length) {
+                        idx = i;
+                        length = min;
+                    }
+                }
+
+                EXPECT_TRUE(test1->tree().isValueOn(ijk));
+                EXPECT_TRUE(test2->tree().isValueOn(ijk));
+                EXPECT_EQ(test1data[idx], test1->tree().getValue(ijk));
+                EXPECT_EQ(test2data[idx], test2->tree().getValue(ijk));
+            }
+
+            tools::foreach(test1->cbeginValueOff(), [&sdf](auto iter) {
+                EXPECT_TRUE(!sdf->tree().isValueOn(iter.getCoord()));
+                EXPECT_EQ(zeroVal<int64_t>(), *iter);
+            });
+            tools::foreach(test2->cbeginValueOff(), [&sdf](auto iter) {
+                EXPECT_TRUE(!sdf->tree().isValueOn(iter.getCoord()));
+                EXPECT_EQ(zeroVal<double>(), *iter);
+            });
+        }
+    }
+}
+
+
+TEST_F(TestPointRasterizeSDF, testVariableAttrTransfer)
+{
+    // Test no points
+    {
+        float radius = 0.2f, search = 0.4f;
+        VariableSpheres<points::NullFilter> s;
+        s.halfband = 3;
+        s.points = PointBuilder({}).voxelsize(0.1).get();
+        s.transform = nullptr;
+
+        GridPtrVec grids = s.surface<TypeList<>>(radius, "pscale", {"test1", "test2"});
+        EXPECT_EQ(size_t(1), grids.size());
+        auto sdf = DynamicPtrCast<FloatGrid>(grids[0]);
+        EXPECT_TRUE(sdf && sdf->getName() == "variable");
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+
+        grids = s.surfaceSmooth<TypeList<>>(radius, search, "pscale", {"test1", "test2"});
+        EXPECT_EQ(size_t(1), grids.size());
+        sdf = DynamicPtrCast<FloatGrid>(grids[0]);
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == s.points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+    }
+
+    // Test 8 point attribute transfers - overlapping spheres with varying
+    // radii and a different target transform
+    {
+        VariableSpheres<points::NullFilter> s;
+
+        std::vector<Vec3f> positions = getBoxPoints(/*scale*/0.35f);
+        const std::vector<int64_t> test1data = {0,1,2,3,4,5,6,7};
+        const std::vector<double> test2data = {-1.1,-2.2,-3.3,-4.4,-5.5,-6.6,-7.7,-8.8};
+        const std::vector<float> rads = {1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f};
+        // @note search needs to be high enough here to pick up all
+        //   contributions to match normal sphere attribute transfer
+        const float radscale = 0.5, search = 3.0;
+
+        // test cloest point transfer
+        s.halfband = 3;
+        s.transform = math::Transform::createLinearTransform(0.3);
+        s.points = PointBuilder(positions)
+            .voxelsize(0.7)
+            .attribute(rads, "myrad")
+            .attribute(test1data, "test1")
+            .attribute(test2data, "test2")
+            .get();
+
+        // check throw on invalid attr type list
+        EXPECT_THROW(s.surface<TypeList<>>(radscale, "myrad", {"test1", "test2"}), RuntimeError);
+        EXPECT_THROW(s.surface<TypeList<char>>(radscale, "myrad", {"test1", "test2"}), RuntimeError);
+        EXPECT_THROW(s.surfaceSmooth<TypeList<>>(radscale, search, "myrad", {"test1", "test2"}), RuntimeError);
+        EXPECT_THROW(s.surfaceSmooth<TypeList<char>>(radscale, search, "myrad", {"test1", "test2"}), RuntimeError);
+
+        // test both transfers
+        GridPtrVec grids1 = s.surface<TypeList<int64_t, double>>(radscale, "myrad", {"test1", "test2"});
+        GridPtrVec grids2 = s.surfaceSmooth<TypeList<int64_t, double>>(radscale, search, "myrad", {"test1", "test2"});
+        EXPECT_EQ(size_t(3), grids1.size());
+        EXPECT_EQ(size_t(3), grids2.size());
+
+        for (int i = 0; i < 2; ++ i) {
+            GridPtrVec grids = i == 0 ? grids1 : grids2;
+
+            auto sdf = DynamicPtrCast<FloatGrid>(grids[0]);
+            EXPECT_TRUE(sdf);
+            if (i == 0) EXPECT_TRUE(sdf->getName() == "variable");
+            else        EXPECT_TRUE(sdf->getName() == "variable_avg");
+            EXPECT_TRUE(sdf->transform() == *s.transform);
+            EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+            EXPECT_EQ(float(s.halfband * s.transform->voxelSize()[0]), sdf->background());
+
+            if (i == 0) EXPECT_EQ(Index64(1525), sdf->tree().activeVoxelCount());
+            else        EXPECT_EQ(Index64(998), sdf->tree().activeVoxelCount());
+
+            auto test1 = DynamicPtrCast<Int64Grid>(grids[1]);
+            EXPECT_TRUE(test1 && test1->getName() == "test1");
+            EXPECT_TRUE(sdf->transform() == test1->transform());
+            EXPECT_EQ(GRID_UNKNOWN, test1->getGridClass());
+            EXPECT_EQ(zeroVal<int64_t>(), test1->background());
+
+            auto test2 = DynamicPtrCast<DoubleGrid>(grids[2]);
+            EXPECT_TRUE(test2 && test2->getName() == "test2");
+            EXPECT_TRUE(sdf->transform() == test2->transform());
+            EXPECT_EQ(GRID_UNKNOWN, test2->getGridClass());
+            EXPECT_EQ(zeroVal<double>(), test2->background());
+
+            EXPECT_TRUE(sdf->tree().hasSameTopology(test1->tree()));
+            EXPECT_TRUE(sdf->tree().hasSameTopology(test2->tree()));
+
+            // check atributes that have been transfered are correct
+            for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+                const Coord ijk = iter.getCoord();
+                const Vec3d ws = sdf->transform().indexToWorld(ijk);
+                // get closest dist from all points including rad
+                float length = std::numeric_limits<float>::max();
+                size_t idx = 0;
+                for (size_t i = 0; i < positions.size(); ++i) {
+                    float min = float((ws-positions[i]).length()) - (rads[i] * radscale);
+                    if (min < length) {
+                        idx = i;
+                        length = min;
+                    }
+                }
+
+                EXPECT_TRUE(test1->tree().isValueOn(ijk));
+                EXPECT_TRUE(test2->tree().isValueOn(ijk));
+                EXPECT_EQ(test1data[idx], test1->tree().getValue(ijk));
+                EXPECT_EQ(test2data[idx], test2->tree().getValue(ijk));
+            }
+
+            tools::foreach(test1->cbeginValueOff(), [&sdf](auto iter) {
+                EXPECT_TRUE(!sdf->tree().isValueOn(iter.getCoord()));
+                EXPECT_EQ(zeroVal<int64_t>(), *iter);
+            });
+            tools::foreach(test2->cbeginValueOff(), [&sdf](auto iter) {
+                EXPECT_TRUE(!sdf->tree().isValueOn(iter.getCoord()));
+                EXPECT_EQ(zeroVal<double>(), *iter);
+            });
+        }
+    }
+}

--- a/openvdb/openvdb/unittest/TestPointRasterizeTrilinear.cc
+++ b/openvdb/openvdb/unittest/TestPointRasterizeTrilinear.cc
@@ -1,0 +1,492 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2017-2020 Double Negative Visual Effects
+//
+///////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include <openvdb/openvdb.h>
+#include <openvdb/points/PointAttribute.h>
+#include <openvdb/points/PointCount.h>
+#include <openvdb/points/PointConversion.h>
+#include <openvdb/points/PointScatter.h>
+#include <openvdb/points/PointRasterizeTrilinear.h>
+
+using namespace openvdb;
+
+class TestPointRasterize: public ::testing::Test
+{
+public:
+    void SetUp() override { openvdb::initialize(); }
+    void TearDown() override { openvdb::uninitialize(); }
+}; // class TestPointRasterize
+
+struct DefaultTransfer
+{
+    inline bool startPointLeaf(const points::PointDataTree::LeafNodeType&) { return true; }
+    inline bool endPointLeaf(const points::PointDataTree::LeafNodeType&) { return true; }
+    inline bool finalize(const Coord&, size_t) { return true; }
+};
+
+template <typename T, bool Staggered>
+inline void testTrilinear(const T& v)
+{
+    static constexpr bool IsVec = ValueTraits<T>::IsVec;
+    using VecT = typename std::conditional<IsVec, T, math::Vec3<T>>::type;
+    using ResultValueT = typename std::conditional<Staggered && !IsVec, VecT, T>::type;
+    using ResultTreeT = typename points::PointDataTree::ValueConverter<ResultValueT>::Type;
+
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid, Vec3f>(positions, *transform);
+
+    points::appendAttribute<T>(points->tree(), "test", v);
+    TreeBase::Ptr tree =
+        points::rasterizeTrilinear<Staggered, T>(points->tree(), "test");
+
+    EXPECT_TRUE(tree);
+    typename ResultTreeT::Ptr typed = DynamicPtrCast<ResultTreeT>(tree);
+    EXPECT_TRUE(typed);
+
+    const ResultValueT result = typed->getValue(Coord(0,0,0));
+
+    // convert both to vecs even if they are scalars to avoid having
+    // to specialise this method
+    const VecT expected(v);
+    const VecT vec(result);
+    EXPECT_NEAR(expected[0], vec[0], 1e-6);
+    EXPECT_NEAR(expected[1], vec[1], 1e-6);
+    EXPECT_NEAR(expected[2], vec[2], 1e-6);
+}
+
+TEST_F(TestPointRasterize, testTrilinearRasterizeFloat)
+{
+    testTrilinear<float, false>(111.0f);
+    testTrilinear<float, true>(111.0f);
+}
+
+TEST_F(TestPointRasterize, testTrilinearRasterizeDouble)
+{
+    testTrilinear<double, false>(222.0);
+    testTrilinear<double, true>(222.0);
+}
+
+TEST_F(TestPointRasterize, testTrilinearRasterizeVec3f)
+{
+    testTrilinear<Vec3f, false>(Vec3f(111.0f,222.0f,333.0f));
+    testTrilinear<Vec3f, true>(Vec3f(111.0f,222.0f,333.0f));
+}
+
+TEST_F(TestPointRasterize, testTrilinearRasterizeVec3d)
+{
+    testTrilinear<Vec3d, false>(Vec3d(444.0,555.0,666.0));
+    testTrilinear<Vec3d, true>(Vec3d(444.0,555.0,666.0));
+}
+
+TEST_F(TestPointRasterize, testRasterizeWithFilter)
+{
+    struct CountPointsTransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<Int32Tree>
+    {
+        CountPointsTransferScheme(Int32Tree& tree)
+            : points::VolumeTransfer<Int32Tree>(&tree) {}
+
+        inline Int32 range(const Coord&, size_t) const { return 0; }
+        inline void rasterizePoint(const Coord& ijk,
+                        const Index,
+                        const CoordBBox&)
+        {
+            const Index offset = points::PointDataTree::LeafNodeType::coordToOffset(ijk);
+            auto* const data = this->template buffer<0>();
+            data[offset] += 1;
+        }
+    };
+
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    points::PointDataTree& tree = points->tree();
+    points::appendGroup(tree, "test");
+
+    auto groupHandle = tree.beginLeaf()->groupWriteHandle("test");
+    groupHandle.set(0, true);
+    groupHandle.set(1, false);
+    groupHandle.set(2, true);
+    groupHandle.set(3, false);
+
+    Int32Tree::Ptr intTree(new Int32Tree);
+    intTree->setValueOn(Coord(0,0,0));
+
+    CountPointsTransferScheme transfer(*intTree);
+    points::GroupFilter filter("test", tree.cbeginLeaf()->attributeSet());
+
+    points::rasterize(*points, transfer, filter);
+    const int count = intTree->getValue(Coord(0,0,0));
+    EXPECT_EQ(2, count);
+}
+
+TEST_F(TestPointRasterize, testRasterizeWithInitializeAndFinalize)
+{
+    struct LinearFunctionPointCountTransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<Int32Tree>
+    {
+        LinearFunctionPointCountTransferScheme(Int32Tree& tree) :
+            points::VolumeTransfer<Int32Tree>(&tree) {}
+
+        inline Int32 range(const Coord&, size_t) const { return 0; }
+
+        inline void initialize(const Coord& c, size_t i, const CoordBBox& b)
+        {
+            this->points::VolumeTransfer<Int32Tree>::initialize(c,i,b);
+            auto* const data = this->template buffer<0>();
+            const auto& mask = *(this->template mask<0>());
+            for (auto iter = mask.beginOn(); iter; ++iter) {
+                data[iter.pos()] += 10;
+            }
+        }
+
+        inline bool finalize(const Coord&, size_t)
+        {
+            auto* const data = this->template buffer<0>();
+            const auto& mask = *(this->template mask<0>());
+            for (auto iter = mask.beginOn(); iter; ++iter) {
+                data[iter.pos()] *= 2;
+            }
+            return true;
+        }
+
+        inline void rasterizePoint(const Coord& ijk, const Index, const CoordBBox&)
+        {
+            const Index offset = points::PointDataTree::LeafNodeType::coordToOffset(ijk);
+            auto* const data = this->template buffer<0>();
+            data[offset] += 1;
+        }
+    };
+
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    Int32Tree::Ptr intTree(new Int32Tree);
+    intTree->setValueOn(Coord(0,0,0));
+
+    LinearFunctionPointCountTransferScheme transfer(*intTree);
+    points::rasterize(*points, transfer);
+
+    const int value = intTree->getValue(Coord(0,0,0));
+    EXPECT_EQ(/*(10+4)*2*/28, value);
+}
+
+TEST_F(TestPointRasterize, tetsSingleTreeRasterize)
+{
+    struct CountPoints27TransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<Int32Tree>
+    {
+        CountPoints27TransferScheme(Int32Tree& tree)
+            : points::VolumeTransfer<Int32Tree>(&tree) {}
+
+        /// @brief  The maximum lookup range of this transfer scheme in voxels.
+        inline Int32 range(const Coord&, size_t) const { return 1; }
+
+        /// @brief  The point stamp function. Each point which contributes to the
+        ///         current leaf that the thread has access to will call this function
+        ///         exactly once.
+        /// @param ijk     The current voxel containing the point being rasterized. May
+        ///                not be inside the destination leaf nodes.
+        /// @param id      The point index being rasterized
+        /// @param bounds  The active bounds of the leaf node(s) being written to.
+        void rasterizePoint(const Coord& ijk, const Index, const CoordBBox& bounds)
+        {
+            static const Index DIM = Int32Tree::LeafNodeType::DIM;
+            static const Index LOG2DIM = Int32Tree::LeafNodeType::LOG2DIM;
+
+            CoordBBox intersectBox(ijk.offsetBy(-1), ijk.offsetBy(1));
+            intersectBox.intersect(bounds);
+            if (intersectBox.empty()) return;
+            auto* const data = this->template buffer<0>();
+            const auto& mask = *(this->template mask<0>());
+
+            // loop over voxels in this leaf which are affected by this point
+
+            const Coord& a(intersectBox.min());
+            const Coord& b(intersectBox.max());
+            for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+                const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM);
+                for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                    const Index j = ((c.y() & (DIM-1u)) << LOG2DIM);
+                    for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                        assert(bounds.isInside(c));
+                        const Index offset = i + j + /*k*/(c.z() & (DIM-1u));
+                        if (!mask.isOn(offset)) continue;
+                        data[offset] += 1;
+
+                    }
+                }
+            }
+        }
+    };
+
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.1f, 0.1f, 0.1f));
+    positions.emplace_back(Vec3f(0.2f, 0.2f, 0.2f));
+    positions.emplace_back(Vec3f(-0.1f,-0.1f,-0.1f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    Int32Tree::Ptr intTree(new Int32Tree);
+    intTree->setValueOn(Coord(0,0,0));
+    intTree->setValueOn(Coord(1,1,1));
+    intTree->setValueOn(Coord(-1,-1,-1));
+
+    CountPoints27TransferScheme transfer(*intTree);
+    points::rasterize(*points, transfer);
+
+    int count = intTree->getValue(Coord(0,0,0));
+    EXPECT_EQ(3, count);
+    count = intTree->getValue(Coord(1,1,1));
+    EXPECT_EQ(3, count);
+    count = intTree->getValue(Coord(-1,-1,-1));
+    EXPECT_EQ(2, count);
+}
+
+TEST_F(TestPointRasterize, testMultiTreeRasterize)
+{
+    /// @brief  An example multi tree transfer scheme which rasterizes a vector
+    ///         attribute into an int grid using length, and an int attribute
+    ///         into a vector grid. Based on a 27 lookup stencil.
+    ///
+    struct MultiTransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<Int32Tree, Vec3DTree>
+    {
+        using BaseT = points::VolumeTransfer<Int32Tree, Vec3DTree>;
+
+        MultiTransferScheme(const size_t vIdx,const size_t iIdx,
+                            Int32Tree& t1, Vec3DTree& t2)
+            : BaseT(t1, t2)
+            , mVIdx(vIdx), mIIdx(iIdx)
+            , mVHandle(), mIHandle() {}
+
+        MultiTransferScheme(const MultiTransferScheme& other)
+            : BaseT(other), mVIdx(other.mVIdx), mIIdx(other.mIIdx)
+            , mVHandle(), mIHandle() {}
+
+        inline Int32 range(const Coord&, size_t) const { return 1; }
+
+        inline bool startPointLeaf(const points::PointDataTree::LeafNodeType& leaf)
+        {
+            mVHandle = points::AttributeHandle<Vec3d>::create(leaf.constAttributeArray(mVIdx));
+            mIHandle = points::AttributeHandle<int>::create(leaf.constAttributeArray(mIIdx));
+            return true;
+        }
+
+        void rasterizePoint(const Coord& ijk, const Index id, const CoordBBox& bounds)
+        {
+            static const Index DIM = Int32Tree::LeafNodeType::DIM;
+            static const Index LOG2DIM = Int32Tree::LeafNodeType::LOG2DIM;
+
+            CoordBBox intersectBox(ijk.offsetBy(-1), ijk.offsetBy(1));
+            intersectBox.intersect(bounds);
+            if (intersectBox.empty()) return;
+
+            auto* const data1 = this->template buffer<0>();
+            auto* const data2 = this->template buffer<1>();
+            const auto& mask = *(this->template mask<0>());
+
+            // loop over voxels in this leaf which are affected by this point
+            const Vec3d& vec = mVHandle->get(id);
+            const int integer = mIHandle->get(id);
+
+            const Coord& a(intersectBox.min());
+            const Coord& b(intersectBox.max());
+            for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+                const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM);
+                for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                    const Index j = ((c.y() & (DIM-1u)) << LOG2DIM);
+                    for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                        assert(bounds.isInside(c));
+                        const Index offset = i + j + /*k*/(c.z() & (DIM-1u));
+                        if (!mask.isOn(offset)) continue;
+                        data1[offset] += static_cast<int>(vec.length());
+                        data2[offset] += Vec3d(integer);
+                    }
+                }
+            }
+        }
+
+    private:
+        const size_t mVIdx;
+        const size_t mIIdx;
+        points::AttributeHandle<Vec3d>::Ptr mVHandle;
+        points::AttributeHandle<int>::Ptr mIHandle;
+    };
+
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    points::PointDataTree& tree = points->tree();
+
+    const Vec3d vectorValue(444.0f,555.0f,666.0f);
+    points::appendAttribute<Vec3d>(tree, "testVec3d", vectorValue);
+    points::appendAttribute<int>(tree, "testInt", 7);
+
+    Vec3DTree::Ptr vecTree(new Vec3DTree);
+    Int32Tree::Ptr intTree(new Int32Tree);
+    vecTree->topologyUnion(tree);
+    intTree->topologyUnion(tree);
+
+    const points::PointDataTree::LeafNodeType& leaf = *(tree.cbeginLeaf());
+    const size_t vidx = leaf.attributeSet().descriptor().find("testVec3d");
+    const size_t iidx = leaf.attributeSet().descriptor().find("testInt");
+
+    MultiTransferScheme transfer(vidx, iidx, *intTree, *vecTree);
+    points::rasterize(*points, transfer);
+
+    const Vec3d vecResult = vecTree->getValue(Coord(0,0,0));
+    const int intResult = intTree->getValue(Coord(0,0,0));
+
+    EXPECT_EQ(7.0, vecResult[0]);
+    EXPECT_EQ(7.0, vecResult[1]);
+    EXPECT_EQ(7.0, vecResult[2]);
+    const int expected = static_cast<int>(vectorValue.length());
+    EXPECT_EQ(expected, intResult);
+}
+
+TEST_F(TestPointRasterize, testMultiTreeRasterizeWithMask)
+{
+    struct CountPointsMaskTransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<BoolTree, Int32Tree>
+    {
+        using BaseT = points::VolumeTransfer<BoolTree, Int32Tree>;
+        CountPointsMaskTransferScheme(BoolTree& t1, Int32Tree& t2)
+            : BaseT(t1, t2) {}
+
+        inline Int32 range(const Coord&, size_t) const { return 0; }
+        inline void rasterizePoint(const Coord& ijk, const Index, const CoordBBox&)
+        {
+            auto* const data = this->template buffer<1>();
+            const Index offset = points::PointDataTree::LeafNodeType::coordToOffset(ijk);
+            data[offset] += 1;
+        }
+    };
+
+    // Setup test data
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(1.0f, 1.0f, 1.0f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    Int32Tree::Ptr intTree(new Int32Tree);
+    BoolTree::Ptr topology(new BoolTree);
+    intTree->topologyUnion(points->tree());
+    topology->setValueOn(Coord(0,0,0));
+
+    EXPECT_TRUE(intTree->isValueOn(Coord(10,10,10)));
+
+    CountPointsMaskTransferScheme transfer(*topology, *intTree);
+    points::rasterize(*points, transfer);
+
+    int count = intTree->getValue(Coord(0,0,0));
+    EXPECT_EQ(1, count);
+    count = intTree->getValue(Coord(10,10,10));
+    EXPECT_EQ(0, count);
+}
+
+// void
+// TestPointRasterize::testMultiTreeRasterizeConstTopology()
+// {
+//     // Test const-ness is respected and works at compile time through
+//     // the points::rasterize function (transfer function signatures should
+//     // respect the const flag of the topology mask leaf nodes)
+
+//     struct CountPointsConstMaskTransferScheme
+//         : public DefaultTransfer,
+//         : public points::VolumeTransfer<const BoolTree, Int32Tree>
+//     {
+//         using VolumeTransferT =
+//             points::rasterize_tree_containers::MultiTreeRasterizer
+//                 <const BoolTree, Int32Tree>;
+
+//         using BufferT = VolumeTransferT::BufferT;
+//         using NodeMaskT = VolumeTransferT::NodeMaskT;
+
+//         static_assert(std::is_const<NodeMaskT>::value,
+//             "Node mask should be const");
+//         static_assert(std::is_const<VolumeTransferT::TopologyTreeT>::value,
+//             "TopologyTreeT should be const");
+
+//         inline Int32 range() const { return 0; }
+//         inline void initialize(BufferT, NodeMaskT&, const Coord&) {}
+//         inline void initLeaf(const points::PointDataTree::LeafNodeType&) {}
+//         inline void finalize(BufferT, NodeMaskT&, const Coord&) {}
+//         inline void rasterizePoint(const Coord&,
+//                         const Index,
+//                         const CoordBBox&,
+//                         BufferT,
+//                         NodeMaskT&) {}
+//     };
+
+//     points::PointDataTree tree;
+//     Int32Tree::Ptr intTree(new Int32Tree);
+//     BoolTree::Ptr topology(new BoolTree);
+
+//     CountPointsConstMaskTransferScheme transfer;
+//     CountPointsConstMaskTransferScheme::VolumeTransferT::TreeArrayT array = {intTree};
+//     CountPointsConstMaskTransferScheme::VolumeTransferT container(*topology, array);
+//     points::rasterize(tree, transfer, container);
+// }

--- a/openvdb/openvdb/unittest/TestPointRasterizeTrilinear.cc
+++ b/openvdb/openvdb/unittest/TestPointRasterizeTrilinear.cc
@@ -1,10 +1,5 @@
-///////////////////////////////////////////////////////////////////////////
-//
-// Copyright (c) 2017-2020 Double Negative Visual Effects
-//
-///////////////////////////////////////////////////////////////////////////
-
-#include <gtest/gtest.h>
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
 
 #include <openvdb/openvdb.h>
 #include <openvdb/points/PointAttribute.h>
@@ -12,6 +7,8 @@
 #include <openvdb/points/PointConversion.h>
 #include <openvdb/points/PointScatter.h>
 #include <openvdb/points/PointRasterizeTrilinear.h>
+
+#include <gtest/gtest.h>
 
 using namespace openvdb;
 


### PR DESCRIPTION
This is a draft pull request of the point transfer/rasterization framework and spherical, ZB and trilinear kernels. The final commit adds a dummy Houdini SOP which can be used to test the surfacing methods in Houdini, but I anticipate this to be left out of a final PR. Note that this PR also includes the PointStatistics #997 work.

Below are some preliminary timings. More data to be added (timings, images of results, surface comparisons etc).
**Input**: https://artifacts.aswf.io/io/aswf/openvdb/models/waterfall_points.vdb/1.0.0/waterfall_points.vdb-1.0.0.zip

----------------------------------------------------------------------------------------------------------------------------------------------

`tools::rasterizeSpheres()` vs `tools::ParticlesToLevelSet` (From Particle SOP)
No attribute transfers, no pscale on points (reads from parameter)

Target Voxel Size 0.1, Target  Half Band 3 
Input pscale | Old Time (ms) | New Time (ms) | Speedup
-- | -- | -- | -- 
0.1 | 2588.47 | 1764.82 | x1.467 
0.2 | 4435.08 | 2524.45 | x1.757 
0.5 | 17639.2 | 6946.8 | x2.539 
1.0 | 57238.1 | 16061.5 | x3.567

Input  pscale 0.1, Target  Half Band 3 
Target Voxel Size | Old Time (ms) | New Time (ms) | Speedup
-- | -- | -- | -- 
0.01 | 53369.9 | 25959.1 | x2.056 
0.1  | 2588.47 | 1764.82 | x1.467  
1.0  | 4260.55 | 2801.18 | x1.521 
5.0  | 8869.62 | 4194.94 | x2.114

Target Voxel Size 0.1, Input pscale 0.1,
Target Half Band | Old Time (ms) | New Time (ms) | Speedup
-- | -- | -- | -- 
1 | 739.048 | 479.244 | x1.542 
3 | 2588.47 | 1764.82 |  x1.467 
10 | 37725.9 | 19165.4 | x1.968 
15 | 118521 | 51222.2 |  x2.314

----------------------------------------------------------------------------------------------------------------------------------------------

`tools::rasterizeSpheres()` vs `tools::ParticlesToLevelSet` (VDB From Particle SOP)
6 attributes to transfer `v@v` (varying), `v@Cd` (varying), `int@id` (varying), `int64@a` (uniform), `float@b` (uniform). `float@c` (varying)
no pscale on points (reads from parameter)

Target Voxel Size 0.1, Target Half Band 3

Input pscale | Old Time (ms) | New Time (ms) | Speedup
-- | -- | -- | -- 
0.1 | 2815.53 | 1659.43 | x1.697 
0.2 | 4818.51 | 2828.60 | x1.703 
0.5 | 16674.90 | 6948.99 |  x2.4 
1   | 66442.40 | 16395.70 | x4.052 

----------------------------------------------------------------------------------------------------------------------------------------------

`tools::rasterizeSpheres()` vs `tools::ParticlesToLevelSet` (VDB From Particle SOP)
pscale on points (uniform and varying)

// more to document / upload

----------------------------------------------------------------------------------------------------------------------------------------------

`tools::rasterizeSpheres()` vs `tools::rasterizeSmoothSpheres`

This section compares the two new methods against each other and additionally compares `tools::rasterizeSmoothSpheres` against the VDB From Particle Fluid SOP. Note that the latter comparison is not strictly fair; the VDB From Particle Fluid SOP does not perform the exact same functionality as `tools::rasterizeSmoothSpheres`, but in all tests the `Limit Refinement` parameter is on and set to `0`, and the `Resample Input` parameter is `OFF`.

// more to document / upload

Target Voxel Size 0.075, Input Pscale 0.15, Influence Scale (for Smooth Spheres) 3
rasterizeSpheres  |  rasterizeSmoothSpheres
-- | --  
<img src="https://user-images.githubusercontent.com/4256455/111845288-71f5c380-88fc-11eb-82f1-4c57d75bebdc.png" width="500"> | <img src="https://user-images.githubusercontent.com/4256455/111845296-73bf8700-88fc-11eb-950b-02541ee8523c.png" width="500">
2643.64ms | 4361.73ms (x0.6)

Target Voxel Size 0.075, Input Pscale 0.15, Influence Scale (for Smooth Spheres) 3
VDB From Particle Fluid  |  rasterizeSmoothSpheres
-- | --  
<img src="https://user-images.githubusercontent.com/4256455/111845275-702c0000-88fc-11eb-9559-ccb6d51341e5.png" width="500"> | <img src="https://user-images.githubusercontent.com/4256455/111845296-73bf8700-88fc-11eb-950b-02541ee8523c.png" width="500">
5466.03ms | 4361.73ms (x1.253)
