### PR TITLE
Fix PointData and PointIndex aliases

### DIFF
--- a/openvdb/openvdb/points/PointAttribute.h
+++ b/openvdb/openvdb/points/PointAttribute.h
@@ -284,7 +284,7 @@ inline void appendAttribute(PointDataTreeT& tree,
 
     tree::LeafManager<PointDataTreeT> leafManager(tree);
     leafManager.foreach(
-        [&](typename PointDataTree::LeafNodeType& leaf, size_t /*idx*/) {
+        [&](typename PointDataTreeT::LeafNodeType& leaf, size_t /*idx*/) {
             auto expected = leaf.attributeSet().descriptorPtr();
 
             auto attribute = leaf.appendAttribute(*expected, newDescriptor,
@@ -360,7 +360,7 @@ inline void collapseAttribute(  PointDataTreeT& tree,
 
     tree::LeafManager<PointDataTreeT> leafManager(tree);
     leafManager.foreach(
-        [&](typename PointDataTree::LeafNodeType& leaf, size_t /*idx*/) {
+        [&](typename PointDataTreeT::LeafNodeType& leaf, size_t /*idx*/) {
             assert(leaf.hasAttribute(index));
             AttributeArray& array = leaf.attributeArray(index);
             point_attribute_internal::collapseAttribute(
@@ -397,7 +397,7 @@ inline void dropAttributes( PointDataTreeT& tree,
 
     tree::LeafManager<PointDataTreeT> leafManager(tree);
     leafManager.foreach(
-        [&](typename PointDataTree::LeafNodeType& leaf, size_t /*idx*/) {
+        [&](typename PointDataTreeT::LeafNodeType& leaf, size_t /*idx*/) {
             auto expected = leaf.attributeSet().descriptorPtr();
             leaf.dropAttributes(indices, *expected, newDescriptor);
         }, /*threaded=*/true
@@ -528,7 +528,7 @@ inline void compactAttributes(PointDataTreeT& tree)
 
     tree::LeafManager<PointDataTreeT> leafManager(tree);
     leafManager.foreach(
-        [&](typename PointDataTree::LeafNodeType& leaf, size_t /*idx*/) {
+        [&](typename PointDataTreeT::LeafNodeType& leaf, size_t /*idx*/) {
             leaf.compactAttributes();
         }, /*threaded=*/ true
     );

--- a/openvdb/openvdb/points/PointAttribute.h
+++ b/openvdb/openvdb/points/PointAttribute.h
@@ -67,7 +67,7 @@ inline void appendAttribute(PointDataTreeT& tree,
 /// @param transient          mark attribute as transient
 template <typename ValueType,
           typename CodecType = NullCodec,
-          typename PointDataTreeT = PointDataTree>
+          typename PointDataTreeT>
 inline void appendAttribute(PointDataTreeT& tree,
                             const std::string& name,
                             const ValueType& uniformValue =

--- a/openvdb/openvdb/points/PointConversion.h
+++ b/openvdb/openvdb/points/PointConversion.h
@@ -619,7 +619,7 @@ createPointDataGrid(const PointIndexGridT& pointIndexGrid,
                     const Metadata* positionDefaultValue)
 {
     using PointDataTreeT        = typename PointDataGridT::TreeType;
-    using LeafT                 = typename PointDataTree::LeafNodeType;
+    using LeafT                 = typename PointDataTreeT::LeafNodeType;
     using PointIndexLeafT       = typename PointIndexGridT::TreeType::LeafNodeType;
     using PointIndexT           = typename PointIndexLeafT::ValueType;
     using LeafManagerT          = typename tree::LeafManager<PointDataTreeT>;
@@ -855,7 +855,7 @@ convertPointDataGridGroup(  Group& group,
     if (!iter)  return;
 
     LeafManagerT leafManager(tree);
-    ConvertPointDataGridGroupOp<PointDataTree, Group, FilterT> convert(
+    ConvertPointDataGridGroupOp<PointDataTreeT, Group, FilterT> convert(
                     group, pointOffsets, startOffset, index,
                     filter, inCoreOnly);
     tbb::parallel_for(leafManager.leafRange(), convert);

--- a/openvdb/openvdb/points/PointDataGrid.h
+++ b/openvdb/openvdb/points/PointDataGrid.h
@@ -180,6 +180,11 @@ namespace points {
 // forward declaration
 template<typename T, Index Log2Dim> class PointDataLeafNode;
 
+// these aliases are disabled in one of the unit tests to ensure that
+// they are not used by the Point headers
+
+#ifndef OPENVDB_DISABLE_POINT_DATA_TREE_ALIAS
+
 /// @brief Point index tree configured to match the default VDB configurations.
 using PointDataTree = tree::Tree<tree::RootNode<tree::InternalNode<tree::InternalNode
     <PointDataLeafNode<PointDataIndex32, 3>, 4>, 5>>>;
@@ -188,6 +193,7 @@ using PointDataTree = tree::Tree<tree::RootNode<tree::InternalNode<tree::Interna
 /// @brief Point data grid.
 using PointDataGrid = Grid<PointDataTree>;
 
+#endif
 
 /// @brief  Deep copy the descriptor across all leaf nodes.
 ///

--- a/openvdb/openvdb/points/PointGroup.h
+++ b/openvdb/openvdb/points/PointGroup.h
@@ -42,16 +42,16 @@ inline void deleteMissingPointGroups(   std::vector<std::string>& groups,
 ///
 /// @param tree          the PointDataTree to be appended to.
 /// @param group         name of the new group.
-template <typename PointDataTree>
-inline void appendGroup(PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void appendGroup(PointDataTreeT& tree,
                         const Name& group);
 
 /// @brief Appends new empty groups to the VDB tree.
 ///
 /// @param tree          the PointDataTree to be appended to.
 /// @param groups        names of the new groups.
-template <typename PointDataTree>
-inline void appendGroups(PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void appendGroups(PointDataTreeT& tree,
                          const std::vector<Name>& groups);
 
 /// @brief Drops an existing group from the VDB tree.
@@ -60,8 +60,8 @@ inline void appendGroups(PointDataTree& tree,
 /// @param group         name of the group.
 /// @param compact       compact attributes if possible to reduce memory - if dropping
 ///                      more than one group, compacting once at the end will be faster
-template <typename PointDataTree>
-inline void dropGroup(  PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void dropGroup(  PointDataTreeT& tree,
                         const Name& group,
                         const bool compact = true);
 
@@ -69,21 +69,21 @@ inline void dropGroup(  PointDataTree& tree,
 ///
 /// @param tree          the PointDataTree to be dropped from.
 /// @param groups        names of the groups.
-template <typename PointDataTree>
-inline void dropGroups( PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void dropGroups( PointDataTreeT& tree,
                         const std::vector<Name>& groups);
 
 /// @brief Drops all existing groups from the VDB tree, the tree is compacted after dropping.
 ///
 /// @param tree          the PointDataTree to be dropped from.
-template <typename PointDataTree>
-inline void dropGroups( PointDataTree& tree);
+template <typename PointDataTreeT>
+inline void dropGroups( PointDataTreeT& tree);
 
 /// @brief Compacts existing groups of a VDB Tree to use less memory if possible.
 ///
 /// @param tree          the PointDataTree to be compacted.
-template <typename PointDataTree>
-inline void compactGroups(PointDataTree& tree);
+template <typename PointDataTreeT>
+inline void compactGroups(PointDataTreeT& tree);
 
 /// @brief Sets group membership from a PointIndexTree-ordered vector.
 ///
@@ -94,9 +94,9 @@ inline void compactGroups(PointDataTree& tree);
 /// @param remove        if @c true also perform removal of points from the group.
 ///
 /// @note vector<bool> is not thread-safe on concurrent write, so use vector<short> instead
-template <typename PointDataTree, typename PointIndexTree>
-inline void setGroup(   PointDataTree& tree,
-                        const PointIndexTree& indexTree,
+template <typename PointDataTreeT, typename PointIndexTreeT>
+inline void setGroup(   PointDataTreeT& tree,
+                        const PointIndexTreeT& indexTree,
                         const std::vector<short>& membership,
                         const Name& group,
                         const bool remove = false);
@@ -106,8 +106,8 @@ inline void setGroup(   PointDataTree& tree,
 /// @param tree         the PointDataTree.
 /// @param group        the name of the group.
 /// @param member       true / false for membership of the group.
-template <typename PointDataTree>
-inline void setGroup(   PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void setGroup(   PointDataTreeT& tree,
                         const Name& group,
                         const bool member = true);
 
@@ -116,8 +116,8 @@ inline void setGroup(   PointDataTree& tree,
 /// @param tree     the PointDataTree.
 /// @param group    the name of the group.
 /// @param filter   filter data that is used to create a per-leaf filter
-template <typename PointDataTree, typename FilterT>
-inline void setGroupByFilter(   PointDataTree& tree,
+template <typename PointDataTreeT, typename FilterT>
+inline void setGroupByFilter(   PointDataTreeT& tree,
                                 const Name& group,
                                 const FilterT& filter);
 
@@ -163,10 +163,10 @@ struct CopyGroupOp {
 
 
 /// Set membership on or off for the specified group
-template <typename PointDataTree, bool Member>
+template <typename PointDataTreeT, bool Member>
 struct SetGroupOp
 {
-    using LeafManagerT  = typename tree::LeafManager<PointDataTree>;
+    using LeafManagerT  = typename tree::LeafManager<PointDataTreeT>;
     using GroupIndex    = AttributeSet::Descriptor::GroupIndex;
 
     SetGroupOp(const AttributeSet::Descriptor::GroupIndex& index)
@@ -192,17 +192,17 @@ struct SetGroupOp
 }; // struct SetGroupOp
 
 
-template <typename PointDataTree, typename PointIndexTree, bool Remove>
+template <typename PointDataTreeT, typename PointIndexTreeT, bool Remove>
 struct SetGroupFromIndexOp
 {
-    using LeafManagerT          = typename tree::LeafManager<PointDataTree>;
+    using LeafManagerT          = typename tree::LeafManager<PointDataTreeT>;
     using LeafRangeT            = typename LeafManagerT::LeafRange;
-    using PointIndexLeafNode    = typename PointIndexTree::LeafNodeType;
+    using PointIndexLeafNode    = typename PointIndexTreeT::LeafNodeType;
     using IndexArray            = typename PointIndexLeafNode::IndexArray;
     using GroupIndex            = AttributeSet::Descriptor::GroupIndex;
     using MembershipArray       = std::vector<short>;
 
-    SetGroupFromIndexOp(const PointIndexTree& indexTree,
+    SetGroupFromIndexOp(const PointIndexTreeT& indexTree,
                         const MembershipArray& membership,
                         const GroupIndex& index)
         : mIndexTree(indexTree)
@@ -246,18 +246,18 @@ struct SetGroupFromIndexOp
 
     //////////
 
-    const PointIndexTree& mIndexTree;
+    const PointIndexTreeT& mIndexTree;
     const MembershipArray& mMembership;
     const GroupIndex& mIndex;
 }; // struct SetGroupFromIndexOp
 
 
-template <typename PointDataTree, typename FilterT, typename IterT = typename PointDataTree::LeafNodeType::ValueAllCIter>
+template <typename PointDataTreeT, typename FilterT, typename IterT = typename PointDataTreeT::LeafNodeType::ValueAllCIter>
 struct SetGroupByFilterOp
 {
-    using LeafManagerT  = typename tree::LeafManager<PointDataTree>;
+    using LeafManagerT  = typename tree::LeafManager<PointDataTreeT>;
     using LeafRangeT    = typename LeafManagerT::LeafRange;
-    using LeafNodeT     = typename PointDataTree::LeafNodeType;
+    using LeafNodeT     = typename PointDataTreeT::LeafNodeType;
     using GroupIndex    = AttributeSet::Descriptor::GroupIndex;
 
     SetGroupByFilterOp( const GroupIndex& index, const FilterT& filter)
@@ -384,8 +384,8 @@ inline void appendGroup(PointDataTreeT& tree, const Name& group)
 ////////////////////////////////////////
 
 
-template <typename PointDataTree>
-inline void appendGroups(PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void appendGroups(PointDataTreeT& tree,
                          const std::vector<Name>& groups)
 {
     // TODO: could be more efficient by appending multiple groups at once
@@ -400,8 +400,8 @@ inline void appendGroups(PointDataTree& tree,
 ////////////////////////////////////////
 
 
-template <typename PointDataTree>
-inline void dropGroup(PointDataTree& tree, const Name& group, const bool compact)
+template <typename PointDataTreeT>
+inline void dropGroup(PointDataTreeT& tree, const Name& group, const bool compact)
 {
     using Descriptor = AttributeSet::Descriptor;
 
@@ -433,8 +433,8 @@ inline void dropGroup(PointDataTree& tree, const Name& group, const bool compact
 ////////////////////////////////////////
 
 
-template <typename PointDataTree>
-inline void dropGroups( PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void dropGroups( PointDataTreeT& tree,
                         const std::vector<Name>& groups)
 {
     for (const Name& name : groups) {
@@ -450,8 +450,8 @@ inline void dropGroups( PointDataTree& tree,
 ////////////////////////////////////////
 
 
-template <typename PointDataTree>
-inline void dropGroups( PointDataTree& tree)
+template <typename PointDataTreeT>
+inline void dropGroups( PointDataTreeT& tree)
 {
     using Descriptor = AttributeSet::Descriptor;
 
@@ -481,12 +481,12 @@ inline void dropGroups( PointDataTree& tree)
 ////////////////////////////////////////
 
 
-template <typename PointDataTree>
-inline void compactGroups(PointDataTree& tree)
+template <typename PointDataTreeT>
+inline void compactGroups(PointDataTreeT& tree)
 {
     using Descriptor = AttributeSet::Descriptor;
     using GroupIndex = Descriptor::GroupIndex;
-    using LeafManagerT = typename tree::template LeafManager<PointDataTree>;
+    using LeafManagerT = typename tree::template LeafManager<PointDataTreeT>;
 
     using point_group_internal::CopyGroupOp;
 
@@ -517,7 +517,7 @@ inline void compactGroups(PointDataTree& tree)
         const GroupIndex sourceIndex = attributeSet.groupIndex(sourceOffset);
         const GroupIndex targetIndex = attributeSet.groupIndex(targetOffset);
 
-        CopyGroupOp<PointDataTree> copy(targetIndex, sourceIndex);
+        CopyGroupOp<PointDataTreeT> copy(targetIndex, sourceIndex);
         LeafManagerT leafManager(tree);
         tbb::parallel_for(leafManager.leafRange(), copy);
 
@@ -542,15 +542,15 @@ inline void compactGroups(PointDataTree& tree)
 ////////////////////////////////////////
 
 
-template <typename PointDataTree, typename PointIndexTree>
-inline void setGroup(   PointDataTree& tree,
-                        const PointIndexTree& indexTree,
+template <typename PointDataTreeT, typename PointIndexTreeT>
+inline void setGroup(   PointDataTreeT& tree,
+                        const PointIndexTreeT& indexTree,
                         const std::vector<short>& membership,
                         const Name& group,
                         const bool remove)
 {
     using Descriptor    = AttributeSet::Descriptor;
-    using LeafManagerT  = typename tree::template LeafManager<PointDataTree>;
+    using LeafManagerT  = typename tree::LeafManager<PointDataTreeT>;
     using point_group_internal::SetGroupFromIndexOp;
 
     auto iter = tree.cbeginLeaf();
@@ -569,7 +569,7 @@ inline void setGroup(   PointDataTree& tree,
         // values. If the index tree was constructed with nan positions, this index will
         // differ from the PointDataTree count
 
-        using IndexTreeManager = tree::LeafManager<const PointIndexTree>;
+        using IndexTreeManager = tree::LeafManager<const PointIndexTreeT>;
         IndexTreeManager leafManager(indexTree);
 
         const int64_t max = tbb::parallel_reduce(leafManager.leafRange(), -1,
@@ -597,12 +597,12 @@ inline void setGroup(   PointDataTree& tree,
     // set membership
 
     if (remove) {
-        SetGroupFromIndexOp<PointDataTree, PointIndexTree, true>
+        SetGroupFromIndexOp<PointDataTreeT, PointIndexTreeT, true>
             set(indexTree, membership, index);
         tbb::parallel_for(leafManager.leafRange(), set);
     }
     else {
-        SetGroupFromIndexOp<PointDataTree, PointIndexTree, false>
+        SetGroupFromIndexOp<PointDataTreeT, PointIndexTreeT, false>
             set(indexTree, membership, index);
         tbb::parallel_for(leafManager.leafRange(), set);
     }
@@ -612,13 +612,13 @@ inline void setGroup(   PointDataTree& tree,
 ////////////////////////////////////////
 
 
-template <typename PointDataTree>
-inline void setGroup(   PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void setGroup(   PointDataTreeT& tree,
                         const Name& group,
                         const bool member)
 {
     using Descriptor    = AttributeSet::Descriptor;
-    using LeafManagerT  = typename tree::template LeafManager<PointDataTree>;
+    using LeafManagerT  = typename tree::LeafManager<PointDataTreeT>;
 
     using point_group_internal::SetGroupOp;
 
@@ -638,21 +638,21 @@ inline void setGroup(   PointDataTree& tree,
 
     // set membership based on member variable
 
-    if (member)     tbb::parallel_for(leafManager.leafRange(), SetGroupOp<PointDataTree, true>(index));
-    else            tbb::parallel_for(leafManager.leafRange(), SetGroupOp<PointDataTree, false>(index));
+    if (member)     tbb::parallel_for(leafManager.leafRange(), SetGroupOp<PointDataTreeT, true>(index));
+    else            tbb::parallel_for(leafManager.leafRange(), SetGroupOp<PointDataTreeT, false>(index));
 }
 
 
 ////////////////////////////////////////
 
 
-template <typename PointDataTree, typename FilterT>
-inline void setGroupByFilter(   PointDataTree& tree,
+template <typename PointDataTreeT, typename FilterT>
+inline void setGroupByFilter(   PointDataTreeT& tree,
                                 const Name& group,
                                 const FilterT& filter)
 {
     using Descriptor    = AttributeSet::Descriptor;
-    using LeafManagerT  = typename tree::template LeafManager<PointDataTree>;
+    using LeafManagerT  = typename tree::LeafManager<PointDataTreeT>;
 
     using point_group_internal::SetGroupByFilterOp;
 
@@ -671,7 +671,7 @@ inline void setGroupByFilter(   PointDataTree& tree,
 
     // set membership using filter
 
-    SetGroupByFilterOp<PointDataTree, FilterT> set(index, filter);
+    SetGroupByFilterOp<PointDataTreeT, FilterT> set(index, filter);
     LeafManagerT leafManager(tree);
 
     tbb::parallel_for(leafManager.leafRange(), set);
@@ -681,37 +681,37 @@ inline void setGroupByFilter(   PointDataTree& tree,
 ////////////////////////////////////////
 
 
-template <typename PointDataTree>
-inline void setGroupByRandomTarget( PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void setGroupByRandomTarget( PointDataTreeT& tree,
                                     const Name& group,
                                     const Index64 targetPoints,
                                     const unsigned int seed = 0)
 {
-    using RandomFilter = RandomLeafFilter<PointDataTree, std::mt19937>;
+    using RandomFilter = RandomLeafFilter<PointDataTreeT, std::mt19937>;
 
     RandomFilter filter(tree, targetPoints, seed);
 
-    setGroupByFilter<PointDataTree, RandomFilter>(tree, group, filter);
+    setGroupByFilter<PointDataTreeT, RandomFilter>(tree, group, filter);
 }
 
 
 ////////////////////////////////////////
 
 
-template <typename PointDataTree>
-inline void setGroupByRandomPercentage( PointDataTree& tree,
+template <typename PointDataTreeT>
+inline void setGroupByRandomPercentage( PointDataTreeT& tree,
                                         const Name& group,
                                         const float percentage = 10.0f,
                                         const unsigned int seed = 0)
 {
-    using RandomFilter =  RandomLeafFilter<PointDataTree, std::mt19937>;
+    using RandomFilter =  RandomLeafFilter<PointDataTreeT, std::mt19937>;
 
     const int currentPoints = static_cast<int>(pointCount(tree));
     const int targetPoints = int(math::Round((percentage * float(currentPoints))/100.0f));
 
     RandomFilter filter(tree, targetPoints, seed);
 
-    setGroupByFilter<PointDataTree, RandomFilter>(tree, group, filter);
+    setGroupByFilter<PointDataTreeT, RandomFilter>(tree, group, filter);
 }
 
 

--- a/openvdb/openvdb/points/PointMove.h
+++ b/openvdb/openvdb/points/PointMove.h
@@ -548,13 +548,13 @@ inline void movePoints( PointDataGridT& points,
 
     // early exit if no LeafNodes
 
-    PointDataTree::LeafCIter iter = tree.cbeginLeaf();
+    auto iter = tree.cbeginLeaf();
 
     if (!iter)      return;
 
     // build voxel topology taking into account any point group deletion
 
-    auto newPoints = point_mask_internal::convertPointsToScalar<PointDataGrid>(
+    auto newPoints = point_mask_internal::convertPointsToScalar<PointDataGridT>(
         points, transform, filter, deformer, threaded);
     auto& newTree = newPoints->tree();
 

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -141,6 +141,7 @@ else()
     TestPointDelete.cc
     TestPointGroup.cc
     TestPointIndexGrid.cc
+    TestPointInstantiate.cc
     TestPointMask.cc
     TestPointMove.cc
     TestPointPartitioner.cc

--- a/openvdb/openvdb/unittest/TestPointInstantiate.cc
+++ b/openvdb/openvdb/unittest/TestPointInstantiate.cc
@@ -1,0 +1,56 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#include "gtest/gtest.h"
+
+// this removes the PointDataGrid and PointDataTree aliases
+#define OPENVDB_DISABLE_POINT_DATA_TREE_ALIAS
+
+// include all of the point headers and confirm that none are referring directly
+// to the removed aliases
+
+#include <openvdb/points/PointAdvect.h>
+#include <openvdb/points/PointAttribute.h>
+#include <openvdb/points/PointConversion.h>
+#include <openvdb/points/PointCount.h>
+#include <openvdb/points/PointDataGrid.h>
+#include <openvdb/points/PointDelete.h>
+#include <openvdb/points/PointGroup.h>
+#include <openvdb/points/PointMask.h>
+#include <openvdb/points/PointMove.h>
+#include <openvdb/points/PointSample.h>
+#include <openvdb/points/PointScatter.h>
+
+
+class TestPointInstantiate: public ::testing::Test
+{
+}; // class TestPointInstantiate
+
+
+TEST_F(TestPointInstantiate, test)
+{
+    openvdb::initialize();
+
+    std::vector<openvdb::Vec3f> positions;
+    positions.emplace_back(1.0f, 2.0f, 3.0f);
+    openvdb::points::PointAttributeVector<openvdb::Vec3f> wrapper(positions);
+
+    auto transform = openvdb::math::Transform::createLinearTransform(0.5);
+
+    // these custom grid types use a 64-bit value type instead of a 32-bit value type
+    // and have a 16^3 leaf node instead of a 8^3 leaf node
+
+    using CustomPointIndexGrid = openvdb::Grid<openvdb::tree::Tree<openvdb::tree::RootNode<
+        openvdb::tree::InternalNode<openvdb::tree::InternalNode<
+        openvdb::tools::PointIndexLeafNode<openvdb::PointIndex64, 4>, 4>, 5>>>>;
+    using CustomPointDataGrid = openvdb::Grid<openvdb::tree::Tree<openvdb::tree::RootNode<
+        openvdb::tree::InternalNode<openvdb::tree::InternalNode<
+        openvdb::points::PointDataLeafNode<openvdb::PointDataIndex64, 4>, 4>, 5>>>>;
+
+    auto pointIndexGrid = openvdb::tools::createPointIndexGrid<CustomPointIndexGrid>(
+        wrapper, *transform);
+    auto points = openvdb::points::createPointDataGrid<openvdb::points::NullCodec, CustomPointDataGrid>(
+        *pointIndexGrid, wrapper, *transform);
+
+    EXPECT_TRUE(points);
+}

--- a/openvdb_houdini/openvdb_houdini/VRAY_OpenVDB_Points.cc
+++ b/openvdb_houdini/openvdb_houdini/VRAY_OpenVDB_Points.cc
@@ -283,16 +283,16 @@ getBoundingBox( const std::vector<typename PointDataGridT::Ptr>& gridPtrs,
                 const std::vector<Name>& includeGroups,
                 const std::vector<Name>& excludeGroups)
 {
-    using PointDataTree     = typename PointDataGridT::TreeType;
+    using PointDataTreeT     = typename PointDataGridT::TreeType;
 
     BBoxd worldBounds;
 
     for (const auto& grid : gridPtrs) {
 
-        tree::LeafManager<const PointDataTree> leafManager(grid->tree());
+        typename tree::LeafManager<const PointDataTreeT> leafManager(grid->tree());
 
         // size and combine the boxes for each leaf in the tree via a reduction
-        GenerateBBoxOp<PointDataTree> generateBbox(grid->transform(), includeGroups, excludeGroups);
+        GenerateBBoxOp<PointDataTreeT> generateBbox(grid->transform(), includeGroups, excludeGroups);
         tbb::parallel_reduce(leafManager.leafRange(), generateBbox);
 
         if (generateBbox.mBbox.empty())     continue;

--- a/pendingchanges/point_aliases.txt
+++ b/pendingchanges/point_aliases.txt
@@ -1,0 +1,4 @@
+Bug Fixes:
+- Fixed all cases where PointIndex and PointData aliases were used instead of
+  a templated type.
+  [Reported by Karl Marrett]


### PR DESCRIPTION
This fixes all cases where PointIndexTree, PointDataGrid and PointDataTree were used incorrectly instead of the templated T type and also renames any templated typenames that would override these aliases.

Finally, I have added a new unit test that builds a custom PointDataGrid with a different value type and leaf node size and added a macro to disable the PointDataGrid and PointDataTree aliases to ensure that the functionality in the headers only ever uses templated types.