### PR TITLE
VDB Merge

### DIFF
--- a/openvdb/openvdb/unittest/TestMerge.cc
+++ b/openvdb/openvdb/unittest/TestMerge.cc
@@ -2567,3 +2567,535 @@ TEST_F(TestMerge, testCsgDifference)
         EXPECT_EQ(Index32(1), grid2->tree().leafCount());
     }
 }
+
+
+TEST_F(TestMerge, testSum)
+{
+    using RootChildType = FloatTree::RootNodeType::ChildNodeType;
+    using LeafT = FloatTree::LeafNodeType;
+
+    { // construction
+        FloatTree tree1;
+        FloatTree tree2;
+        const FloatTree tree3;
+
+        { // one non-const tree (steal)
+            tools::SumMergeOp<FloatTree> mergeOp(tree1, Steal());
+            EXPECT_EQ(size_t(1), mergeOp.size());
+        }
+        { // one non-const tree (deep-copy)
+            tools::SumMergeOp<FloatTree> mergeOp(tree1, DeepCopy());
+            EXPECT_EQ(size_t(1), mergeOp.size());
+        }
+        { // one const tree (deep-copy)
+            tools::SumMergeOp<FloatTree> mergeOp(tree2, DeepCopy());
+            EXPECT_EQ(size_t(1), mergeOp.size());
+        }
+        { // vector of tree pointers
+            std::vector<FloatTree*> trees{&tree1, &tree2};
+            tools::SumMergeOp<FloatTree> mergeOp(trees, Steal());
+            EXPECT_EQ(size_t(2), mergeOp.size());
+        }
+        { // deque of tree pointers
+            std::deque<FloatTree*> trees{&tree1, &tree2};
+            tools::SumMergeOp<FloatTree> mergeOp(trees, DeepCopy());
+            EXPECT_EQ(size_t(2), mergeOp.size());
+        }
+        { // vector of TreesToMerge (to mix const and non-const trees)
+            std::vector<tools::TreeToMerge<FloatTree>> trees;
+            trees.emplace_back(tree1, Steal());
+            trees.emplace_back(tree3, DeepCopy()); // const tree
+            trees.emplace_back(tree2, Steal());
+            tools::SumMergeOp<FloatTree> mergeOp(trees);
+            EXPECT_EQ(size_t(3), mergeOp.size());
+        }
+        { // implicit copy constructor
+            std::vector<FloatTree*> trees{&tree1, &tree2};
+            tools::SumMergeOp<FloatTree> mergeOp(trees, Steal());
+            tools::SumMergeOp<FloatTree> mergeOp2(mergeOp);
+            EXPECT_EQ(size_t(2), mergeOp2.size());
+        }
+        { // implicit assignment operator
+            std::vector<FloatTree*> trees{&tree1, &tree2};
+            tools::SumMergeOp<FloatTree> mergeOp(trees, Steal());
+            tools::SumMergeOp<FloatTree> mergeOp2 = mergeOp;
+            EXPECT_EQ(size_t(2), mergeOp2.size());
+        }
+    }
+
+    { // merge two different background root tiles from one tree into an empty tree
+        FloatTree tree, tree2;
+        tree2.root().addTile(Coord(0, 0, 0), tree2.background(), false);
+        tree2.root().addTile(Coord(8192, 0, 0), tree2.background(), true);
+
+        const auto& root2 = tree2.root();
+        EXPECT_EQ(Index(2), root2.getTableSize());
+        EXPECT_EQ(Index(2), getTileCount(root2));
+        EXPECT_EQ(Index(1), getActiveTileCount(root2));
+        EXPECT_EQ(Index(1), getInactiveTileCount(root2));
+
+        tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        // background tiles are not erased
+        EXPECT_EQ(Index(2), tree.root().getTableSize());
+    }
+
+    { // merge two different root tiles from one tree into an empty tree
+        FloatTree tree, tree2;
+        tree2.root().addTile(Coord(0, 0, 0), 1.1f, false);
+        tree2.root().addTile(Coord(8192, 0, 0), 2.2f, true);
+        EXPECT_EQ(Index(2), getTileCount(tree2.root()));
+
+        tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        EXPECT_EQ(Index(2), tree.root().getTableSize());
+        EXPECT_EQ(Index(1), getActiveTileCount(tree.root()));
+        EXPECT_EQ(Index(1), getInactiveTileCount(tree.root()));
+    }
+
+    { // merge two different root tiles from one tree into a tree with one root tile
+        FloatTree tree, tree2;
+        tree.root().addTile(Coord(-8192, 0, 0), -3.3f, true);
+        tree2.root().addTile(Coord(0, 0, 0), 1.1f, false);
+        tree2.root().addTile(Coord(8192, 0, 0), 2.2f, true);
+
+        EXPECT_EQ(Index(1), getTileCount(tree.root()));
+        EXPECT_EQ(Index(2), getTileCount(tree2.root()));
+
+        tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        const auto& root = tree.root();
+        EXPECT_EQ(Index(3), root.getTableSize());
+        EXPECT_EQ(Index(2), getActiveTileCount(root));
+        EXPECT_EQ(Index(1), getInactiveTileCount(root));
+        auto iter = root.cbeginValueAll();
+        EXPECT_EQ(-3.3f, *iter);
+        EXPECT_TRUE(iter.isValueOn());
+        ++iter;
+        EXPECT_EQ(1.1f, *iter);
+        EXPECT_TRUE(iter.isValueOff());
+        ++iter;
+        EXPECT_EQ(2.2f, *iter);
+        EXPECT_TRUE(iter.isValueOn());
+    }
+
+    { // merge root tiles with the same active state
+        FloatTree tree, tree2;
+        tree.root().addTile(Coord(0, 0, 0), 1.1f, false);
+        tree2.root().addTile(Coord(0, 0, 0), 2.2f, false);
+        tree.root().addTile(Coord(8192, 0, 0), 1.1f, true);
+        tree2.root().addTile(Coord(8192, 0, 0), 2.2f, true);
+
+        EXPECT_EQ(Index(2), getTileCount(tree.root()));
+        EXPECT_EQ(Index(2), getTileCount(tree2.root()));
+
+        tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        const auto& root = tree.root();
+        EXPECT_EQ(Index(1), getActiveTileCount(root));
+        auto iter = root.cbeginValueAll();
+        EXPECT_EQ(1.1f+2.2f, *iter);
+        EXPECT_TRUE(iter.isValueOff());
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f, *iter);
+        EXPECT_TRUE(iter.isValueOn());
+    }
+
+    { // merge root tiles with different active state
+        FloatTree tree, tree2;
+        tree.root().addTile(Coord(0, 0, 0), 1.1f, false);
+        tree2.root().addTile(Coord(0, 0, 0), 2.2f, true);
+        tree.root().addTile(Coord(8192, 0, 0), 1.1f, true);
+        tree2.root().addTile(Coord(8192, 0, 0), 2.2f, false);
+
+        EXPECT_EQ(Index(2), getTileCount(tree.root()));
+        EXPECT_EQ(Index(2), getTileCount(tree2.root()));
+
+        tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        const auto& root = tree.root();
+        EXPECT_EQ(Index(2), getActiveTileCount(root));
+        auto iter = root.cbeginValueAll();
+        EXPECT_EQ(1.1f+2.2f, *iter);
+        EXPECT_TRUE(iter.isValueOn());
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f, *iter);
+        EXPECT_TRUE(iter.isValueOn());
+    }
+
+    { // merge root tiles from three trees
+        FloatTree tree, tree2, tree3;
+        tree.root().addTile(Coord(0, 0, 0), 1.1f, false);
+        tree2.root().addTile(Coord(0, 0, 0), 2.2f, false);
+        tree3.root().addTile(Coord(0, 0, 0), 3.3f, false);
+        tree2.root().addTile(Coord(8192, 0, 0), 2.2f, false);
+        tree3.root().addTile(Coord(8192, 0, 0), 3.3f, true);
+        tree3.root().addTile(Coord(-8192, 0, 0), -9.9f, false);
+
+        EXPECT_EQ(Index(1), getTileCount(tree.root()));
+        EXPECT_EQ(Index(2), getTileCount(tree2.root()));
+        EXPECT_EQ(Index(3), getTileCount(tree3.root()));
+
+        std::vector<FloatTree*> trees{&tree2, &tree3};
+        tools::SumMergeOp<FloatTree> mergeOp(trees, Steal());
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        const auto& root = tree.root();
+        auto iter = root.cbeginValueAll();
+        EXPECT_EQ(-9.9f, *iter);
+        EXPECT_TRUE(iter.isValueOff());
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f+3.3f, *iter);
+        EXPECT_TRUE(iter.isValueOff());
+        ++iter;
+        EXPECT_EQ(2.2f+3.3f, *iter);
+        EXPECT_TRUE(iter.isValueOn());
+    }
+
+    { // merge root tiles and root children
+        FloatTree tree, tree2;
+        tree.root().addTile(Coord(0, 0, 0), 1.1f, false);
+        tree2.root().addChild(new RootChildType(Coord(0, 0, 0), 2.2f, false));
+        tree.root().addTile(Coord(8192, 0, 0), 1.1f, false);
+        tree2.root().addChild(new RootChildType(Coord(8192, 0, 0), 2.2f, true));
+        tree.root().addTile(Coord(16384, 0, 0), 1.1f, true);
+        tree2.root().addChild(new RootChildType(Coord(16384, 0, 0), 2.2f, false));
+        tree.root().addChild(new RootChildType(Coord(24576, 0, 0), 1.1f, false));
+        tree2.root().addTile(Coord(24576, 0, 0), 2.2f, false);
+        tree.root().addChild(new RootChildType(Coord(32768, 0, 0), 1.1f, true));
+        tree2.root().addTile(Coord(32768, 0, 0), 2.2f, false);
+        tree.root().addChild(new RootChildType(Coord(40960, 0, 0), 1.1f, false));
+        tree2.root().addTile(Coord(40960, 0, 0), 2.2f, true);
+
+        EXPECT_EQ(Index(3), getTileCount(tree.root()));
+        EXPECT_EQ(Index(3), getTileCount(tree2.root()));
+        EXPECT_EQ(Index(3), getChildCount(tree.root()));
+        EXPECT_EQ(Index(3), getChildCount(tree2.root()));
+
+        tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        const auto& root = tree.root();
+        EXPECT_EQ(Index(6), getChildCount(root));
+        EXPECT_EQ(Index(0), getTileCount(root));
+        auto iter = root.cbeginChildOn();
+        EXPECT_EQ(1.1f+2.2f, iter->getFirstValue());
+        EXPECT_FALSE(iter->isValueOn(0));
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f, iter->getFirstValue());
+        EXPECT_TRUE(iter->isValueOn(0));
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f, iter->getFirstValue());
+        EXPECT_TRUE(iter->isValueOn(0));
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f, iter->getFirstValue());
+        EXPECT_FALSE(iter->isValueOn(0));
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f, iter->getFirstValue());
+        EXPECT_TRUE(iter->isValueOn(0));
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f, iter->getFirstValue());
+        EXPECT_TRUE(iter->isValueOn(0));
+    }
+
+    { // merge root children
+        FloatTree tree, tree2;
+        tree.root().addChild(new RootChildType(Coord(0, 0, 0), 1.1f, false));
+        tree2.root().addChild(new RootChildType(Coord(0, 0, 0), 2.2f, false));
+        tree.root().addChild(new RootChildType(Coord(8192, 0, 0), 1.1f, false));
+        tree2.root().addChild(new RootChildType(Coord(8192, 0, 0), 2.2f, true));
+        tree.root().addChild(new RootChildType(Coord(16384, 0, 0), 1.1f, true));
+        tree2.root().addChild(new RootChildType(Coord(16384, 0, 0), 2.2f, false));
+
+        EXPECT_EQ(Index(0), getTileCount(tree.root()));
+        EXPECT_EQ(Index(0), getTileCount(tree2.root()));
+        EXPECT_EQ(Index(3), getChildCount(tree.root()));
+        EXPECT_EQ(Index(3), getChildCount(tree2.root()));
+
+        tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        const auto& root = tree.root();
+        EXPECT_EQ(Index(3), getChildCount(root));
+        EXPECT_EQ(Index(0), getTileCount(root));
+        auto iter = root.cbeginChildOn();
+        EXPECT_EQ(1.1f+2.2f, iter->getFirstValue());
+        EXPECT_FALSE(iter->isValueOn(0));
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f, iter->getFirstValue());
+        EXPECT_TRUE(iter->isValueOn(0));
+        ++iter;
+        EXPECT_EQ(1.1f+2.2f, iter->getFirstValue());
+        EXPECT_TRUE(iter->isValueOn(0));
+    }
+
+    { // merge root children tiles
+        FloatTree tree, tree2;
+        auto* child = new RootChildType(Coord(0, 0, 0), 0.0f, false);
+        child->addTile(0, 1.1f, false);
+        child->addTile(1, 2.2f, true);
+        child->addTile(2, 3.3f, false);
+        tree.root().addChild(child);
+        child = new RootChildType(Coord(0, 0, 0), 2.2f, false);
+        child->addTile(0, 4.4f, false);
+        child->addTile(1, 5.5f, false);
+        child->addTile(2, 6.6f, true);
+        tree2.root().addChild(child);
+
+        tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        const auto& root = tree.root();
+        EXPECT_EQ(Index(1), getChildCount(root));
+        EXPECT_EQ(Index(0), getTileCount(root));
+        auto iter = root.cbeginChildOn()->cbeginValueAll();
+        EXPECT_EQ(1.1f+4.4f, *iter);
+        EXPECT_FALSE(iter.isValueOn());
+        ++iter;
+        EXPECT_EQ(2.2f+5.5f, *iter);
+        EXPECT_TRUE(iter.isValueOn());
+        ++iter;
+        EXPECT_EQ(3.3f+6.6f, *iter);
+        EXPECT_TRUE(iter.isValueOn());
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    { // test merging leaf nodes
+
+        { // merge a leaf node into an empty tree
+            FloatTree tree, tree2;
+            auto* leaf = tree2.touchLeaf(Coord(0, 0, 0));
+            leaf->setValueOnly(10, -2.3f);
+
+            tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+            tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+            nodeManager.foreachTopDown(mergeOp);
+
+            EXPECT_EQ(Index32(1), tree.leafCount());
+            EXPECT_EQ(tree.cbeginLeaf()->getFirstValue(), 0.0f);
+        }
+
+        { // merge a leaf node into a tree with a tile
+            FloatTree tree, tree2;
+            tree.root().addTile(Coord(0, 0, 0), 10.0f, false);
+            auto* leaf = tree2.touchLeaf(Coord(0, 0, 0));
+            leaf->setValueOnly(10, -2.3f);
+            leaf->setValueOn(11, 1.5f);
+
+            tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+            tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+            nodeManager.foreachTopDown(mergeOp);
+
+            EXPECT_EQ(Index32(1), tree.leafCount());
+            EXPECT_EQ(Index(0), getTileCount(tree.root()));
+            auto iter = tree.cbeginLeaf();
+            EXPECT_EQ(iter->getValue(0), 10.0f);
+            EXPECT_FALSE(iter->isValueOn(0));
+            EXPECT_EQ(iter->getValue(10), 10.0f-2.3f);
+            EXPECT_FALSE(iter->isValueOn(10));
+            EXPECT_EQ(iter->getValue(11), 10.0f+1.5f);
+            EXPECT_TRUE(iter->isValueOn(11));
+        }
+
+        { // merge a tile into a tree with a leaf node
+            FloatTree tree, tree2;
+            auto* leaf = tree.touchLeaf(Coord(0, 0, 0));
+            leaf->setValueOnly(10, -2.3f);
+            leaf->setValueOn(11, 1.5f);
+            tree2.root().addTile(Coord(0, 0, 0), 10.0f, false);
+
+            tools::SumMergeOp<FloatTree> mergeOp(tree2, DeepCopy());
+            tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+            nodeManager.foreachTopDown(mergeOp);
+
+            EXPECT_EQ(Index32(1), tree.leafCount());
+            EXPECT_EQ(Index(0), getTileCount(tree.root()));
+            auto iter = tree.cbeginLeaf();
+            EXPECT_EQ(iter->getValue(0), 10.0f);
+            EXPECT_FALSE(iter->isValueOn(0));
+            EXPECT_EQ(iter->getValue(10), 10.0f-2.3f);
+            EXPECT_FALSE(iter->isValueOn(10));
+            EXPECT_EQ(iter->getValue(11), 10.0f+1.5f);
+            EXPECT_TRUE(iter->isValueOn(11));
+        }
+
+        { // merge a root child tile into a tree with a leaf node
+            FloatTree tree, tree2;
+            auto* leaf = tree.touchLeaf(Coord(0, 0, 0));
+            leaf->setValueOnly(10, -2.3f);
+            leaf->setValueOn(11, 1.5f);
+            tree2.root().addChild(new RootChildType(Coord(0, 0, 0), 10.0f, true));
+
+            tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+            tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+            nodeManager.foreachTopDown(mergeOp);
+
+            EXPECT_EQ(Index32(1), tree.leafCount());
+            EXPECT_EQ(Index(0), getTileCount(tree.root()));
+            auto iter = tree.cbeginLeaf();
+            EXPECT_EQ(iter->getValue(0), 10.0f);
+            EXPECT_TRUE(iter->isValueOn(0));
+            EXPECT_EQ(iter->getValue(10), 10.0f-2.3f);
+            EXPECT_TRUE(iter->isValueOn(10));
+            EXPECT_EQ(iter->getValue(11), 10.0f+1.5f);
+            EXPECT_TRUE(iter->isValueOn(11));
+        }
+
+        { // merge an empty tree with non-zero background value into a tree with a leaf node
+            FloatTree tree, tree2;
+            auto* leaf = tree.touchLeaf(Coord(0, 0, 0));
+            leaf->setValueOnly(10, -2.3f);
+            leaf->setValueOn(11, 1.5f);
+            tree2.root().setBackground(10.0f, /*updateChildNodes=*/false);
+
+            tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+            tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+            nodeManager.foreachTopDown(mergeOp);
+
+            EXPECT_EQ(Index32(1), tree.leafCount());
+            EXPECT_EQ(Index(0), getTileCount(tree.root()));
+            auto iter = tree.cbeginLeaf();
+            EXPECT_EQ(iter->getValue(0), 10.0f);
+            EXPECT_FALSE(iter->isValueOn(0));
+            EXPECT_EQ(iter->getValue(10), 10.0f-2.3f);
+            EXPECT_FALSE(iter->isValueOn(10));
+            EXPECT_EQ(iter->getValue(11), 10.0f+1.5f);
+            EXPECT_TRUE(iter->isValueOn(11));
+        }
+
+        { // merge a leaf node into a grid with a partially constructed leaf node
+            FloatTree tree, tree2;
+
+            tree.addLeaf(new LeafT(PartialCreate(), Coord(0, 0, 0)));
+            auto* leaf = tree2.touchLeaf(Coord(0, 0, 0));
+            leaf->setValueOnly(10, -2.3f);
+
+            tools::SumMergeOp<FloatTree> mergeOp(tree2, Steal());
+            tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+            nodeManager.foreachTopDown(mergeOp);
+
+            const auto* testLeaf = tree.probeConstLeaf(Coord(0, 0, 0));
+            EXPECT_EQ(-2.3f, testLeaf->getValue(10));
+        }
+
+        { // merge three leaf nodes from different grids
+            DoubleTree tree, tree2, tree3;
+
+            auto* leaf = tree.touchLeaf(Coord(0, 0, 0));
+            auto* leaf2 = tree2.touchLeaf(Coord(0, 0, 0));
+            auto* leaf3 = tree3.touchLeaf(Coord(0, 0, 0));
+
+            // active state from the voxel with the minimum value preserved
+
+            leaf->setValueOnly(5, 0.7);
+            leaf2->setValueOnly(5, 0.2);
+            leaf2->setValueOn(5);
+            leaf3->setValueOnly(5, 0.1);
+
+            leaf->setValueOnly(7, 0.2);
+            leaf->setValueOn(7);
+            leaf2->setValueOnly(7, 0.1);
+            leaf3->setValueOnly(7, 0.7);
+
+            leaf->setValueOnly(9, 0.7);
+            leaf2->setValueOnly(9, 0.1);
+            leaf3->setValueOnly(9, 0.2);
+
+            std::vector<DoubleTree*> trees{&tree2, &tree3};
+            tools::SumMergeOp<DoubleTree> mergeOp(trees, Steal());
+            tree::DynamicNodeManager<DoubleTree, 3> nodeManager(tree);
+            nodeManager.foreachTopDown(mergeOp);
+
+            // non-associativity of floating-point addition
+            EXPECT_NE(0.7 + 0.2 + 0.1, 0.7 + 0.1 + 0.2);
+
+            // order of additions must be preserved
+
+            const auto* testLeaf = tree.probeConstLeaf(Coord(0, 0, 0));
+            EXPECT_EQ(0.7 + 0.2 + 0.1, testLeaf->getValue(5));
+            EXPECT_TRUE(testLeaf->isValueOn(5));
+            EXPECT_EQ(0.2 + 0.1 + 0.7, testLeaf->getValue(7));
+            EXPECT_TRUE(testLeaf->isValueOn(7));
+            EXPECT_EQ(0.7 + 0.1 + 0.2, testLeaf->getValue(9));
+            EXPECT_FALSE(testLeaf->isValueOn(9));
+        }
+
+        { // merge a leaf node into an empty grid from a const grid
+            FloatTree tree, tree2;
+            tree.root().addTile(Coord(0, 0, 0), 1.0f, false);
+            FloatGrid::Ptr grid2 = createLevelSet<FloatGrid>();
+            tree2.touchLeaf(Coord(0, 0, 0));
+
+            EXPECT_EQ(Index32(0), tree.leafCount());
+            EXPECT_EQ(Index32(1), tree2.leafCount());
+
+            // merge from a const tree
+
+            const FloatTree& constTree2 = tree2;
+
+            std::vector<tools::TreeToMerge<FloatTree>> treesToMerge;
+            treesToMerge.emplace_back(constTree2, DeepCopy());
+            tools::SumMergeOp<FloatTree> mergeOp(treesToMerge);
+            tree::DynamicNodeManager<FloatTree, 3> nodeManager(tree);
+            nodeManager.foreachTopDown(mergeOp);
+
+            EXPECT_EQ(Index32(1), tree.leafCount());
+            // leaf has been deep copied not stolen
+            EXPECT_EQ(Index32(1), tree2.leafCount());
+        }
+    }
+
+    { // test a Vec3STree
+        Vec3STree tree, tree2;
+        tree.root().addTile(Coord(0, 0, 0), Vec3s(1.0f, 2.0f, 3.0f), false);
+        auto* leaf = tree2.touchLeaf(Coord(0, 0, 0));
+        leaf->setValueOnly(10, Vec3s(0.1f, 0.2f, 0.3f));
+        leaf->setValueOn(11, Vec3s(0.4f, 0.5f, 0.6f));
+
+        tools::SumMergeOp<Vec3STree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<Vec3STree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        EXPECT_EQ(Index32(1), tree.leafCount());
+        EXPECT_EQ(Index(0), getTileCount(tree.root()));
+        auto iter = tree.cbeginLeaf();
+        EXPECT_EQ(iter->getValue(0), Vec3s(1.0f, 2.0f, 3.0f));
+        EXPECT_FALSE(iter->isValueOn(0));
+        EXPECT_EQ(iter->getValue(10), Vec3s(1.0f+0.1f, 2.0f+0.2f, 3.0f+0.3f));
+        EXPECT_FALSE(iter->isValueOn(10));
+        EXPECT_EQ(iter->getValue(11), Vec3s(1.0f+0.4f, 2.0f+0.5f, 3.0f+0.6f));
+        EXPECT_TRUE(iter->isValueOn(11));
+    }
+
+    { // test a MaskTree
+        MaskTree tree, tree2;
+        tree.root().addTile(Coord(0, 0, 0), false, false);
+        auto* leaf = tree2.touchLeaf(Coord(0, 0, 0));
+        leaf->setValueOnly(10, true);
+
+        tools::SumMergeOp<MaskTree> mergeOp(tree2, Steal());
+        tree::DynamicNodeManager<MaskTree, 3> nodeManager(tree);
+        nodeManager.foreachTopDown(mergeOp);
+
+        EXPECT_EQ(Index32(1), tree.leafCount());
+        EXPECT_EQ(Index(0), getTileCount(tree.root()));
+        auto iter = tree.cbeginLeaf();
+        EXPECT_FALSE(iter->isValueOn(0));
+        EXPECT_TRUE(iter->isValueOn(10));
+    }
+}

--- a/openvdb_houdini/openvdb_houdini/CMakeLists.txt
+++ b/openvdb_houdini/openvdb_houdini/CMakeLists.txt
@@ -254,6 +254,7 @@ set(OPENVDB_DSO_NAMES
   SOP_OpenVDB_From_Particles
   SOP_OpenVDB_From_Polygons
   SOP_OpenVDB_LOD
+  SOP_OpenVDB_Merge
   SOP_OpenVDB_Metadata
   SOP_OpenVDB_Morph_Level_Set
   SOP_OpenVDB_Noise

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Merge.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Merge.cc
@@ -70,7 +70,7 @@ newSopOperator(OP_OperatorTable* table)
         .setChoiceListItems(PRM_CHOICELIST_SINGLE, {
             "name",             "Name",
             "primitive_number", "Primitive Number",
-            "none",             "None"
+            "all",              "All"
         })
         .setTooltip(
             "Criteria under which groups of grids are merged.")

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Merge.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Merge.cc
@@ -1,0 +1,682 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+/// @file SOP_OpenVDB_Merge.cc
+///
+/// @authors Dan Bailey
+///
+/// @brief Merge OpenVDB grids.
+
+#include <houdini_utils/ParmFactory.h>
+#include <openvdb_houdini/Utils.h>
+#include <openvdb_houdini/PointUtils.h>
+#include <openvdb_houdini/SOP_NodeVDB.h>
+#include <openvdb_houdini/GEO_PrimVDB.h>
+
+#include <openvdb/points/PointDataGrid.h> // points::PointDataGrid
+#include <openvdb/tools/GridTransformer.h> // tools::replaceToMatch()
+#include <openvdb/tools/LevelSetRebuild.h> // tools::doLevelSetRebuild()
+#include <openvdb/tools/Merge.h>
+
+#include <UT/UT_Interrupt.h>
+#include <UT/UT_Version.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+
+using namespace openvdb;
+
+namespace hvdb = openvdb_houdini;
+namespace hutil = houdini_utils;
+
+
+class SOP_OpenVDB_Merge: public hvdb::SOP_NodeVDB
+{
+public:
+    SOP_OpenVDB_Merge(OP_Network*, const char* name, OP_Operator*);
+    ~SOP_OpenVDB_Merge() final {}
+
+    static OP_Node* factory(OP_Network*, const char* name, OP_Operator*);
+
+    class Cache: public SOP_VDBCacheOptions
+    {
+    public:
+        fpreal getTime() const { return mTime; }
+    protected:
+        OP_ERROR cookVDBSop(OP_Context&) final;
+    private:
+        fpreal mTime = 0.0;
+    };
+};
+
+
+void
+newSopOperator(OP_OperatorTable* table)
+{
+    if (table == nullptr) return;
+
+    hutil::ParmList parms;
+
+    parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
+        .setTooltip("Specify a subset of the input VDBs to be modified.")
+        .setChoiceList(&hutil::PrimGroupMenuInput1)
+        .setDocumentation(
+            "A subset of the input VDBs to be modified"
+            " (see [specifying volumes|/model/volumes#group])"));
+
+    parms.add(hutil::ParmFactory(PRM_STRING, "collation", "Collation")
+        .setDefault("nameclassandtype")
+        .setChoiceListItems(PRM_CHOICELIST_SINGLE, {
+            "nameclassandtype", "Name, VDB Class and Value Type",
+            "classandtype",     "VDB Class and Value Type"
+        })
+        .setTooltip(
+            "Criteria under which groups of grids are merged.")
+        .setDocumentation(
+            "The criteria under which groups of grids are merged.\n\n"
+            "Grids with different names will be merged if name is not part"
+            " of the collation criteria"));
+
+    // Menu of resampling options
+    parms.add(hutil::ParmFactory(PRM_STRING, "resample", "Resample VDBs")
+        .setDefault("first")
+        .setChoiceListItems(PRM_CHOICELIST_SINGLE, {
+            "first",        "To Match First VDB"
+        })
+        .setTypeExtended(PRM_TYPE_JOIN_PAIR)
+        .setDocumentation("Specify which grid to use as reference when resampling."));
+
+    // Menu of resampling interpolation order options
+    parms.add(hutil::ParmFactory(PRM_ORD, "resampleinterp", "Interpolation")
+        .setDefault(PRMoneDefaults)
+        .setChoiceListItems(PRM_CHOICELIST_SINGLE, {
+            "point",     "Nearest",
+            "linear",    "Linear",
+            "quadratic", "Quadratic"
+        })
+        .setTooltip(
+            "Specify the type of interpolation to be used when\n"
+            "resampling one VDB to match the other's transform.")
+        .setDocumentation(
+            "The type of interpolation to be used when resampling one VDB"
+            " to match the other's transform\n\n"
+            "Nearest neighbor interpolation is fast but can introduce noticeable"
+            " sampling artifacts.  Quadratic interpolation is slow but high-quality."
+            " Linear interpolation is intermediate in speed and quality."));
+
+    parms.beginSwitcher("Group1");
+
+    parms.addFolder("Merge Operation");
+
+    parms.add(hutil::ParmFactory(PRM_STRING, "op_fog", "Fog VDBs")
+        .setDefault("add")
+        .setChoiceListItems(PRM_CHOICELIST_SINGLE, {
+            "none",             "None            ",
+            "add",              "Add"
+        })
+        .setTooltip("Merge operation for Fog VDBs.")
+        .setDocumentation(
+            "Merge operation for Fog VDBs.\n\n"
+            "None:\n"
+            "   Add grids to the output of the SOP without merging them.\n\n"
+            "Add:\n"
+            "    Generate the sum of all fog VDBs with same collation.\n\n"));
+
+    parms.add(hutil::ParmFactory(PRM_STRING, "op_sdf", "SDF VDBs")
+        .setDefault("sdfunion")
+        .setChoiceListItems(PRM_CHOICELIST_SINGLE, {
+            "none",             "None            ",
+            "sdfunion",         "SDF Union",
+            "sdfintersect",     "SDF Intersect"
+        })
+        .setTooltip("Merge operation for SDF VDBs.")
+        .setDocumentation(
+            "Merge operation for SDF VDBs.\n\n"
+            "None:\n"
+            "   Add grids to the output of the SOP without merging them.\n\n"
+            "SDF Union:\n"
+            "    Generate the union of all signed distance fields with same collation.\n\n"
+            "SDF Intersection:\n"
+            "    Generate the intersection of all signed distance fields with same collation.\n\n"));
+
+    parms.endSwitcher();
+
+    // Register this operator.
+    hvdb::OpenVDBOpFactory("VDB Merge", SOP_OpenVDB_Merge::factory, parms, *table)
+#ifndef SESI_OPENVDB
+        .setInternalName("DW_OpenVDBMerge")
+#endif
+        .addInput("VDBs To Merge")
+        .setMaxInputs()
+        .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Merge::Cache; })
+        .setDocumentation("\
+#icon: COMMON/openvdb\n\
+#tags: vdb\n\
+\n\
+\"\"\"Merge VDB SDF grids.\"\"\"\n\
+\n\
+@overview\n\
+\n\
+Merges VDB SDF grids.\n\
+\n\
+Unlike the VDB Combine SOP, it provides a multi-input so can merge more than two grids without needing an \
+additional merge SOP. \n\
+Float and double VDB SDF grids can be merged, all other VDB grids are added to the output without merging. \n\
+\n\
+Grids with different transforms will be resampled to match the first VDB in the collation group. \n\
+\n\
+@related\n\
+\n\
+- [OpenVDB Combine|Node:sop/DW_OpenVDBCombine]\n\
+- [Node:sop/merge]\n\
+\n\
+@examples\n\
+\n\
+See [openvdb.org|http://www.openvdb.org/download/] for source code\n\
+and usage examples.\n");
+}
+
+
+OP_Node*
+SOP_OpenVDB_Merge::factory(OP_Network* net,
+    const char* name, OP_Operator* op)
+{
+    return new SOP_OpenVDB_Merge(net, name, op);
+}
+
+
+SOP_OpenVDB_Merge::SOP_OpenVDB_Merge(OP_Network* net,
+    const char* name, OP_Operator* op):
+    hvdb::SOP_NodeVDB(net, name, op)
+{
+}
+
+
+namespace {
+
+
+// The merge key stores the grid class and value type and optionally the grid name
+// depending on the requested collation and is an abstraction used to test whether
+// different grids should be merged together or not
+struct MergeKey
+{
+    enum Collation
+    {
+        NameClassAndType = 0,
+        ClassAndType
+    };
+
+    explicit MergeKey(   const GU_PrimVDB& vdbPrim,
+                    const Collation collation = NameClassAndType)
+        : name(collation == NameClassAndType ? vdbPrim.getGridName() : "")
+        , valueType(vdbPrim.getStorageType())
+        , gridClass(vdbPrim.getGrid().getGridClass()) { }
+
+    inline bool operator==(const MergeKey& rhs) const
+    {
+        return (name == rhs.name &&
+                valueType == rhs.valueType &&
+                gridClass == rhs.gridClass);
+    }
+
+    inline bool operator!=(const MergeKey& rhs) const { return !this->operator==(rhs); }
+
+    inline bool operator<(const MergeKey& rhs) const
+    {
+        if (name < rhs.name)                                                return true;
+        if (name == rhs.name) {
+            if (valueType < rhs.valueType)                                  return true;
+            if (valueType == rhs.valueType && gridClass < rhs.gridClass)    return true;
+        }
+        return false;
+    }
+
+    std::string name = "";
+    UT_VDBType valueType = UT_VDB_INVALID;
+    openvdb::GridClass gridClass = GRID_UNKNOWN;
+}; // struct MergeKey
+
+
+// This class reads all grids from the vdbPrims and constVdbPrims arrays and merges those
+// that have the same merge key using the requested merge mode for each grid type/class.
+// It chooses whether to deep-copy or steal grids and will resample if needed adding all
+// resulting grids to the output. It is thread-safe and is designed to be called from
+// multiple threads in parallel so as to be able to concurrently merge different input
+// grids using different merge operations at once.
+struct MergeOp
+{
+    enum Resample
+    {
+        Nearest = 0,
+        Linear,
+        Quadratic
+    };
+
+    struct OutputGrid
+    {
+        explicit OutputGrid(GridBase::Ptr _grid, GEO_PrimVDB* _primitive = nullptr)
+            : grid(_grid), primitive(_primitive) { }
+
+        GridBase::Ptr grid;
+        GEO_PrimVDB* primitive = nullptr;
+    };
+
+    using OutputGrids = std::deque<OutputGrid>;
+
+    using StringRemapType = std::unordered_map<std::string, std::string>;
+
+    SOP_OpenVDB_Merge::Cache* self;
+    hvdb::Interrupter& interrupt;
+    StringRemapType opRemap;
+    std::deque<GU_PrimVDB*> vdbPrims;
+    std::deque<const GU_PrimVDB*> constVdbPrims;
+    std::deque<GU_PrimVDB*> vdbPrimsToRemove;
+
+    explicit MergeOp(hvdb::Interrupter& _interrupt): self(nullptr), interrupt(_interrupt) { }
+
+    inline std::string getOp(const MergeKey& key) const
+    {
+        std::string op;
+
+        if (key.gridClass == openvdb::GRID_LEVEL_SET) {
+            if (key.valueType == UT_VDB_FLOAT || key.valueType == UT_VDB_DOUBLE) {
+                op = opRemap.at("op_sdf");
+            }
+        } else if (key.gridClass == openvdb::GRID_FOG_VOLUME) {
+            if (key.valueType == UT_VDB_FLOAT || key.valueType == UT_VDB_DOUBLE) {
+                op = opRemap.at("op_fog");
+            }
+        }
+
+        if (op == "none")   op = "";
+
+        return op;
+    }
+
+    template<typename GridT>
+    typename GridT::Ptr resampleToMatch(const GridT& src, const GridT& ref, int order)
+    {
+        using ValueT = typename GridT::ValueType;
+        const ValueT ZERO = openvdb::zeroVal<ValueT>();
+
+        const openvdb::math::Transform& refXform = ref.constTransform();
+
+        typename GridT::Ptr dest;
+        if (src.getGridClass() == openvdb::GRID_LEVEL_SET) {
+            // For level set grids, use the level set rebuild tool to both resample the
+            // source grid to match the reference grid and to rebuild the resulting level set.
+            const bool refIsLevelSet = ref.getGridClass() == openvdb::GRID_LEVEL_SET;
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+            const ValueT halfWidth = refIsLevelSet
+                ? ValueT(ZERO + ref.background() * (1.0 / ref.voxelSize()[0]))
+                : ValueT(src.background() * (1.0 / src.voxelSize()[0]));
+            OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+
+            if (!openvdb::math::isFinite(halfWidth)) {
+                std::stringstream msg;
+                msg << "Resample to match: Illegal narrow band width = " << halfWidth
+                    << ", caused by grid '" << src.getName() << "' with background "
+                    << ref.background();
+                throw std::invalid_argument(msg.str());
+            }
+
+            try {
+                dest = openvdb::tools::doLevelSetRebuild(src, /*iso=*/ZERO,
+                    /*exWidth=*/halfWidth, /*inWidth=*/halfWidth, &refXform, &interrupt);
+            } catch (openvdb::TypeError&) {
+                self->addWarning(SOP_MESSAGE, ("skipped rebuild of level set grid "
+                    + src.getName() + " of type " + src.type()).c_str());
+                dest.reset();
+            }
+        }
+        if (!dest && src.constTransform() != refXform) {
+            // For non-level set grids or if level set rebuild failed due to an unsupported
+            // grid type, use the grid transformer tool to resample the source grid to match
+            // the reference grid.
+            dest = src.copyWithNewTree();
+            dest->setTransform(refXform.copy());
+            switch (order) {
+                case 0: tools::resampleToMatch<tools::PointSampler>(src, *dest, interrupt); break;
+                case 1: tools::resampleToMatch<tools::BoxSampler>(src, *dest, interrupt); break;
+                case 2: tools::resampleToMatch<tools::QuadraticSampler>(src, *dest, interrupt); break;
+            }
+        }
+        return dest;
+    }
+
+    template <typename GridT>
+    OutputGrids mergeTypedNoop( const MergeKey& mergeKey,
+                                const MergeKey::Collation& collationKey)
+    {
+        using TreeT = typename GridT::TreeType;
+
+        // this method steals or deep-copies grids from the multi-input
+        // stealing can only be performed for the first input in the multi-input,
+        // provided that the tree is unique, all other inputs are read-only
+
+        OutputGrids result;
+
+        std::deque<tools::TreeToMerge<TreeT>> trees;
+
+        tbb::task_group tasks;
+
+        auto hasUniqueTree = [&](GU_PrimVDB* vdbPrim)
+        {
+#if OPENVDB_ABI_VERSION_NUMBER >= 8
+            return vdbPrim->getConstGridPtr()->isTreeUnique();
+#else
+            const TreeBase::ConstPtr treeBaseConstPtr = vdbPrim->getConstGridPtr()->constBaseTreePtr();
+            return treeBaseConstPtr.use_count() <= 2;
+#endif
+        };
+
+        auto stealTree = [&](auto& gridBase, GU_PrimVDB* vdbPrim = nullptr)
+        {
+            result.emplace_back(gridBase, vdbPrim);
+        };
+
+        auto copyTree = [&](auto& gridBase, GU_PrimVDB* vdbPrim = nullptr)
+        {
+            auto grid = GridBase::grid<GridT>(gridBase);
+            // insert an empty shared pointer and asynchronously replace with a deep copy
+            result.emplace_back(GridBase::Ptr(), vdbPrim);
+            OutputGrid& output = result.back();
+            tasks.run(
+                [&, grid] {
+                    output.grid = grid->deepCopy();
+                }
+            );
+        };
+
+        for (GU_PrimVDB* vdbPrim : vdbPrims) {
+            MergeKey key(*vdbPrim, collationKey);
+            if (key != mergeKey)    continue;
+
+            if (hasUniqueTree(vdbPrim)) {
+                GridBase::Ptr gridBase = vdbPrim->getGridPtr();
+                stealTree(gridBase, vdbPrim);
+            } else {
+                GridBase::ConstPtr gridBase = vdbPrim->getConstGridPtr();
+                copyTree(gridBase, vdbPrim);
+            }
+        }
+
+        for (const GU_PrimVDB* constVdbPrim : constVdbPrims) {
+            MergeKey key(*constVdbPrim, collationKey);
+            if (key != mergeKey)    continue;
+
+            GridBase::ConstPtr gridBase = constVdbPrim->getConstGridPtr();
+            copyTree(gridBase);
+        }
+
+        if (interrupt.wasInterrupted())
+        {
+            tasks.cancel();
+            return OutputGrids();
+        }
+
+        // resampling and deep copying of trees is done in parallel asynchronously,
+        // now synchronize to ensure all these tasks have completed
+        tasks.wait();
+
+        if (interrupt.wasInterrupted())     return OutputGrids();
+
+        return result;
+    }
+
+    template <typename GridT>
+    OutputGrids mergeTyped( const MergeKey& mergeKey,
+                            const MergeKey::Collation& collationKey)
+    {
+        using TreeT = typename GridT::TreeType;
+
+        // this method steals or deep-copies grids from the multi-input and resamples if necessary
+        // stealing can only be performed for the first input in the multi-input,
+        // provided that the tree is unique, all other inputs are read-only
+        // const GU_PrimVDBs cannot be stolen
+
+        OutputGrids result;
+
+        const std::string op = this->getOp(mergeKey);
+
+        const int samplingOrder = static_cast<int>(
+            self->evalInt("resampleinterp", 0, self->getTime()));
+
+        GridBase::Ptr reference;
+
+        std::deque<tools::TreeToMerge<TreeT>> trees;
+
+        tbb::task_group tasks;
+
+        auto hasUniqueTree = [&](GU_PrimVDB* vdbPrim)
+        {
+#if OPENVDB_ABI_VERSION_NUMBER >= 8
+            return vdbPrim->getConstGridPtr()->isTreeUnique();
+#else
+            const TreeBase::ConstPtr treeBaseConstPtr = vdbPrim->getConstGridPtr()->constBaseTreePtr();
+            return treeBaseConstPtr.use_count() <= 2;
+#endif
+        };
+
+        auto stealTree = [&](auto& gridBase, GU_PrimVDB* vdbPrim = nullptr)
+        {
+            result.emplace_back(gridBase, vdbPrim);
+            if (!reference)  reference = gridBase;
+        };
+
+        auto copyTree = [&](auto& gridBase, GU_PrimVDB* vdbPrim = nullptr)
+        {
+            auto grid = GridBase::grid<GridT>(gridBase);
+            if (!reference)  reference = grid->copyWithNewTree();
+            // insert a reference and asynchronously replace with a deep copy
+            result.emplace_back(reference, vdbPrim);
+            OutputGrid& output = result.back();
+            tasks.run(
+                [&, grid] {
+                    output.grid = grid->deepCopy();
+                }
+            );
+        };
+
+        auto addConstTree = [&](auto& gridBase, GU_PrimVDB* vdbPrim = nullptr)
+        {
+            auto grid = GridBase::grid<GridT>(gridBase);
+            if (grid->constTransform() == reference->constTransform()) {
+                trees.emplace_back(grid->tree(), openvdb::DeepCopy());
+            } else {
+                // insert an empty tree and asynchronously replace with a resampled tree
+                trees.emplace_back(typename TreeT::Ptr(new TreeT), openvdb::Steal());
+                tools::TreeToMerge<TreeT>& treeToMerge = trees.back();
+                tasks.run(
+                    [&, grid] {
+                        auto refGrid = GridBase::grid<GridT>(reference);
+                        auto newGrid = this->resampleToMatch(*grid, *refGrid, samplingOrder);
+                        treeToMerge.reset(newGrid->treePtr(), openvdb::Steal());
+                    }
+                );
+            }
+            if (vdbPrim)    vdbPrimsToRemove.push_back(vdbPrim);
+        };
+
+        for (GU_PrimVDB* vdbPrim : vdbPrims) {
+            MergeKey key(*vdbPrim, collationKey);
+            if (key != mergeKey)    continue;
+
+            if (hasUniqueTree(vdbPrim)) {
+                GridBase::Ptr gridBase = vdbPrim->getGridPtr();
+                if ((!reference) || op.empty()) stealTree(gridBase, vdbPrim);
+                else                            addConstTree(gridBase, vdbPrim);
+            } else {
+                GridBase::ConstPtr gridBase = vdbPrim->getConstGridPtr();
+                if ((!reference) || op.empty()) copyTree(gridBase, vdbPrim);
+                else                            addConstTree(gridBase, vdbPrim);
+            }
+        }
+        // const GU_PrimVDBs cannot be stolen
+        for (const GU_PrimVDB* constVdbPrim : constVdbPrims) {
+            MergeKey key(*constVdbPrim, collationKey);
+            if (key != mergeKey)    continue;
+
+            GridBase::ConstPtr gridBase = constVdbPrim->getConstGridPtr();
+            if ((!reference) || op.empty())     copyTree(gridBase);
+            else                                addConstTree(gridBase);
+        }
+
+        if (interrupt.wasInterrupted())
+        {
+            tasks.cancel();
+            return OutputGrids();
+        }
+
+        // resampling and deep copying of trees is done in parallel asynchronously,
+        // now synchronize to ensure all these tasks have completed
+        tasks.wait();
+
+        if (interrupt.wasInterrupted())     return OutputGrids();
+
+        // perform merge
+
+        if (result.size() == 1 && !trees.empty()) {
+            auto grid = GridBase::grid<GridT>(result.front().grid);
+            tree::DynamicNodeManager<TreeT> nodeManager(grid->tree());
+            if (op == "sdfunion") {
+                nodeManager.foreachTopDown(tools::CsgUnionOp<TreeT>(trees));
+            } else if (op == "sdfintersect") {
+                nodeManager.foreachTopDown(tools::CsgIntersectionOp<TreeT>(trees));
+            } else if (op == "add") {
+                nodeManager.foreachTopDown(tools::SumMergeOp<TreeT>(trees));
+            }
+        }
+
+        return result;
+    }
+
+    OutputGrids merge(  const MergeKey& key,
+                        const MergeKey::Collation& collationKey)
+    {
+        // only float and double grids can be merged currently
+
+        if (key.valueType == UT_VDB_FLOAT) {
+            return this->mergeTyped<FloatGrid>(key, collationKey);
+        } else if (key.valueType == UT_VDB_DOUBLE) {
+            return this->mergeTyped<DoubleGrid>(key, collationKey);
+        } else if (key.valueType == UT_VDB_INT32) {
+            return this->mergeTypedNoop<Int32Grid>(key, collationKey);
+        } else if (key.valueType == UT_VDB_INT64) {
+            return this->mergeTypedNoop<Int64Grid>(key, collationKey);
+        } else if (key.valueType == UT_VDB_BOOL) {
+            return this->mergeTypedNoop<BoolGrid>(key, collationKey);
+        } else if (key.valueType == UT_VDB_VEC3F) {
+            return this->mergeTypedNoop<Vec3SGrid>(key, collationKey);
+        } else if (key.valueType == UT_VDB_VEC3D) {
+            return this->mergeTypedNoop<Vec3DGrid>(key, collationKey);
+        } else if (key.valueType == UT_VDB_VEC3I) {
+            return this->mergeTypedNoop<Vec3IGrid>(key, collationKey);
+        } else if (key.valueType == UT_VDB_POINTDATA) {
+            return this->mergeTypedNoop<points::PointDataGrid>(key, collationKey);
+        }
+
+        return OutputGrids();
+    }
+
+}; // struct MergeOp
+
+} // namespace
+
+
+OP_ERROR
+SOP_OpenVDB_Merge::Cache::cookVDBSop(OP_Context& context)
+{
+    try {
+        mTime = context.getTime();
+
+        const std::string groupName = evalStdString("group", mTime);
+
+        MergeKey::Collation collationKey = MergeKey::NameClassAndType;
+        const std::string collation = evalStdString("collation", mTime);
+        if (collation == "classandtype")    collationKey = MergeKey::ClassAndType;
+
+        hvdb::Interrupter boss("Merging VDBs");
+
+        MergeOp mergeOp(boss);
+        mergeOp.self = this;
+        mergeOp.opRemap["op_sdf"] = evalStdString("op_sdf", mTime);
+        mergeOp.opRemap["op_fog"] = evalStdString("op_fog", mTime);
+
+        // extract non-const VDB primitives from first input
+
+        hvdb::VdbPrimIterator vdbIt(gdp, matchGroup(*gdp, groupName));
+        for (; vdbIt; ++vdbIt) {
+            GU_PrimVDB* vdbPrim = *vdbIt;
+            mergeOp.vdbPrims.push_back(vdbPrim);
+        }
+
+        // extract const VDB primitives from second or more input
+
+        for (int i = 1; i < nInputs(); i++) {
+            const GU_Detail* pointsGeo = inputGeo(i);
+            hvdb::VdbPrimCIterator vdbIt(pointsGeo, matchGroup(*pointsGeo, groupName));
+            for (; vdbIt; ++vdbIt) {
+                const GU_PrimVDB* constVdbPrim = *vdbIt;
+                mergeOp.constVdbPrims.push_back(constVdbPrim);
+            }
+        }
+
+        // extract all merge keys
+
+        std::set<MergeKey> uniqueKeys;
+
+        for (GU_PrimVDB* vdbPrim : mergeOp.vdbPrims) {
+            MergeKey key(*vdbPrim, collationKey);
+            uniqueKeys.insert(key);
+        }
+        for (const GU_PrimVDB* constVdbPrim : mergeOp.constVdbPrims) {
+            MergeKey key(*constVdbPrim, collationKey);
+            uniqueKeys.insert(key);
+        }
+
+        std::vector<MergeKey> keys(uniqueKeys.begin(), uniqueKeys.end());
+
+        // iterate over each merge key in parallel and perform merge operations
+
+        std::vector<MergeOp::OutputGrids> outputGridsArray;
+        outputGridsArray.resize(keys.size());
+
+        tbb::parallel_for(
+            tbb::blocked_range<size_t>(0, keys.size()),
+            [&](tbb::blocked_range<size_t>& range)
+            {
+                for (size_t i = range.begin(); i < range.end(); i++) {
+                    outputGridsArray[i] = mergeOp.merge(keys[i], collationKey);
+                }
+            }
+        );
+
+        // replace primitives from first input, create primitives from second or more input
+
+        for (MergeOp::OutputGrids& outputGrids : outputGridsArray) {
+            for (MergeOp::OutputGrid& outputGrid : outputGrids) {
+                GridBase::Ptr grid = outputGrid.grid;
+                if (!grid)  continue;
+                GEO_PrimVDB* primitive = outputGrid.primitive;
+                if (primitive)  hvdb::replaceVdbPrimitive(*gdp, grid, *primitive);
+                else            hvdb::createVdbPrimitive(*gdp, grid);
+            }
+        }
+
+        // remove old primitives that have now been merged into another
+
+        for (GU_PrimVDB* primitive : mergeOp.vdbPrimsToRemove) {
+            if (primitive)  gdp->destroyPrimitive(*primitive, /*andPoints=*/true);
+        }
+
+        if (boss.wasInterrupted()) addWarning(SOP_MESSAGE, "processing was interrupted");
+        boss.end();
+
+    } catch (std::exception& e) {
+        addError(SOP_MESSAGE, e.what());
+    }
+
+    return error();
+}

--- a/pendingchanges/vdb_merge.txt
+++ b/pendingchanges/vdb_merge.txt
@@ -1,0 +1,7 @@
+New features:
+- Added tools::SumMergeOp that uses a parallel breadth-first algorithm to
+  accelerate summing grids.
+
+Houdini:
+- Introduced the VDB Merge SOP that merges multiple grids in parallel and is
+  faster and more convenient to use than the VDB Combine SOP.


### PR DESCRIPTION
This PR extends `tools/merge.h` to add a new `SumMergeOp` for parallel breadth-first summing of multiple aligned VDBs using the DynamicNodeManager. The implementation carefully preserves the order of operations to ensure the same result in spite of the non-associativity of floating-point addition. As an example, collapsing a constant value leaf node into a tile of one of the input grids will not change the resulting merged grid.

This also adds a new VDB Merge SOP which partially implements the prototype from #623. At present, the only two options available on this SOP are for merging SDF VDBs and fog volume VDBs. This implementation works well in parallel when merging a few very large VDBs and a lot of very small VDBs or some combination of both and can deep-copy and/or resample concurrently with the merging of other grids.