### PR TITLE
Lock macos CI to openexr@2

### DIFF
--- a/ci/install_macos.sh
+++ b/ci/install_macos.sh
@@ -6,7 +6,7 @@ brew update
 brew install bash
 brew install cmake
 brew install ilmbase
-brew install openexr
+brew install openexr@2
 brew install boost
 brew install boost-python3 # also installs the dependent python version
 brew install gtest
@@ -23,3 +23,7 @@ echo "Using python $py_version"
 echo "Python_ROOT_DIR=/usr/local/opt/$py_version" >> $GITHUB_ENV
 echo "/usr/local/opt/$py_version/bin" >> $GITHUB_PATH
 
+# Export OpenEXR paths which is no longer installed to /usr/local (as v2.x is deprecated)
+echo "IlmBase_ROOT=/usr/local/opt/ilmbase" >> $GITHUB_ENV
+echo "OpenEXR_ROOT=/usr/local/opt/openexr@2" >> $GITHUB_ENV
+echo "/usr/local/opt/openexr@2/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>

brew now uses OpenEXR 3 which we don't yet support