### PR TITLE
Fix VDB Resample SOP - Voxel Size + Voxel Scale

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Resample.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Resample.cc
@@ -195,10 +195,11 @@ Using Voxel Scale Only:\n\
             "Larger voxels correspond to lower resolution.\n"));
 
     // Toggle to use the input grid transform
-    parms.add(hutil::ParmFactory(PRM_TOGGLE, "linearxform", "Axis-aligned Linear Transform")
+    parms.add(hutil::ParmFactory(PRM_TOGGLE, "linearxform", "Force Axis Aligned")
         .setDefault(PRMzeroDefaults)
         .setTooltip(
             "Apply the input VDB voxel size or scale to an axis-aligned linear transform.\n\n"
+            "An axis-aligned linear transform cannot have taper.\n\n"
             "Disable this toggle to use the transform from the input VDB.\n"));
 
     // Toggle to apply transform to vector values

--- a/pendingchanges/vdb_resample_voxel_size.txt
+++ b/pendingchanges/vdb_resample_voxel_size.txt
@@ -1,0 +1,3 @@
+Houdini:
+- Fix a bug in VDB Resample SOP where input transform was not being used for
+  voxel size and voxel scale transform modes.


### PR DESCRIPTION
Both of these modes have text such as this in the help:

> Using Voxel Scale Only
> 
> Keep the transform of the input VDB but scale the voxel size, increasing or decreasing the resolution.

However, the VDB Resample SOP was always creating a new linear transform and applying the voxel size/scale. This fix takes the transform from the input VDB as I believe was intended.