### PR TITLE
Fix Rebuild LevelSet Metadata

### DIFF
--- a/openvdb/openvdb/tools/LevelSetRebuild.h
+++ b/openvdb/openvdb/tools/LevelSetRebuild.h
@@ -245,13 +245,18 @@ doLevelSetRebuild(const GridType& grid, typename GridType::ValueType iso,
 
     QuadAndTriangleDataAdapter<Vec3s, Vec4I> mesh(points, primitives);
 
+    typename GridType::Ptr newGrid;
+
     if (interrupter) {
-        return meshToVolume<GridType>(*interrupter, mesh, *transform, exBandWidth, inBandWidth,
+        newGrid = meshToVolume<GridType>(*interrupter, mesh, *transform, exBandWidth, inBandWidth,
+            DISABLE_RENORMALIZATION, nullptr);
+    } else {
+        newGrid = meshToVolume<GridType>(mesh, *transform, exBandWidth, inBandWidth,
             DISABLE_RENORMALIZATION, nullptr);
     }
 
-    return meshToVolume<GridType>(mesh, *transform, exBandWidth, inBandWidth,
-        DISABLE_RENORMALIZATION, nullptr);
+    newGrid->insertMeta(*grid.copyMeta());
+    return newGrid;
 }
 
 

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -113,6 +113,7 @@ else()
     TestLeafMask.cc
     TestLeafOrigin.cc
     TestLevelSetRayIntersector.cc
+    TestLevelSetRebuild.cc
     TestLevelSetUtil.cc
     TestLinearInterp.cc
     TestMaps.cc

--- a/openvdb/openvdb/unittest/TestLevelSetRebuild.cc
+++ b/openvdb/openvdb/unittest/TestLevelSetRebuild.cc
@@ -33,5 +33,7 @@ TEST_F(TestLevelSetRebuild, test)
 
     auto newMeta = (*newGrid)["foo"];
     EXPECT_TRUE(newMeta);
-    if (newMeta) EXPECT_EQ(newMeta->str(), "bar");
+    if (newMeta) {
+        EXPECT_EQ(newMeta->str(), "bar");
+    }
 }

--- a/openvdb/openvdb/unittest/TestLevelSetRebuild.cc
+++ b/openvdb/openvdb/unittest/TestLevelSetRebuild.cc
@@ -1,0 +1,37 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#include <vector>
+#include "gtest/gtest.h"
+
+#include <openvdb/openvdb.h>
+#include <openvdb/tools/LevelSetRebuild.h>
+
+class TestLevelSetRebuild: public ::testing::Test
+{
+};
+
+
+////////////////////////////////////////
+
+TEST_F(TestLevelSetRebuild, test)
+{
+    openvdb::FloatGrid::Ptr grid = openvdb::FloatGrid::create(10.0);
+
+    grid->fill(openvdb::CoordBBox(openvdb::Coord(-100), openvdb::Coord(100)), 9.0);
+    grid->fill(openvdb::CoordBBox(openvdb::Coord(-50), openvdb::Coord(50)), -9.0);
+
+    openvdb::StringMetadata meta;
+    meta.setValue("bar");
+
+    grid->insertMeta("foo", meta);
+
+    openvdb::FloatGrid::Ptr newGrid = openvdb::tools::levelSetRebuild(
+        *grid, /*isovalue=*/0.0f, /*exBandWidth=*/3.0f, /*inBandWidth=*/3.0f);
+
+    // check the metadata has been copied from the input grid
+
+    auto newMeta = (*newGrid)["foo"];
+    EXPECT_TRUE(newMeta);
+    if (newMeta) EXPECT_EQ(newMeta->str(), "bar");
+}

--- a/pendingchanges/rebuild_sdf_meta.txt
+++ b/pendingchanges/rebuild_sdf_meta.txt
@@ -1,0 +1,3 @@
+    Bug Fixes:
+    - Fix a bug in tools::levelSetRebuild() where metadata was not being copied
+      from the input grid when rebuilding.


### PR DESCRIPTION
This fixes a bug where metadata was not being copied from the input grid when doing tools::levelSetRebuild().

This showed up in Houdini where using the VDB Rebuild SDF SOP was resulting in a VDB primitive that was returning a value of "" for the vdb_value_type intrinsic instead of "float".

I also added a TestLevelSetRebuild unit test because this method was only being tangentially tested through TestFastSweeping. For now it only calls one of these methods and tests that metadata persists but it may be worth expanding this to validate the API properly.