### PR TITLE
Various CI improvements

### DIFF
--- a/.github/workflows/ax.yml
+++ b/.github/workflows/ax.yml
@@ -10,6 +10,7 @@ on:
       - 'doc/**'
       - 'openvdb_maya/**'
       - 'openvdb_houdini/**'
+      - 'pendingchanges/**'
       - '**.md'
   pull_request:
     branches:
@@ -19,6 +20,7 @@ on:
       - 'doc/**'
       - 'openvdb_maya/**'
       - 'openvdb_houdini/**'
+      - 'pendingchanges/**'
       - '**.md'
   schedule:
     # run this workflow every midnight Tuesday
@@ -26,8 +28,12 @@ on:
 
 jobs:
   linux-ax-vfx:
-    runs-on: ubuntu-16.04
-    name: linux-ax-vfx:${{ matrix.image }}-cxx:${{ matrix.compiler }}-${{ matrix.build }}
+    # VFX platform builds for OpenVDB AX
+    runs-on: ubuntu-latest
+    name: >
+      linux-ax-vfx:${{ matrix.image }}-
+      cxx:${{ matrix.compiler }}-
+      ${{ matrix.build }}
     container:
       image: aswf/ci-openvdb:${{ matrix.image }}
     env:
@@ -45,20 +51,22 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      # Build
       - name: build
         run: |
-          ./ci/build.sh ${{ matrix.build }} None ON None "core,axcore,axbin,axtest" \
-            -DOPENVDB_CXX_STRICT=ON
-      # Tests
+          ./ci/build.sh ${{ matrix.build }} "core,axcore,axbin,axtest" -DOPENVDB_CXX_STRICT=ON
       - name: test
         run: cd build && ctest -V
       - name: test_doxygen_examples
         run: ./ci/extract_test_examples.sh
 
   linux-ax-standalone-vfx:
-    runs-on: ubuntu-16.04
-    name: linux-ax-standalone-vfx:${{ matrix.image }}-cxx:${{ matrix.compiler }}-llvm:${{ matrix.llvm }}-${{ matrix.build }}
+    # VFX platform builds for OpenVDB AX against an existing VDB installation
+    runs-on: ubuntu-latest
+    name: >
+      linux-ax-standalone-vfx:${{ matrix.image }}-
+      cxx:${{ matrix.compiler }}-
+      llvm:${{ matrix.llvm }}-
+      ${{ matrix.build }}
     container:
       image: aswf/ci-openvdb:${{ matrix.image }}
     env:
@@ -79,16 +87,12 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      # Build
       - name: vdb
         run: |
-          ./ci/build.sh ${{ matrix.build }} None ON None "core" -DOPENVDB_CXX_STRICT=ON
+          ./ci/build.sh ${{ matrix.build }} "core" -DOPENVDB_CXX_STRICT=ON
           rm -rf build
       - name: build
-        run: |
-          ./ci/build.sh ${{ matrix.build }} None ON None "axcore,axbin,axtest" \
-            -DOPENVDB_CXX_STRICT=ON
-      # Tests
+        run: ./ci/build.sh ${{ matrix.build }} "axcore,axbin,axtest" -DOPENVDB_CXX_STRICT=ON
       - name: test
         run: cd build && ctest -V
       - name: test_doxygen_examples
@@ -115,15 +119,12 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      # Setup
       - name: install_deps
         run: ./ci/install_macos_ax.sh ${{ matrix.llvm }}
-      # Build
       - name: build
         run: |
-          ./ci/build.sh ${{ matrix.build }} None ON None "core,axcore,axbin,axtest" \
+          ./ci/build.sh ${{ matrix.build }} "core,axcore,axbin,axtest" \
             -DLLVM_DIR=/usr/local/opt/llvm@${{ matrix.llvm }}/lib/cmake/llvm
-      # Tests
       - name: test
         run: cd build && ctest -V
       - name: test_doxygen_examples

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - 'openvdb_maya/**'
       - 'openvdb_houdini/**'
       - 'openvdb_ax/**'
+      - 'pendingchanges/**'
       - '**.md'
   pull_request:
     branches:
@@ -21,6 +22,7 @@ on:
       - 'openvdb_maya/**'
       - 'openvdb_houdini/**'
       - 'openvdb_ax/**'
+      - 'pendingchanges/**'
       - '**.md'
   schedule:
     # run this workflow every day at 7am UTC
@@ -31,8 +33,14 @@ on:
 
 jobs:
   linux-vfx:
-    runs-on: ubuntu-16.04
-    name: linux-vfx:${{ matrix.config.image }}-abi:${{ matrix.config.abi }}-cxx:${{ matrix.config.cxx }}-type:${{ matrix.config.build }}
+    # VFX platform jobs. These are run on the appropriate CentOS images from
+    # the provided ASWF docker containers
+    runs-on: ubuntu-latest
+    name: >
+      linux-vfx:${{ matrix.config.image }}-
+      abi:${{ matrix.config.abi }}-
+      cxx:${{ matrix.config.cxx }}-
+      type:${{ matrix.config.build }}
     container:
       image: aswf/ci-openvdb:${{ matrix.config.image }}
     env:
@@ -40,29 +48,31 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cxx: clang++, image: '2019', abi: '6', build: 'Release', test: 'ON'  }
-          - { cxx: clang++, image: '2020', abi: '7', build: 'Release', test: 'ON'  }
-          - { cxx: clang++, image: '2021', abi: '8', build: 'Release', test: 'ON'  }
-          - { cxx: clang++, image: '2021', abi: '9', build: 'Release', test: 'ON'  }
-          - { cxx: clang++, image: '2021', abi: '8', build: 'Debug',   test: 'OFF' }
-          - { cxx: g++,     image: '2020', abi: '7', build: 'Release', test: 'ON'  }
-          - { cxx: g++,     image: '2021', abi: '8', build: 'Release', test: 'ON'  }
+          - { cxx: clang++, image: '2019', abi: '6', build: 'Release' }
+          - { cxx: clang++, image: '2020', abi: '7', build: 'Release' }
+          - { cxx: clang++, image: '2021', abi: '8', build: 'Release' }
+          - { cxx: clang++, image: '2021', abi: '9', build: 'Release' }
+          - { cxx: clang++, image: '2021', abi: '8', build: 'Debug'   }
+          - { cxx: g++,     image: '2020', abi: '7', build: 'Release' }
+          - { cxx: g++,     image: '2021', abi: '8', build: 'Release' }
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: install_gtest
       run: ./ci/install_gtest.sh 1.8.0
     - name: build
-      run: ./ci/build.sh ${{ matrix.config.build }} ${{ matrix.config.abi }} ON None "core,python,bin,test" -DOPENVDB_CXX_STRICT=ON
+      run: ./ci/build.sh ${{ matrix.config.build }} "core,python,bin,test" \
+        -DOPENVDB_CXX_STRICT=ON -DOPENVDB_ABI_VERSION_NUMBER=${{ matrix.config.abi }}
     - name: test
-      # Always run tests on weekly builds
+      # Always run tests on weekly builds but skip Debug on commits as they take a while.
       # https://github.community/t/distinct-job-for-each-schedule/17811/2
-      if: contains(github.event.schedule, '0 0 * * 1') || matrix.config.test == 'ON'
+      if: contains(github.event.schedule, '0 0 * * 1') || matrix.config.build == 'Release'
       run: |
-        ./ci/test.sh
-        ./ci/test_install.sh
+        cd build && ctest -V
+        cd - && ./ci/test_install.sh
 
   windows:
+    # Windows CI. Tests static and dynamic builds with MT and MD respectively.
     runs-on: windows-2019
     name: windows-vc:${{ matrix.config.vc }}-type:${{ matrix.config.build }}
     env:
@@ -73,10 +83,10 @@ jobs:
           # static build of blosc from vcpkg does not build internal sources.
           # USE_STATIC_DEPENDENCIES is required for IlmBase/OpenEXR defines and
           # Boost as both shared and static libs are installed.
-          - { vc: 'x64-windows-static', build: 'Release', test: 'ON',  cmake: '-DOPENVDB_CORE_SHARED=OFF -DUSE_STATIC_DEPENDENCIES=ON -DBLOSC_USE_EXTERNAL_SOURCES=ON' }
-          - { vc: 'x64-windows-static', build: 'Debug',   test: 'OFF', cmake: '-DOPENVDB_CORE_SHARED=OFF -DUSE_STATIC_DEPENDENCIES=ON -DBLOSC_USE_EXTERNAL_SOURCES=ON' }
-          - { vc: 'x64-windows',        build: 'Release', test: 'ON',  cmake: '-DOPENVDB_CORE_STATIC=OFF' }
-          - { vc: 'x64-windows',        build: 'Debug',   test: 'OFF', cmake: '-DOPENVDB_CORE_STATIC=OFF' }
+          - { vc: 'x64-windows-static', build: 'Release', cmake: '-DOPENVDB_CORE_SHARED=OFF -DUSE_STATIC_DEPENDENCIES=ON -DBLOSC_USE_EXTERNAL_SOURCES=ON' }
+          - { vc: 'x64-windows-static', build: 'Debug',   cmake: '-DOPENVDB_CORE_SHARED=OFF -DUSE_STATIC_DEPENDENCIES=ON -DBLOSC_USE_EXTERNAL_SOURCES=ON' }
+          - { vc: 'x64-windows',        build: 'Release', cmake: '-DOPENVDB_CORE_STATIC=OFF' }
+          - { vc: 'x64-windows',        build: 'Debug',   cmake: '-DOPENVDB_CORE_STATIC=OFF' }
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -93,62 +103,45 @@ jobs:
       run: ./ci/build_windows.sh ${{ matrix.config.build }} ${{ matrix.config.cmake }}
     - name: test
       shell: bash
-      # Always run tests on weekly builds
+      # Always run tests on weekly builds but skip Debug on commits as they take a while.
       # https://github.community/t/distinct-job-for-each-schedule/17811/2
-      if: contains(github.event.schedule, '0 0 * * 1') || matrix.config.test == 'ON'
-      run: ./ci/test.sh
+      if: contains(github.event.schedule, '0 0 * * 1') || matrix.config.build == 'Release'
+      run: cd build && ctest -V
 
-  testabi8lite:
-    runs-on: ubuntu-16.04
-    env:
-      CXX: clang++
+  linux-extra:
+    # Extra configuration tests, all run on the ASWF docker images. These run weekly
+    # rather than on PR/merge
+    if: contains(github.event.schedule, '0 0 * * 1')
+    runs-on: ubuntu-latest
+    name: linux-extra:${{ matrix.config.name }}
     container:
       image: aswf/ci-openvdb:2021
+    env:
+      CXX: clang++
+    strategy:
+      matrix:
+        config:
+          - { name: 'abi8lite', cmake: '-DUSE_BLOSC=OFF -DUSE_ZLIB=OFF' }
+          - { name: 'abi8half', cmake: '-DUSE_BLOSC=OFF -DUSE_IMATH_HALF=ON' }
+          - { name: 'abi8sse',  cmake: '-DOPENVDB_SIMD=SSE42' }
+          - { name: 'abi8avx',  cmake: '-DOPENVDB_SIMD=AVX' }
+      fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: install_gtest
       run: ./ci/install_gtest.sh 1.10.0
     - name: build
-      run: ./ci/build.sh Release 8 OFF None "core,python,bin,test" -DOPENVDB_CXX_STRICT=ON -DUSE_ZLIB=OFF
+      run: ./ci/build.sh Release "core,python,bin,test" \
+        -DOPENVDB_CXX_STRICT=ON -DOPENVDB_ABI_VERSION_NUMBER=8 ${{ matrix.config.cmake }}
     - name: test
-      run: ./ci/test.sh
-
-  testabi8half:
-    runs-on: ubuntu-16.04
-    env:
-      CXX: clang++
-    container:
-      image: aswf/ci-openvdb:2021
-    steps:
-    - uses: actions/checkout@v1
-    - name: install_gtest
-      run: ./ci/install_gtest.sh 1.10.0
-    - name: build
-      run: ./ci/build.sh Release 8 OFF None "core,python,bin,test" -DOPENVDB_CXX_STRICT=ON -DUSE_IMATH_HALF=ON
-    - name: test
-      run: ./ci/test.sh
-
-  testabi8sse:
-    runs-on: ubuntu-16.04
-    env:
-      CXX: clang++
-    container:
-      image: aswf/ci-openvdb:2021
-    steps:
-    - uses: actions/checkout@v1
-    - name: install_gtest
-      run: ./ci/install_gtest.sh 1.10.0
-    - name: build
-      run: ./ci/build.sh Release 8 ON SSE42 "core,python,bin,test" -DOPENVDB_CXX_STRICT=ON
-    - name: test
-      run: ./ci/test.sh
+      run: cd build && ctest -V
 
   testabi8gcc10:
     runs-on: ubuntu-20.04
     env:
       CXX: g++-10
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: install_boost
       run: sudo apt-get -q install -y libboost-dev libboost-system-dev libboost-iostreams-dev
     - name: install_tbb
@@ -156,16 +149,17 @@ jobs:
     - name: install_gtest
       run: sudo apt-get -q install -y libgtest-dev
     - name: build
-      run: ./ci/build.sh Release 8 OFF None "core,test" -DUSE_ZLIB=OFF -DCMAKE_INSTALL_PREFIX=`pwd`
+      run: ./ci/build.sh Release "core,test" \
+        -DUSE_BLOSC=OFF -DUSE_ZLIB=OFF -DOPENVDB_ABI_VERSION_NUMBER=8 -DCMAKE_INSTALL_PREFIX=`pwd`
     - name: test
-      run: ./ci/test.sh
+      run: cd build && ctest -V
 
   testabi8clang10:
     runs-on: ubuntu-20.04
     env:
       CXX: clang++-10
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: install_boost
       run: sudo apt-get -q install -y libboost-dev libboost-system-dev libboost-iostreams-dev
     - name: install_tbb
@@ -173,9 +167,10 @@ jobs:
     - name: install_gtest
       run: sudo apt-get -q install -y libgtest-dev
     - name: build
-      run: ./ci/build.sh Release 8 OFF None "core,test" -DUSE_ZLIB=OFF -DCMAKE_INSTALL_PREFIX=`pwd`
+      run: ./ci/build.sh Release "core,test" \
+        -DUSE_BLOSC=OFF -DUSE_ZLIB=OFF -DOPENVDB_ABI_VERSION_NUMBER=8 -DCMAKE_INSTALL_PREFIX=`pwd`
     - name: test
-      run: ./ci/test.sh
+      run: cd build && ctest -V
 
   testmacos1015:
     runs-on: macos-10.15
@@ -200,7 +195,8 @@ jobs:
       shell: bash
       # Also need to disable compiler warnings for ABI 6 and above due to
       # the version of clang installed
-      run: ./ci/build.sh Release 8 ON SSE42 "core,python,bin,test" -DOPENVDB_CXX_STRICT=OFF
+      run: ./ci/build.sh Release "core,python,bin,test" \
+        -DOPENVDB_CXX_STRICT=OFF -DOPENVDB_ABI_VERSION_NUMBER=8 -DOPENVDB_SIMD=SSE42
     - name: test
       shell: bash
-      run: ./ci/test.sh
+      run: cd build && ctest -V

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - 'CHANGES'
       - 'openvdb_maya/**'
+      - 'pendingchanges/**'
       - '**.md'
   pull_request:
     branches:
@@ -15,6 +16,7 @@ on:
     paths-ignore:
       - 'CHANGES'
       - 'openvdb_maya/**'
+      - 'pendingchanges/**'
       - '**.md'
   workflow_dispatch:
 
@@ -34,7 +36,11 @@ jobs:
     - name: install_latex
       run: yum -y install texlive-latex-bin texlive-dvips texlive-collection-fontsrecommended texlive-collection-latexrecommended
     - name: build
-      run: ./ci/build.sh Release None OFF None "core,python,doc" -DOPENVDB_PYTHON_WRAP_ALL_GRID_TYPES=ON -DDISABLE_DEPENDENCY_VERSION_CHECKS=ON
+      run: ./ci/build.sh Release "core,python,doc" \
+        -DUSE_BLOSC=OFF \
+        -DOPENVDB_CORE_STATIC=OFF \
+        -DOPENVDB_PYTHON_WRAP_ALL_GRID_TYPES=ON \
+        -DDISABLE_DEPENDENCY_VERSION_CHECKS=ON
     - name: epydoc
       run: |
         export LD_LIBRARY_PATH=/usr/local/lib64

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -9,6 +9,7 @@ on:
       - 'CHANGES'
       - 'doc/**'
       - 'openvdb_maya/**'
+      - 'pendingchanges/**'
       - '**.md'
   pull_request:
     branches:
@@ -17,6 +18,7 @@ on:
       - 'CHANGES'
       - 'doc/**'
       - 'openvdb_maya/**'
+      - 'pendingchanges/**'
       - '**.md'
   schedule:
     # run this workflow every day at 7am UTC
@@ -24,7 +26,7 @@ on:
 
 jobs:
   linux-vfx-houdini:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     name: hou:${{ matrix.config.hou }}-vfx:${{ matrix.config.image }}-cxx:${{ matrix.config.cxx }}
     container:
       image: aswf/ci-base:${{ matrix.config.image }}
@@ -41,7 +43,7 @@ jobs:
           - { cxx: g++,     image: '2020', hou: '18_5', build: 'Release', extras: 'OFF', disable_checks: 'OFF' }
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: install_cmake
       run: ./ci/install_cmake.sh 3.12.0
     - name: install_gtest

--- a/.github/workflows/houdini_cache_update.yml
+++ b/.github/workflows/houdini_cache_update.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   houdini18_5:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       CXX: clang++
     container:
@@ -36,7 +36,7 @@ jobs:
         key: vdb1-houdini18_5-${{ hashFiles('hou/hou.tar.gz') }}
 
   houdini18_0:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       CXX: clang++
     container:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   linux-vfx:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     name: linux-clang-sanitizer:${{ matrix.config.build }}
     container:
       image: aswf/ci-openvdb:2021
@@ -31,13 +31,12 @@ jobs:
           #- { build: 'coverage', cmake: '' } # todo
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: install_gtest
       run: ./ci/install_gtest.sh 1.8.0
     - name: build
-      run: ./ci/build.sh ${{ matrix.config.build }} 8 ON None "core,axcore,test,axtest" \
+      run: ./ci/build.sh ${{ matrix.config.build }} "core,axcore,test,axtest" \
         -DOPENVDB_CXX_STRICT=ON -DOPENVDB_CORE_STATIC=OFF -DOPENVDB_AX_STATIC=OFF \
-        -DCMAKE_VERBOSE_MAKEFILE=ON \
         ${{ matrix.config.cmake }}
     - name: test
-      run: ./ci/test.sh
+      run: cd build && ctest -V

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Search the git repository for any trailing spaces excluding meeting notes
   trailingspaces:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: test
@@ -23,7 +23,7 @@ jobs:
 
   # Search for any tabs excluding meeting notes, image files and a few others
   spacesnottabs:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: test

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -10,9 +10,6 @@ cmake --version
 ################################################
 
 BUILD_TYPE="$1"; shift
-ABI="$1"; shift
-BLOSC="$1"; shift
-SIMD="$1"; shift
 # Command seperated list of components i.e. "core,ax,bin"
 IN_COMPONENTS="$1"; shift
 CMAKE_EXTRA="$@"
@@ -58,10 +55,6 @@ for comp in "${!COMPONENTS[@]}"; do
     fi
 done
 
-if [ "$ABI" != "None" ]; then
-    CMAKE_EXTRA+=" -DOPENVDB_ABI_VERSION_NUMBER=${ABI} "
-fi
-
 #
 ################################################
 
@@ -69,24 +62,22 @@ fi
 # https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
 export CMAKE_BUILD_PARALLEL_LEVEL=2
 
-# DebugNoInfo is a custom CMAKE_BUILD_TYPE - no optimizations, no symbols, asserts enabled
-
 mkdir -p build
 cd build
 
 # Note: all sub binary options are always on and can be toggles with
 # OPENVDB_BUILD_BINARIES=ON/OFF
+# Using CMAKE_VERBOSE_MAKEFILE rather than `cmake --verbose` to support older
+# versions of CMake. Always run verbose make to have the full logs available
 cmake \
-    -DCMAKE_CXX_FLAGS_DebugNoInfo="" \
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
     -DOPENVDB_USE_DEPRECATED_ABI_6=ON \
     -DOPENVDB_USE_FUTURE_ABI_9=ON \
-    -DUSE_BLOSC=${BLOSC} \
-    -DOPENVDB_SIMD=${SIMD} \
     -DOPENVDB_BUILD_VDB_PRINT=ON \
     -DOPENVDB_BUILD_VDB_LOD=ON \
     -DOPENVDB_BUILD_VDB_RENDER=ON \
     -DOPENVDB_BUILD_VDB_VIEW=ON \
+    -DCMAKE_VERBOSE_MAKEFILE=ON \
     ${CMAKE_EXTRA} \
     ..
 

--- a/ci/build_windows.sh
+++ b/ci/build_windows.sh
@@ -32,4 +32,6 @@ cmake \
 # However it does not seem to for our project.
 # https://gitlab.kitware.com/cmake/cmake/-/issues/20564
 
-cmake --build . --parallel 4 --config $BUILD_TYPE --target install
+# cmake 3.14 and later required for --verbose
+
+cmake --build . --parallel 4 --config $BUILD_TYPE --target install --verbose


### PR DESCRIPTION
 - Improved the usage of various actions
 - Bumped ubuntu images to latest
 - Simplified the ./build scripts to not use arbitrary positional arguments
 - Introduced a `linux-extra` build matrix in `build.yml` which includes various jobs which are designed to test different build types outside the standard build types. This includes the existing `NO_BLOSC`, `SSE` and `USE_IMATH` builds. Added an `AVX` build. In an attempt to speed up builds, these builds only build weekly, not on commit.
 - Various tweaks to improve the speed of some of the configurations
 - Don't trigger any CI if `pendingchanges/**` changes


Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>