### PR TITLE
Update the UI for SOP OpenVDB Extrapolate

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Extrapolate.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Extrapolate.cc
@@ -783,10 +783,10 @@ SOP_OpenVDB_Extrapolate::Cache::cookVDBSop(OP_Context& context)
                 }
                 case UT_VDB_DOUBLE:
                 {
-                    float isoValue = (parms.mMode == "convert" || parms.mMode == "fogext") ?
-                                         static_cast<double>(evalFloat("fogisovalue", 0, time)) :
-                                         (parms.mMode == "renormalize" || parms.mMode == "sdfext") ?
-                                         static_cast<double>(evalFloat("sdfisovalue", 0, time)) : 0.;
+                    double isoValue = (parms.mMode == "convert" || parms.mMode == "fogext") ?
+                                        static_cast<double>(evalFloat("fogisovalue", 0, time)) :
+                                        (parms.mMode == "renormalize" || parms.mMode == "sdfext") ?
+                                        static_cast<double>(evalFloat("sdfisovalue", 0, time)) : 0.0;
                     processHelper<openvdb::DoubleGrid>(parms, *it /*lsPrim*/, isoValue, maskPrim);
                     parms.mExtFieldProcessed = true;
                     break;


### PR DESCRIPTION
The isovalue of SOP OpenVDB Extrapolate is now splitted into an sdf isovalue and a fog isovalue. Because of this change, we also split the parameter Extend Field(s) Off Scalar VDB to:

- Extend Field(s) Off Fog VDB
- Extend Field(s) Off SDF

Signed-off-by: Andre Pradhana <andre.pradhana@dreamworks.com>