### PR TITLE
bugfix when calling points::pointOffsets with an empty grid

### DIFF
--- a/openvdb/openvdb/points/PointCount.h
+++ b/openvdb/openvdb/points/PointCount.h
@@ -131,6 +131,7 @@ Index64 pointOffsets(   std::vector<Index64>& pointOffsets,
     // allocate and zero values in point offsets array
 
     pointOffsets.assign(tree.leafCount(), Index64(0));
+    if (pointOffsets.empty()) return 0;
 
     // compute total points per-leaf
 

--- a/openvdb/openvdb/unittest/TestPointCount.cc
+++ b/openvdb/openvdb/unittest/TestPointCount.cc
@@ -425,6 +425,15 @@ TEST_F(TestPointCount, testOffsets)
 {
     using namespace openvdb::math;
 
+    // empty tree
+    {
+        PointDataTree tree;
+        std::vector<Index64> offsets{ 10 };
+        Index64 total = pointOffsets(offsets, tree);
+        EXPECT_EQ(total, Index64(0));
+        EXPECT_TRUE(offsets.empty());
+    }
+
     const float voxelSize(1.0);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 

--- a/pendingchanges/point_offsets.txt
+++ b/pendingchanges/point_offsets.txt
@@ -1,0 +1,2 @@
+Bug Fix:
+ - Fixed a crash when calling openvdb::points::pointOffsets with an empty PointDataGrid input.


### PR DESCRIPTION
Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>