### PR TITLE
Guard the cmakedefines in case systems have -D options

### DIFF
--- a/.github/workflows/ax.yml
+++ b/.github/workflows/ax.yml
@@ -122,8 +122,7 @@ jobs:
       - name: build
         run: |
           ./ci/build.sh ${{ matrix.build }} None ON None "core,axcore,axbin,axtest" \
-            -DLLVM_DIR=/usr/local/opt/llvm@${{ matrix.llvm }}/lib/cmake/llvm \
-            -DOPENVDB_ROOT=$HOME/openvdb-7.0.0-${{ matrix.compiler }}
+            -DLLVM_DIR=/usr/local/opt/llvm@${{ matrix.llvm }}/lib/cmake/llvm
       # Tests
       - name: test
         run: cd build && ctest -V

--- a/ci/install_macos.sh
+++ b/ci/install_macos.sh
@@ -10,7 +10,7 @@ brew install openexr@2
 brew install boost
 brew install boost-python3 # also installs the dependent python version
 brew install gtest
-brew install tbb
+brew install tbb@2020
 brew install zlib
 brew install glfw
 brew install jq # for trivial parsing of brew json
@@ -23,7 +23,11 @@ echo "Using python $py_version"
 echo "Python_ROOT_DIR=/usr/local/opt/$py_version" >> $GITHUB_ENV
 echo "/usr/local/opt/$py_version/bin" >> $GITHUB_PATH
 
-# Export OpenEXR paths which is no longer installed to /usr/local (as v2.x is deprecated)
+# Export OpenEXR paths which are no longer installed to /usr/local (as v2.x is deprecated)
 echo "IlmBase_ROOT=/usr/local/opt/ilmbase" >> $GITHUB_ENV
 echo "OpenEXR_ROOT=/usr/local/opt/openexr@2" >> $GITHUB_ENV
 echo "/usr/local/opt/openexr@2/bin" >> $GITHUB_PATH
+
+# Export TBB paths which are no longer installed to /usr/local (as v2020 is deprecated)
+echo "TBB_ROOT=/usr/local/opt/tbb@2020" >> $GITHUB_ENV
+echo "/usr/local/opt/tbb@2020/bin" >> $GITHUB_PATH

--- a/ci/install_macos_ax.sh
+++ b/ci/install_macos_ax.sh
@@ -10,12 +10,14 @@ fi
 
 brew update
 brew install bash
-brew install ilmbase
-brew install openexr
 brew install cmake
 brew install boost
 brew install cppunit
 brew install c-blosc
-brew install tbb
+brew install tbb@2020
 brew install llvm@$LLVM_VERSION
 brew install zlib
+
+# Export TBB paths which are no longer installed to /usr/local (as v2020 is deprecated)
+echo "TBB_ROOT=/usr/local/opt/tbb@2020" >> $GITHUB_ENV
+echo "/usr/local/opt/tbb@2020/bin" >> $GITHUB_PATH

--- a/openvdb/openvdb/version.h.in
+++ b/openvdb/openvdb/version.h.in
@@ -117,13 +117,19 @@
 #endif
 
 /* Denotes whether VDB was built with IMath Half support */
+#ifndef OPENVDB_USE_IMATH_HALF
 #cmakedefine OPENVDB_USE_IMATH_HALF
+#endif
 
 /* Denotes whether VDB was built with Blosc support */
+#ifndef OPENVDB_USE_BLOSC
 #cmakedefine OPENVDB_USE_BLOSC
+#endif
 
 /* Denotes whether VDB was built with ZLIB support */
+#ifndef OPENVDB_USE_ZLIB
 #cmakedefine OPENVDB_USE_ZLIB
+#endif
 
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We noticed our internal build was setting OPENVDB_USE_BLOSC, which then conflicted with the version.h.  The intent of the version.h was not to get in the way of people with explicit -D command lines, so thus have disabled it in this fashion.

I'm hesitant to remove from our build command line as then we'll fail if we revert openvdb at any point...