### PR TITLE
Support for worldspace dilation specification in the VDB Activate SOP.

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Activate.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Activate.cc
@@ -212,7 +212,7 @@ an inclusive range, so includes the maximum voxel.)"));
     parms.addFolder("Expand");
 /*
     Expand the active area by at least the specified number of voxels.  Does not
-    operation or setting of values.
+    support operation or setting of values.
 */
     parms.add(hutil::ParmFactory(PRM_INT, "expand", "Voxels to Expand")
                 .setDefault(PRMoneDefaults)
@@ -690,6 +690,10 @@ SOP_VDBActivate::Cache::cookVDBSop(OP_Context &context)
                         UTvdbCallAllTopology(vdb->getStorageType(),
                                          sopErodeVoxels,
                                          vdb->getGrid(), -mindilate);
+                    }
+                    if (mindilate < 0 && maxdilate > 0)
+                    {
+                        addWarning(SOP_MESSAGE, "Conflicting signs in Voxel/Worldspace dilation request.  Applying both, which may not be expected.");
                     }
                     break;
                 }

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Activate.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Activate.cc
@@ -217,7 +217,7 @@ an inclusive range, so includes the maximum voxel.)"));
     parms.add(hutil::ParmFactory(PRM_INT, "expand", "Voxels to Expand")
                 .setDefault(PRMoneDefaults)
                 .setRange(PRM_RANGE_FREE, -5, PRM_RANGE_FREE, 5)
-	      .setTooltip("Expand the active area by at least the specified number of voxels.")
+              .setTooltip("Expand the active area by at least the specified number of voxels.")
                 .setDocumentation(
 R"(Expand the active area by at least the specified number of voxels.  Does not support
 operation or setting of values.)"));
@@ -227,11 +227,11 @@ operation or setting of values.)"));
     operation or setting of values.
 */
     parms.add(hutil::ParmFactory(PRM_FLT, "expanddist", "Expand Distance")
-	      .setDefault(PRMzeroDefaults)
-	      .setRange(PRM_RANGE_UI, 0.0f, PRM_RANGE_UI, 2.0f)
-	      .setTooltip("Expand the active area by at least the specified distance.")
-	      .setDocumentation(
-				R"(Expand the active area by at least the specified distance. Does not support operation or setting of values.)"));
+              .setDefault(PRMzeroDefaults)
+              .setRange(PRM_RANGE_UI, 0.0f, PRM_RANGE_UI, 2.0f)
+              .setTooltip("Expand the active area by at least the specified distance.")
+              .setDocumentation(
+                                R"(Expand the active area by at least the specified distance. Does not support operation or setting of values.)"));
 
     parms.addFolder("Reference");
 /*
@@ -490,16 +490,16 @@ sopFillSDF(GridType &grid, int dummy)
 
 template <typename GridType>
 static void
-sopDilateVoxels(GridType& grid, int count)
+sopDilateVoxels(GridType& grid, exint count)
 {
-    openvdb::tools::dilateActiveValues(grid.tree(), count);
+    openvdb::tools::dilateActiveValues(grid.tree(), static_cast<int>(count));
 }
 
 template <typename GridType>
 static void
-sopErodeVoxels(GridType& grid, int count)
+sopErodeVoxels(GridType& grid, exint count)
 {
-    openvdb::tools::erodeActiveValues(grid.tree(), count);
+    openvdb::tools::erodeActiveValues(grid.tree(), static_cast<int>(count));
     if (grid.getGridClass() == openvdb::GRID_LEVEL_SET) {
         openvdb::tools::pruneLevelSet(grid.tree());
     }
@@ -682,7 +682,7 @@ SOP_VDBActivate::Cache::cookVDBSop(OP_Context &context)
                                          vdb->getGrid(), maxdilate);
                     }
 
-		    exint mindilate = SYSmin(dilatevoxels, dilatedist);
+                    exint mindilate = SYSmin(dilatevoxels, dilatedist);
                     if (mindilate < 0)
                     {
                         if (boss->opInterrupt())

--- a/pendingchanges/vdbactivateworldspace.txt
+++ b/pendingchanges/vdbactivateworldspace.txt
@@ -1,0 +1,4 @@
+Houdini:
+- VDB Activate SOP dilation will affect tiles, changing its behaviour
+  from previous versions, but producing a more expected result.
+- VDB Activate SOP has a world space dilation option.


### PR DESCRIPTION
VDB Activate is also switched to working with tiles, which changes behaviour
but the old behaviour is likely a bug.  Houdini's version will also make
this change.
