### PR TITLE
Fix a bug that crept in when we switched dispatchers.

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Combine.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Combine.cc
@@ -1524,9 +1524,7 @@ SOP_OpenVDB_Combine::Cache::combineGrids(
     compOp.interrupt = hvdb::Interrupter();
 
     int success = false;
-    if (needA || UTvdbGetGridType(*aGrid) == UTvdbGetGridType(*bGrid)) {
-        success = aGrid->apply<hvdb::VolumeGridTypes>(compOp);
-    }
+    success = (needA ? aGrid : bGrid)->apply<hvdb::VolumeGridTypes>(compOp);
     if (!success || !compOp.outGrid) {
         std::ostringstream ostr;
         if (aGrid->type() == bGrid->type()) {

--- a/pendingchanges/vdbcombinefix.txt
+++ b/pendingchanges/vdbcombinefix.txt
@@ -1,0 +1,3 @@
+Houdini:
+    Fix crash in VDB Combine in Copy B mode if the second input has
+    more VDBs than the first.


### PR DESCRIPTION
If needA is false, agrid likely doesn't exist, so we should just
dispatch on the bgrid rather than try to verify a and b have
the same type.  I believe the old code would have ignored the passed
in agrid in this case.