### PR TITLE
Rename VDB Vector Merge to VDB Vector from Scalar

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Vector_Merge.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Vector_Merge.cc
@@ -192,8 +192,13 @@ Position:\n\
         .setDefault("@name=*.z"));
 
     // Register this operator.
-    hvdb::OpenVDBOpFactory("VDB Vector Merge",
+    hvdb::OpenVDBOpFactory("VDB Vector from Scalar",
         SOP_OpenVDB_Vector_Merge::factory, parms, *table)
+#ifndef SESI_OPENVDB
+        .setInternalName("DW_OpenVDBVectorMerge")
+#else
+        .setInternalName("vdbvectormerge")
+#endif
         .addInput("Scalar VDBs to merge into vector")
         .setObsoleteParms(obsoleteParms)
         .setVerb(SOP_NodeVerb::COOK_INPLACE, []() { return new SOP_OpenVDB_Vector_Merge::Cache; })

--- a/pendingchanges/rename_vdbvectormerge_sop.txt
+++ b/pendingchanges/rename_vdbvectormerge_sop.txt
@@ -1,0 +1,4 @@
+Houdini:
+    VDB Vector Merge SOP is now VDB Vector From Scalar SOP to distinguish
+    it from the VDB Merge SOP.   It keeps the same internal name so this
+    is merely a label change.


### PR DESCRIPTION
Internal review found this the least objectionable new name, but it
is up to the TSC if it meets our standards.  Only the label is changed,
I believe I have preserved the internal names properly.
