### PR TITLE
Doxygen Improvements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1544,8 +1544,7 @@ Version 3.2.0 - August 10, 2016
     - Fixed isApproxZero() so that it works correctly when tolerance is zero.
       [Reported by Joshua Olson]
     - Fixed bugs in tree::NodeUnion that could cause crashes.
-    - Fixed memory leak in
-      tools::mesh_to_volume_internal::ExpandNarrowband
+    - Fixed memory leak in a tools::meshToVolume sub-tool (expandNarrowband).
       [Reported by Kévin Dietrich]
     - Fixed parameter type inconsistencies in math/Stencils.h and
       tools/RayIntersector.h.

--- a/ci/extract_test_examples.sh
+++ b/ci/extract_test_examples.sh
@@ -52,13 +52,13 @@ for DOC in "${DOCS[@]}"; do
         elif [[ $line == @code* ]]; then
             str=""
             compile="none"
-        elif [[ $line == "<!--- V --->@code"* ]]; then
+        elif [[ $line == "<!-- V -->@code"* ]]; then
             str=""
             compile="volumes"
-        elif [[ $line == "<!--- P --->@code"* ]]; then
+        elif [[ $line == "<!-- P -->@code"* ]]; then
             str=""
             compile="points"
-        elif [[ $line == "<!--- A --->@code"* ]]; then
+        elif [[ $line == "<!-- A -->@code"* ]]; then
             str=""
             compile=""
         elif [[ $line == @endcode ]]; then

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -81,12 +81,16 @@ set(DOXYGEN_EXTRACT_LOCAL_CLASSES NO)
 # Rather than just the file names (e.g. File.h). This makes it far
 # easier to navigate the docs
 set(DOXYGEN_FULL_PATH_NAMES YES)
-# Should be the same as the WORKING_DIRECTORY argument to doxygen_add_docs
-set(DOXYGEN_STRIP_FROM_PATH "${CMAKE_SOURCE_DIR}")
+set(DOXYGEN_STRIP_FROM_PATH
+  "${CMAKE_SOURCE_DIR}/openvdb"
+  "${CMAKE_SOURCE_DIR}/openvdb_ax"
+  "${CMAKE_SOURCE_DIR}/openvdb_houdini"
+  "${CMAKE_SOURCE_DIR}")
 set(DOXYGEN_STRIP_FROM_INC_PATH
   "${CMAKE_SOURCE_DIR}/openvdb"
   "${CMAKE_SOURCE_DIR}/openvdb_ax"
   "${CMAKE_SOURCE_DIR}/openvdb_houdini")
+
 # Shows which source files generated the respected doxygen docs
 # at the bottom of each html page. Don't bother listing these.
 set(DOXYGEN_SHOW_USED_FILES NO)
@@ -134,6 +138,11 @@ set(DOXYGEN_PREDEFINED
   "OPENVDB_VERSION_NAME=v${OpenVDB_MAJOR_VERSION}_${OpenVDB_MINOR_VERSION}"
   "OPENVDB_ABI_VERSION_NUMBER=${OpenVDB_MAJOR_VERSION}"
   [[__declspec(x):= __attribute__(x):=]]
+  # Replace the deprecated macros with doxygen deprecated comments. This ensures
+  # that every bit of deprecated C++ is listed in the doxygen deprecated list,
+  # even if it was not properly tagged
+  [["OPENVDB_DEPRECATED=/** \deprecated */"]]
+  [["OPENVDB_DEPRECATED_MESSAGE(x)=/** \deprecated x */"]]
   "OPENVDB_USE_LOG4CPLUS=")
 
 set(DOXYGEN_ENABLED_SECTIONS "")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -19,8 +19,11 @@ include(GNUInstallDirs)
 # with OPENVDB_BUILD_DOCS=ON and either OPENVDB_BUILD_HOUDINI_PLUGIN=ON or
 # USE_HOUDINI=ON will define Houdini_VERSION. If Houdini_VERSION is not set,
 # all documentation is included.
-option(OPENVDB_DOXYGEN_HOUDINI "Build Houdini documentation" ON)
 option(OPENVDB_DOXYGEN_AX "Build AX documentation" ON)
+option(OPENVDB_DOXYGEN_HOUDINI "Build Houdini documentation" ON)
+option(OPENVDB_DOXYGEN_INTERNAL [=[
+Enable documentation of methods and classes which have been explicitly marked as internal
+]=] OFF)
 
 find_package(Doxygen REQUIRED doxygen)
 if(MINIMUM_DOXYGEN_VERSION)
@@ -59,10 +62,12 @@ set(DOXYGEN_FILE_PATTERNS *.h *h.in) # headers only
 set(DOXYGEN_EXTENSION_MAPPING .in=C) # parse CMake config headers as C
 set(DOXYGEN_IMAGE_PATH "doc/img")
 set(DOXYGEN_RECURSIVE NO)
+set(DOXYGEN_QUIET YES)
 
 set(DOXYGEN_GENERATE_HTML YES)
 set(DOXYGEN_GENERATE_MAN NO)
 set(DOXYGEN_GENERATE_LATEX NO)
+set(DOXYGEN_GENERATE_TODOLIST NO)
 
 set(DOXYGEN_HTML_COLORSTYLE_HUE 4)
 set(DOXYGEN_HTML_COLORSTYLE_SAT 222)
@@ -72,18 +77,32 @@ set(DOXYGEN_EXTRACT_ALL YES)
 set(DOXYGEN_EXTRACT_STATIC YES)
 set(DOXYGEN_EXTRACT_LOCAL_CLASSES NO)
 
+# Allow for root directory paths to be listed (e.g. openvdb/io/File.h)
+# Rather than just the file names (e.g. File.h). This makes it far
+# easier to navigate the docs
+set(DOXYGEN_FULL_PATH_NAMES YES)
+# Should be the same as the WORKING_DIRECTORY argument to doxygen_add_docs
+set(DOXYGEN_STRIP_FROM_PATH "${CMAKE_SOURCE_DIR}")
+set(DOXYGEN_STRIP_FROM_INC_PATH
+  "${CMAKE_SOURCE_DIR}/openvdb"
+  "${CMAKE_SOURCE_DIR}/openvdb_ax"
+  "${CMAKE_SOURCE_DIR}/openvdb_houdini")
+# Shows which source files generated the respected doxygen docs
+# at the bottom of each html page. Don't bother listing these.
+set(DOXYGEN_SHOW_USED_FILES NO)
+# When doxygen adds the source code for each header (see VERBATIM_HEADERS)
+# don't remove the actual doxygen comments
+set(DOXYGEN_STRIP_CODE_COMMENTS NO)
+# Don't add an alpha index of all classes (it's not particularly useful)
 set(DOXYGEN_ALPHABETICAL_INDEX NO)
 set(DOXYGEN_DISTRIBUTE_GROUP_DOC YES)
-set(DOXYGEN_FULL_PATH_NAMES NO)
-set(DOXYGEN_GENERATE_TODOLIST NO)
 set(DOXYGEN_HIDE_IN_BODY_DOCS YES)
 set(DOXYGEN_HIDE_SCOPE_NAMES YES)
 set(DOXYGEN_INLINE_INHERITED_MEMB YES)
 set(DOXYGEN_MACRO_EXPANSION YES)
-set(DOXYGEN_CLASS_DIAGRAMS NO) # @todo use dot with class diagrams for relevant classes
-set(DOXYGEN_ENABLED_SECTIONS "")
+# @todo use dot with class diagrams for relevant classes
+set(DOXYGEN_CLASS_DIAGRAMS NO)
 
-set(DOXYGEN_QUIET YES)
 
 set(DOXYGEN_ALIASES
   [[ijk="(<i>i</i>,&nbsp;<i>j</i>,&nbsp;<i>k</i>)"]]
@@ -116,6 +135,12 @@ set(DOXYGEN_PREDEFINED
   "OPENVDB_ABI_VERSION_NUMBER=${OpenVDB_MAJOR_VERSION}"
   [[__declspec(x):= __attribute__(x):=]]
   "OPENVDB_USE_LOG4CPLUS=")
+
+set(DOXYGEN_ENABLED_SECTIONS "")
+
+if(OPENVDB_DOXYGEN_INTERNAL)
+  list(APPEND DOXYGEN_ENABLED_SECTIONS "OPENVDB_DOCS_INTERNAL")
+endif()
 
 if(OPENVDB_DOXYGEN_HOUDINI)
   # Append Houdini-specific settings to the Doxygen config file.

--- a/doc/ax/ax.txt
+++ b/doc/ax/ax.txt
@@ -119,7 +119,7 @@ observe a small but complete AX program which could be compiled and executed.
 To begin with, here is a very simple example of a program that reads and writes
 to a particular attribute:
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 // read a floating point attribute from the value of "myattribute"
 float temp = float@myattribute;
 // if the value is less than 0, clamp it to 0
@@ -134,7 +134,7 @@ points and OpenVDB volumes. The example demonstrates reading from a value on
 some input, either a point attribute or a voxel value, and storing the
 result in a @ref axdecls "local variable". Importantly, the attribute being
 accessed has the name @b `myattribute` and the type @b `float`. The first statement:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 float temp = float@myattribute;
 @endcode
 Invokes a @b read from this attribute (see @ref axattribaccess), retrieving the
@@ -405,7 +405,7 @@ rankings are defined as follows:
 @par
 For example:
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 int a = 0;
 float b = 0.0f;
 // In the following, the arithmetic a + b chooses floating point precision as
@@ -578,12 +578,12 @@ element type of vector, the scalar is copied and @ref axtypeprecedence
 <td style="text-align:left">Component wise assignment i.e.
 <br/> `a[0]&nbsp;=&nbsp;b;&nbsp;...&nbsp;a[n-1]&nbsp;=&nbsp;b;` <br/>
 where `n` is the size of the vector.
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 0, b = 1;
 a = b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 0, b = 1;
 for (int i = 0; i < 3; ++i) a[i] = b[i];
 @endcode
@@ -600,7 +600,7 @@ element type.
 Diagonal matrix construction. Each diagonal component of the left hand side
 matrix is set to to the right hand side scalar. All other components are zero
 initialized i.e.
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat3f a;
 int dim = 3, b = 1;
 for (int i = 0; i < dim; ++i)
@@ -614,12 +614,12 @@ that type.</td>
 <td style="text-align:left">Component wise assignment i.e.
 <br/> `a[0]&nbsp;=&nbsp;b[0];&nbsp;...&nbsp;a[n-1]&nbsp;=&nbsp;b[n-1];` <br/>
 where `n` is the @b total size of the matrix.
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = 0, b = 1;
 a = b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = 0, b = 1;
 for (int i = 0; i < 16; ++i) a[i] = b[i];
 @endcode
@@ -638,7 +638,7 @@ left hand side string with a copy of the contents in the right hand side string.
 </tr>
 </table>
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 float b;
 vec3f c = 0.0f; // assign components of c (x/y/z) to an floating point literal of value 0.0f
 int a = 1; // assign a from an integer literal of value 1
@@ -675,7 +675,7 @@ important when assigning to an expression which is not an attribute or local
 value. The best example of this is assigning to a @ref axopunincdec "pre-crement"
 operation:
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 int a = 1;
 ++a += 1; // equal to a = ++a + 1 which is equal to 3
 @endcode
@@ -687,7 +687,7 @@ written to. Note that the arithmetic operation may cast either @b `lhs` or @b
 "arithmetic operations" section for more information on arithmetic type
 precedence and explanations on the above compound operators.
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 int a = 3;
 a += a; // the same as a = a + a; a will be set to 6
 float b = 0;
@@ -701,7 +701,7 @@ type of the left hand side. For example:
 @par
 Given
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 float a;
 int b, c;
 @endcode
@@ -782,13 +782,13 @@ additive operations (if an operation is not listed, it is not supported):
 (after @ref axtypeprecedence "implicit conversion") with the left hand side
 scalar to every element of the right hand side vector or matrix, returning a
 vector or matrix.
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 vec3f c = b + a;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 vec3f c;
@@ -808,12 +808,12 @@ for (int i = 0; i < 3; ++i) c[i] = b + a[i];
 <td style="text-align:left">Performs per component binary operations (after
 @ref axtypeprecedence "implicit conversion"), returning a new vector with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2, b = 1;
 vec3f c = a - b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2, b = 1;
 vec3f c;
 for (int i = 0; i < 3; ++i) c[i] = a[i] - b[i];
@@ -830,12 +830,12 @@ for (int i = 0; i < 3; ++i) c[i] = a[i] - b[i];
 <td style="text-align:left">Performs per component binary operations (after
 @ref axtypeprecedence "implicit conversion"), returning a new matrix with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = 0, b = 1;
 mat4f c = a - b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = 0, b = 1;
 mat4f c;
 for (int i = 0; i < 16; ++i) c[i] = a[i] - b[i];
@@ -913,13 +913,13 @@ Performs per component binary operations (after
 @ref axtypeprecedence "implicit conversion") with the left hand side scalar to
 every element of the right hand side vector. The scalar is effectively treated
 as a vector of the same size as the right hand side type.
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 vec3f c = b * a;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 vec3f c;
@@ -931,13 +931,13 @@ for (int i = 0; i < 3; ++i) c[i] = b * a[i];
 <td style="text-align:left" rowspan="1">
 Performs matrix multiplication after diagonal matrix construction from the left
 hand side scalar.
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat3f a = 1;
 float b = 1;
 mat3f c = a * b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat3f a = 1;
 float b = 1;
 mat3f tmp = b; // diagonal matrix
@@ -957,12 +957,12 @@ with the operands reversed (importantly for division and modulus)</td>
 <td style="text-align:left">Performs per component binary operations (after
 @ref axtypeprecedence "implicit conversion"), returning a new vector with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2, b = 1;
 vec3f c = a * b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2, b = 1;
 vec3f c;
 for (int i = 0; i < 3; ++i) c[i] = a[i] * b[i];
@@ -974,13 +974,13 @@ for (int i = 0; i < 3; ++i) c[i] = a[i] * b[i];
 Transforms the left hand side vector by the right hand side matrix using matrix
 multiplication. This is the same as calling the @ref axtransform "transform"
 function. e.g:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 b = b * a;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 b = transform(b, a);
@@ -992,7 +992,7 @@ to positions being represented as `vec3`. `vec3 * mat4` multiplication is
 supported, where by the `vec3` is extended with a `1` component and the
 resulting last last component is dropped from the return
 value:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 // b * a is equal to:
@@ -1024,13 +1024,13 @@ b[2] = tmp[2];
 Transforms the right hand side vector by the left hand side matrix using matrix
 multiplication. This is the same as calling the @ref axpretransform "pretransform"
 function. e.g:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 b = a * b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 b = pretransform(a, b);
@@ -1042,7 +1042,7 @@ to positions being represented as `vec3`. `mat4 * vec3` multiplication is
 supported, where by the `vec3` is extended with a `1` component and the
 resulting last last component is dropped from the return
 value:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = identity4();
 vec3f b = { 1, 2, 3 };
 // a * b is equal to:
@@ -1067,12 +1067,12 @@ b[2] = tmp[2];
 <td style="text-align:left">
 Performs matrix multiplication and returns the matrix product, which is matrix
 of matchign size and type. <b>Operand sizes must match.</b> e.g:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = 1, b = 2;
 mat4f c = a * b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = 1, b = 2;
 mat4f c;
 for(int i = 0; i < 4; ++i) {
@@ -1097,7 +1097,7 @@ Binary bitwise operations have the following forms:
 @par
 <table>
 <tr><td bgcolor="#ffc4c4"> @a `lhs` @b `&` @a `rhs` </td></tr>
-<tr><td bgcolor="#ffc4c4"> @a `lhs` @b `|` @a `rhs` </td></tr>
+<tr><td bgcolor="#ffc4c4"> @a `lhs` <b> `|` </b> @a `rhs` </td></tr>
 <tr><td bgcolor="#ffc4c4"> @a `lhs` @b `^` @a `rhs` </td></tr>
 <tr><td bgcolor="#ffc4c4"> @a `lhs` @b `<<` @a `rhs` </td></tr>
 <tr><td bgcolor="#ffc4c4"> @a `lhs` @b `>>` @a `rhs` </td></tr>
@@ -1108,7 +1108,7 @@ These operations only run on @b integral operands. After @ref axtypeprecedence
  - with the @b `&` (@ref axtokens "ampersand token") is the result of the
   logical AND operation on each pair of the corresponding bits of the input
   operands.
- - with the @b `|` (@ref axtokens "pipe token") is the result of the
+ - with the <b> `|` </b> (@ref axtokens "pipe token") is the result of the
   logical OR operation on each pair of the corresponding bits of the input
   operands.
  - with the @b `^` (@ref axtokens "hat token") is the result of the
@@ -1176,13 +1176,13 @@ Performs per component comparisons (after
 every element of the right hand side vector or matrix and perform a logical AND
 combination on the results of these comparisons. This effectively returns true
 if every element of the vector or matrix is equal to the scalar.
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 bool c = b == a;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2.0f;
 int b = 1;
 bool c = a[0] == b;
@@ -1206,12 +1206,12 @@ Performs binary comparison operations (after
 @ref axtypeprecedence "implicit conversion") on each pair corresponding
 components in the vector operands and returns true if all component pairs are
 equal. <b>Operand sizes must match.</b>
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 1, b = 2;
 bool c = a == b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 1, b = 2;
 bool c = a[0] == b[0];
 for (int i = 1; i < 3; ++i) c &= a[i] == b[i];
@@ -1230,12 +1230,12 @@ Performs binary comparison operations (after
 @ref axtypeprecedence "implicit conversion") on each pair corresponding
 components in the matrix operands and returns true if all component pairs are
 equal. <b>Operand sizes must match.</b>
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = 1, b = 2;
 bool c = a == b;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat4f a = 1, b = 2;
 bool c = a[0] == b[0];
 for (int i = 1; i < 16; ++i) c &= a[i] == b[i];
@@ -1322,12 +1322,12 @@ arithmetic operations (if an operation is not listed, it is not supported):
 <td style="text-align:left">
 Performs per component unary operations, returning a new vector with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2;
 vec3f b = -a;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2;
 vec3f b;
 for (int i = 0; i < 3; ++i) b[i] = -a[i];
@@ -1340,12 +1340,12 @@ for (int i = 0; i < 3; ++i) b[i] = -a[i];
 <td style="text-align:left">
 Performs per component unary operations, returning a new matrix with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2;
 vec3f b = -a;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = 2;
 vec3f b;
 for (int i = 0; i < 3; ++i) b[i] = -a[i];
@@ -1381,12 +1381,12 @@ The scalar operand is converted to a bool if it is not already.</td>
 <td style="text-align:left">
 Performs per component unary operations, returning a new vector with each
 element holding the corresponding result. <b>Operand sizes must match.</b>
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3i a = 2;
 vec3i b = !a;
 @endcode
 is equal to:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3i a = 2;
 vec3i b;
 for (int i = 0; i < 3; ++i) b[i] = !a[i];
@@ -1440,19 +1440,19 @@ the following forms:
 <tr><th>Operator Name</th><th>Operator Syntax</th><th>Returns</th></tr>
 <tr style="text-align:left">
 <td>Dot&nbsp;Component&nbsp;Access</td>
-<td bgcolor="#ffc4c4"> @a `vector`&nbsp;<b>.</b>&nbsp;@a `component` </td>
+<td bgcolor="#ffc4c4"> <em>`vector`</em>&nbsp;<b>.</b>&nbsp;@a `component` </td>
 <td>Reference to component @a `component` of @a `vector`</td>
 </tr>
 <tr style="text-align:left">
 <td>Container&nbsp;Component&nbsp;Access</td>
-<td bgcolor="#ffc4c4"> @a `container`&nbsp;<b>[</b>&nbsp;@a `exp` <b>]</b> </td>
+<td bgcolor="#ffc4c4"> <em>`container`</em>&nbsp;<b>[</b>&nbsp;@a `exp` <b>]</b> </td>
 <td>Reference to component at index @a `exp` of @a `container`</td>
 </tr>
 <tr style="text-align:left">
 <td>Matrix&nbsp;Component&nbsp;Access</td>
-<td bgcolor="#ffc4c4">  @a `matrix`&nbsp;<b>[</b>&nbsp;@a `exp1`,&nbsp;@a `exp2`&nbsp;<b>]</b> </td>
-<td>Reference to component in row <b>@a `exp1`</b>, column <b>@a `exp2`</b>.
-Also equal to returning a reference to component at index: <b> @a `[exp1&nbsp;*&nbsp;dimension&nbsp;+&nbsp;exp2]` </b>
+<td bgcolor="#ffc4c4"> <em>`matrix`</em>&nbsp;<b>[</b>&nbsp;@a `exp1`,&nbsp;<em>`exp2`</em>&nbsp;<b>]</b> </td>
+<td>Reference to component in row <b><em>`exp1`</em></b>, column <b><em>`exp2`</em></b>.
+Also equal to returning a reference to component at index: <b><em> `[exp1&nbsp;*&nbsp;dimension&nbsp;+&nbsp;exp2]` </em></b>
 of @a `matrix` where @a `dimension` is the the size of the matrix</td>
 </tr>
 </table>
@@ -1473,10 +1473,10 @@ The dot operator <b>.</b> is only valid for vector types. It has the form:
 Where component is one of the below supported component letters. It only provides
 access for the first three elements of any vector (for @b `vec2` types, only the
 first 2 components are accessible). Accessing a vector using the dot operator is
-fundamentally the same as using the @b `[]` operator with the corresponding
+fundamentally the same as using the <b>`[]`</b> operator with the corresponding
 integer index.
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec4i a = { 6, 7, 8, 9 };
 int b = a.z; // get the the third elements value (8)
 @endcode
@@ -1500,10 +1500,10 @@ This operator can provide more immediately readability when working with
 expressions that focus on colour or Cartesian coordinate systems.
 @anchor axvecaccessop
 @par [] operator
-The @b `[]` operator is valid for both vectors and matrices. It has the form:
+The <b>`[]`</b> operator is valid for both vectors and matrices. It has the form:
 @par
 <table><tr>
-<td bgcolor="#ffc4c4"> @a `container` <b>[</b>  @a `exp` <b>]</b> </td>
+<td bgcolor="#ffc4c4"> @a `container` <b>[</b><em>`exp`</em><b>]</b> </td>
 </tr></table>
 @par
 @a `exp` is expected to evaluate to a value which is castable to an integer
@@ -1526,10 +1526,10 @@ for (int i = 0; i < 16; ++i) b[i] = i;
 @endcode
 @anchor axmataccessop
 @par [,] operator
-The @b `[,]` operator is only valid for matrices. It has the form:
+The <b>`[,]`</b> operator is only valid for matrices. It has the form:
 @par
 <table><tr>
-<td bgcolor="#ffc4c4"> @a `matrix` <b>[</b> @a `exp1`, @a `exp2` <b>]</b> </td>
+<td bgcolor="#ffc4c4"> @a `matrix` <b>[</b><em>`exp1`</em>, <em>`exp2`</em><b>]</b> </td>
 </tr></table>
 @par
 @a `exp1` and @a `exp2` are expected to evaluate to a value which is castable to
@@ -1540,7 +1540,7 @@ accessing specific elements, where @b `exp1` is the row index and @b `exp2` is
 the column index. The tables below show the different access patterns for
 @b `3x3` and @b `4x4` matrices.
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat3f a;
 for (int i = 0; i < 3; ++i)
     for (int j = 0; j < 3; ++j)
@@ -1699,22 +1699,22 @@ section. They have the following forms:
 <tr><th>Operator Name</th><th>Operator Syntax</th><th>Returns</th></tr>
 <tr style="text-align:left">
 <td>Call / Explicit Cast</td>
-<td bgcolor="#ffc4c4"> @a `a`<b>`(...)`</b></td>
+<td bgcolor="#ffc4c4"> <em>`a`</em><b>`(...)`</b></td>
 <td>Returns the result of a function call or inbuilt explicit cast</td>
 </tr>
 <tr style="text-align:left">
 <td>Comma</td>
-<td bgcolor="#ffc4c4"> @a `a`<b>,</b>&nbsp; @a `b` </td>
+<td bgcolor="#ffc4c4"> <em>`a`</em><b>,</b>&nbsp; <em>`b`</em></td>
 <td>Returns the value of @b `b` after chained evaluation</td>
 </tr>
 <tr style="text-align:left">
 <td>Ternary Conditional</td>
-<td bgcolor="#ffc4c4"> @a `a`&nbsp;<b>`?`</b>&nbsp;@a `b`&nbsp;<b>`:`</b> @a `c` </td>
+<td bgcolor="#ffc4c4"> <em>`a`</em>&nbsp;<b>`?`</b>&nbsp;<em>`b`</em>&nbsp;<b>`:`</b><em>`c`</em></td>
 <td>@b `b` if @b `a` is @b true, @b `c` otherwise.</td>
 </tr>
 <tr>
 <td>Vector/Matrix Initializer</td>
-<td bgcolor="#ffc4c4"> <b>`{`</b>&nbsp;@a `a,&nbsp; `@a `b&nbsp; `<b>`...&nbsp;}`</b> </td>
+<td bgcolor="#ffc4c4"> <b>`{`</b>&nbsp;<em> `a,&nbsp; `</em> `b&nbsp; `<b>`...&nbsp;}`</b> </td>
 <td>Returns a temporary vector or matrix</td>
 </tr>
 </table>
@@ -1724,12 +1724,12 @@ The function call operator provides the ability to invoke functions @b or invoke
 a supported explicit cast. It has the form:
 @par
 <table><tr>
-<td bgcolor="#ffc4c4"> @a `func(`@a `a`, @a `b`, @a `c` `...)`</td>
+<td bgcolor="#ffc4c4"> <em> `func(a, b, c, ...)` </em></td>
 </tr></table>
 @par
 Where @b `func` is a function name @b or a valid explicit cast typename. Explicit
 casts are only supported for @ref axscalars "scalar types". For example:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 int a = int(1.1f);
 vec3f b = 1.0f;
 a = int(b.x);
@@ -1749,7 +1749,7 @@ functions.
 The Comma operator has the form:
 @par
 <table><tr>
-<td bgcolor="#ffc4c4">@a `a`<b>`,` </b>@a `b`</td>
+<td bgcolor="#ffc4c4"><em>`a`</em><b>`,` </b><em>`b`</em></td>
 </tr></table>
 @par
 Where @b `a` and @b `b` are expressions. Chained expressions evaluate each
@@ -1758,7 +1758,7 @@ except for the last expression, which is returned from the entire list. Note tha
 although return values for any expression but the last are discarded, their side
 effects are still applied before subsequent expression are evaluated. For
 example:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 int a = 5;
 a-=1, a+=2; // a = 6
 a = a--, ++a; // exp1: a = a--, exp2: ++a. a = 7
@@ -1776,7 +1776,7 @@ The ternary conditional operator can be thought of as an in-line @ref axbranchin
 a single expression that will be returned. It has the form:
 @par
 <table><tr>
-<td bgcolor="#ffc4c4">@a `a`&nbsp;<b>`?`</b>&nbsp;@a `b`&nbsp;<b>`:`</b> @a `c`</td>
+<td bgcolor="#ffc4c4"><em>`a`</em>&nbsp;<b>`?`</b>&nbsp;<em>`b`</em>&nbsp;<b>`:`</b><em>`c`</em></td>
 </tr></table>
 Where @b `a` is the condition, evaluated and converted to @b bool, and @b `b` and @b
 `c` are expressions of the same or implicit-castable types. @b `b` is evaluated and
@@ -1785,7 +1785,7 @@ condition is @b false. Only the expression out of @b `b` and @b `c` that is
 returned will be evaluated. Expressions with no return value (a.k.a @b `void`)
 are supported as long as @b `b` and @b `c` are both of this type.
 @par
-Also supported is the 'Elvis' operator, @b `a` @b `?` @b `:` @b `c` (or `?:`).
+Also supported is the 'Elvis' operator, <b>`a` `?` `:` `c`</b> (or `?:`).
 Here, @b `a` is evaluated once, and if when converted to @b bool is @b true, @b `a` is
 returned, otherwise @b `c` is evaluated and returned. In this case, @b `a` and @b
 `c` must be the same or implicit-castable types, and both implicit-castable to @b bool.
@@ -1798,7 +1798,7 @@ temporary values using the vector/matrix initializer syntax. This operator has
 the form:
 @par
 <table><tr>
-<td bgcolor="#ffc4c4"> <b>`{`</b>&nbsp;@a `a,&nbsp; `@a `b&nbsp; `<b>`...&nbsp;}`</b> </td>
+<td bgcolor="#ffc4c4"> <b>`{`</b>&nbsp; <em>`a,&nbsp; b&nbsp; `</em><b>`...&nbsp;}`</b> </td>
 </tr></table>
 @par
 Where @b `a` and @b `b` are expressions returning a scalar value. When this
@@ -1808,16 +1808,16 @@ existing container of matching size. Expression in the operator are evaluated
 from first to last. This operator is only valid with argument lists of sizes
 2, 3, 4, 9 and 16, which implicitly represent <b>vec2, vec3, vec4, mat3,</b> and
 @b mat4 types respectively. For example:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec3f a = { 1.0f, 2.0f, 3.0f }; // right hand side of assignment creates a vec3f
 vec3f b = dot(a, { a[0], 5.0, 6.0 }); // second argument creates a vec3d
 @endcode
 @note
-In the above examples, the value of @b `a[0]` is copied into the initializer
+In the above examples, the value of <b>`a[0]`</b> is copied into the initializer
 operator.
 @par Initialization Type
 A mixture of arbitrary scalar types can be used in the initializer operator e.g:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 mat3f a = {
     true, 0s, 0,
     0l, 0.0f, 0.0,
@@ -2027,7 +2027,7 @@ OpenVDB voxels change which voxels AX will process. The defined behavior for all
 cases is shown below.
 @par
 Consider a simple assignment example:
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 float@surface = float@density;
 @endcode
 @par
@@ -2096,8 +2096,7 @@ failure of an AX program if an attempt is made it use them.
 @subsection axuserfunctions User Functions
 @par
 User function declarations are not currently supported, but exist on the
-<a href="https://github.com/dneg/openvdb_ax/blob/master/ROADMAP.md">AX Roadmap</a>
-as a near future feature.
+AX Roadmap as a near future feature.
 
 
 <br/><hr>

--- a/doc/ax/axcplusplus.txt
+++ b/doc/ax/axcplusplus.txt
@@ -296,7 +296,7 @@ applications.
 @par
 Consider this trivial example:
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 f@density = f$my_value;
 // f$my_value = f@density; NOTE: writing to $ values is disallowed
 @endcode
@@ -457,7 +457,7 @@ requires both the AX compiler @b and the underlying geometry to support the
 given type. As mentioned above, there may be times where this isn't the case.
 Consider the following:
 @par
-<!--- A --->@code{.c}
+<!-- A -->@code{.c}
 vec4i a = {1,2,3,4};
 vec4i@attr = a;
 @endcode

--- a/doc/ax/axexamples.txt
+++ b/doc/ax/axexamples.txt
@@ -40,7 +40,7 @@ a @b vec3f float attribute @b velocity and a @b vec3f float attribute @b colour.
 This snippet uses the functions @ref axlength "length" and @ref axfit "fit" to
 give points a colour between black and white based on their speed.
 @par
-<!--- P --->@code{.c}
+<!-- P -->@code{.c}
 // This statement writes to a new float attribute called speed and reads from a
 // vector float attribute called velocity. The length function is used here to
 // return the length of the point's velocity vector.
@@ -71,7 +71,7 @@ This example demonstrates a simple way of removing points from a VDB points grid
 It uses a combination of @ref axrand and @ref axdeletepoint to randomly delete
 roughly half of the points in the input VDB points grid.
 @par
-<!--- P --->@code{.c}
+<!-- P -->@code{.c}
 float threshold = 0.5f;
 
 // The rand function takes a seed and produces a random value between 0 and 1.
@@ -91,7 +91,7 @@ different seed value per point producing a good distribution of random values.
 This example shows something a bit more complex: modifying a point's velocity
 with a drag force and then moving the point with the modified velocity.
 @par
-<!--- P --->@code{.c}
+<!-- P -->@code{.c}
 float dt = 1.0f / (4.0f * 24.0f); // timestep
 vec3f gravity = {0.0f, -9.81f, 0.0f}; // gravity
 vec3f dV = {2.0f, 0.0f, 0.0f} - v@v; // drag
@@ -123,7 +123,7 @@ The following example demonstrates using various native AX functions to
 calculate a position based curl noise on points in a particular group, and to
 use that calculation to update point velocities.
 @par
-<!--- P --->@code{.c}
+<!-- P -->@code{.c}
 // Only calcualte noise and apply it to points if the current point is NOT in
 // a group called "escaped". Note that the PointExecutable also has native
 // support for group based execution.
@@ -158,7 +158,7 @@ accessed via row, column operators or as a flat array and have defined
 operators (such as matrix multiplication etc.). The following demonstrates
 some trivial matrix math on VDB Point positions.
 @par
-<!--- P --->@code{.c}
+<!-- P -->@code{.c}
 // get the 4x4 identity matrix. note that scalar->matrix promotion handles
 // this, so writing 'mat4f transform = 1;' has the same effect.
 mat4f transform = identity4();
@@ -205,7 +205,7 @@ example: `float@density` would imply a @b float volume called @b density.
 This snippet uses @ref axclamp function to constrain the @b density attribute
 between zero and one.
 @par
-<!--- V --->@code{.c}
+<!-- V -->@code{.c}
 float@density = clamp(float@density, 0.f, 1.f);
 @endcode
 
@@ -215,7 +215,7 @@ AX can be used to read and write to multiple volumes. Here we have a typical
 example of a eulerian velocity update which takes into account an updated
 vector force and scalar mass.
 @par
-<!--- V --->@code{.c}
+<!-- V -->@code{.c}
 // Access the current timestep - this could instead be provided by the AX
 // integration and made accessible with custom data (i/e: float$timestep)
 float dt = 1.0f / 24.0f;
@@ -239,7 +239,7 @@ stored in `surface_a`, will only be updated in `surface_a`'s topology. Should
 we want a combined blend of @b non @b overlapping areas of both surface a and b,
 we would need to activate a's topology with respect to b first.
 @par
-<!--- V --->@code{.c}
+<!-- V -->@code{.c}
 // time constants for each run.
 float time = float$time;
 float maxDuration = 100.0f;

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -1954,9 +1954,8 @@ Bug fixes:
   <I>[Reported by Joshua&nbsp;Olson]</I>
 - Fixed bugs in @vdblink::tree::NodeUnion NodeUnion@endlink that could cause
   crashes.
-- Fixed memory leak in
-  @vdblink::tools::mesh_to_volume_internal::ExpandNarrowband
-  tools::mesh_to_volume_internal::ExpandNarrowband@endlink
+- Fixed memory leak in a @vdblink::tools::meshToVolume tools::meshToVolume@endlink
+  sub-tool (expandNarrowband).
   <I>[Reported by K&eacute;vin&nbsp;Dietrich]</I>
 - Fixed parameter type inconsistencies in @link math/Stencils.h@endlink and
   @link tools/RayIntersector.h@endlink.

--- a/openvdb/openvdb/Grid.h
+++ b/openvdb/openvdb/Grid.h
@@ -1779,6 +1779,7 @@ createLevelSet(Real voxelSize, Real halfWidth)
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace internal {
 
@@ -1803,6 +1804,7 @@ struct GridApplyImpl<OpT, GridBaseT, TypeList<GridT, GridTs...>>
 
 } // namespace internal
 
+/// @endcond
 
 template<typename GridTypeListT, typename OpT>
 inline bool

--- a/openvdb/openvdb/Platform.h
+++ b/openvdb/openvdb/Platform.h
@@ -10,7 +10,7 @@
 
 /// @name Utilities
 /// @{
-/// @cond OPENVDB_VERSION_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 #define OPENVDB_PREPROC_STRINGIFY_(x) #x
 /// @endcond
 /// @brief Return @a x as a string literal.  If @a x is a macro,
@@ -18,7 +18,7 @@
 /// @hideinitializer
 #define OPENVDB_PREPROC_STRINGIFY(x) OPENVDB_PREPROC_STRINGIFY_(x)
 
-/// @cond OPENVDB_VERSION_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 #define OPENVDB_PREPROC_CONCAT_(x, y) x ## y
 /// @endcond
 /// @brief Form a new token by concatenating two existing tokens.

--- a/openvdb/openvdb/TypeList.h
+++ b/openvdb/openvdb/TypeList.h
@@ -21,7 +21,7 @@ namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
 
-/// @cond OPENVDB_TYPES_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 template<typename... Ts> struct TypeList; // forward declaration
 

--- a/openvdb/openvdb/Types.h
+++ b/openvdb/openvdb/Types.h
@@ -317,7 +317,7 @@ template<typename FromType, typename ToType> struct CopyConstness {
     using Type = typename std::remove_const<ToType>::type;
 };
 
-/// @cond OPENVDB_TYPES_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 template<typename FromType, typename ToType> struct CopyConstness<const FromType, ToType> {
     using Type = const ToType;
 };

--- a/openvdb/openvdb/math/LegacyFrustum.h
+++ b/openvdb/openvdb/math/LegacyFrustum.h
@@ -17,6 +17,9 @@ namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
 namespace math {
+
+/// @cond OPENVDB_DOCS_INTERNAL
+
 namespace internal {
 
 /// @brief LegacyFrustum class used at DreamWorks for converting old vdb files.
@@ -158,6 +161,9 @@ private:
 };
 
 } // namespace internal
+
+/// @endcond
+
 } // namespace math
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb

--- a/openvdb/openvdb/math/Math.h
+++ b/openvdb/openvdb/math/Math.h
@@ -558,7 +558,7 @@ inline Type Pow3(Type x) { return x*x*x; }
 template<typename Type>
 inline Type Pow4(Type x) { return Pow2(Pow2(x)); }
 
-/// Return @a x<sup>@a n</sup>.
+/// Return @a x<sup>n</sup>.
 template<typename Type>
 Type
 Pow(Type x, int n)
@@ -573,7 +573,7 @@ Pow(Type x, int n)
 }
 
 //@{
-/// Return @a b<sup>@a e</sup>.
+/// Return @a b<sup>e</sup>.
 inline float
 Pow(float b, float e)
 {
@@ -708,7 +708,7 @@ Min(const Type& a, const Type& b, const Type& c, const Type& d,
 
 // ============> Exp <==================
 
-/// Return @a e<sup>@a x</sup>.
+/// Return @a e<sup>x</sup>.
 template<typename Type>
 inline Type Exp(const Type& x) { return std::exp(x); }
 

--- a/openvdb/openvdb/math/Operators.h
+++ b/openvdb/openvdb/math/Operators.h
@@ -75,6 +75,7 @@ struct OpMagnitude {
     }
 };
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace internal {
 
@@ -86,6 +87,8 @@ struct ReturnValue {
 };
 
 } // namespace internal
+
+/// @endcond
 
 // ---- Operators defined in index space
 

--- a/openvdb/openvdb/points/IndexFilter.h
+++ b/openvdb/openvdb/points/IndexFilter.h
@@ -63,7 +63,7 @@ namespace points {
 
 ////////////////////////////////////////
 
-
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace index_filter_internal {
 
@@ -96,6 +96,8 @@ generateRandomSubset(const unsigned int seed, const IntType n, const IntType m)
 
 
 } // namespace index_filter_internal
+
+/// @endcond
 
 
 /// Index filtering on active / inactive state of host voxel

--- a/openvdb/openvdb/points/PointAdvect.h
+++ b/openvdb/openvdb/points/PointAdvect.h
@@ -49,6 +49,7 @@ inline void advectPoints(PointDataGridT& points, const VelGridT& velocity,
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_advect_internal {
 
@@ -208,6 +209,7 @@ private:
 
 } // namespace point_advect_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/points/PointAttribute.h
+++ b/openvdb/openvdb/points/PointAttribute.h
@@ -156,6 +156,7 @@ inline void compactAttributes(PointDataTreeT& tree);
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_attribute_internal {
 
@@ -233,6 +234,8 @@ struct MetadataStorage<PointDataTreeT, Name>
 
 
 } // namespace point_attribute_internal
+
+/// @endcond
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/points/PointConversion.h
+++ b/openvdb/openvdb/points/PointConversion.h
@@ -211,6 +211,7 @@ private:
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_conversion_internal {
 
@@ -607,6 +608,7 @@ private:
 
 } // namespace point_conversion_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/points/PointDelete.h
+++ b/openvdb/openvdb/points/PointDelete.h
@@ -72,6 +72,7 @@ inline void deleteFromGroup(PointDataTreeT& pointTree,
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_delete_internal {
 
@@ -186,6 +187,7 @@ private:
 
 } // namespace point_delete_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/points/PointGroup.h
+++ b/openvdb/openvdb/points/PointGroup.h
@@ -124,6 +124,7 @@ inline void setGroupByFilter(   PointDataTreeT& tree,
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_group_internal {
 
@@ -296,6 +297,7 @@ struct SetGroupByFilterOp
 
 } // namespace point_group_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/points/PointMask.h
+++ b/openvdb/openvdb/points/PointMask.h
@@ -81,6 +81,7 @@ struct DeformerTraits
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_mask_internal {
 
@@ -353,6 +354,7 @@ inline typename GridT::Ptr convertPointsToScalar(
 
 } // namespace point_mask_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/points/PointSample.h
+++ b/openvdb/openvdb/points/PointSample.h
@@ -124,6 +124,7 @@ inline void sampleGrid( size_t order,
 
 ///////////////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_sample_internal {
 
@@ -398,6 +399,7 @@ struct AppendAttributeOp<PointDataGridT, DummySampleType>
 
 } // namespace point_sample_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/points/PointScatter.h
+++ b/openvdb/openvdb/points/PointScatter.h
@@ -146,6 +146,7 @@ nonUniformPointScatter(const GridT& grid,
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_scatter_internal
 {
@@ -208,6 +209,7 @@ generatePositions(LeafNodeT& leaf,
 
 } // namespace point_scatter_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/Activate.h
+++ b/openvdb/openvdb/tools/Activate.h
@@ -47,6 +47,8 @@ inline void deactivate(
 ////////////////////////////////////////
 
 
+/// @cond OPENVDB_DOCS_INTERNAL
+
 namespace activate_internal {
 
 template<typename TreeT, bool IgnoreTolerance = false>
@@ -160,6 +162,8 @@ private:
 };// DeactivateOp
 
 } // namespace activate_internal
+
+/// @endcond
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tools/Clip.h
+++ b/openvdb/openvdb/tools/Clip.h
@@ -68,6 +68,7 @@ clip(const GridType& grid, const Grid<MaskTreeType>& mask, bool keepInterior = t
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace clip_internal {
 
@@ -337,6 +338,8 @@ doClip(
 }
 
 } // namespace clip_internal
+
+/// @endcond
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tools/Composite.h
+++ b/openvdb/openvdb/tools/Composite.h
@@ -145,6 +145,8 @@ divide(const T& a, const T& b)
 inline bool divide(bool a, bool /*b*/) { return a; }
 
 
+/// @cond OPENVDB_DOCS_INTERNAL
+
 enum CSGOperation { CSG_UNION, CSG_INTERSECTION, CSG_DIFFERENCE };
 
 template<typename TreeType, CSGOperation Operation>
@@ -597,13 +599,10 @@ struct GridOrTreeConstructor<Grid<TreeType> >
 
 ////////////////////////////////////////
 
-/// @cond COMPOSITE_INTERNAL
 /// List of pairs of leaf node pointers
 template <typename LeafT>
 using LeafPairList = std::vector<std::pair<LeafT*, LeafT*>>;
-/// @endcond
 
-/// @cond COMPOSITE_INTERNAL
 /// Transfers leaf nodes from a source tree into a
 /// desitnation tree, unless it already exists in the destination tree
 /// in which case pointers to both leaf nodes are added to a list for
@@ -627,9 +626,7 @@ inline void transferLeafNodes(TreeT &srcTree, TreeT &dstTree,
         }
     }
 }
-/// @endcond
 
-/// @cond COMPOSITE_INTERNAL
 /// Template specailization of compActiveLeafVoxels
 template <typename TreeT, typename OpT>
 inline
@@ -655,9 +652,7 @@ doCompActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT op)
         }
    });
 }
-/// @endcond
 
-/// @cond COMPOSITE_INTERNAL
 /// Template specailization of compActiveLeafVoxels
 template <typename TreeT, typename OpT>
 inline
@@ -679,7 +674,6 @@ doCompActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT)
     });
 }
 
-/// @cond COMPOSITE_INTERNAL
 /// Template specailization of compActiveLeafVoxels
 template <typename TreeT, typename OpT>
 inline
@@ -710,9 +704,7 @@ doCompActiveLeafVoxels(TreeT &srcTree, TreeT &dstTree, OpT op)
         }
     });
 }
-/// @endcond
 
-/// @cond COMPOSITE_INTERNAL
 /// Default functor for compActiveLeafVoxels
 template <typename TreeT>
 struct CopyOp
@@ -721,7 +713,6 @@ struct CopyOp
     CopyOp() = default;
     void operator()(ValueT& dst, const ValueT& src) const { dst = src; }
 };
-/// @endcond
 
 template <typename TreeT>
 inline void validateLevelSet(const TreeT& tree, const std::string& gridName = std::string(""))
@@ -743,6 +734,8 @@ inline void validateLevelSet(const TreeT& tree, const std::string& gridName = st
         OPENVDB_THROW(ValueError, ss.str());
     }
 }
+
+/// @endcond
 
 } // namespace composite
 

--- a/openvdb/openvdb/tools/Count.h
+++ b/openvdb/openvdb/tools/Count.h
@@ -38,6 +38,7 @@ Index64 memUsage(const TreeT& tree, bool threaded = true);
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace count_internal {
 
@@ -201,6 +202,8 @@ struct MemUsageOp
 }; // struct MemUsageOp
 
 } // namespace count_internal
+
+/// @endcond
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tools/Diagnostics.h
+++ b/openvdb/openvdb/tools/Diagnostics.h
@@ -1091,6 +1091,7 @@ checkFogVolume(const GridType& grid, size_t n)
 
 // Internal utility objects and implementation details
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace diagnostics_internal {
 
@@ -1278,6 +1279,7 @@ InactiveTileValues<TreeType>::getInactiveValues(SetType& values) const
 
 } // namespace diagnostics_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/Filter.h
+++ b/openvdb/openvdb/tools/Filter.h
@@ -205,6 +205,7 @@ private:
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace filter_internal {
 
@@ -487,8 +488,10 @@ private:
 template<typename T> static inline void accum(T& sum, T addend) { sum += addend; }
 // Overload for bool ValueType
 inline void accum(bool& sum, bool addend) { sum = sum || addend; }
-}
 
+} // namespace filter_internal
+
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/GridTransformer.h
+++ b/openvdb/openvdb/tools/GridTransformer.h
@@ -81,6 +81,7 @@ resampleToMatch(const GridType& inGrid, GridType& outGrid);
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace internal {
 
@@ -133,6 +134,8 @@ public:
 };
 
 } // namespace internal
+
+/// @endcond
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tools/LevelSetFracture.h
+++ b/openvdb/openvdb/tools/LevelSetFracture.h
@@ -95,6 +95,7 @@ private:
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 // Internal utility objects and implementation details
 
@@ -143,6 +144,7 @@ struct FindMinMaxVoxelValue {
 
 } // namespace level_set_fracture_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/LevelSetMeasure.h
+++ b/openvdb/openvdb/tools/LevelSetMeasure.h
@@ -400,7 +400,7 @@ MeasureCurvatures::operator()(const LeafRange& range) const
 ////////////////////////////////////////
 
 //{
-/// @cond OPENVDB_LEVEL_SET_MEASURE_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 template<class GridT>
 inline
@@ -433,7 +433,7 @@ levelSetArea(const GridT& grid, bool useWorldUnits)
 ////////////////////////////////////////
 
 //{
-/// @cond OPENVDB_LEVEL_SET_MEASURE_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 template<class GridT>
 inline
@@ -466,7 +466,7 @@ levelSetVolume(const GridT& grid, bool useWorldUnits)
 ////////////////////////////////////////
 
 //{
-/// @cond OPENVDB_LEVEL_SET_MEASURE_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 template<class GridT>
 inline
@@ -500,7 +500,7 @@ levelSetEulerCharacteristic(const GridT& grid)
 ////////////////////////////////////////
 
 //{
-/// @cond OPENVDB_LEVEL_SET_MEASURE_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 template<class GridT>
 inline

--- a/openvdb/openvdb/tools/LevelSetRebuild.h
+++ b/openvdb/openvdb/tools/LevelSetRebuild.h
@@ -87,6 +87,7 @@ levelSetRebuild(const GridType& grid, float isovalue, float exBandWidth, float i
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 // Internal utility objects and implementation details
 
@@ -185,12 +186,13 @@ private:
 
 } // namespace internal
 
+/// @endcond
 
 ////////////////////////////////////////
 
 
 //{
-/// @cond OPENVDB_LEVEL_SET_REBUILD_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 /// The normal entry points for level set rebuild are the levelSetRebuild() functions.
 /// doLevelSetRebuild() is mainly for internal use, but when the isovalue and half band

--- a/openvdb/openvdb/tools/LevelSetUtil.h
+++ b/openvdb/openvdb/tools/LevelSetUtil.h
@@ -176,6 +176,7 @@ segmentSDF(const GridOrTreeType& volume, std::vector<typename GridOrTreeType::Pt
 
 // Internal utility objects and implementation details
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace level_set_util_internal {
 
@@ -2145,6 +2146,8 @@ struct GridOrTreeConstructor<Grid<TreeType> >
 
 } // namespace level_set_util_internal
 
+
+/// @endcond OPENVDB_DOCS_INTERNAL
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/Mask.h
+++ b/openvdb/openvdb/tools/Mask.h
@@ -31,10 +31,9 @@ interiorMask(const GridType& grid, const double isovalue = 0.0);
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace mask_internal {
-
-/// @private
 template<typename GridType>
 struct Traits {
     static const bool isBool = std::is_same<typename GridType::ValueType, bool>::value;
@@ -42,8 +41,6 @@ struct Traits {
     using BoolGridPtrType = typename BoolGridType::Ptr;
 };
 
-
-/// @private
 template<typename GridType>
 inline typename std::enable_if<std::is_floating_point<typename GridType::ValueType>::value,
     typename mask_internal::Traits<GridType>::BoolGridPtrType>::type
@@ -59,8 +56,6 @@ doLevelSetInteriorMask(const GridType& grid, const double isovalue)
     return MaskGridPtrT{};
 }
 
-
-/// @private
 // No-op specialization for non-floating-point grids
 template<typename GridType>
 inline typename std::enable_if<!std::is_floating_point<typename GridType::ValueType>::value,
@@ -71,8 +66,6 @@ doLevelSetInteriorMask(const GridType&, const double /*isovalue*/)
     return MaskGridPtrT{};
 }
 
-
-/// @private
 template<typename GridType>
 inline typename std::enable_if<mask_internal::Traits<GridType>::isBool,
     typename mask_internal::Traits<GridType>::BoolGridPtrType>::type
@@ -82,8 +75,6 @@ doInteriorMask(const GridType& grid, const double /*isovalue*/)
     return grid.deepCopy();
 }
 
-
-/// @private
 template<typename GridType>
 inline typename std::enable_if<!(mask_internal::Traits<GridType>::isBool),
     typename mask_internal::Traits<GridType>::BoolGridPtrType>::type
@@ -104,6 +95,8 @@ doInteriorMask(const GridType& grid, const double isovalue)
 }
 
 } // namespace mask_internal
+
+/// @endcond
 
 
 template<typename GridType>

--- a/openvdb/openvdb/tools/Merge.h
+++ b/openvdb/openvdb/tools/Merge.h
@@ -533,6 +533,7 @@ bool TreeToMerge<TreeT>::MaskUnionOp::operator()(NodeT& node, size_t /*idx*/) co
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace merge_internal {
 
@@ -665,6 +666,8 @@ private:
 
 } // namespace merge_internal
 
+
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -504,6 +504,8 @@ private:
 
 // Internal utility objects and implementation details
 
+/// @cond OPENVDB_DOCS_INTERNAL
+
 namespace mesh_to_volume_internal {
 
 template<typename PointType>
@@ -3008,6 +3010,8 @@ private:
 
 } // mesh_to_volume_internal namespace
 
+/// @endcond
+
 
 ////////////////////////////////////////
 
@@ -3435,7 +3439,7 @@ meshToVolume(
 
 
 //{
-/// @cond OPENVDB_MESH_TO_VOLUME_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 /// @internal This overload is enabled only for grids with a scalar, floating-point ValueType.
 template<typename GridType, typename Interrupter>

--- a/openvdb/openvdb/tools/Morphology.h
+++ b/openvdb/openvdb/tools/Morphology.h
@@ -1031,6 +1031,8 @@ Morphology<TreeType>::NodeMaskOp::gatherEdgesXY(int x, int y, int i1, int n, int
 /////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
+
 namespace morph_internal {
 template <typename T> struct Adapter {
     using TreeType = T;
@@ -1044,6 +1046,8 @@ struct Adapter<openvdb::tree::LeafManager<T>> {
     static void sync(openvdb::tree::LeafManager<T>& M) { M.rebuild(); }
 };
 }
+
+/// @endcond
 
 template<typename TreeOrLeafManagerT>
 inline void dilateActiveValues(TreeOrLeafManagerT& treeOrLeafM,

--- a/openvdb/openvdb/tools/ParticleAtlas.h
+++ b/openvdb/openvdb/tools/ParticleAtlas.h
@@ -239,6 +239,7 @@ private:
 
 // Internal operators and implementation details
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace particle_atlas_internal {
 
@@ -678,6 +679,7 @@ private:
 
 } // namespace particle_atlas_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/ParticlesToLevelSet.h
+++ b/openvdb/openvdb/tools/ParticlesToLevelSet.h
@@ -137,6 +137,7 @@ inline void particleTrailsToMask(const ParticleListT&, GridT&,Real delta=1,Inter
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace p2ls_internal {
 // This is a simple type that combines a distance value and a particle
@@ -146,6 +147,7 @@ namespace p2ls_internal {
 template<typename VisibleT, typename BlindT> class BlindData;
 }
 
+/// @endcond
 
 template<typename SdfGridT,
          typename AttributeT = void,
@@ -857,6 +859,7 @@ private:
 
 ///////////////////// YOU CAN SAFELY IGNORE THIS SECTION /////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace p2ls_internal {
 
@@ -921,6 +924,7 @@ operator+(const BlindData<VisibleT, BlindT>& x, const T& rhs)
 
 } // namespace p2ls_internal
 
+/// @endcond
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/PointIndexGrid.h
+++ b/openvdb/openvdb/tools/PointIndexGrid.h
@@ -337,6 +337,7 @@ private:
 
 // Internal operators and implementation details
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_index_grid_internal {
 
@@ -911,6 +912,7 @@ pointIndexSearch(RangeDeque& rangeList, ConstAccessor& acc, const CoordBBox& bbo
 
 } // namespace point_index_grid_internal
 
+/// @endcond
 
 // PointIndexIterator implementation
 

--- a/openvdb/openvdb/tools/PointPartitioner.h
+++ b/openvdb/openvdb/tools/PointPartitioner.h
@@ -221,6 +221,7 @@ private:
 
 // Implementation details
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace point_partitioner_internal {
 
@@ -934,6 +935,7 @@ inline void partition(
 
 } // namespace point_partitioner_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/PoissonSolver.h
+++ b/openvdb/openvdb/tools/PoissonSolver.h
@@ -278,6 +278,7 @@ struct DirichletBoundaryOp {
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace internal {
 
@@ -311,6 +312,7 @@ struct LeafIndexOp
 
 } // namespace internal
 
+/// @endcond
 
 template<typename VIndexTreeType>
 inline void
@@ -367,6 +369,7 @@ createIndexTree(const TreeType& tree)
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace internal {
 
@@ -408,6 +411,7 @@ struct CopyToVecOp
 
 } // namespace internal
 
+/// @endcond
 
 template<typename VectorValueType, typename SourceTreeType>
 inline typename math::pcg::Vector<VectorValueType>::Ptr
@@ -433,6 +437,7 @@ createVectorFromTree(const SourceTreeType& tree,
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace internal {
 
@@ -464,6 +469,7 @@ struct CopyFromVecOp
 
 } // namespace internal
 
+/// @endcond
 
 template<typename TreeValueType, typename VIndexTreeType, typename VectorValueType>
 inline typename VIndexTreeType::template ValueConverter<TreeValueType>::Type::Ptr
@@ -491,6 +497,7 @@ createTreeFromVector(
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace internal {
 
@@ -682,6 +689,8 @@ struct ISLaplacianOp
 };
 
 } // namespace internal
+
+/// @endcond
 
 
 template<typename BoolTreeType>

--- a/openvdb/openvdb/tools/PotentialFlow.h
+++ b/openvdb/openvdb/tools/PotentialFlow.h
@@ -93,6 +93,7 @@ computePotentialFlow(const typename VectorToScalarGrid<Vec3GridT>::Type& potenti
 
 //////////////////////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace potential_flow_internal {
 
@@ -205,6 +206,7 @@ struct SolveBoundaryOp
 
 } // namespace potential_flow_internal
 
+/// @endcond
 
 ////////////////////////////////////////////////////////////////////////////
 

--- a/openvdb/openvdb/tools/SignedFloodFill.h
+++ b/openvdb/openvdb/tools/SignedFloodFill.h
@@ -210,7 +210,7 @@ private:
 
 
 //{
-/// @cond OPENVDB_SIGNED_FLOOD_FILL_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 template<typename TreeOrLeafManagerT>
 inline

--- a/openvdb/openvdb/tools/Statistics.h
+++ b/openvdb/openvdb/tools/Statistics.h
@@ -194,6 +194,7 @@ opExtrema(const IterT& iter, const OperatorT& op = OperatorT(), bool threaded = 
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace stats_internal {
 
@@ -335,6 +336,7 @@ struct MathOp
 
 } // namespace stats_internal
 
+/// @endcond
 
 template<typename IterT>
 inline math::Histogram

--- a/openvdb/openvdb/tools/TopologyToLevelSet.h
+++ b/openvdb/openvdb/tools/TopologyToLevelSet.h
@@ -70,6 +70,7 @@ topologyToLevelSet(const GridT& grid, int halfWidth = 3, int closingSteps = 1, i
 
 ////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace ttls_internal {
 
@@ -184,7 +185,7 @@ smoothLevelSet(GridType& grid, int iterations, int halfBandWidthInVoxels,
 
 } // namespace ttls_internal
 
-
+/// @endcond
 
 template<typename GridT, typename InterrupterT>
 inline typename GridT::template ValueConverter<float>::Type::Ptr

--- a/openvdb/openvdb/tools/VectorTransformer.h
+++ b/openvdb/openvdb/tools/VectorTransformer.h
@@ -70,7 +70,7 @@ struct MatMulNormalize
 
 
 //{
-/// @cond OPENVDB_VECTOR_TRANSFORMER_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 /// @internal This overload is enabled only for scalar-valued grids.
 template<typename GridType> inline

--- a/openvdb/openvdb/tools/VolumeToMesh.h
+++ b/openvdb/openvdb/tools/VolumeToMesh.h
@@ -363,6 +363,7 @@ inline Vec3d findFeaturePoint(
 
 // Internal utility objects and implementation details
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace volume_to_mesh_internal {
 
@@ -4640,6 +4641,7 @@ relaxDisorientedTriangles(
 
 } // volume_to_mesh_internal namespace
 
+/// @endcond
 
 ////////////////////////////////////////
 
@@ -5151,7 +5153,7 @@ VolumeToMesh::operator()(const InputGridType& inputGrid)
 
 
 //{
-/// @cond OPENVDB_VOLUME_TO_MESH_INTERNAL
+/// @cond OPENVDB_DOCS_INTERNAL
 
 /// @internal This overload is enabled only for grids with a scalar ValueType.
 template<typename GridType>

--- a/openvdb/openvdb/tools/VolumeToSpheres.h
+++ b/openvdb/openvdb/tools/VolumeToSpheres.h
@@ -140,6 +140,8 @@ private:
 
 // Internal utility methods
 
+/// @cond OPENVDB_DOCS_INTERNAL
+
 namespace v2s_internal {
 
 struct PointAccessor
@@ -622,6 +624,7 @@ UpdatePoints::operator()(const tbb::blocked_range<size_t>& range)
 
 } // namespace v2s_internal
 
+/// @endcond
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/util/logging.h
+++ b/openvdb/openvdb/util/logging.h
@@ -36,6 +36,7 @@ enum class Level {
     Fatal = log4cplus::FATAL_LOG_LEVEL
 };
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace internal {
 
@@ -131,6 +132,8 @@ getAppender()
 }
 
 } // namespace internal
+
+/// @endcond
 
 
 /// @brief Return the current logging level.

--- a/openvdb_ax/openvdb_ax/ast/Scanners.h
+++ b/openvdb_ax/openvdb_ax/ast/Scanners.h
@@ -128,6 +128,7 @@ const ast::Variable* lastUse(const ast::Node& node, const std::string& token);
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 
+/// @cond OPENVDB_DOCS_INTERNAL
 
 namespace internal {
 template<typename ContainerType, typename T, typename ...Ts>
@@ -143,6 +144,8 @@ struct CollectForEach<ContainerType, TypeList<T, Ts...>> {
     }
 };
 }
+
+// @endcond
 
 template<typename NodeT, typename ContainerType>
 inline void collectNodeType(const ast::Node& node, ContainerType& array)

--- a/pendingchanges/doxygen_improvements.txt
+++ b/pendingchanges/doxygen_improvements.txt
@@ -1,0 +1,4 @@
+Build:
+  - Introduced a OPENVDB_DOXYGEN_INTERNAL CMake variable which is ON by default and removes the majority of internal namespaces from the generated doxygen
+  - Improved the doxygen deprecation listings, folder layouts and fixes issues when using later versions of doxygen
+


### PR DESCRIPTION
 - A variety of fixes (primary to AX \<!-- --> syntax and in `math/Math.h`) for later versions of doxygen
 - Consolidated all `OPENVDB_<>_INTERNAL` doxygen clauses into a single `OPENVDB_DOCS_INTERNAL` variable
 - In an attempt to streamline the doxygen and remove unnecessary information, encapsulated the majority of internal namespaces with the `OPENVDB_DOCS_INTERNAL` variable
 - Added full path support to the VDB folder layouts
 - Added better deprecation listings

Old | New
-- | --
<img src="https://user-images.githubusercontent.com/4256455/121238852-7644d380-c890-11eb-8f94-89ceff36f221.PNG" width=500> | <img src="https://user-images.githubusercontent.com/4256455/121336439-6a4e2580-c913-11eb-9d8e-77193c6e0fe7.PNG" width=500>
<img src="https://user-images.githubusercontent.com/4256455/121239148-c2901380-c890-11eb-82b8-3cf7c1607bd4.PNG" width=500> | <img src="https://user-images.githubusercontent.com/4256455/121239150-c328aa00-c890-11eb-8130-e87200935d8e.png" width=500>

Deprecation listings example:
<img src="https://user-images.githubusercontent.com/4256455/121336172-2bb86b00-c913-11eb-9df1-17ad0e04ce6a.PNG" width=300>