### PR TITLE
Re-introduced the OPENVDB_DEPRECATED macros

### DIFF
--- a/openvdb/openvdb/Platform.h
+++ b/openvdb/openvdb/Platform.h
@@ -93,13 +93,22 @@
     #define OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
 #endif
 
+/// Deprecation macros. Define OPENVDB_NO_DEPRECATION_WARNINGS to disable all
+/// deprecation warnings in OpenVDB.
+#ifndef OPENVDB_NO_DEPRECATION_WARNINGS
+#define OPENVDB_DEPRECATED [[deprecated]]
+#define OPENVDB_DEPRECATED_MESSAGE(msg) [[deprecated(msg)]]
+#else
+#define OPENVDB_DEPRECATED
+#define OPENVDB_DEPRECATED_MESSAGE(msg)
+#endif
 
 /// @brief Bracket code with OPENVDB_NO_DEPRECATION_WARNING_BEGIN/_END,
 /// to inhibit warnings about deprecated code.
 /// @note Use this sparingly.  Remove references to deprecated code if at all possible.
 /// @details Example:
 /// @code
-/// [[deprecated]] void myDeprecatedFunction() {}
+/// OPENVDB_DEPRECATED void myDeprecatedFunction() {}
 ///
 /// {
 ///     OPENVDB_NO_DEPRECATION_WARNING_BEGIN

--- a/openvdb/openvdb/points/AttributeArray.h
+++ b/openvdb/openvdb/points/AttributeArray.h
@@ -146,7 +146,7 @@ public:
 
     /// Return a copy of this attribute.
 #ifndef _MSC_VER
-    [[deprecated("In-memory compression no longer supported, use AttributeArray::copy() instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("In-memory compression no longer supported, use AttributeArray::copy() instead")
 #endif
     virtual AttributeArray::Ptr copyUncompressed() const = 0;
 
@@ -220,7 +220,7 @@ public:
     /// @brief Set value at given index @a n from @a sourceIndex of another @a sourceArray.
     // Windows does not allow base classes to be easily deprecated.
 #ifndef _MSC_VER
-    [[deprecated("Use copyValues() with source-target index pairs")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use copyValues() with source-target index pairs")
 #endif
     virtual void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) = 0;
 
@@ -267,12 +267,12 @@ public:
 
     // Windows does not allow base classes to be deprecated
 #ifndef _MSC_VER
-    [[deprecated("Previously this compressed the attribute array, now it does nothing")]]
+    OPENVDB_DEPRECATED_MESSAGE("Previously this compressed the attribute array, now it does nothing")
 #endif
     virtual bool compress() = 0;
     // Windows does not allow base classes to be deprecated
 #ifndef _MSC_VER
-    [[deprecated("Previously this uncompressed the attribute array, now it does nothing")]]
+    OPENVDB_DEPRECATED_MESSAGE("Previously this uncompressed the attribute array, now it does nothing")
 #endif
     virtual bool decompress() = 0;
 
@@ -548,7 +548,7 @@ public:
     /// It is not thread-safe for write.
     TypedAttributeArray(const TypedAttributeArray&);
     /// Deep copy constructor.
-    [[deprecated("Use copy-constructor without unused bool parameter")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use copy-constructor without unused bool parameter")
     TypedAttributeArray(const TypedAttributeArray&, bool /*unused*/);
 #else
     /// Deep copy constructor.
@@ -572,7 +572,7 @@ public:
 
     /// Return a copy of this attribute.
     /// @note This method is thread-safe.
-    [[deprecated("In-memory compression no longer supported, use AttributeArray::copy() instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("In-memory compression no longer supported, use AttributeArray::copy() instead")
     AttributeArray::Ptr copyUncompressed() const override;
 
     /// Return a new attribute array of the given length @a n and @a stride with uniform value zero.
@@ -667,7 +667,7 @@ public:
     static void setUnsafe(AttributeArray* array, const Index n, const ValueType& value);
 
     /// Set value at given index @a n from @a sourceIndex of another @a sourceArray
-    [[deprecated("Use copyValues() with source-target index pairs")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use copyValues() with source-target index pairs")
     void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) override;
 
     /// Return @c true if this array is stored as a single uniform value.
@@ -693,10 +693,10 @@ public:
     static void fill(AttributeArray* array, const ValueType& value);
 
     /// Compress the attribute array.
-    [[deprecated("Previously this compressed the attribute array, now it does nothing")]]
+    OPENVDB_DEPRECATED_MESSAGE("Previously this compressed the attribute array, now it does nothing")
     bool compress() override;
     /// Uncompress the attribute array.
-    [[deprecated("Previously this uncompressed the attribute array, now it does nothing")]]
+    OPENVDB_DEPRECATED_MESSAGE("Previously this uncompressed the attribute array, now it does nothing")
     bool decompress() override;
 
     /// Read attribute data from a stream.

--- a/openvdb/openvdb/tools/FindActiveValues.h
+++ b/openvdb/openvdb/tools/FindActiveValues.h
@@ -176,11 +176,11 @@ public:
     ///        between active tiles in the tree and the specified bounding box.
     std::vector<TileDataT> activeTiles(const CoordBBox &bbox) const;
 
-    [[deprecated("Use anyActiveValues() instead")]] inline bool any(const CoordBBox &bbox, bool useAccessor = false) const
+    OPENVDB_DEPRECATED_MESSAGE("Use anyActiveValues() instead") inline bool any(const CoordBBox &bbox, bool useAccessor = false) const
     {
         return this->anyActiveValues(bbox, useAccessor);
     }
-    [[deprecated("Use noActiveValues() instead")]] inline bool none(const CoordBBox &bbox, bool useAccessor = false) const
+    OPENVDB_DEPRECATED_MESSAGE("Use noActiveValues() instead") inline bool none(const CoordBBox &bbox, bool useAccessor = false) const
     {
         return this->noActiveValues(bbox, useAccessor);
     }

--- a/openvdb/openvdb/tools/Morphology.h
+++ b/openvdb/openvdb/tools/Morphology.h
@@ -1192,7 +1192,7 @@ inline void erodeActiveValues(TreeOrLeafManagerT& treeOrLeafM,
 ///
 /// @note The values of any voxels are unchanged.
 template<typename TreeType>
-[[deprecated]]
+OPENVDB_DEPRECATED
 inline void dilateVoxels(TreeType& tree,
                          int iterations = 1,
                          NearestNeighbors nn = NN_FACE)
@@ -1219,7 +1219,7 @@ inline void dilateVoxels(TreeType& tree,
 ///
 /// @note The values of any voxels are unchanged.
 template<typename TreeType>
-[[deprecated]]
+OPENVDB_DEPRECATED
 inline void dilateVoxels(tree::LeafManager<TreeType>& manager,
                          int iterations = 1,
                          NearestNeighbors nn = NN_FACE)
@@ -1237,7 +1237,7 @@ inline void dilateVoxels(tree::LeafManager<TreeType>& manager,
 /// of any voxels, only their active states.
 /// @todo Currently operates only on leaf voxels; need to extend to tiles.
 template<typename TreeType>
-[[deprecated]]
+OPENVDB_DEPRECATED
 inline void erodeVoxels(TreeType& tree,
                         int iterations=1,
                         NearestNeighbors nn = NN_FACE)
@@ -1252,7 +1252,7 @@ inline void erodeVoxels(TreeType& tree,
 }
 
 template<typename TreeType>
-[[deprecated]]
+OPENVDB_DEPRECATED
 inline void erodeVoxels(tree::LeafManager<TreeType>& manager,
                         int iterations = 1,
                         NearestNeighbors nn = NN_FACE)

--- a/openvdb/openvdb/tree/LeafManager.h
+++ b/openvdb/openvdb/tree/LeafManager.h
@@ -536,7 +536,7 @@ public:
     }
 
     template<typename ArrayT>
-    [[deprecated("Use Tree::getNodes()")]] void getNodes(ArrayT& array)
+    OPENVDB_DEPRECATED_MESSAGE("Use Tree::getNodes()") void getNodes(ArrayT& array)
     {
         using T = typename ArrayT::value_type;
         static_assert(std::is_pointer<T>::value, "argument to getNodes() must be a pointer array");
@@ -554,7 +554,7 @@ public:
     }
 
     template<typename ArrayT>
-    [[deprecated("Use Tree::getNodes()")]] void getNodes(ArrayT& array) const
+    OPENVDB_DEPRECATED_MESSAGE("Use Tree::getNodes()") void getNodes(ArrayT& array) const
     {
         using T = typename ArrayT::value_type;
         static_assert(std::is_pointer<T>::value, "argument to getNodes() must be a pointer array");

--- a/openvdb/openvdb/tree/Tree.h
+++ b/openvdb/openvdb/tree/Tree.h
@@ -933,35 +933,35 @@ public:
 #endif
 
     template<typename BBoxOp>
-    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")
     void visitActiveBBox(BBoxOp& op) const { mRoot.visitActiveBBox(op); }
 
     template<typename VisitorOp>
-    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")
     void visit(VisitorOp& op);
     template<typename VisitorOp>
-    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")
     void visit(const VisitorOp& op);
 
     template<typename VisitorOp>
-    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")
     void visit(VisitorOp& op) const;
     template<typename VisitorOp>
-    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")
     void visit(const VisitorOp& op) const;
 
     template<typename OtherTreeType, typename VisitorOp>
-    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")
     void visit2(OtherTreeType& other, VisitorOp& op);
     template<typename OtherTreeType, typename VisitorOp>
-    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")
     void visit2(OtherTreeType& other, const VisitorOp& op);
 
     template<typename OtherTreeType, typename VisitorOp>
-    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")
     void visit2(OtherTreeType& other, VisitorOp& op) const;
     template<typename OtherTreeType, typename VisitorOp>
-    [[deprecated("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")]]
+    OPENVDB_DEPRECATED_MESSAGE("Use tools::visitNodesDepthFirst or DynamicNodeManager instead")
     void visit2(OtherTreeType& other, const VisitorOp& op) const;
 
 

--- a/openvdb/openvdb/util/PagedArray.h
+++ b/openvdb/openvdb/util/PagedArray.h
@@ -185,7 +185,7 @@ public:
     class Iterator;
 
     /// @brief This method is deprecated and will be removed shortly!
-    [[deprecated]] size_t push_back(const ValueType& value)
+    OPENVDB_DEPRECATED size_t push_back(const ValueType& value)
     {
         return this->push_back_unsafe(value);
     }

--- a/pendingchanges/deprecation_macro.txt
+++ b/pendingchanges/deprecation_macro.txt
@@ -1,0 +1,3 @@
+Build:
+- Re-introduced the OPENVDB_DEPRECATED macro with an additional option that takes a message.
+  Added support to disable deprecations throughout OpenVDB by defining OPENVDB_NO_DEPRECATION_WARNINGS


### PR DESCRIPTION
Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>

This macro controls the C++ standard `[[deprecated]]` attribute's behaviour.