### PR TITLE
Add optional CMake variable to build a subset of the unit tests

### DIFF
--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -12,6 +12,12 @@ project(OpenVDBUnitTests LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
+set(OPENVDB_TESTS "" CACHE STRING [=[
+  An optional list of unit tests to build. If not provided, all unit tests will be built.
+  Tests should be listed without the Test prefix or the .cc suffix, for example the string
+  \"Activate;NodeManager\" would build just the TestActivate.cc and TestNodeManager.cc
+  unit tests.]=])
+
 ##########################################################################
 
 message(STATUS "----------------------------------------------------")
@@ -53,111 +59,122 @@ endif()
 
 set(UNITTEST_SOURCE_FILES
   main.cc
-  TestActivate.cc
-  TestAttributeArray.cc
-  TestAttributeArrayString.cc
-  TestAttributeGroup.cc
-  TestAttributeSet.cc
-  TestBBox.cc
-  TestClip.cc
-  TestConjGradient.cc
-  TestCoord.cc
-  TestCpt.cc
-  TestCurl.cc
-  TestDelayedLoadMetadata.cc
-  TestDense.cc
-  TestDenseSparseTools.cc
-  TestDiagnostics.cc
-  TestDivergence.cc
-  TestDoubleMetadata.cc
-  TestExceptions.cc
-  TestFastSweeping.cc
-  TestFile.cc
-  TestFilter.cc
-  TestFindActiveValues.cc
-  TestFloatMetadata.cc
-  TestGradient.cc
-  TestGrid.cc
-  TestGridBbox.cc
-  TestGridDescriptor.cc
-  TestGridIO.cc
-  TestGridTransformer.cc
-  TestIndexFilter.cc
-  TestIndexIterator.cc
-  TestInit.cc
-  TestInt32Metadata.cc
-  TestInt64Metadata.cc
-  TestInternalOrigin.cc
-  TestLaplacian.cc
-  TestLeaf.cc
-  TestLeafBool.cc
-  TestLeafIO.cc
-  TestLeafManager.cc
-  TestLeafMask.cc
-  TestLeafOrigin.cc
-  TestLevelSetRayIntersector.cc
-  TestLevelSetUtil.cc
-  TestLinearInterp.cc
-  TestMaps.cc
-  TestMat4Metadata.cc
-  TestMath.cc
-  TestMeanCurvature.cc
-  TestMerge.cc
-  TestMeshToVolume.cc
-  TestMetadata.cc
-  TestMetadataIO.cc
-  TestMetaMap.cc
-  TestMorphology.cc
-  TestMultiResGrid.cc
-  TestName.cc
-  TestNodeIterator.cc
-  TestNodeManager.cc
-  TestNodeMask.cc
-  TestNodeVisitor.cc
-  TestParticleAtlas.cc
-  TestParticlesToLevelSet.cc
-  TestPointAdvect.cc
-  TestPointAttribute.cc
-  TestPointConversion.cc
-  TestPointCount.cc
-  TestPointDataLeaf.cc
-  TestPointDelete.cc
-  TestPointGroup.cc
-  TestPointIndexGrid.cc
-  TestPointMask.cc
-  TestPointMove.cc
-  TestPointPartitioner.cc
-  TestPointSample.cc
-  TestPointScatter.cc
-  TestPointsToMask.cc
-  TestPoissonSolver.cc
-  TestPotentialFlow.cc
-  TestPrePostAPI.cc
-  TestQuadraticInterp.cc
-  TestQuantizedUnitVec.cc
-  TestQuat.cc
-  TestRay.cc
-  TestStats.cc
-  TestStream.cc
-  TestStreamCompression.cc
-  TestStringMetadata.cc
-  TestTools.cc
-  TestTopologyToLevelSet.cc
-  TestTransform.cc
-  TestTree.cc
-  TestTreeCombine.cc
-  TestTreeGetSetValues.cc
-  TestTreeIterators.cc
-  TestTreeVisitor.cc
-  TestTypes.cc
-  TestUtil.cc
-  TestValueAccessor.cc
-  TestVec2Metadata.cc
-  TestVec3Metadata.cc
-  TestVolumeRayIntersector.cc
-  TestVolumeToMesh.cc
-  TestVolumeToSpheres.cc
 )
+
+if(OPENVDB_TESTS)
+  foreach(test ${OPENVDB_TESTS})
+    list(APPEND UNITTEST_SOURCE_FILES
+      Test${test}.cc
+    )
+  endforeach()
+else()
+  list(APPEND UNITTEST_SOURCE_FILES
+    TestActivate.cc
+    TestAttributeArray.cc
+    TestAttributeArrayString.cc
+    TestAttributeGroup.cc
+    TestAttributeSet.cc
+    TestBBox.cc
+    TestClip.cc
+    TestConjGradient.cc
+    TestCoord.cc
+    TestCpt.cc
+    TestCurl.cc
+    TestDelayedLoadMetadata.cc
+    TestDense.cc
+    TestDenseSparseTools.cc
+    TestDiagnostics.cc
+    TestDivergence.cc
+    TestDoubleMetadata.cc
+    TestExceptions.cc
+    TestFastSweeping.cc
+    TestFile.cc
+    TestFilter.cc
+    TestFindActiveValues.cc
+    TestFloatMetadata.cc
+    TestGradient.cc
+    TestGrid.cc
+    TestGridBbox.cc
+    TestGridDescriptor.cc
+    TestGridIO.cc
+    TestGridTransformer.cc
+    TestIndexFilter.cc
+    TestIndexIterator.cc
+    TestInit.cc
+    TestInt32Metadata.cc
+    TestInt64Metadata.cc
+    TestInternalOrigin.cc
+    TestLaplacian.cc
+    TestLeaf.cc
+    TestLeafBool.cc
+    TestLeafIO.cc
+    TestLeafManager.cc
+    TestLeafMask.cc
+    TestLeafOrigin.cc
+    TestLevelSetRayIntersector.cc
+    TestLevelSetUtil.cc
+    TestLinearInterp.cc
+    TestMaps.cc
+    TestMat4Metadata.cc
+    TestMath.cc
+    TestMeanCurvature.cc
+    TestMerge.cc
+    TestMeshToVolume.cc
+    TestMetadata.cc
+    TestMetadataIO.cc
+    TestMetaMap.cc
+    TestMorphology.cc
+    TestMultiResGrid.cc
+    TestName.cc
+    TestNodeIterator.cc
+    TestNodeManager.cc
+    TestNodeMask.cc
+    TestNodeVisitor.cc
+    TestParticleAtlas.cc
+    TestParticlesToLevelSet.cc
+    TestPointAdvect.cc
+    TestPointAttribute.cc
+    TestPointConversion.cc
+    TestPointCount.cc
+    TestPointDataLeaf.cc
+    TestPointDelete.cc
+    TestPointGroup.cc
+    TestPointIndexGrid.cc
+    TestPointMask.cc
+    TestPointMove.cc
+    TestPointPartitioner.cc
+    TestPointSample.cc
+    TestPointScatter.cc
+    TestPointsToMask.cc
+    TestPoissonSolver.cc
+    TestPotentialFlow.cc
+    TestPrePostAPI.cc
+    TestQuadraticInterp.cc
+    TestQuantizedUnitVec.cc
+    TestQuat.cc
+    TestRay.cc
+    TestStats.cc
+    TestStream.cc
+    TestStreamCompression.cc
+    TestStringMetadata.cc
+    TestTools.cc
+    TestTopologyToLevelSet.cc
+    TestTransform.cc
+    TestTree.cc
+    TestTreeCombine.cc
+    TestTreeGetSetValues.cc
+    TestTreeIterators.cc
+    TestTreeVisitor.cc
+    TestTypes.cc
+    TestUtil.cc
+    TestValueAccessor.cc
+    TestVec2Metadata.cc
+    TestVec3Metadata.cc
+    TestVolumeRayIntersector.cc
+    TestVolumeToMesh.cc
+    TestVolumeToSpheres.cc
+  )
+endif()
 
 add_executable(vdb_test ${UNITTEST_SOURCE_FILES})
 

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -63,8 +63,9 @@ set(UNITTEST_SOURCE_FILES
 
 if(OPENVDB_TESTS)
   foreach(test ${OPENVDB_TESTS})
+    file(GLOB UNITTEST_GLOB Test${test}*.cc)
     list(APPEND UNITTEST_SOURCE_FILES
-      Test${test}.cc
+      ${UNITTEST_GLOB}
     )
   endforeach()
 else()

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -63,7 +63,7 @@ set(UNITTEST_SOURCE_FILES
 
 if(OPENVDB_TESTS)
   foreach(test ${OPENVDB_TESTS})
-    file(GLOB UNITTEST_GLOB Test${test}*.cc)
+    file(GLOB UNITTEST_GLOB CONFIGURE_DEPENDS Test${test}*.cc)
     list(APPEND UNITTEST_SOURCE_FILES
       ${UNITTEST_GLOB}
     )

--- a/pendingchanges/openvdbtests.txt
+++ b/pendingchanges/openvdbtests.txt
@@ -1,0 +1,3 @@
+Build:
+- Added an optional OPENVDB_TESTS variable to easily build a subset of the
+  unit tests.


### PR DESCRIPTION
I very frequently do not wish to build all the unit tests and only wish to iterate on one or even a few. Right now, this requires modifying the CMakeLists.txt for the unit tests and carefully managing this edit, so as not to commit this change.

This PR adds a new optional CMake variable to define the unit tests you wish to build such as:

cmake -DOPENVDB_TESTS=NodeManager
cmake -DOPENVDB_TESTS="Activate;NodeManager"

If this variable isn't provided by the user, all the unit tests will be built. You'll note that this list assumes the format "Test<Name>.cc" which is our convention.