### PR TITLE
Updated AX example docs

### DIFF
--- a/ci/extract_test_examples.sh
+++ b/ci/extract_test_examples.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+#################################################################################
+# This script extracts all code blocks from AX documentation which are NOT      #
+# marked as cpp/sh/unparsed and attempts to parse or compile them through the   #
+# vdb_ax command line binary. Code blocks can be marked with a preceding        #
+# notation to determine compilation mode:                                       #
+#    <!--- P --->  = points                                                     #
+#    <!--- V --->  = volumes                                                    #
+#    <!--- A --->  = all                                                        #
+# If not marked, code is only parsed (though ideally all code blocks should be  #
+# compiled)                                                                     #
+#################################################################################
 set -e
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../"
@@ -11,6 +22,8 @@ DOCS+=($ROOT/doc/ax/axexamples.txt)
 # DOCS+=($ROOT/doc/ax/axfunctionlist.txt) do not test this file
 DOCS+=($ROOT/doc/ax/doc.txt)
 
+uncompiled=0
+
 for DOC in "${DOCS[@]}"; do
     echo "Checking doxygen code in '$DOC...'"
     # Make sure the file exists
@@ -20,9 +33,10 @@ for DOC in "${DOCS[@]}"; do
     fi
 
     # Extract all code segments from doxygen documentation in between @code and @endcode
-    data=$(sed -n '/^ *@code.* *$/,/^ *@endcode *$/p' $DOC)
+    data=$(sed -n '/@code.* *$/,/^ *@endcode *$/p' $DOC)
 
     str=""
+    compile=""
     skip=false
     count=0
     # For each extracted line, rebuild each code segment from @code and @endcode and
@@ -37,6 +51,16 @@ for DOC in "${DOCS[@]}"; do
             skip=true
         elif [[ $line == @code* ]]; then
             str=""
+            compile="none"
+        elif [[ $line == "<!--- V --->@code"* ]]; then
+            str=""
+            compile="volumes"
+        elif [[ $line == "<!--- P --->@code"* ]]; then
+            str=""
+            compile="points"
+        elif [[ $line == "<!--- A --->@code"* ]]; then
+            str=""
+            compile=""
         elif [[ $line == @endcode ]]; then
             echo -e "\nTesting [$count]:"
             if [ "$skip" = true ]; then
@@ -44,14 +68,25 @@ for DOC in "${DOCS[@]}"; do
                 echo -e "$str" | sed 's/^/    /'
             else
                 # parse
-                $VDB_AX analyze -s "$str" -v
+                if [ "$compile" = "none" ]; then
+                    $VDB_AX analyze -s "$str" -v
+                    uncompiled=$((uncompiled+1))
+                else
+                    $VDB_AX analyze -s "$str" --try-compile $compile -v
+                fi
             fi
             skip=false
             count=$((count+1))
             str=""
+            compile="none"
         else
             str+="$line"$'\n'
         fi
-
     done <<< "$data"
 done
+
+echo ""
+echo "Extract test examples completed successfully"
+if [ $uncompiled -gt 0 ]; then
+    echo " with $uncompiled uncompiled tests"
+fi

--- a/doc/ax/ax.txt
+++ b/doc/ax/ax.txt
@@ -11,8 +11,8 @@ functionality (including OpenVDB specific methods) execution structure and
 control flow. See the @subpage axcplusplus documentation for the C++ developer
 documentation.
 @note
-These documents are currently in @b BETA and are subject to change. Please
-contact us for more information.
+Some sections of this document are still to be completed. Please get in touch
+should you have any questions!
 
 @section axcontents Contents
 - @ref axintro
@@ -119,7 +119,7 @@ observe a small but complete AX program which could be compiled and executed.
 To begin with, here is a very simple example of a program that reads and writes
 to a particular attribute:
 @par
-@code{.c}
+<!--- A --->@code{.c}
 // read a floating point attribute from the value of "myattribute"
 float temp = float@myattribute;
 // if the value is less than 0, clamp it to 0
@@ -134,7 +134,7 @@ points and OpenVDB volumes. The example demonstrates reading from a value on
 some input, either a point attribute or a voxel value, and storing the
 result in a @ref axdecls "local variable". Importantly, the attribute being
 accessed has the name @b `myattribute` and the type @b `float`. The first statement:
-@code{.c}
+<!--- A --->@code{.c}
 float temp = float@myattribute;
 @endcode
 Invokes a @b read from this attribute (see @ref axattribaccess), retrieving the
@@ -405,7 +405,7 @@ rankings are defined as follows:
 @par
 For example:
 @par
-@code{.c}
+<!--- A --->@code{.c}
 int a = 0;
 float b = 0.0f;
 // In the following, the arithmetic a + b chooses floating point precision as
@@ -578,12 +578,12 @@ element type of vector, the scalar is copied and @ref axtypeprecedence
 <td style="text-align:left">Component wise assignment i.e.
 <br/> `a[0]&nbsp;=&nbsp;b;&nbsp;...&nbsp;a[n-1]&nbsp;=&nbsp;b;` <br/>
 where `n` is the size of the vector.
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 0, b = 1;
 a = b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 0, b = 1;
 for (int i = 0; i < 3; ++i) a[i] = b[i];
 @endcode
@@ -600,7 +600,7 @@ element type.
 Diagonal matrix construction. Each diagonal component of the left hand side
 matrix is set to to the right hand side scalar. All other components are zero
 initialized i.e.
-@code{.c}
+<!--- A --->@code{.c}
 mat3f a;
 int dim = 3, b = 1;
 for (int i = 0; i < dim; ++i)
@@ -614,12 +614,12 @@ that type.</td>
 <td style="text-align:left">Component wise assignment i.e.
 <br/> `a[0]&nbsp;=&nbsp;b[0];&nbsp;...&nbsp;a[n-1]&nbsp;=&nbsp;b[n-1];` <br/>
 where `n` is the @b total size of the matrix.
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = 0, b = 1;
 a = b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = 0, b = 1;
 for (int i = 0; i < 16; ++i) a[i] = b[i];
 @endcode
@@ -638,7 +638,7 @@ left hand side string with a copy of the contents in the right hand side string.
 </tr>
 </table>
 @par
-@code{.c}
+<!--- A --->@code{.c}
 float b;
 vec3f c = 0.0f; // assign components of c (x/y/z) to an floating point literal of value 0.0f
 int a = 1; // assign a from an integer literal of value 1
@@ -675,7 +675,7 @@ important when assigning to an expression which is not an attribute or local
 value. The best example of this is assigning to a @ref axopunincdec "pre-crement"
 operation:
 @par
-@code{.c}
+<!--- A --->@code{.c}
 int a = 1;
 ++a += 1; // equal to a = ++a + 1 which is equal to 3
 @endcode
@@ -687,7 +687,7 @@ written to. Note that the arithmetic operation may cast either @b `lhs` or @b
 "arithmetic operations" section for more information on arithmetic type
 precedence and explanations on the above compound operators.
 @par
-@code{.c}
+<!--- A --->@code{.c}
 int a = 3;
 a += a; // the same as a = a + a; a will be set to 6
 float b = 0;
@@ -701,7 +701,7 @@ type of the left hand side. For example:
 @par
 Given
 @par
-@code{.c}
+<!--- A --->@code{.c}
 float a;
 int b, c;
 @endcode
@@ -782,13 +782,13 @@ additive operations (if an operation is not listed, it is not supported):
 (after @ref axtypeprecedence "implicit conversion") with the left hand side
 scalar to every element of the right hand side vector or matrix, returning a
 vector or matrix.
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 vec3f c = b + a;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 vec3f c;
@@ -808,12 +808,12 @@ for (int i = 0; i < 3; ++i) c[i] = b + a[i];
 <td style="text-align:left">Performs per component binary operations (after
 @ref axtypeprecedence "implicit conversion"), returning a new vector with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2, b = 1;
 vec3f c = a - b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2, b = 1;
 vec3f c;
 for (int i = 0; i < 3; ++i) c[i] = a[i] - b[i];
@@ -830,12 +830,12 @@ for (int i = 0; i < 3; ++i) c[i] = a[i] - b[i];
 <td style="text-align:left">Performs per component binary operations (after
 @ref axtypeprecedence "implicit conversion"), returning a new matrix with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = 0, b = 1;
 mat4f c = a - b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = 0, b = 1;
 mat4f c;
 for (int i = 0; i < 16; ++i) c[i] = a[i] - b[i];
@@ -913,13 +913,13 @@ Performs per component binary operations (after
 @ref axtypeprecedence "implicit conversion") with the left hand side scalar to
 every element of the right hand side vector. The scalar is effectively treated
 as a vector of the same size as the right hand side type.
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 vec3f c = b * a;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 vec3f c;
@@ -931,13 +931,13 @@ for (int i = 0; i < 3; ++i) c[i] = b * a[i];
 <td style="text-align:left" rowspan="1">
 Performs matrix multiplication after diagonal matrix construction from the left
 hand side scalar.
-@code{.c}
+<!--- A --->@code{.c}
 mat3f a = 1;
 float b = 1;
 mat3f c = a * b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 mat3f a = 1;
 float b = 1;
 mat3f tmp = b; // diagonal matrix
@@ -957,12 +957,12 @@ with the operands reversed (importantly for division and modulus)</td>
 <td style="text-align:left">Performs per component binary operations (after
 @ref axtypeprecedence "implicit conversion"), returning a new vector with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2, b = 1;
 vec3f c = a * b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2, b = 1;
 vec3f c;
 for (int i = 0; i < 3; ++i) c[i] = a[i] * b[i];
@@ -974,13 +974,13 @@ for (int i = 0; i < 3; ++i) c[i] = a[i] * b[i];
 Transforms the left hand side vector by the right hand side matrix using matrix
 multiplication. This is the same as calling the @ref axtransform "transform"
 function. e.g:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 b = b * a;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 b = transform(b, a);
@@ -992,7 +992,7 @@ to positions being represented as `vec3`. `vec3 * mat4` multiplication is
 supported, where by the `vec3` is extended with a `1` component and the
 resulting last last component is dropped from the return
 value:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 // b * a is equal to:
@@ -1024,13 +1024,13 @@ b[2] = tmp[2];
 Transforms the right hand side vector by the left hand side matrix using matrix
 multiplication. This is the same as calling the @ref axpretransform "pretransform"
 function. e.g:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 b = a * b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 b = pretransform(a, b);
@@ -1042,7 +1042,7 @@ to positions being represented as `vec3`. `mat4 * vec3` multiplication is
 supported, where by the `vec3` is extended with a `1` component and the
 resulting last last component is dropped from the return
 value:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 // a * b is equal to:
@@ -1067,17 +1067,17 @@ b[2] = tmp[2];
 <td style="text-align:left">
 Performs matrix multiplication and returns the matrix product, which is matrix
 of matchign size and type. <b>Operand sizes must match.</b> e.g:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = 1, b = 2;
 mat4f c = a * b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = 1, b = 2;
 mat4f c;
-for(i = 0; i < 4; ++i) {
-    for(j = 0; j < 4; ++j) {
-        for(k = 0; k < 4; ++k) {
+for(int i = 0; i < 4; ++i) {
+    for(int j = 0; j < 4; ++j) {
+        for(int k = 0; k < 4; ++k) {
             c[i,j] += a[i,k] * b[k,j];
         }
     }
@@ -1176,13 +1176,13 @@ Performs per component comparisons (after
 every element of the right hand side vector or matrix and perform a logical AND
 combination on the results of these comparisons. This effectively returns true
 if every element of the vector or matrix is equal to the scalar.
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 bool c = b == a;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 bool c = a[0] == b;
@@ -1206,12 +1206,12 @@ Performs binary comparison operations (after
 @ref axtypeprecedence "implicit conversion") on each pair corresponding
 components in the vector operands and returns true if all component pairs are
 equal. <b>Operand sizes must match.</b>
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 1, b = 2;
 bool c = a == b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 1, b = 2;
 bool c = a[0] == b[0];
 for (int i = 1; i < 3; ++i) c &= a[i] == b[i];
@@ -1230,12 +1230,12 @@ Performs binary comparison operations (after
 @ref axtypeprecedence "implicit conversion") on each pair corresponding
 components in the matrix operands and returns true if all component pairs are
 equal. <b>Operand sizes must match.</b>
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = 1, b = 2;
 bool c = a == b;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 mat4f a = 1, b = 2;
 bool c = a[0] == b[0];
 for (int i = 1; i < 16; ++i) c &= a[i] == b[i];
@@ -1322,12 +1322,12 @@ arithmetic operations (if an operation is not listed, it is not supported):
 <td style="text-align:left">
 Performs per component unary operations, returning a new vector with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2;
 vec3f b = -a;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2;
 vec3f b;
 for (int i = 0; i < 3; ++i) b[i] = -a[i];
@@ -1340,12 +1340,12 @@ for (int i = 0; i < 3; ++i) b[i] = -a[i];
 <td style="text-align:left">
 Performs per component unary operations, returning a new matrix with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2;
 vec3f b = -a;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = 2;
 vec3f b;
 for (int i = 0; i < 3; ++i) b[i] = -a[i];
@@ -1381,12 +1381,12 @@ The scalar operand is converted to a bool if it is not already.</td>
 <td style="text-align:left">
 Performs per component unary operations, returning a new vector with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-@code{.c}
+<!--- A --->@code{.c}
 vec3i a = 2;
 vec3i b = !a;
 @endcode
 is equal to:
-@code{.c}
+<!--- A --->@code{.c}
 vec3i a = 2;
 vec3i b;
 for (int i = 0; i < 3; ++i) b[i] = !a[i];
@@ -1476,7 +1476,7 @@ first 2 components are accessible). Accessing a vector using the dot operator is
 fundamentally the same as using the @b `[]` operator with the corresponding
 integer index.
 @par
-@code{.c}
+<!--- A --->@code{.c}
 vec4i a = { 6, 7, 8, 9 };
 int b = a.z; // get the the third elements value (8)
 @endcode
@@ -1540,7 +1540,7 @@ accessing specific elements, where @b `exp1` is the row index and @b `exp2` is
 the column index. The tables below show the different access patterns for
 @b `3x3` and @b `4x4` matrices.
 @par
-@code{.c}
+<!--- A --->@code{.c}
 mat3f a;
 for (int i = 0; i < 3; ++i)
     for (int j = 0; j < 3; ++j)
@@ -1729,7 +1729,7 @@ a supported explicit cast. It has the form:
 @par
 Where @b `func` is a function name @b or a valid explicit cast typename. Explicit
 casts are only supported for @ref axscalars "scalar types". For example:
-@code{.c}
+<!--- A --->@code{.c}
 int a = int(1.1f);
 vec3f b = 1.0f;
 a = int(b.x);
@@ -1758,7 +1758,7 @@ except for the last expression, which is returned from the entire list. Note tha
 although return values for any expression but the last are discarded, their side
 effects are still applied before subsequent expression are evaluated. For
 example:
-@code{.c}
+<!--- A --->@code{.c}
 int a = 5;
 a-=1, a+=2; // a = 6
 a = a--, ++a; // exp1: a = a--, exp2: ++a. a = 7
@@ -1808,7 +1808,7 @@ existing container of matching size. Expression in the operator are evaluated
 from first to last. This operator is only valid with argument lists of sizes
 2, 3, 4, 9 and 16, which implicitly represent <b>vec2, vec3, vec4, mat3,</b> and
 @b mat4 types respectively. For example:
-@code{.c}
+<!--- A --->@code{.c}
 vec3f a = { 1.0f, 2.0f, 3.0f }; // right hand side of assignment creates a vec3f
 vec3f b = dot(a, { a[0], 5.0, 6.0 }); // second argument creates a vec3d
 @endcode
@@ -1817,7 +1817,7 @@ In the above examples, the value of @b `a[0]` is copied into the initializer
 operator.
 @par Initialization Type
 A mixture of arbitrary scalar types can be used in the initializer operator e.g:
-@code{.c}
+<!--- A --->@code{.c}
 mat3f a = {
     true, 0s, 0,
     0l, 0.0f, 0.0,
@@ -2027,7 +2027,7 @@ OpenVDB voxels change which voxels AX will process. The defined behavior for all
 cases is shown below.
 @par
 Consider a simple assignment example:
-@code{.c}
+<!--- A --->@code{.c}
 float@surface = float@density;
 @endcode
 @par

--- a/doc/ax/axcplusplus.txt
+++ b/doc/ax/axcplusplus.txt
@@ -296,7 +296,7 @@ applications.
 @par
 Consider this trivial example:
 @par
-@code{.c}
+<!--- A --->@code{.c}
 f@density = f$my_value;
 // f$my_value = f@density; NOTE: writing to $ values is disallowed
 @endcode
@@ -457,7 +457,7 @@ requires both the AX compiler @b and the underlying geometry to support the
 given type. As mentioned above, there may be times where this isn't the case.
 Consider the following:
 @par
-@code{.c}
+<!--- A --->@code{.c}
 vec4i a = {1,2,3,4};
 vec4i@attr = a;
 @endcode

--- a/doc/ax/axexamples.txt
+++ b/doc/ax/axexamples.txt
@@ -3,34 +3,44 @@
 
 @page axexamples AX Code Examples
 
-@section sExpmaplesContents Contents
-- @ref secPointsExamples
-    - @ref subsecPointAttributesExample
-    - @ref subsecCullPointsExample
-    - @ref subsecDragExample
-- @ref secVolumeExamples
-    - @ref subsecVolumeAssignmentExample
-
-@section secPointsExamples Points Examples
+@section axexamplesintro AX Code Examples
 @par
-These examples demonstrate how to use AX on VDB points grids.
+This page demonstrates a range of examples which use AX to manipulate OpenVDB
+point and volume data and can be used as a quick start demonstration on the
+capabilities of the software. These examples are constantly being updated but
+do not cover all aspects of AX!
+
+@section axexamplecontents Contents
+- @ref axexamplepoints
+    - @ref axexamplepointbasic
+    - @ref axexamplepointdelete
+    - @ref axexamplepointdrag
+    - @ref axexamplepointcurlnoise
+    - @ref axexamplepointtransforms
+- @ref axexamplevolumes
+    - @ref axexamplevolumeclamp
+    - @ref axexamplevolumevel
+    - @ref axexamplevolumeblend
 
 
-@subsection subsecPointAttributesExample Point Attributes Example
+@section axexamplepoints Points Examples
 @par
-This example shows a couple of ways to use AX with points attributes. The @
-symbol is the identifier for a point attribute. The type of each attribute is
-specified before the @ symbol and the name is specified afterwards. For example:
-@b `int@count` would imply an @b integer attribute called @b count.
+These examples demonstrate how to use AX on OpenVDB points grids.
+
+@subsection axexamplepointbasic Basic point attributes
+@par
+Below is a small example which demonstrates working with a few point attributes.
+The @ symbol is the identifier for an AX attribute. The type of each attribute
+is specified before the @ symbol and the name is specified afterwards. For
+example: @b `int@count` would imply an @b integer attribute called @b count.
 @par
 In this example there are three point attributes: a @b float attribute @b speed,
-a @b vector3 float attribute @b velocity and a @b vector3 float attribute
-@b colour.
+a @b vec3f float attribute @b velocity and a @b vec3f float attribute @b colour.
 @par
 This snippet uses the functions @ref axlength "length" and @ref axfit "fit" to
 give points a colour between black and white based on their speed.
 @par
-@code{.c}
+<!--- P --->@code{.c}
 // This statement writes to a new float attribute called speed and reads from a
 // vector float attribute called velocity. The length function is used here to
 // return the length of the point's velocity vector.
@@ -50,24 +60,24 @@ of values to produce some visual variance in colour. The attributes @b speed and
 @b colour do not need to exist before this snippet is run as the attributes are
 only written to and will be created on the fly.
 @par
-@b Note. In Houdini (AX SOP) changing the name of the attribute from @b colour to
-@b Cd will result in the points being given a colour in the viewport as Cd is
-a special attribute.
+@note
+In Houdini (AX SOP) changing the name of the attribute from @b colour to @b Cd
+will result in the points being given a colour in the viewport as Cd is a
+special attribute.
 
-
-@subsection subsecCullPointsExample Delete Points
+@subsection axexamplepointdelete Deleting Points
 @par
 This example demonstrates a simple way of removing points from a VDB points grid.
 It uses a combination of @ref axrand and @ref axdeletepoint to randomly delete
 roughly half of the points in the input VDB points grid.
 @par
-@code{.c}
-float threshold = 0.5;
+<!--- P --->@code{.c}
+float threshold = 0.5f;
 
 // The rand function takes a seed and produces a random value between 0 and 1.
 // The integer attribute id from the points is used to seed the rand function.
 // If the value from rand is greater than the threshold (0.5) then delete the point.
-if (rand(i@id) > threshold) {
+if (rand(int64@id) > threshold) {
     deletepoint();
 }
 @endcode
@@ -76,20 +86,18 @@ The @b id attribute in this example is assumed to be a unique @b integer for
 each point in the VDB points grid such that @ref axrand will receive a
 different seed value per point producing a good distribution of random values.
 
-
-@subsection subsecDragExample Drag Example
+@subsection axexamplepointdrag Applying Drag
 @par
 This example shows something a bit more complex: modifying a point's velocity
 with a drag force and then moving the point with the modified velocity.
 @par
-@code{.c}
+<!--- P --->@code{.c}
 float dt = 1.0f / (4.0f * 24.0f); // timestep
 vec3f gravity = {0.0f, -9.81f, 0.0f}; // gravity
 vec3f dV = {2.0f, 0.0f, 0.0f} - v@v; // drag
 
 float lengthV = length(dV);
 float Re = lengthV * @rad / 1.225f;
-
 float C = 0.0f;
 
 if (Re > 1000.0f) C = 24.0f / Re;
@@ -104,30 +112,156 @@ v@v += (gravity -  drag / ((4.0f / 3.0f) * 3.14f * pow(@rad, 3.0f))) * dt;
 // update position
 v@P += v@v * dt;
 @endcode
+@par
+The final AX command, `v@P += v@v * dt;` writes to the position attribute of
+the points @b `v@P`. Whenever position is written to in this way, the AX
+`PointExecutable` will move (re-bucket) points in PointDataGrids.
+
+@subsection axexamplepointcurlnoise Curl Noise
+@par
+The following example demonstrates using various native AX functions to
+calculate a position based curl noise on points in a particular group, and to
+use that calculation to update point velocities.
+@par
+<!--- P --->@code{.c}
+// Only calcualte noise and apply it to points if the current point is NOT in
+// a group called "escaped". Note that the PointExecutable also has native
+// support for group based execution.
+if (!ingroup("escaped")) {
+
+    // Read custom data
+    float amplitude = $amplitude;
+    float persistence = $persistence;
+    float lacunarity = $lacunarity;
+    vec3f freq = vec3f$frequency;
+    vec3f offset = vec3f$offset;
+
+    vec3f noise = 0.0f;
+
+    // Position based curl simplex noise
+    for (int octave = 0; octave < int($octaves); ++octave) {
+        vec3f noisePos = vec3f@P * freq + offset;
+        noise += curlsimplexnoise(noisePos) * amplitude;
+        amplitude *= persistence;
+        freq *= lacunarity;
+    }
+
+    // Apply noise scaled by the current velocity length
+    vec3f@v += length(vec3f@v) * noise;
+}
+@endcode
+
+@subsection axexamplepointtransforms Transformations
+@par
+AX supports 3x3 and 4x4 matrix types and various transformations. They can be
+accessed via row, column operators or as a flat array and have defined
+operators (such as matrix multiplication etc.). The following demonstrates
+some trivial matrix math on VDB Point positions.
+@par
+<!--- P --->@code{.c}
+// get the 4x4 identity matrix. note that scalar->matrix promotion handles
+// this, so writing 'mat4f transform = 1;' has the same effect.
+mat4f transform = identity4();
+
+// set the X transform component
+transform[3,0] = 5;
+
+// pre scale the matrix. this is equal to writing: 'transform = scale * transform;'
+vec3f scale = { 1,2,3 };
+prescale(transform, scale);
+
+// double the value of the scale Y component
+transform[5] *= 2;
+
+// construct a basic rotation matrix, representing 90 degree rotation around Y
+float degrees = 90.0f;
+float rad = radians(degrees);
+mat3f rotation = {
+    cos(rad), 0.0f, -sin(rad),
+    0.0f,     1.0f,      0.0f,
+    sin(rad), 0.0f,  cos(rad)
+};
+
+// apply the rotation and transformation to the current points position
+vec3f@P *= rotation;
+vec3f@P *= transform;
+@endcode
+
 
 <br/><hr>
 
-@section secVolumeExamples Volume Examples
+
+@section axexamplevolumes Volume Examples
 @par
 These examples demonstrate how to use AX on VDB volume grids.
 
-
-@subsection subsecVolumeAssignmentExample Volume Assignment Example
+@subsection axexamplevolumeclamp Volume Clamping
 @par
-This example shows a couple of ways to use AX with volumes. The @ symbol is the
-identifier for a volume. The type of each volume is specified before the
-@ symbol and the name is specified afterwards. For example: `float@density`
-would imply a @b float volume called @b density.
+Below is a small example of reading adn writing to voxels within a VDB volume.
+As with points, the @ symbol specifies an access to a named volume, with the
+type of each volume preceding it and the name appearing as a suffix. For
+example: `float@density` would imply a @b float volume called @b density.
 @par
-Unlike when working on points AX will not create new volumes if they don't
-already exist when written to in a snippet. This snippet uses @ref axclamp to
-constrain the @b density attribute between zero and one.
+This snippet uses @ref axclamp function to constrain the @b density attribute
+between zero and one.
 @par
-@code{.c}
+<!--- V --->@code{.c}
 float@density = clamp(float@density, 0.f, 1.f);
 @endcode
+
+@subsection axexamplevolumevel Velocity Update
 @par
-The @b density attribute in this example is assumed to exist already.
+AX can be used to read and write to multiple volumes. Here we have a typical
+example of a eulerian velocity update which takes into account an updated
+vector force and scalar mass.
+@par
+<!--- V --->@code{.c}
+// Access the current timestep - this could instead be provided by the AX
+// integration and made accessible with custom data (i/e: float$timestep)
+float dt = 1.0f / 24.0f;
+// read from the mass grid the corresponding (matching index space) value
+float mass = float@mass;
+// safe divide, in case mass is zero
+float massInverse = 0.0f;
+if (mass > 0.0f) massInverse = 1.0f / mass;
+
+// update the current velocity value by scaling the corresponding force
+// by the timestep and inverse mass
+vec3f@vel += dt * massInverse * vec3f@force;
+@endcode
+
+@subsection axexamplevolumeblend Linear Blending
+@par
+Here we demonstrate how AX can be used to blend two volumes together. Note that
+only the volumes which are written to are executed over. In the below code,
+only @b `@surface_a` is written to. This means that the final blended result,
+stored in `surface_a`, will only be updated in `surface_a`'s topology. Should
+we want a combined blend of @b non @b overlapping areas of both surface a and b,
+we would need to activate a's topology with respect to b first.
+@par
+<!--- V --->@code{.c}
+// time constants for each run.
+float time = float$time;
+float maxDuration = 100.0f;
+
+// read both surface a and surface b values
+float a = @surface_a; // source value
+float b = @surface_b; // target value
+
+// calculate the fractional mask value in respect to time
+float mask = time / maxDuration;
+
+// optionally scale the mask by a per index space density. if
+// $enable_density_mask is true, a density grid is used to vary the blend per
+// voxel
+if ($enable_density_mask) mask *= @density;
+
+// finally, clamp the mask value and update the level set value in surface a.
+// Note that this may produce a no longer valid level set and might need to be
+// rebuilt!
+mask = clamp(mask, 0.0f, 1.0f);
+@surface_a = a + (b-a) * mask;
+@endcode
 
 </div>
 */


### PR DESCRIPTION
 - Improved AX examples in doxygen documentation
 - Updated `ci/extract_test_examples.sh` to also compile AX code in documentation (would previously just parse)

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>

@richhones 