### PR TITLE
CI Sanitizers

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,43 @@
+
+# This workflow is for running various sanitizers on OpenVDB. We currently
+# only use clang over gcc (for no particular reason). Note that some of the
+# errors produces by these sanitizers may be fairly obscure as the
+# llvm-symbolizer is not installed on the openvdb image. The address
+# sanitizer should never fail.
+
+name: Sanitizers
+
+on:
+  schedule:
+    # run this workflow every Monday 00:00 UTC
+    - cron:  '0 0 * * 1'
+
+jobs:
+  linux-vfx:
+    runs-on: ubuntu-16.04
+    name: linux-clang-sanitizer:${{ matrix.config.build }}
+    container:
+      image: aswf/ci-openvdb:2021
+    env:
+      CXX: clang++
+    strategy:
+      matrix:
+        config:
+          - { build: 'asan',  cmake: '-DUSE_BLOSC=OFF' } # We never called blosc_destroy(), so disable blosc to silence these errors
+          - { build: 'ubsan', cmake: '' } # Currently doesn't error, just reports all issues
+          #- { build: 'lsan', cmake: '' } # asan encompasses and includes lsan
+          #- { build: 'tsan', cmake: '' } # requires full stack rebuild for valid results (including libc++)
+          #- { build: 'msan', cmake: '' } # requires full stack rebuild for valid results (including libc++)
+          #- { build: 'coverage', cmake: '' } # todo
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v1
+    - name: install_gtest
+      run: ./ci/install_gtest.sh 1.8.0
+    - name: build
+      run: ./ci/build.sh ${{ matrix.config.build }} 8 ON None "core,test" \
+        -DOPENVDB_CXX_STRICT=ON -DOPENVDB_CORE_STATIC=OFF \
+        -DCMAKE_VERBOSE_MAKEFILE=ON \
+        ${{ matrix.config.cmake }}
+    - name: test
+      run: ./ci/test.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,6 @@ option(OPENVDB_BUILD_AX_UNITTESTS "Build the OpenVDB AX unit tests" OFF)
 option(OPENVDB_BUILD_MAYA_PLUGIN "Build the Maya plugin" OFF)
 option(OPENVDB_ENABLE_RPATH "Build with RPATH information" ON)
 option(OPENVDB_CXX_STRICT "Enable or disable pre-defined compiler warnings" OFF)
-option(OPENVDB_CODE_COVERAGE "Enable code coverage. This also overrides CMAKE_BUILD_TYPE to Debug" OFF)
 cmake_dependent_option(OPENVDB_INSTALL_CMAKE_MODULES
   "Install the provided OpenVDB CMake modules when building the core library"
   ON "OPENVDB_BUILD_CORE" OFF)
@@ -194,7 +193,6 @@ mark_as_advanced(
   OPENVDB_USE_DEPRECATED_ABI_6
   OPENVDB_FUTURE_DEPRECATION
   CONCURRENT_MALLOC
-  OPENVDB_CODE_COVERAGE
   USE_COLORED_OUTPUT
   SYSTEM_LIBRARY_PATHS
   OPENVDB_SIMD
@@ -423,38 +421,30 @@ if(USE_CCACHE)
   endif()
 endif()
 
-# Build type configuration - default to Release if none is set unless
-# code coverage is in use, in which case override to Debug
+# Build type configuration
 
 if(OPENVDB_CODE_COVERAGE)
-  message(WARNING "Code coverage requires debug mode, setting CMAKE_BUILD_TYPE "
-    "to Debug.")
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING
-    "Code coverage requires debug mode." FORCE
-  )
+  message(DEPRECATION "The OPENVDB_CODE_COVERAGE option is deprecated. Choose instead the unique"
+    "build type -DCMAKE_BUILD_TYPE=coverage")
+  set(CMAKE_BUILD_TYPE coverage)
+endif()
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+include(cmake/config/OpenVDBBuildTypes.cmake)
+
+if(CMAKE_BUILD_TYPE EQUAL coverage)
+  # use .gcno extension instead of .cc.gcno
+  # @note This is an undocumented internal cmake var and does not work
+  # with multi config generators
+  set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 endif()
 
 # CMAKE_BUILD_TYPE is ignored for multi config generators i.e. MSVS
 get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT _isMultiConfig)
-  if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release CACHE STRING
-      "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE
-    )
-  endif()
   message(STATUS "CMake Build Type: ${CMAKE_BUILD_TYPE}")
-endif()
-
-# Code coverage configuration
-
-if(OPENVDB_CODE_COVERAGE)
-  # set gcov compile and link flags
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
-
-  # use .gcno extension instead of .cc.gcno
-  set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 endif()
 
 #########################################################################

--- a/cmake/config/OpenVDBBuildTypes.cmake
+++ b/cmake/config/OpenVDBBuildTypes.cmake
@@ -1,0 +1,68 @@
+# Build Types
+set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
+    CACHE STRING [=[Choose the type of build. CMake natively supports the following options: None Debug Release
+        RelWithDebInfo MinSizeRel. OpenVDB additionally supports the following sanitizers and tools:
+        coverage tsan asan lsan msan ubsan]=]
+    FORCE)
+
+# DebugNoInfo - An internal build type only used by the OpenVDB CI. no optimizations, no symbols, asserts enabled
+set(CMAKE_CXX_FLAGS_DebugNoInfo ""
+  CACHE STRING "Flags used by the C++ compiler during DebugNoInfo builds." FORCE)
+
+# Coverage
+set(CMAKE_CXX_FLAGS_COVERAGE "--coverage"
+  CACHE STRING "Flags used by the C++ compiler during code coverage builds." FORCE)
+set(CMAKE_STATIC_LINKER_FLAGS_COVERAGE "--coverage"
+  CACHE STRING "Flags used by the linker during code coverage builds." FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE "--coverage"
+  CACHE STRING "Flags used by the linker during code coverage builds." FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_COVERAGE "--coverage"
+  CACHE STRING "Flags used by the linker during code coverage builds." FORCE)
+
+# Note that the thread, address and memory sanitizers are icompatible with each other
+set(SANITIZERS tsan asan lsan msan ubsan)
+
+# ThreadSanitizer
+set(CMAKE_CXX_FLAGS_TSAN "-fsanitize=thread -g -O1"
+  CACHE STRING "Flags used by the C++ compiler during ThreadSanitizer builds." FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_TSAN "-fsanitize=thread"
+  CACHE STRING "Flags used by the linker during ThreadSanitizer builds." FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_TSAN "-fsanitize=thread"
+  CACHE STRING "Flags used by the linker during ThreadSanitizer builds." FORCE)
+
+# AddressSanitize
+if(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+  set(CMAKE_CXX_FLAGS_ASAN "-fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1"
+    CACHE STRING "Flags used by the C++ compiler during AddressSanitizer builds." FORCE)
+  set(CMAKE_SHARED_LINKER_FLAGS_ASAN "-fsanitize=address"
+    CACHE STRING "Flags used by the linker during AddressSanitizer builds." FORCE)
+  set(CMAKE_EXE_LINKER_FLAGS_ASAN "-fsanitize=address"
+    CACHE STRING "Flags used by the linker during AddressSanitizer builds." FORCE)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+  set(CMAKE_CXX_FLAGS_ASAN "-fsanitize=address -fno-optimize-sibling-calls -fno-omit-frame-pointer -g -O1"
+    CACHE STRING "Flags used by the C++ compiler during AddressSanitizer builds." FORCE)
+endif()
+
+# LeakSanitizer
+set(CMAKE_CXX_FLAGS_LSAN "-fsanitize=leak -fno-omit-frame-pointer -g -O1"
+  CACHE STRING "Flags used by the C++ compiler during LeakSanitizer builds." FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_LSAN "-fsanitize=leak"
+  CACHE STRING "Flags used by the linker during LeakSanitizer builds." FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_LSAN "-fsanitize=leak"
+  CACHE STRING "Flags used by the linker during LeakSanitizer builds." FORCE)
+
+# MemorySanitizer
+set(CMAKE_CXX_FLAGS_MSAN "-fsanitize=memory -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -g -O2"
+  CACHE STRING "Flags used by the C++ compiler during MemorySanitizer builds." FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_MSAN "-fsanitize=memory"
+  CACHE STRING "Flags used by the linker during MemorySanitizer builds." FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_MSAN "-fsanitize=memory"
+  CACHE STRING "Flags used by the linker during MemorySanitizer builds." FORCE)
+
+# UndefinedBehaviour
+set(CMAKE_CXX_FLAGS_UBSAN "-fsanitize=undefined"
+  CACHE STRING "Flags used by the C++ compiler during UndefinedBehaviourSanitizer builds." FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_UBSAN "-fsanitize=undefined"
+  CACHE STRING "Flags used by the linker during UndefinedBehaviourSanitizer builds." FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_UBSAN "-fsanitize=undefined"
+  CACHE STRING "Flags used by the linker during UndefinedBehaviourSanitizer builds." FORCE)

--- a/cmake/config/OpenVDBBuildTypes.cmake
+++ b/cmake/config/OpenVDBBuildTypes.cmake
@@ -1,7 +1,4 @@
 
-# Requires add_link_options from 3.13
-cmake_minimum_required(VERSION 3.13)
-
 # Build Types
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
   CACHE STRING [=[Choose the type of build. CMake natively supports the following options: None Debug Release
@@ -16,6 +13,15 @@ set(EXTRA_BUILD_TYPES coverage tsan asan lsan msan ubsan)
 
 # DebugNoInfo - An internal build type only used by the OpenVDB CI. no optimizations, no symbols, asserts enabled
 set(CMAKE_CXX_FLAGS_DebugNoInfo "" CACHE STRING "Flags used by the C++ compiler during DebugNoInfo builds.")
+
+# Requires add_link_options from 3.13
+if(${CMAKE_VERSION} VERSION_LESS 3.13)
+  if(${CMAKE_BUILD_TYPE} IN_LIST EXTRA_BUILD_TYPES)
+    message(FATAL_ERROR "Build type ${CMAKE_BUILD_TYPE} requires CMake version 3.13 or higher.")
+  endif()
+  return()
+endif()
+cmake_minimum_required(VERSION 3.13)
 
 foreach(TYPE ${EXTRA_BUILD_TYPES})
   set(CMAKE_CXX_FLAGS_${U_TYPE} "" CACHE STRING "Flags used by the C++ compiler during ${TYPE} builds.")


### PR DESCRIPTION
Adds support for address, memory, thread and UB sanitizers and reworks the coverage option

An example run: https://github.com/Idclip/openvdb/actions/runs/679869827
