### PR TITLE
Blind Data (ABI=9)

### DIFF
--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -268,6 +268,18 @@ public:
     /// Set the grid index coordinates of this node's local origin.
     void setOrigin(const Coord& origin) { mOrigin = origin; }
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    /// Return the transitive offset value.
+    Index64 transitiveOffset() const { return Index64(mTransitiveOffset); }
+    /// Set the transitive offset value.
+    void setTransitiveOffset(Index64 transitiveOffset)
+    {
+        // assert that offset does not exceed 32-bit limit
+        assert(transitiveOffset <= Index64(std::numeric_limits<Index32>::max()));
+        mTransitiveOffset = static_cast<Index32>(transitiveOffset);
+    }
+#endif
+
     Index32 leafCount() const;
     void nodeCount(std::vector<Index32> &vec) const;
     Index32 nonLeafCount() const;
@@ -818,6 +830,10 @@ protected:
     NodeMaskType mChildMask, mValueMask;
     /// Global grid index coordinates (x,y,z) of the local origin of this node
     Coord mOrigin;
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    /// Transitive offset
+    Index32 mTransitiveOffset = 0;
+#endif
 }; // class InternalNode
 
 
@@ -897,10 +913,13 @@ struct InternalNode<ChildT, Log2Dim>::DeepCopy
 
 template<typename ChildT, Index Log2Dim>
 inline
-InternalNode<ChildT, Log2Dim>::InternalNode(const InternalNode& other):
-    mChildMask(other.mChildMask),
-    mValueMask(other.mValueMask),
-    mOrigin(other.mOrigin)
+InternalNode<ChildT, Log2Dim>::InternalNode(const InternalNode& other)
+    : mChildMask(other.mChildMask)
+    , mValueMask(other.mValueMask)
+    , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
     DeepCopy<InternalNode<ChildT, Log2Dim> > tmp(&other, this);
 }
@@ -914,6 +933,9 @@ InternalNode<ChildT, Log2Dim>::InternalNode(const InternalNode<OtherChildNodeTyp
     : mChildMask(other.mChildMask)
     , mValueMask(other.mValueMask)
     , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
     DeepCopy<InternalNode<OtherChildNodeType, Log2Dim> > tmp(&other, this);
 }
@@ -946,10 +968,13 @@ template<typename ChildT, Index Log2Dim>
 template<typename OtherChildNodeType>
 inline
 InternalNode<ChildT, Log2Dim>::InternalNode(const InternalNode<OtherChildNodeType, Log2Dim>& other,
-                                            const ValueType& background, TopologyCopy):
-    mChildMask(other.mChildMask),
-    mValueMask(other.mValueMask),
-    mOrigin(other.mOrigin)
+                                            const ValueType& background, TopologyCopy)
+    : mChildMask(other.mChildMask)
+    , mValueMask(other.mValueMask)
+    , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
     TopologyCopy1<InternalNode<OtherChildNodeType, Log2Dim> > tmp(&other, this, background);
 }
@@ -983,10 +1008,13 @@ template<typename OtherChildNodeType>
 inline
 InternalNode<ChildT, Log2Dim>::InternalNode(const InternalNode<OtherChildNodeType, Log2Dim>& other,
                                             const ValueType& offValue,
-                                            const ValueType& onValue, TopologyCopy):
-    mChildMask(other.mChildMask),
-    mValueMask(other.mValueMask),
-    mOrigin(other.mOrigin)
+                                            const ValueType& onValue, TopologyCopy)
+    : mChildMask(other.mChildMask)
+    , mValueMask(other.mValueMask)
+    , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
     TopologyCopy2<InternalNode<OtherChildNodeType, Log2Dim> > tmp(&other, this, offValue, onValue);
 }

--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -269,14 +269,14 @@ public:
     void setOrigin(const Coord& origin) { mOrigin = origin; }
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Return the transitive offset value.
-    Index64 transitiveOffset() const { return Index64(mTransitiveOffset); }
-    /// Set the transitive offset value.
-    void setTransitiveOffset(Index64 transitiveOffset)
+    /// Return the transient data value.
+    Index64 transientData() const { return Index64(mTransientData); }
+    /// Set the transient data value.
+    void setTransientData(Index64 transientData)
     {
         // assert that offset does not exceed 32-bit limit
-        assert(transitiveOffset <= Index64(std::numeric_limits<Index32>::max()));
-        mTransitiveOffset = static_cast<Index32>(transitiveOffset);
+        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
+        mTransientData = static_cast<Index32>(transientData);
     }
 #endif
 
@@ -831,8 +831,8 @@ protected:
     /// Global grid index coordinates (x,y,z) of the local origin of this node
     Coord mOrigin;
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Transitive offset
-    Index32 mTransitiveOffset = 0;
+    /// Transient data (not serialized)
+    Index32 mTransientData = 0;
 #endif
 }; // class InternalNode
 
@@ -918,7 +918,7 @@ InternalNode<ChildT, Log2Dim>::InternalNode(const InternalNode& other)
     , mValueMask(other.mValueMask)
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     DeepCopy<InternalNode<ChildT, Log2Dim> > tmp(&other, this);
@@ -934,7 +934,7 @@ InternalNode<ChildT, Log2Dim>::InternalNode(const InternalNode<OtherChildNodeTyp
     , mValueMask(other.mValueMask)
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     DeepCopy<InternalNode<OtherChildNodeType, Log2Dim> > tmp(&other, this);
@@ -973,7 +973,7 @@ InternalNode<ChildT, Log2Dim>::InternalNode(const InternalNode<OtherChildNodeTyp
     , mValueMask(other.mValueMask)
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     TopologyCopy1<InternalNode<OtherChildNodeType, Log2Dim> > tmp(&other, this, background);
@@ -1013,7 +1013,7 @@ InternalNode<ChildT, Log2Dim>::InternalNode(const InternalNode<OtherChildNodeTyp
     , mValueMask(other.mValueMask)
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     TopologyCopy2<InternalNode<OtherChildNodeType, Log2Dim> > tmp(&other, this, offValue, onValue);

--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -270,14 +270,9 @@ public:
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
     /// Return the transient data value.
-    Index64 transientData() const { return Index64(mTransientData); }
+    Index32 transientData() const { return mTransientData; }
     /// Set the transient data value.
-    void setTransientData(Index64 transientData)
-    {
-        // assert that offset does not exceed 32-bit limit
-        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
-        mTransientData = static_cast<Index32>(transientData);
-    }
+    void setTransientData(Index32 transientData) { mTransientData = transientData; }
 #endif
 
     Index32 leafCount() const;

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -182,6 +182,18 @@ public:
     /// Return the global coordinates for a linear table offset.
     Coord offsetToGlobalCoord(Index n) const;
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    /// Return the transitive offset value.
+    Index64 transitiveOffset() const { return Index64(mTransitiveOffset); }
+    /// Set the transitive offset value.
+    void setTransitiveOffset(Index64 transitiveOffset)
+    {
+        // assert that offset does not exceed 32-bit limit
+        assert(transitiveOffset <= Index64(std::numeric_limits<Index32>::max()));
+        mTransitiveOffset = static_cast<Index32>(transitiveOffset);
+    }
+#endif
+
     /// Return a string representation of this node.
     std::string str() const;
 
@@ -899,6 +911,10 @@ private:
     NodeMaskType mValueMask;
     /// Global grid index coordinates (x,y,z) of the local origin of this node
     Coord mOrigin;
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    /// Transitive offset
+    Index32 mTransitiveOffset = 0;
+#endif
 }; // end of LeafNode class
 
 
@@ -950,10 +966,13 @@ LeafNode<T, Log2Dim>::LeafNode(PartialCreate, const Coord& xyz, const ValueType&
 
 template<typename T, Index Log2Dim>
 inline
-LeafNode<T, Log2Dim>::LeafNode(const LeafNode& other):
-    mBuffer(other.mBuffer),
-    mValueMask(other.valueMask()),
-    mOrigin(other.mOrigin)
+LeafNode<T, Log2Dim>::LeafNode(const LeafNode& other)
+    : mBuffer(other.mBuffer)
+    , mValueMask(other.valueMask())
+    , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
 }
 
@@ -962,9 +981,12 @@ LeafNode<T, Log2Dim>::LeafNode(const LeafNode& other):
 template<typename T, Index Log2Dim>
 template<typename OtherValueType>
 inline
-LeafNode<T, Log2Dim>::LeafNode(const LeafNode<OtherValueType, Log2Dim>& other):
-    mValueMask(other.valueMask()),
-    mOrigin(other.mOrigin)
+LeafNode<T, Log2Dim>::LeafNode(const LeafNode<OtherValueType, Log2Dim>& other)
+    : mValueMask(other.valueMask())
+    , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
     struct Local {
         /// @todo Consider using a value conversion functor passed as an argument instead.
@@ -981,10 +1003,13 @@ template<typename T, Index Log2Dim>
 template<typename OtherValueType>
 inline
 LeafNode<T, Log2Dim>::LeafNode(const LeafNode<OtherValueType, Log2Dim>& other,
-                               const ValueType& background, TopologyCopy):
-    mBuffer(background),
-    mValueMask(other.valueMask()),
-    mOrigin(other.mOrigin)
+                               const ValueType& background, TopologyCopy)
+    : mBuffer(background)
+    , mValueMask(other.valueMask())
+    , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
 }
 
@@ -993,9 +1018,12 @@ template<typename T, Index Log2Dim>
 template<typename OtherValueType>
 inline
 LeafNode<T, Log2Dim>::LeafNode(const LeafNode<OtherValueType, Log2Dim>& other,
-    const ValueType& offValue, const ValueType& onValue, TopologyCopy):
-    mValueMask(other.valueMask()),
-    mOrigin(other.mOrigin)
+    const ValueType& offValue, const ValueType& onValue, TopologyCopy)
+    : mValueMask(other.valueMask())
+    , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
     for (Index i = 0; i < SIZE; ++i) {
         mBuffer[i] = (mValueMask.isOn(i) ? onValue : offValue);

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -183,14 +183,14 @@ public:
     Coord offsetToGlobalCoord(Index n) const;
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Return the transitive offset value.
-    Index64 transitiveOffset() const { return Index64(mTransitiveOffset); }
-    /// Set the transitive offset value.
-    void setTransitiveOffset(Index64 transitiveOffset)
+    /// Return the transient data value.
+    Index64 transientData() const { return Index64(mTransientData); }
+    /// Set the transient data value.
+    void setTransientData(Index64 transientData)
     {
         // assert that offset does not exceed 32-bit limit
-        assert(transitiveOffset <= Index64(std::numeric_limits<Index32>::max()));
-        mTransitiveOffset = static_cast<Index32>(transitiveOffset);
+        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
+        mTransientData = static_cast<Index32>(transientData);
     }
 #endif
 
@@ -912,8 +912,8 @@ private:
     /// Global grid index coordinates (x,y,z) of the local origin of this node
     Coord mOrigin;
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Transitive offset
-    Index32 mTransitiveOffset = 0;
+    /// Transient data (not serialized)
+    Index32 mTransientData = 0;
 #endif
 }; // end of LeafNode class
 
@@ -971,7 +971,7 @@ LeafNode<T, Log2Dim>::LeafNode(const LeafNode& other)
     , mValueMask(other.valueMask())
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
 }
@@ -985,7 +985,7 @@ LeafNode<T, Log2Dim>::LeafNode(const LeafNode<OtherValueType, Log2Dim>& other)
     : mValueMask(other.valueMask())
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     struct Local {
@@ -1008,7 +1008,7 @@ LeafNode<T, Log2Dim>::LeafNode(const LeafNode<OtherValueType, Log2Dim>& other,
     , mValueMask(other.valueMask())
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
 }
@@ -1022,7 +1022,7 @@ LeafNode<T, Log2Dim>::LeafNode(const LeafNode<OtherValueType, Log2Dim>& other,
     : mValueMask(other.valueMask())
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     for (Index i = 0; i < SIZE; ++i) {

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -184,14 +184,9 @@ public:
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
     /// Return the transient data value.
-    Index64 transientData() const { return Index64(mTransientData); }
+    Index32 transientData() const { return mTransientData; }
     /// Set the transient data value.
-    void setTransientData(Index64 transientData)
-    {
-        // assert that offset does not exceed 32-bit limit
-        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
-        mTransientData = static_cast<Index32>(transientData);
-    }
+    void setTransientData(Index32 transientData) { mTransientData = transientData; }
 #endif
 
     /// Return a string representation of this node.

--- a/openvdb/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/openvdb/tree/LeafNodeBool.h
@@ -164,6 +164,18 @@ public:
     /// Return the global coordinates for a linear table offset.
     Coord offsetToGlobalCoord(Index n) const;
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    /// Return the transitive offset value.
+    Index64 transitiveOffset() const { return Index64(mTransitiveOffset); }
+    /// Set the transitive offset value.
+    void setTransitiveOffset(Index64 transitiveOffset)
+    {
+        // assert that offset does not exceed 32-bit limit
+        assert(transitiveOffset <= Index64(std::numeric_limits<Index32>::max()));
+        mTransitiveOffset = static_cast<Index32>(transitiveOffset);
+    }
+#endif
+
     /// Return a string representation of this node.
     std::string str() const;
 
@@ -728,6 +740,10 @@ protected:
     Buffer mBuffer;
     /// Global grid index coordinates (x,y,z) of the local origin of this node
     Coord mOrigin;
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    /// Transitive offset
+    Index32 mTransitiveOffset = 0;
+#endif
 
 private:
     /// @brief During topology-only construction, access is needed
@@ -792,6 +808,9 @@ LeafNode<bool, Log2Dim>::LeafNode(const LeafNode &other)
     : mValueMask(other.valueMask())
     , mBuffer(other.mBuffer)
     , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
 }
 
@@ -803,6 +822,9 @@ inline
 LeafNode<bool, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other)
     : mValueMask(other.valueMask())
     , mOrigin(other.origin())
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
     struct Local {
         /// @todo Consider using a value conversion functor passed as an argument instead.
@@ -823,6 +845,9 @@ LeafNode<bool, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other,
     : mValueMask(other.valueMask())
     , mBuffer(background)
     , mOrigin(other.origin())
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
 }
 
@@ -834,6 +859,9 @@ LeafNode<bool, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other, Topolo
     : mValueMask(other.valueMask())
     , mBuffer(other.valueMask())// value = active state
     , mOrigin(other.origin())
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
 }
 
@@ -846,6 +874,9 @@ LeafNode<bool, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other,
     : mValueMask(other.valueMask())
     , mBuffer(other.valueMask())
     , mOrigin(other.origin())
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
     if (offValue) { if (!onValue) mBuffer.mData.toggle(); else mBuffer.mData.setOn(); }
 }

--- a/openvdb/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/openvdb/tree/LeafNodeBool.h
@@ -166,14 +166,9 @@ public:
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
     /// Return the transient data value.
-    Index64 transientData() const { return Index64(mTransientData); }
+    Index32 transientData() const { return mTransientData; }
     /// Set the transient data value.
-    void setTransientData(Index64 transientData)
-    {
-        // assert that offset does not exceed 32-bit limit
-        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
-        mTransientData = static_cast<Index32>(transientData);
-    }
+    void setTransientData(Index32 transientData) { mTransientData = transientData; }
 #endif
 
     /// Return a string representation of this node.

--- a/openvdb/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/openvdb/tree/LeafNodeBool.h
@@ -165,14 +165,14 @@ public:
     Coord offsetToGlobalCoord(Index n) const;
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Return the transitive offset value.
-    Index64 transitiveOffset() const { return Index64(mTransitiveOffset); }
-    /// Set the transitive offset value.
-    void setTransitiveOffset(Index64 transitiveOffset)
+    /// Return the transient data value.
+    Index64 transientData() const { return Index64(mTransientData); }
+    /// Set the transient data value.
+    void setTransientData(Index64 transientData)
     {
         // assert that offset does not exceed 32-bit limit
-        assert(transitiveOffset <= Index64(std::numeric_limits<Index32>::max()));
-        mTransitiveOffset = static_cast<Index32>(transitiveOffset);
+        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
+        mTransientData = static_cast<Index32>(transientData);
     }
 #endif
 
@@ -741,8 +741,8 @@ protected:
     /// Global grid index coordinates (x,y,z) of the local origin of this node
     Coord mOrigin;
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Transitive offset
-    Index32 mTransitiveOffset = 0;
+    /// Transient data (not serialized)
+    Index32 mTransientData = 0;
 #endif
 
 private:
@@ -809,7 +809,7 @@ LeafNode<bool, Log2Dim>::LeafNode(const LeafNode &other)
     , mBuffer(other.mBuffer)
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
 }
@@ -823,7 +823,7 @@ LeafNode<bool, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other)
     : mValueMask(other.valueMask())
     , mOrigin(other.origin())
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     struct Local {
@@ -846,7 +846,7 @@ LeafNode<bool, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other,
     , mBuffer(background)
     , mOrigin(other.origin())
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
 }
@@ -860,7 +860,7 @@ LeafNode<bool, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other, Topolo
     , mBuffer(other.valueMask())// value = active state
     , mOrigin(other.origin())
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
 }
@@ -875,7 +875,7 @@ LeafNode<bool, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other,
     , mBuffer(other.valueMask())
     , mOrigin(other.origin())
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     if (offValue) { if (!onValue) mBuffer.mData.toggle(); else mBuffer.mData.setOn(); }

--- a/openvdb/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/openvdb/tree/LeafNodeMask.h
@@ -170,14 +170,9 @@ public:
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
     /// Return the transient data value.
-    Index64 transientData() const { return Index64(mTransientData); }
+    Index32 transientData() const { return mTransientData; }
     /// Set the transient data value.
-    void setTransientData(Index64 transientData)
-    {
-        // assert that offset does not exceed 32-bit limit
-        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
-        mTransientData = static_cast<Index32>(transientData);
-    }
+    void setTransientData(Index32 transientData) { mTransientData = transientData; }
 #endif
 
     /// Return a string representation of this node.

--- a/openvdb/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/openvdb/tree/LeafNodeMask.h
@@ -169,14 +169,14 @@ public:
     Coord offsetToGlobalCoord(Index n) const;
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Return the transitive offset value.
-    Index64 transitiveOffset() const { return Index64(mTransitiveOffset); }
-    /// Set the transitive offset value.
-    void setTransitiveOffset(Index64 transitiveOffset)
+    /// Return the transient data value.
+    Index64 transientData() const { return Index64(mTransientData); }
+    /// Set the transient data value.
+    void setTransientData(Index64 transientData)
     {
         // assert that offset does not exceed 32-bit limit
-        assert(transitiveOffset <= Index64(std::numeric_limits<Index32>::max()));
-        mTransitiveOffset = static_cast<Index32>(transitiveOffset);
+        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
+        mTransientData = static_cast<Index32>(transientData);
     }
 #endif
 
@@ -746,8 +746,8 @@ protected:
     /// Global grid index coordinates (x,y,z) of the local origin of this node
     Coord mOrigin;
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Transitive offset
-    Index32 mTransitiveOffset = 0;
+    /// Transient data (not serialized)
+    Index32 mTransientData = 0;
 #endif
 
 private:
@@ -809,7 +809,7 @@ LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode &other)
     : mBuffer(other.mBuffer)
     , mOrigin(other.mOrigin)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
 }
@@ -823,7 +823,7 @@ LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other)
     : mBuffer(other.valueMask())
     , mOrigin(other.origin())
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
 }
@@ -837,7 +837,7 @@ LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other,
     : mBuffer(other.valueMask())// value = active state
     , mOrigin(other.origin())
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
 }
@@ -850,7 +850,7 @@ LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other, T
     : mBuffer(other.valueMask())// value = active state
     , mOrigin(other.origin())
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
 }
@@ -864,7 +864,7 @@ LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other,
     : mBuffer(other.valueMask())
     , mOrigin(other.origin())
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     if (offValue==true) {

--- a/openvdb/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/openvdb/tree/LeafNodeMask.h
@@ -168,6 +168,18 @@ public:
     /// Return the global coordinates for a linear table offset.
     Coord offsetToGlobalCoord(Index n) const;
 
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    /// Return the transitive offset value.
+    Index64 transitiveOffset() const { return Index64(mTransitiveOffset); }
+    /// Set the transitive offset value.
+    void setTransitiveOffset(Index64 transitiveOffset)
+    {
+        // assert that offset does not exceed 32-bit limit
+        assert(transitiveOffset <= Index64(std::numeric_limits<Index32>::max()));
+        mTransitiveOffset = static_cast<Index32>(transitiveOffset);
+    }
+#endif
+
     /// Return a string representation of this node.
     std::string str() const;
 
@@ -731,9 +743,12 @@ protected:
 
     /// Bitmask representing the values AND state of voxels
     Buffer mBuffer;
-
     /// Global grid index coordinates (x,y,z) of the local origin of this node
     Coord mOrigin;
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    /// Transitive offset
+    Index32 mTransitiveOffset = 0;
+#endif
 
 private:
     /// @brief During topology-only construction, access is needed
@@ -793,6 +808,9 @@ inline
 LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode &other)
     : mBuffer(other.mBuffer)
     , mOrigin(other.mOrigin)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
 }
 
@@ -804,6 +822,9 @@ inline
 LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other)
     : mBuffer(other.valueMask())
     , mOrigin(other.origin())
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
 }
 
@@ -815,6 +836,9 @@ LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other,
                                          bool, TopologyCopy)
     : mBuffer(other.valueMask())// value = active state
     , mOrigin(other.origin())
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
 }
 
@@ -825,6 +849,9 @@ inline
 LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other, TopologyCopy)
     : mBuffer(other.valueMask())// value = active state
     , mOrigin(other.origin())
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
 }
 
@@ -836,6 +863,9 @@ LeafNode<ValueMask, Log2Dim>::LeafNode(const LeafNode<ValueT, Log2Dim>& other,
                                          bool offValue, bool onValue, TopologyCopy)
     : mBuffer(other.valueMask())
     , mOrigin(other.origin())
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    , mTransitiveOffset(other.mTransitiveOffset)
+#endif
 {
     if (offValue==true) {
         if (onValue==false) {

--- a/openvdb/openvdb/tree/RootNode.h
+++ b/openvdb/openvdb/tree/RootNode.h
@@ -406,14 +406,14 @@ public:
     static CoordBBox getNodeBoundingBox() { return CoordBBox::inf(); }
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Return the transitive offset value.
-    Index64 transitiveOffset() const { return Index64(mTransitiveOffset); }
-    /// Set the transitive offset value.
-    void setTransitiveOffset(Index64 transitiveOffset)
+    /// Return the transient data value.
+    Index64 transientData() const { return Index64(mTransientData); }
+    /// Set the transient data value.
+    void setTransientData(Index64 transientData)
     {
         // assert that offset does not exceed 32-bit limit
-        assert(transitiveOffset <= Index64(std::numeric_limits<Index32>::max()));
-        mTransitiveOffset = static_cast<Index32>(transitiveOffset);
+        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
+        mTransientData = static_cast<Index32>(transientData);
     }
 #endif
 
@@ -979,8 +979,8 @@ private:
     MapType mTable;
     ValueType mBackground;
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    /// Transitive offset
-    Index32 mTransitiveOffset = 0;
+    /// Transient Data (not serialized)
+    Index32 mTransientData = 0;
 #endif
 }; // end of RootNode class
 
@@ -1065,7 +1065,7 @@ RootNode<ChildT>::RootNode(const RootNode<OtherChildType>& other,
     const ValueType& backgd, const ValueType& foregd, TopologyCopy)
     : mBackground(backgd)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     using OtherRootT = RootNode<OtherChildType>;
@@ -1090,7 +1090,7 @@ RootNode<ChildT>::RootNode(const RootNode<OtherChildType>& other,
     const ValueType& backgd, TopologyCopy)
     : mBackground(backgd)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-    , mTransitiveOffset(other.mTransitiveOffset)
+    , mTransientData(other.mTransientData)
 #endif
 {
     using OtherRootT = RootNode<OtherChildType>;
@@ -1151,7 +1151,7 @@ struct RootNodeCopyHelper<RootT, OtherRootT, /*Compatible=*/true>
 
         self.mBackground = Local::convertValue(other.mBackground);
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-        self.mTransitiveOffset = other.mTransitiveOffset;
+        self.mTransientData = other.mTransientData;
 #endif
 
         self.clear();
@@ -1180,7 +1180,7 @@ RootNode<ChildT>::operator=(const RootNode& other)
     if (&other != this) {
         mBackground = other.mBackground;
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
-        mTransitiveOffset = other.mTransitiveOffset;
+        mTransientData = other.mTransientData;
 #endif
 
         this->clear();

--- a/openvdb/openvdb/tree/RootNode.h
+++ b/openvdb/openvdb/tree/RootNode.h
@@ -407,14 +407,9 @@ public:
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
     /// Return the transient data value.
-    Index64 transientData() const { return Index64(mTransientData); }
+    Index32 transientData() const { return mTransientData; }
     /// Set the transient data value.
-    void setTransientData(Index64 transientData)
-    {
-        // assert that offset does not exceed 32-bit limit
-        assert(transientData <= Index64(std::numeric_limits<Index32>::max()));
-        mTransientData = static_cast<Index32>(transientData);
-    }
+    void setTransientData(Index32 transientData) { mTransientData = transientData; }
 #endif
 
     /// @brief Change inactive tiles or voxels with a value equal to +/- the

--- a/openvdb/openvdb/unittest/TestLeaf.cc
+++ b/openvdb/openvdb/unittest/TestLeaf.cc
@@ -518,18 +518,20 @@ TEST_F(TestLeaf, testCount)
     EXPECT_EQ(Index(3), dims[0]);
 }
 
-TEST_F(TestLeaf, testTransitiveOffset)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+TEST_F(TestLeaf, testTransientData)
 {
     using namespace openvdb;
     using LeafT = tree::LeafNode<float, 3>;
     const Coord origin(-9, -2, -8);
     LeafT leaf(origin, 1.0f, false);
 
-    EXPECT_EQ(Index64(0), leaf.transitiveOffset());
-    leaf.setTransitiveOffset(Index64(5));
-    EXPECT_EQ(Index64(5), leaf.transitiveOffset());
+    EXPECT_EQ(Index64(0), leaf.transientData());
+    leaf.setTransientData(Index64(5));
+    EXPECT_EQ(Index64(5), leaf.transientData());
     LeafT leaf2(leaf);
-    EXPECT_EQ(Index64(5), leaf2.transitiveOffset());
+    EXPECT_EQ(Index64(5), leaf2.transientData());
     LeafT leaf3 = leaf;
-    EXPECT_EQ(Index64(5), leaf3.transitiveOffset());
+    EXPECT_EQ(Index64(5), leaf3.transientData());
 }
+#endif

--- a/openvdb/openvdb/unittest/TestLeaf.cc
+++ b/openvdb/openvdb/unittest/TestLeaf.cc
@@ -517,3 +517,19 @@ TEST_F(TestLeaf, testCount)
     EXPECT_EQ(size_t(1), dims.size());
     EXPECT_EQ(Index(3), dims[0]);
 }
+
+TEST_F(TestLeaf, testTransitiveOffset)
+{
+    using namespace openvdb;
+    using LeafT = tree::LeafNode<float, 3>;
+    const Coord origin(-9, -2, -8);
+    LeafT leaf(origin, 1.0f, false);
+
+    EXPECT_EQ(Index64(0), leaf.transitiveOffset());
+    leaf.setTransitiveOffset(Index64(5));
+    EXPECT_EQ(Index64(5), leaf.transitiveOffset());
+    LeafT leaf2(leaf);
+    EXPECT_EQ(Index64(5), leaf2.transitiveOffset());
+    LeafT leaf3 = leaf;
+    EXPECT_EQ(Index64(5), leaf3.transitiveOffset());
+}

--- a/openvdb/openvdb/unittest/TestLeaf.cc
+++ b/openvdb/openvdb/unittest/TestLeaf.cc
@@ -526,12 +526,12 @@ TEST_F(TestLeaf, testTransientData)
     const Coord origin(-9, -2, -8);
     LeafT leaf(origin, 1.0f, false);
 
-    EXPECT_EQ(Index64(0), leaf.transientData());
-    leaf.setTransientData(Index64(5));
-    EXPECT_EQ(Index64(5), leaf.transientData());
+    EXPECT_EQ(Index32(0), leaf.transientData());
+    leaf.setTransientData(Index32(5));
+    EXPECT_EQ(Index32(5), leaf.transientData());
     LeafT leaf2(leaf);
-    EXPECT_EQ(Index64(5), leaf2.transientData());
+    EXPECT_EQ(Index32(5), leaf2.transientData());
     LeafT leaf3 = leaf;
-    EXPECT_EQ(Index64(5), leaf3.transientData());
+    EXPECT_EQ(Index32(5), leaf3.transientData());
 }
 #endif

--- a/openvdb/openvdb/unittest/TestLeafBool.cc
+++ b/openvdb/openvdb/unittest/TestLeafBool.cc
@@ -556,15 +556,17 @@ TEST_F(TestLeafBool, testMedian)
 //     EXPECT_TRUE(tree->hasSameTopology(*copyOfTree));
 // }
 
-TEST_F(TestLeafBool, testTransitiveOffset)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+TEST_F(TestLeafBool, testTransientData)
 {
     LeafType leaf(openvdb::Coord(0, 0, 0), /*background=*/false);
 
-    EXPECT_EQ(openvdb::Index64(0), leaf.transitiveOffset());
-    leaf.setTransitiveOffset(openvdb::Index64(5));
-    EXPECT_EQ(openvdb::Index64(5), leaf.transitiveOffset());
+    EXPECT_EQ(openvdb::Index64(0), leaf.transientData());
+    leaf.setTransientData(openvdb::Index64(5));
+    EXPECT_EQ(openvdb::Index64(5), leaf.transientData());
     LeafType leaf2(leaf);
-    EXPECT_EQ(openvdb::Index64(5), leaf2.transitiveOffset());
+    EXPECT_EQ(openvdb::Index64(5), leaf2.transientData());
     LeafType leaf3 = leaf;
-    EXPECT_EQ(openvdb::Index64(5), leaf3.transitiveOffset());
+    EXPECT_EQ(openvdb::Index64(5), leaf3.transientData());
 }
+#endif

--- a/openvdb/openvdb/unittest/TestLeafBool.cc
+++ b/openvdb/openvdb/unittest/TestLeafBool.cc
@@ -561,12 +561,12 @@ TEST_F(TestLeafBool, testTransientData)
 {
     LeafType leaf(openvdb::Coord(0, 0, 0), /*background=*/false);
 
-    EXPECT_EQ(openvdb::Index64(0), leaf.transientData());
-    leaf.setTransientData(openvdb::Index64(5));
-    EXPECT_EQ(openvdb::Index64(5), leaf.transientData());
+    EXPECT_EQ(openvdb::Index32(0), leaf.transientData());
+    leaf.setTransientData(openvdb::Index32(5));
+    EXPECT_EQ(openvdb::Index32(5), leaf.transientData());
     LeafType leaf2(leaf);
-    EXPECT_EQ(openvdb::Index64(5), leaf2.transientData());
+    EXPECT_EQ(openvdb::Index32(5), leaf2.transientData());
     LeafType leaf3 = leaf;
-    EXPECT_EQ(openvdb::Index64(5), leaf3.transientData());
+    EXPECT_EQ(openvdb::Index32(5), leaf3.transientData());
 }
 #endif

--- a/openvdb/openvdb/unittest/TestLeafBool.cc
+++ b/openvdb/openvdb/unittest/TestLeafBool.cc
@@ -555,3 +555,16 @@ TEST_F(TestLeafBool, testMedian)
 //     // since the active voxels were all true to begin with.
 //     EXPECT_TRUE(tree->hasSameTopology(*copyOfTree));
 // }
+
+TEST_F(TestLeafBool, testTransitiveOffset)
+{
+    LeafType leaf(openvdb::Coord(0, 0, 0), /*background=*/false);
+
+    EXPECT_EQ(openvdb::Index64(0), leaf.transitiveOffset());
+    leaf.setTransitiveOffset(openvdb::Index64(5));
+    EXPECT_EQ(openvdb::Index64(5), leaf.transitiveOffset());
+    LeafType leaf2(leaf);
+    EXPECT_EQ(openvdb::Index64(5), leaf2.transitiveOffset());
+    LeafType leaf3 = leaf;
+    EXPECT_EQ(openvdb::Index64(5), leaf3.transitiveOffset());
+}

--- a/openvdb/openvdb/unittest/TestLeafMask.cc
+++ b/openvdb/openvdb/unittest/TestLeafMask.cc
@@ -562,3 +562,16 @@ TEST_F(TestLeafMask, testMedian)
 //     // since the active voxels were all true to begin with.
 //     EXPECT_TRUE(tree->hasSameTopology(*copyOfTree));
 // }
+
+TEST_F(TestLeafMask, testTransitiveOffset)
+{
+    LeafType leaf(openvdb::Coord(0, 0, 0), /*background=*/false);
+
+    EXPECT_EQ(openvdb::Index64(0), leaf.transitiveOffset());
+    leaf.setTransitiveOffset(openvdb::Index64(5));
+    EXPECT_EQ(openvdb::Index64(5), leaf.transitiveOffset());
+    LeafType leaf2(leaf);
+    EXPECT_EQ(openvdb::Index64(5), leaf2.transitiveOffset());
+    LeafType leaf3 = leaf;
+    EXPECT_EQ(openvdb::Index64(5), leaf3.transitiveOffset());
+}

--- a/openvdb/openvdb/unittest/TestLeafMask.cc
+++ b/openvdb/openvdb/unittest/TestLeafMask.cc
@@ -568,12 +568,12 @@ TEST_F(TestLeafMask, testTransientData)
 {
     LeafType leaf(openvdb::Coord(0, 0, 0), /*background=*/false);
 
-    EXPECT_EQ(openvdb::Index64(0), leaf.transientData());
-    leaf.setTransientData(openvdb::Index64(5));
-    EXPECT_EQ(openvdb::Index64(5), leaf.transientData());
+    EXPECT_EQ(openvdb::Index32(0), leaf.transientData());
+    leaf.setTransientData(openvdb::Index32(5));
+    EXPECT_EQ(openvdb::Index32(5), leaf.transientData());
     LeafType leaf2(leaf);
-    EXPECT_EQ(openvdb::Index64(5), leaf2.transientData());
+    EXPECT_EQ(openvdb::Index32(5), leaf2.transientData());
     LeafType leaf3 = leaf;
-    EXPECT_EQ(openvdb::Index64(5), leaf3.transientData());
+    EXPECT_EQ(openvdb::Index32(5), leaf3.transientData());
 }
 #endif

--- a/openvdb/openvdb/unittest/TestLeafMask.cc
+++ b/openvdb/openvdb/unittest/TestLeafMask.cc
@@ -563,15 +563,17 @@ TEST_F(TestLeafMask, testMedian)
 //     EXPECT_TRUE(tree->hasSameTopology(*copyOfTree));
 // }
 
-TEST_F(TestLeafMask, testTransitiveOffset)
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+TEST_F(TestLeafMask, testTransientData)
 {
     LeafType leaf(openvdb::Coord(0, 0, 0), /*background=*/false);
 
-    EXPECT_EQ(openvdb::Index64(0), leaf.transitiveOffset());
-    leaf.setTransitiveOffset(openvdb::Index64(5));
-    EXPECT_EQ(openvdb::Index64(5), leaf.transitiveOffset());
+    EXPECT_EQ(openvdb::Index64(0), leaf.transientData());
+    leaf.setTransientData(openvdb::Index64(5));
+    EXPECT_EQ(openvdb::Index64(5), leaf.transientData());
     LeafType leaf2(leaf);
-    EXPECT_EQ(openvdb::Index64(5), leaf2.transitiveOffset());
+    EXPECT_EQ(openvdb::Index64(5), leaf2.transientData());
     LeafType leaf3 = leaf;
-    EXPECT_EQ(openvdb::Index64(5), leaf3.transitiveOffset());
+    EXPECT_EQ(openvdb::Index64(5), leaf3.transientData());
 }
+#endif

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -3051,13 +3051,13 @@ TEST_F(TestTree, testRootNode)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
     { // test transient data
         RootNodeType rootNode(0.0f);
-        EXPECT_EQ(openvdb::Index64(0), rootNode.transientData());
-        rootNode.setTransientData(openvdb::Index64(5));
-        EXPECT_EQ(openvdb::Index64(5), rootNode.transientData());
+        EXPECT_EQ(openvdb::Index32(0), rootNode.transientData());
+        rootNode.setTransientData(openvdb::Index32(5));
+        EXPECT_EQ(openvdb::Index32(5), rootNode.transientData());
         RootNodeType rootNode2(rootNode);
-        EXPECT_EQ(openvdb::Index64(5), rootNode2.transientData());
+        EXPECT_EQ(openvdb::Index32(5), rootNode2.transientData());
         RootNodeType rootNode3 = rootNode;
-        EXPECT_EQ(openvdb::Index64(5), rootNode3.transientData());
+        EXPECT_EQ(openvdb::Index32(5), rootNode3.transientData());
     }
 #endif
 }
@@ -3158,13 +3158,13 @@ TEST_F(TestTree, testInternalNode)
 #if OPENVDB_ABI_VERSION_NUMBER >= 9
     { // test transient data
         InternalNodeType internalNode(c1, 0.0f);
-        EXPECT_EQ(openvdb::Index64(0), internalNode.transientData());
-        internalNode.setTransientData(openvdb::Index64(5));
-        EXPECT_EQ(openvdb::Index64(5), internalNode.transientData());
+        EXPECT_EQ(openvdb::Index32(0), internalNode.transientData());
+        internalNode.setTransientData(openvdb::Index32(5));
+        EXPECT_EQ(openvdb::Index32(5), internalNode.transientData());
         InternalNodeType internalNode2(internalNode);
-        EXPECT_EQ(openvdb::Index64(5), internalNode2.transientData());
+        EXPECT_EQ(openvdb::Index32(5), internalNode2.transientData());
         InternalNodeType internalNode3 = internalNode;
-        EXPECT_EQ(openvdb::Index64(5), internalNode3.transientData());
+        EXPECT_EQ(openvdb::Index32(5), internalNode3.transientData());
     }
 #endif
 }

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -3048,16 +3048,18 @@ TEST_F(TestTree, testRootNode)
         }
     }
 
-    { // test transitive offset
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    { // test transient data
         RootNodeType rootNode(0.0f);
-        EXPECT_EQ(openvdb::Index64(0), rootNode.transitiveOffset());
-        rootNode.setTransitiveOffset(openvdb::Index64(5));
-        EXPECT_EQ(openvdb::Index64(5), rootNode.transitiveOffset());
+        EXPECT_EQ(openvdb::Index64(0), rootNode.transientData());
+        rootNode.setTransientData(openvdb::Index64(5));
+        EXPECT_EQ(openvdb::Index64(5), rootNode.transientData());
         RootNodeType rootNode2(rootNode);
-        EXPECT_EQ(openvdb::Index64(5), rootNode2.transitiveOffset());
+        EXPECT_EQ(openvdb::Index64(5), rootNode2.transientData());
         RootNodeType rootNode3 = rootNode;
-        EXPECT_EQ(openvdb::Index64(5), rootNode3.transitiveOffset());
+        EXPECT_EQ(openvdb::Index64(5), rootNode3.transientData());
     }
+#endif
 }
 
 TEST_F(TestTree, testInternalNode)
@@ -3153,16 +3155,18 @@ TEST_F(TestTree, testInternalNode)
         delete child;
     }
 
-    { // test transitive offset
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    { // test transient data
         InternalNodeType internalNode(c1, 0.0f);
-        EXPECT_EQ(openvdb::Index64(0), internalNode.transitiveOffset());
-        internalNode.setTransitiveOffset(openvdb::Index64(5));
-        EXPECT_EQ(openvdb::Index64(5), internalNode.transitiveOffset());
+        EXPECT_EQ(openvdb::Index64(0), internalNode.transientData());
+        internalNode.setTransientData(openvdb::Index64(5));
+        EXPECT_EQ(openvdb::Index64(5), internalNode.transientData());
         InternalNodeType internalNode2(internalNode);
-        EXPECT_EQ(openvdb::Index64(5), internalNode2.transitiveOffset());
+        EXPECT_EQ(openvdb::Index64(5), internalNode2.transientData());
         InternalNodeType internalNode3 = internalNode;
-        EXPECT_EQ(openvdb::Index64(5), internalNode3.transitiveOffset());
+        EXPECT_EQ(openvdb::Index64(5), internalNode3.transientData());
     }
+#endif
 }
 
 // Copyright (c) DreamWorks Animation LLC

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -3047,6 +3047,17 @@ TEST_F(TestTree, testRootNode)
             EXPECT_EQ(c1, rootIter.getCoord());
         }
     }
+
+    { // test transitive offset
+        RootNodeType rootNode(0.0f);
+        EXPECT_EQ(openvdb::Index64(0), rootNode.transitiveOffset());
+        rootNode.setTransitiveOffset(openvdb::Index64(5));
+        EXPECT_EQ(openvdb::Index64(5), rootNode.transitiveOffset());
+        RootNodeType rootNode2(rootNode);
+        EXPECT_EQ(openvdb::Index64(5), rootNode2.transitiveOffset());
+        RootNodeType rootNode3 = rootNode;
+        EXPECT_EQ(openvdb::Index64(5), rootNode3.transitiveOffset());
+    }
 }
 
 TEST_F(TestTree, testInternalNode)
@@ -3140,6 +3151,17 @@ TEST_F(TestTree, testInternalNode)
         auto* child = new ChildType(c0.offsetBy(8000,0,0));
         EXPECT_TRUE(!internalNode.addChild(child));
         delete child;
+    }
+
+    { // test transitive offset
+        InternalNodeType internalNode(c1, 0.0f);
+        EXPECT_EQ(openvdb::Index64(0), internalNode.transitiveOffset());
+        internalNode.setTransitiveOffset(openvdb::Index64(5));
+        EXPECT_EQ(openvdb::Index64(5), internalNode.transitiveOffset());
+        InternalNodeType internalNode2(internalNode);
+        EXPECT_EQ(openvdb::Index64(5), internalNode2.transitiveOffset());
+        InternalNodeType internalNode3 = internalNode;
+        EXPECT_EQ(openvdb::Index64(5), internalNode3.transitiveOffset());
     }
 }
 

--- a/pendingchanges/blind_data.txt
+++ b/pendingchanges/blind_data.txt
@@ -1,0 +1,3 @@
+ABI changes (v9.0.0):
+- Added a transitive offset to the RootNode, InternalNode and LeafNode for
+  ABI=9.

--- a/pendingchanges/blind_data.txt
+++ b/pendingchanges/blind_data.txt
@@ -1,3 +1,3 @@
 ABI changes (v9.0.0):
-- Added a transitive offset to the RootNode, InternalNode and LeafNode for
+- Added transient data to the RootNode, InternalNode and LeafNode for
   ABI=9.


### PR DESCRIPTION
Adding a transitive offset to the RootNode, InternalNode and LeafNodes. This is an ABI=9 feature and doesn't change the size of the nodes in memory, just adds a 32-bit integer to each.

I hesitated on the naming and decided to call this a "transitive offset" - we use offset quite frequently in various contexts and making the transitive nature of this explicit seemed like a good idea.

The other aspect I hesitated on is the size of the integer type. In this implementation, the underlying size is a 32-bit integer (so as not the need to expand the node), but input and output is a 64-bit integer. As mentioned previously, we can steal a few unused bits from the origin to stretch the size of the offset we can store - by making the interface 64-bit, this saves needing to make an ABI change at a later date.