### PR TITLE
Fixes for building for Windows with MinGW

### DIFF
--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -503,6 +503,7 @@ if(OPENVDB_CORE_STATIC)
     PROPERTIES OUTPUT_NAME ${OPENVDB_STATIC_LIBRARY_NAME})
 
   if(MSVC)
+    # on Windows, but only for MSVC, not for MinGW
     if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
       # NOTE: MSVC_RUNTIME_LIBRARY does not propagate to targets, so
       # also add it explicitly as a compile option
@@ -554,6 +555,7 @@ if(OPENVDB_CORE_SHARED)
   endif()
 
   if(MSVC)
+    # on Windows, but only for MSVC, not for MinGW
     if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
       # NOTE: MSVC_RUNTIME_LIBRARY does not propagate to targets, so
       # also add it explicitly as a compile option

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -503,7 +503,6 @@ if(OPENVDB_CORE_STATIC)
     PROPERTIES OUTPUT_NAME ${OPENVDB_STATIC_LIBRARY_NAME})
 
   if(MSVC)
-    # on Windows, but only for MSVC, not for MinGW
     if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
       # NOTE: MSVC_RUNTIME_LIBRARY does not propagate to targets, so
       # also add it explicitly as a compile option
@@ -555,7 +554,6 @@ if(OPENVDB_CORE_SHARED)
   endif()
 
   if(MSVC)
-    # on Windows, but only for MSVC, not for MinGW
     if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
       # NOTE: MSVC_RUNTIME_LIBRARY does not propagate to targets, so
       # also add it explicitly as a compile option

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -502,7 +502,7 @@ if(OPENVDB_CORE_STATIC)
   set_target_properties(openvdb_static
     PROPERTIES OUTPUT_NAME ${OPENVDB_STATIC_LIBRARY_NAME})
 
-  if(WIN32)
+  if(MSVC)
     if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
       # NOTE: MSVC_RUNTIME_LIBRARY does not propagate to targets, so
       # also add it explicitly as a compile option
@@ -553,7 +553,7 @@ if(OPENVDB_CORE_SHARED)
     )
   endif()
 
-  if(WIN32)
+  if(MSVC)
     if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
       # NOTE: MSVC_RUNTIME_LIBRARY does not propagate to targets, so
       # also add it explicitly as a compile option

--- a/openvdb/openvdb/io/TempFile.cc
+++ b/openvdb/openvdb/io/TempFile.cc
@@ -70,7 +70,7 @@ struct TempFile::TempFileImpl
     {
         if (const char* dir = std::getenv("OPENVDB_TEMP_DIR")) {
             if (0 != ::access(dir, F_OK)) {
-#ifdef _WIN32
+#ifdef __MINGW32__
                 ::mkdir(dir);
 #else
                 ::mkdir(dir, S_IRUSR | S_IWUSR | S_IXUSR);

--- a/openvdb/openvdb/io/TempFile.cc
+++ b/openvdb/openvdb/io/TempFile.cc
@@ -70,7 +70,11 @@ struct TempFile::TempFileImpl
     {
         if (const char* dir = std::getenv("OPENVDB_TEMP_DIR")) {
             if (0 != ::access(dir, F_OK)) {
+#ifdef _WIN32
+                ::mkdir(dir);
+#else
                 ::mkdir(dir, S_IRUSR | S_IWUSR | S_IXUSR);
+#endif
                 if (0 != ::access(dir, F_OK)) {
                     OPENVDB_THROW(IoError,
                         "failed to create OPENVDB_TEMP_DIR (" + std::string(dir) + ")");

--- a/openvdb/openvdb/io/TempFile.cc
+++ b/openvdb/openvdb/io/TempFile.cc
@@ -70,7 +70,7 @@ struct TempFile::TempFileImpl
     {
         if (const char* dir = std::getenv("OPENVDB_TEMP_DIR")) {
             if (0 != ::access(dir, F_OK)) {
-#ifdef __MINGW32__
+#ifdef _WIN32
                 ::mkdir(dir);
 #else
                 ::mkdir(dir, S_IRUSR | S_IWUSR | S_IXUSR);


### PR DESCRIPTION
When building for Windows with MinGW-w64 2 fixes are needed:

- `mkdir()` takes only one parameter on Windows
- avoid invalid compiler flags `/MT` and `/MD`