### PR TITLE
Add 8-bit and 16-bit unit attribute registration

### DIFF
--- a/openvdb/openvdb/points/points.cc
+++ b/openvdb/openvdb/points/points.cc
@@ -42,6 +42,8 @@ internal::initialize()
     TypedAttributeArray<math::Vec3<float>, TruncateCodec>::registerType();
 
     // Register attribute arrays with fixed point compression
+    TypedAttributeArray<float, FixedPointCodec<true, UnitRange>>::registerType();
+    TypedAttributeArray<float, FixedPointCodec<false, UnitRange>>::registerType();
     TypedAttributeArray<math::Vec3<float>, FixedPointCodec<true>>::registerType();
     TypedAttributeArray<math::Vec3<float>, FixedPointCodec<false>>::registerType();
     TypedAttributeArray<math::Vec3<float>, FixedPointCodec<true, PositionRange>>::registerType();

--- a/openvdb/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/openvdb/unittest/TestAttributeArray.cc
@@ -533,6 +533,32 @@ TEST_F(TestAttributeArray, testAttributeArray)
             EXPECT_TRUE(!attr.valueTypeIsQuaternion());
             EXPECT_TRUE(!attr.valueTypeIsMatrix());
         }
+        {
+            TypedAttributeArray<float, FixedPointCodec<false, UnitRange>> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            EXPECT_EQ(Name("float"), attr.valueType());
+            EXPECT_EQ(Name("ufxpt16"), attr.codecType());
+            EXPECT_EQ(Index(4), attr.valueTypeSize());
+            EXPECT_EQ(Index(2), attr.storageTypeSize());
+            EXPECT_TRUE(attr.valueTypeIsFloatingPoint());
+            EXPECT_TRUE(!attr.valueTypeIsClass());
+            EXPECT_TRUE(!attr.valueTypeIsVector());
+            EXPECT_TRUE(!attr.valueTypeIsQuaternion());
+            EXPECT_TRUE(!attr.valueTypeIsMatrix());
+        }
+        {
+            TypedAttributeArray<float, FixedPointCodec<true, UnitRange>> typedAttr(size);
+            AttributeArray& attr(typedAttr);
+            EXPECT_EQ(Name("float"), attr.valueType());
+            EXPECT_EQ(Name("ufxpt8"), attr.codecType());
+            EXPECT_EQ(Index(4), attr.valueTypeSize());
+            EXPECT_EQ(Index(1), attr.storageTypeSize());
+            EXPECT_TRUE(attr.valueTypeIsFloatingPoint());
+            EXPECT_TRUE(!attr.valueTypeIsClass());
+            EXPECT_TRUE(!attr.valueTypeIsVector());
+            EXPECT_TRUE(!attr.valueTypeIsQuaternion());
+            EXPECT_TRUE(!attr.valueTypeIsMatrix());
+        }
     }
 
     {

--- a/pendingchanges/point_unit_types.txt
+++ b/pendingchanges/point_unit_types.txt
@@ -1,0 +1,2 @@
+Bug Fixes:
+- Add missing 8-bit and 16-bit attribute type registration.


### PR DESCRIPTION
These attribute types are used by Houdini and should be registered by default.