### PR TITLE
Nacho/fix python path ubuntu

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,8 +37,6 @@ jobs:
       run: ./ci/build.sh Release None OFF None "core,python,doc" -DOPENVDB_PYTHON_WRAP_ALL_GRID_TYPES=ON -DDISABLE_DEPENDENCY_VERSION_CHECKS=ON
     - name: epydoc
       run: |
-        export LD_LIBRARY_PATH=/usr/local/lib64
-        export PYTHONPATH=/usr/local/lib64/python2.7
         epydoc --html -o /usr/local/share/doc/OpenVDB/html/python pyopenvdb
     - name: deploy
       # only deploy documentation to gh-pages on a manual workflow dispatch

--- a/cmake/FindOpenVDB.cmake
+++ b/cmake/FindOpenVDB.cmake
@@ -306,9 +306,6 @@ list(APPEND _OPENVDB_LIBRARYDIR_SEARCH_DIRS
 set(_OPENVDB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
 set(OPENVDB_PYTHON_PATH_SUFFIXES
-  ${CMAKE_INSTALL_LIBDIR}/python
-  ${CMAKE_INSTALL_LIBDIR}/python2.7
-  ${CMAKE_INSTALL_LIBDIR}/python3
   lib64/python
   lib64/python2.7
   lib64/python3
@@ -316,6 +313,14 @@ set(OPENVDB_PYTHON_PATH_SUFFIXES
   lib/python2.7
   lib/python3
 )
+
+# Recurse through all the site-packages and dist-packages on the file system
+file(GLOB PYTHON_SITE_PACKAGES ${CMAKE_INSTALL_FULL_LIBDIR}/python**/*)
+foreach(_site_package_full_dir ${PYTHON_SITE_PACKAGES})
+  string(REPLACE ${CMAKE_INSTALL_FULL_LIBDIR} "${CMAKE_INSTALL_LIBDIR}"
+                 _site_package_dir ${_site_package_full_dir})
+  list(APPEND OPENVDB_PYTHON_PATH_SUFFIXES ${_site_package_dir})
+endforeach()
 
 set(OPENVDB_LIB_PATH_SUFFIXES
   ${CMAKE_INSTALL_LIBDIR}

--- a/openvdb/openvdb/python/CMakeLists.txt
+++ b/openvdb/openvdb/python/CMakeLists.txt
@@ -69,12 +69,14 @@ endfunction()
 # To ensure consistent versions between components Interpreter, Compiler,
 # Development and NumPy, specify all components at the same time when using
 # FindPython.
-# @note  the Interpreter component is only required for the python test.
 # @note  the Python::Module target should be used over the Python::Python
 #   target but this was only added in CMake 3.15. See:
 #      https://github.com/AcademySoftwareFoundation/openvdb/issues/886
 set(OPENVDB_PYTHON_DEPS)
-set(OPENVDB_PYTHON_REQUIRED_COMPONENTS Development Interpreter)
+set(OPENVDB_PYTHON_REQUIRED_COMPONENTS Development)
+if(NOT DEFINED PYOPENVDB_INSTALL_DIRECTORY)
+    list(APPEND OPENVDB_PYTHON_REQUIRED_COMPONENTS Interpreter)
+endif()
 
 if(${CMAKE_VERSION} VERSION_LESS 3.14)
   find_package(Python QUIET COMPONENTS ${OPENVDB_PYTHON_REQUIRED_COMPONENTS})

--- a/openvdb/openvdb/python/CMakeLists.txt
+++ b/openvdb/openvdb/python/CMakeLists.txt
@@ -74,11 +74,7 @@ endfunction()
 #   target but this was only added in CMake 3.15. See:
 #      https://github.com/AcademySoftwareFoundation/openvdb/issues/886
 set(OPENVDB_PYTHON_DEPS)
-set(OPENVDB_PYTHON_REQUIRED_COMPONENTS Development)
-
-if(OPENVDB_BUILD_PYTHON_UNITTESTS)
-  list(APPEND OPENVDB_PYTHON_REQUIRED_COMPONENTS Interpreter)
-endif()
+set(OPENVDB_PYTHON_REQUIRED_COMPONENTS Development Interpreter)
 
 if(${CMAKE_VERSION} VERSION_LESS 3.14)
   find_package(Python QUIET COMPONENTS ${OPENVDB_PYTHON_REQUIRED_COMPONENTS})
@@ -210,8 +206,9 @@ set(OPENVDB_PYTHON_MODULE_SOURCE_FILES
 )
 
 if(NOT DEFINED PYOPENVDB_INSTALL_DIRECTORY)
+  get_filename_component(Python_PACKAGES_DIR ${Python_SITELIB} NAME)
   set(PYOPENVDB_INSTALL_DIRECTORY
-    ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}
+    ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/${Python_PACKAGES_DIR}
     CACHE STRING "The directory to install the pyopenvdb.so module."
   )
 endif()


### PR DESCRIPTION
# Fix Python path

**WARNING:** I don't use any Windows or macOS systems, nor Houdinim Maya, or any of the software that uses OpenVDB. Thus, this method has been only tested under Linux (though I don't see why this will break other installations)

## Problem description

The `pyopenvdb.so` gets installed in (as example) `/usr/local/lib/python3.8`. This looks to be correct, but sadly most of the Linux-based distributions **does not** look for python packages there but rather under `/usr/local/lib/python3.8/dist-packages`. Therefore when one tries to `import pyopenvdb as vdb` it doesn't find the shared library.

To check this, one can run:
```sh
python -c 'import site; print(site.getsitepackages())'
```
that in my case outputs:
```sh
['/usr/local/lib/python3.8/dist-packages', '/usr/lib/python3/dist-packages', '/usr/lib/python3.8/dist-packages']
```
## Possible solution

One possible solution is to update the PYTHONPATH as follow:
```sh
export PYTHONPATH=/usr/local/lib/python3.8/
```

But of course, this is no too optimal, since one needs to do it on all systems that are using the library. Plus, at least on my systems, there is no other library located in there.

## One word about FindPython

So the [FindPython](https://cmake.org/cmake/help/v3.12/module/FindPython.html) module provides great functionality but sadly nothing outputs the `/usr/local/<>` directory I need. Please check the cmake example below


## Minimal CMake Example

I made this rather small example so reviewers can look through the introduced variables in more detail in different systems

```cmake
cmake_minimum_required(VERSION 3.12)
project(test_find_python)

include(GNUInstallDirs)
find_package(Python)

# FindPython Variables
message(STATUS "Python_EXECUTABLE:${Python_EXECUTABLE}")
message(STATUS "Python_STDLIB:${Python_STDLIB}")
message(STATUS "Python_SITELIB:${Python_SITELIB}")
message(STATUS "Python_SITEARCH:${Python_SITEARCH}")
message(STATUS "Python_SITEARCH:${Python_SITEARCH}")

# Method used to get the dist-packages location
get_filename_component(Python_PACKAGES_DIR ${Python_SITELIB} NAME)
message(STATUS "pyopenvdb.so install dir:${CMAKE_INSTALL_FULL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/${Python_PACKAGES_DIR}")

# How to find this library later when we need pyopenvdb by other targets
set(OPENVDB_PYTHON_PATH_SUFFIXES
  lib64/python
  lib64/python2.7
  lib64/python3
  lib/python
  lib/python2.7
  lib/python3
)

file(GLOB PYTHON_SITE_PACKAGES ${CMAKE_INSTALL_FULL_LIBDIR}/python**/*)
foreach(_site_package_full_dir ${PYTHON_SITE_PACKAGES})
  string(REPLACE ${CMAKE_INSTALL_FULL_LIBDIR} "${CMAKE_INSTALL_LIBDIR}"
                 _site_package_dir ${_site_package_full_dir})
  list(APPEND OPENVDB_PYTHON_PATH_SUFFIXES ${_site_package_dir})
endforeach()

# Debug msg
message(STATUS "OPENVDB_PYTHON_PATH_SUFFIXES:")
foreach(OPENVDB_PYTHON_PATH_SUFFIX ${OPENVDB_PYTHON_PATH_SUFFIXES})
    message(STATUS "${OPENVDB_PYTHON_PATH_SUFFIX}")
endforeach()
```

In my case the output is:
```sh
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/local/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/local/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python: /usr/bin/python3.8 (found version "3.8.5") found components: Interpreter 
-- Python_EXECUTABLE:/usr/bin/python3.8
-- Python_STDLIB:/usr/lib/python3.8
-- Python_SITELIB:/usr/lib/python3/dist-packages
-- Python_SITEARCH:/usr/lib/python3/dist-packages
-- Python_SITEARCH:/usr/lib/python3/dist-packages
-- pyopenvdb.so install dir:/usr/local/lib/python3.8/dist-packages
-- OPENVDB_PYTHON_PATH_SUFFIXES:
-- lib64/python
-- lib64/python2.7
-- lib64/python3
-- lib/python
-- lib/python2.7
-- lib/python3
-- lib/python2.7/dist-packages
-- lib/python2.7/site-packages
-- lib/python3.8/dist-packages
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ivizzo/dev/examples/FindPythonCmake/build
```