### PR TITLE
DynamicNodeManager Grain Size

### DIFF
--- a/openvdb/openvdb/tree/NodeManager.h
+++ b/openvdb/openvdb/tree/NodeManager.h
@@ -808,41 +808,45 @@ public:
     DynamicNodeManagerLink() = default;
 
     template<typename NodeOpT, typename RootT>
-    void foreachTopDown(const NodeOpT& op, RootT& root, bool threaded, size_t grainSize)
+    void foreachTopDown(const NodeOpT& op, RootT& root, bool threaded,
+        size_t leafGrainSize, size_t nonLeafGrainSize)
     {
         if (!op(root, /*index=*/0))         return;
         if (!mList.initRootChildren(root))  return;
         ForeachFilterOp<NodeOpT> filterOp(op, mList.nodeCount());
-        mList.foreachWithIndex(filterOp, threaded, grainSize);
-        mNext.foreachTopDownRecurse(filterOp, mList, threaded, grainSize);
+        mList.foreachWithIndex(filterOp, threaded, LEVEL == 0 ? leafGrainSize : nonLeafGrainSize);
+        mNext.foreachTopDownRecurse(filterOp, mList, threaded, leafGrainSize, nonLeafGrainSize);
     }
 
     template<typename FilterOpT, typename ParentT>
-    void foreachTopDownRecurse(const FilterOpT& filterOp, ParentT& parent, bool threaded, size_t grainSize)
+    void foreachTopDownRecurse(const FilterOpT& filterOp, ParentT& parent, bool threaded,
+        size_t leafGrainSize, size_t nonLeafGrainSize)
     {
         if (!mList.initNodeChildren(parent, filterOp, !threaded))   return;
         FilterOpT childFilterOp(filterOp.op(), mList.nodeCount());
-        mList.foreachWithIndex(childFilterOp, threaded, grainSize);
-        mNext.foreachTopDownRecurse(childFilterOp, mList, threaded, grainSize);
+        mList.foreachWithIndex(childFilterOp, threaded, LEVEL == 0 ? leafGrainSize : nonLeafGrainSize);
+        mNext.foreachTopDownRecurse(childFilterOp, mList, threaded, leafGrainSize, nonLeafGrainSize);
     }
 
     template<typename NodeOpT, typename RootT>
-    void reduceTopDown(NodeOpT& op, RootT& root, bool threaded, size_t grainSize)
+    void reduceTopDown(NodeOpT& op, RootT& root, bool threaded,
+        size_t leafGrainSize, size_t nonLeafGrainSize)
     {
         if (!op(root, /*index=*/0))         return;
         if (!mList.initRootChildren(root))  return;
         ReduceFilterOp<NodeOpT> filterOp(op, mList.nodeCount());
-        mList.reduceWithIndex(filterOp, threaded, grainSize);
-        mNext.reduceTopDownRecurse(filterOp, mList, threaded, grainSize);
+        mList.reduceWithIndex(filterOp, threaded, LEVEL == 0 ? leafGrainSize : nonLeafGrainSize);
+        mNext.reduceTopDownRecurse(filterOp, mList, threaded, leafGrainSize, nonLeafGrainSize);
     }
 
     template<typename FilterOpT, typename ParentT>
-    void reduceTopDownRecurse(FilterOpT& filterOp, ParentT& parent, bool threaded, size_t grainSize)
+    void reduceTopDownRecurse(FilterOpT& filterOp, ParentT& parent, bool threaded,
+        size_t leafGrainSize, size_t nonLeafGrainSize)
     {
         if (!mList.initNodeChildren(parent, filterOp, !threaded))   return;
         FilterOpT childFilterOp(filterOp.op(), mList.nodeCount());
-        mList.reduceWithIndex(childFilterOp, threaded, grainSize);
-        mNext.reduceTopDownRecurse(childFilterOp, mList, threaded, grainSize);
+        mList.reduceWithIndex(childFilterOp, threaded, LEVEL == 0 ? leafGrainSize : nonLeafGrainSize);
+        mNext.reduceTopDownRecurse(childFilterOp, mList, threaded, leafGrainSize, nonLeafGrainSize);
     }
 
 protected:
@@ -861,17 +865,19 @@ public:
     DynamicNodeManagerLink() = default;
 
     template<typename NodeFilterOp, typename ParentT>
-    void foreachTopDownRecurse(const NodeFilterOp& nodeFilterOp, ParentT& parent, bool threaded, size_t grainSize)
+    void foreachTopDownRecurse(const NodeFilterOp& nodeFilterOp, ParentT& parent, bool threaded,
+        size_t leafGrainSize, size_t /*nonLeafGrainSize*/)
     {
         if (!mList.initNodeChildren(parent, nodeFilterOp, !threaded))   return;
-        mList.foreachWithIndex(nodeFilterOp.op(), threaded, grainSize);
+        mList.foreachWithIndex(nodeFilterOp.op(), threaded, leafGrainSize);
     }
 
     template<typename NodeFilterOp, typename ParentT>
-    void reduceTopDownRecurse(NodeFilterOp& nodeFilterOp, ParentT& parent, bool threaded, size_t grainSize)
+    void reduceTopDownRecurse(NodeFilterOp& nodeFilterOp, ParentT& parent, bool threaded,
+        size_t leafGrainSize, size_t /*nonLeafGrainSize*/)
     {
         if (!mList.initNodeChildren(parent, nodeFilterOp, !threaded))   return;
-        mList.reduceWithIndex(nodeFilterOp.op(), threaded, grainSize);
+        mList.reduceWithIndex(nodeFilterOp.op(), threaded, leafGrainSize);
     }
 
 protected:
@@ -902,10 +908,12 @@ public:
     /// @brief   Threaded method that applies a user-supplied functor
     ///          to all the nodes in the tree.
     ///
-    /// @param op        user-supplied functor, see examples for interface details.
-    /// @param threaded  optional toggle to disable threading, on by default.
-    /// @param grainSize optional parameter to specify the grainsize
-    ///                  for threading, one by default.
+    /// @param op               user-supplied functor, see examples for interface details.
+    /// @param threaded         optional toggle to disable threading, on by default.
+    /// @param leafGrainSize    optional parameter to specify the grainsize
+    ///                         for threading over leaf nodes, one by default.
+    /// @param nonLeafGrainSize optional parameter to specify the grainsize
+    ///                         for threading over non-leaf nodes, one by default.
     ///
     /// @note There are two key differences to the interface of the
     /// user-supplied functor to the NodeManager class - (1) the operator()
@@ -965,17 +973,20 @@ public:
     ///
     /// @endcode
     template<typename NodeOp>
-    void foreachTopDown(const NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void foreachTopDown(const NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t nonLeafGrainSize=1)
     {
-        mChain.foreachTopDown(op, mRoot, threaded, grainSize);
+        mChain.foreachTopDown(op, mRoot, threaded, leafGrainSize, nonLeafGrainSize);
     }
 
     /// @brief   Threaded method that processes nodes with a user supplied functor
     ///
     /// @param op        user-supplied functor, see examples for interface details.
     /// @param threaded  optional toggle to disable threading, on by default.
-    /// @param grainSize optional parameter to specify the grainsize
-    ///                  for threading, one by default.
+    /// @param leafGrainSize    optional parameter to specify the grainsize
+    ///                         for threading over leaf nodes, one by default.
+    /// @param nonLeafGrainSize optional parameter to specify the grainsize
+    ///                         for threading over non-leaf nodes, one by default.
     ///
     /// @note There are two key differences to the interface of the
     /// user-supplied functor to the NodeManager class - (1) the operator()
@@ -1029,9 +1040,10 @@ public:
     ///
     /// @endcode
     template<typename NodeOp>
-    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void reduceTopDown(NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t nonLeafGrainSize=1)
     {
-        mChain.reduceTopDown(op, mRoot, threaded, grainSize);
+        mChain.reduceTopDown(op, mRoot, threaded, leafGrainSize, nonLeafGrainSize);
     }
 
 protected:
@@ -1502,25 +1514,27 @@ public:
     const RootNodeType& root() const { return mRoot; }
 
     template<typename NodeOp>
-    void foreachTopDown(const NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void foreachTopDown(const NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t /*nonLeafGrainSize*/ =1)
     {
         // root
         if (!op(mRoot, /*index=*/0))                                return;
         // list0
         if (!mList0.initRootChildren(mRoot))                        return;
         ForeachFilterOp<NodeOp> nodeOp(op, mList0.nodeCount());
-        mList0.foreachWithIndex(nodeOp, threaded, grainSize);
+        mList0.foreachWithIndex(nodeOp, threaded, leafGrainSize);
     }
 
     template<typename NodeOp>
-    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void reduceTopDown(NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t /*nonLeafGrainSize*/ =1)
     {
         // root
         if (!op(mRoot, /*index=*/0))                                return;
         // list0
         if (!mList0.initRootChildren(mRoot))                        return;
         ReduceFilterOp<NodeOp> nodeOp(op, mList0.nodeCount());
-        mList0.reduceWithIndex(nodeOp, threaded, grainSize);
+        mList0.reduceWithIndex(nodeOp, threaded, leafGrainSize);
     }
 
 protected:
@@ -1556,31 +1570,33 @@ public:
     const RootNodeType& root() const { return mRoot; }
 
     template<typename NodeOp>
-    void foreachTopDown(const NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void foreachTopDown(const NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t nonLeafGrainSize=1)
     {
         // root
         if (!op(mRoot, /*index=*/0))                                return;
         // list1
         if (!mList1.initRootChildren(mRoot))                        return;
         ForeachFilterOp<NodeOp> nodeOp(op, mList1.nodeCount());
-        mList1.foreachWithIndex(nodeOp, threaded, grainSize);
+        mList1.foreachWithIndex(nodeOp, threaded, nonLeafGrainSize);
         // list0
         if (!mList0.initNodeChildren(mList1, nodeOp, !threaded))   return;
-        mList0.foreachWithIndex(op, threaded, grainSize);
+        mList0.foreachWithIndex(op, threaded, leafGrainSize);
     }
 
     template<typename NodeOp>
-    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void reduceTopDown(NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t nonLeafGrainSize=1)
     {
         // root
         if (!op(mRoot, /*index=*/0))                                return;
         // list1
         if (!mList1.initRootChildren(mRoot))                        return;
         ReduceFilterOp<NodeOp> nodeOp(op, mList1.nodeCount());
-        mList1.reduceWithIndex(nodeOp, threaded, grainSize);
+        mList1.reduceWithIndex(nodeOp, threaded, nonLeafGrainSize);
         // list0
         if (!mList0.initNodeChildren(mList1, nodeOp, !threaded))   return;
-        mList0.reduceWithIndex(op, threaded, grainSize);
+        mList0.reduceWithIndex(op, threaded, leafGrainSize);
     }
 
 protected:
@@ -1621,39 +1637,41 @@ public:
     const RootNodeType& root() const { return mRoot; }
 
     template<typename NodeOp>
-    void foreachTopDown(const NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void foreachTopDown(const NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t nonLeafGrainSize=1)
     {
         // root
         if (!op(mRoot, /*index=*/0))                                return;
         // list2
         if (!mList2.initRootChildren(mRoot))                        return;
         ForeachFilterOp<NodeOp> nodeOp2(op, mList2.nodeCount());
-        mList2.foreachWithIndex(nodeOp2, threaded, grainSize);
+        mList2.foreachWithIndex(nodeOp2, threaded, nonLeafGrainSize);
         // list1
         if (!mList1.initNodeChildren(mList2, nodeOp2, !threaded))   return;
         ForeachFilterOp<NodeOp> nodeOp1(op, mList1.nodeCount());
-        mList1.foreachWithIndex(nodeOp1, threaded, grainSize);
+        mList1.foreachWithIndex(nodeOp1, threaded, nonLeafGrainSize);
         // list0
         if (!mList0.initNodeChildren(mList1, nodeOp1, !threaded))   return;
-        mList0.foreachWithIndex(op, threaded, grainSize);
+        mList0.foreachWithIndex(op, threaded, leafGrainSize);
     }
 
     template<typename NodeOp>
-    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void reduceTopDown(NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t nonLeafGrainSize=1)
     {
         // root
         if (!op(mRoot, /*index=*/0))                                return;
         // list2
         if (!mList2.initRootChildren(mRoot))                        return;
         ReduceFilterOp<NodeOp> nodeOp2(op, mList2.nodeCount());
-        mList2.reduceWithIndex(nodeOp2, threaded, grainSize);
+        mList2.reduceWithIndex(nodeOp2, threaded, nonLeafGrainSize);
         // list1
         if (!mList1.initNodeChildren(mList2, nodeOp2, !threaded))   return;
         ReduceFilterOp<NodeOp> nodeOp1(op, mList1.nodeCount());
-        mList1.reduceWithIndex(nodeOp1, threaded, grainSize);
+        mList1.reduceWithIndex(nodeOp1, threaded, nonLeafGrainSize);
         // list0
         if (!mList0.initNodeChildren(mList1, nodeOp1, !threaded))   return;
-        mList0.reduceWithIndex(op, threaded, grainSize);
+        mList0.reduceWithIndex(op, threaded, leafGrainSize);
     }
 
 protected:
@@ -1698,47 +1716,49 @@ public:
     const RootNodeType& root() const { return mRoot; }
 
     template<typename NodeOp>
-    void foreachTopDown(const NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void foreachTopDown(const NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t nonLeafGrainSize=1)
     {
         // root
         if (!op(mRoot, /*index=*/0))                                return;
         // list3
         if (!mList3.initRootChildren(mRoot))                        return;
         ForeachFilterOp<NodeOp> nodeOp3(op, mList3.nodeCount());
-        mList3.foreachWithIndex(nodeOp3, threaded, grainSize);
+        mList3.foreachWithIndex(nodeOp3, threaded, nonLeafGrainSize);
         // list2
         if (!mList2.initNodeChildren(mList3, nodeOp3, !threaded))   return;
         ForeachFilterOp<NodeOp> nodeOp2(op, mList2.nodeCount());
-        mList2.foreachWithIndex(nodeOp2, threaded, grainSize);
+        mList2.foreachWithIndex(nodeOp2, threaded, nonLeafGrainSize);
         // list1
         if (!mList1.initNodeChildren(mList2, nodeOp2, !threaded))   return;
         ForeachFilterOp<NodeOp> nodeOp1(op, mList1.nodeCount());
-        mList1.foreachWithIndex(nodeOp1, threaded, grainSize);
+        mList1.foreachWithIndex(nodeOp1, threaded, nonLeafGrainSize);
         // list0
         if (!mList0.initNodeChildren(mList1, nodeOp1, !threaded))   return;
-        mList0.foreachWithIndex(op, threaded, grainSize);
+        mList0.foreachWithIndex(op, threaded, leafGrainSize);
     }
 
     template<typename NodeOp>
-    void reduceTopDown(NodeOp& op, bool threaded = true, size_t grainSize=1)
+    void reduceTopDown(NodeOp& op, bool threaded = true,
+        size_t leafGrainSize=1, size_t nonLeafGrainSize=1)
     {
         // root
         if (!op(mRoot, /*index=*/0))                                return;
         // list3
         if (!mList3.initRootChildren(mRoot))                        return;
         ReduceFilterOp<NodeOp> nodeOp3(op, mList3.nodeCount());
-        mList3.reduceWithIndex(nodeOp3, threaded, grainSize);
+        mList3.reduceWithIndex(nodeOp3, threaded, nonLeafGrainSize);
         // list2
         if (!mList2.initNodeChildren(mList3, nodeOp3, !threaded))   return;
         ReduceFilterOp<NodeOp> nodeOp2(op, mList2.nodeCount());
-        mList2.reduceWithIndex(nodeOp2, threaded, grainSize);
+        mList2.reduceWithIndex(nodeOp2, threaded, nonLeafGrainSize);
         // list1
         if (!mList1.initNodeChildren(mList2, nodeOp2, !threaded))   return;
         ReduceFilterOp<NodeOp> nodeOp1(op, mList1.nodeCount());
-        mList1.reduceWithIndex(nodeOp1, threaded, grainSize);
+        mList1.reduceWithIndex(nodeOp1, threaded, nonLeafGrainSize);
         // list0
         if (!mList0.initNodeChildren(mList1, nodeOp1, !threaded))   return;
-        mList0.reduceWithIndex(op, threaded, grainSize);
+        mList0.reduceWithIndex(op, threaded, leafGrainSize);
     }
 
 protected:

--- a/openvdb/openvdb/unittest/TestNodeManager.cc
+++ b/openvdb/openvdb/unittest/TestNodeManager.cc
@@ -323,7 +323,7 @@ TEST_F(TestNodeManager, testDynamic)
     { // use DynamicNodeManager::foreachTopDown
         Int32Tree tree(sourceTree);
         openvdb::tree::DynamicNodeManager<Int32Tree> manager(tree);
-        manager.foreachTopDown(expandOp);
+        manager.foreachTopDown(expandOp, /*threaded=*/true, /*leafGrainSize=*/32, /*nonLeafGrainSize=*/8);
         EXPECT_EQ(Index32(32768), tree.leafCount());
 
         SumOp<Int32Tree> sumOp;

--- a/pendingchanges/nodemanagergrainsize.txt
+++ b/pendingchanges/nodemanagergrainsize.txt
@@ -1,0 +1,3 @@
+API:
+- DynamicNodeManager can now set one grain size for threading across leaf nodes
+  and another for threading across non-leaf nodes.


### PR DESCRIPTION
After some consideration, I decided to make the current grain size apply only to threading across leaf nodes and to add an additional grain size to thread across non-leaf nodes.

For most cases, adjusting the grain size for the leaf node threading is what you want, but at least with this implementation there's the option to provide an additional grain size for internal node threading rather than having this hard-coded to any particular value. By default, non-leaf node threading is set to 1.