### PR TITLE
Bugfix for empty points in AX SOP

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_AX.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_AX.cc
@@ -932,10 +932,13 @@ SOP_OpenVDB_AX::Cache::cookVDBSop(OP_Context& context)
                     throw std::runtime_error("No point executable has been built");
                 }
 
+                const auto& leafIter = points->tree().cbeginLeaf();
+                if (!leafIter) continue; // empty
+
                 // check the attributes that are not being created already exist
 
                 std::vector<UT_String> missingAttributes;
-                const auto& desc = points->tree().cbeginLeaf()->attributeSet().descriptor();
+                const auto& desc = leafIter->attributeSet().descriptor();
 
                 for (const auto& attribute : mCompilerCache.mAttributeRegistry->data()) {
                     const auto& name = attribute.name();

--- a/pendingchanges/ax_sop_empty.txt
+++ b/pendingchanges/ax_sop_empty.txt
@@ -1,0 +1,2 @@
+Bug Fix:
+ - Fixed a crash in the AX Houdini SOP with an empty PointDataGrid input.


### PR DESCRIPTION
This fixes a bug where the AX Houdini SOP would crash using an empty points grid as input.