### PR TITLE
Fix VDB Rebuild SDF SOP Metadata

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Rebuild_Level_Set.cc
@@ -292,8 +292,11 @@ SOP_OpenVDB_Rebuild_Level_Set::Cache::cookVDBSop(
 
                 openvdb::FloatGrid& grid = UTvdbGridCast<openvdb::FloatGrid>(vdbPrim->getGrid());
 
-                vdbPrim->setGrid(*openvdb::tools::levelSetRebuild(
-                    grid, iso, exWidth, inWidth, /*xform=*/nullptr, &boss));
+                openvdb::FloatGrid::Ptr newGrid = openvdb::tools::levelSetRebuild(
+                    grid, iso, exWidth, inWidth, /*xform=*/nullptr, &boss);
+                newGrid->insertMeta(*grid.copyMeta());
+
+                vdbPrim->setGrid(*newGrid);
 
                 const GEO_VolumeOptions& visOps = vdbPrim->getVisOptions();
                 vdbPrim->setVisualization(GEO_VOLUMEVIS_ISO, visOps.myIso, visOps.myDensity);
@@ -302,8 +305,11 @@ SOP_OpenVDB_Rebuild_Level_Set::Cache::cookVDBSop(
 
                 openvdb::DoubleGrid& grid = UTvdbGridCast<openvdb::DoubleGrid>(vdbPrim->getGrid());
 
-                vdbPrim->setGrid(*openvdb::tools::levelSetRebuild(
-                    grid, iso, exWidth, inWidth, /*xform=*/nullptr, &boss));
+                openvdb::DoubleGrid::Ptr newGrid = openvdb::tools::levelSetRebuild(
+                    grid, iso, exWidth, inWidth, /*xform=*/nullptr, &boss);
+                newGrid->insertMeta(*grid.copyMeta());
+
+                vdbPrim->setGrid(*newGrid);
 
                 const GEO_VolumeOptions& visOps = vdbPrim->getVisOptions();
                 vdbPrim->setVisualization(GEO_VOLUMEVIS_ISO, visOps.myIso, visOps.myDensity);

--- a/pendingchanges/vdb_rebuild_sdf_meta.txt
+++ b/pendingchanges/vdb_rebuild_sdf_meta.txt
@@ -1,0 +1,3 @@
+    Houdini:
+    - Fix a bug where the VDB Rebuild SDF was not preserving metadata from the
+      input grid.


### PR DESCRIPTION
This showed up in Houdini where using the VDB Rebuild SDF SOP was resulting in a VDB primitive that was returning a value of "" for the vdb_value_type intrinsic instead of "float".

I believe the expectation here is that the VDB Rebuild SDF SOP should behave like the VDB Renormalize SDF SOP and carry across metadata from the input grid. The language here "Repair level sets represented by VDB volumes" leads me to believe that this SOP is modifying the input grid rather than creating a new grid. 

The alternative is perhaps to follow the example of SOPs like the VDB Resample SOP which copies across attributes and group membership by using `hvdb::replaceVdbPrimitive()` and then reconstructs the metadata.