### PR TITLE
Mark `-background` values as inactive in copyFromDense()

### DIFF
--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -1265,9 +1265,9 @@ LeafNode<T, Log2Dim>::copyFromDense(const CoordBBox& bbox, const DenseT& dense,
             const DenseValueType* s2 = s1 + yStride * (y - min[1]);
             Int32 n2 = n1 + ((y & (DIM-1u)) << LOG2DIM);
             for (Int32 z = bbox.min()[2], ez = bbox.max()[2]+1; z < ez; ++z, ++n2, s2 += zStride) {
-                if (math::isApproxEqual(background, ValueType(*s2), tolerance)) {
+                if (math::isApproxEqual(background, math::Abs(ValueType(*s2)), tolerance)) {
                     mValueMask.setOff(n2);
-                    mBuffer[n2] = background;
+                    mBuffer[n2] = math::Sign(ValueType(*s2)) * background;
                 } else {
                     mValueMask.setOn(n2);
                     mBuffer[n2] = ValueType(*s2);


### PR DESCRIPTION
This solves the bugs encountered in #1096. If the voxel value is the
same as the background but with a negative sign, then that voxel should
also, mark as inactive.

Signed-off-by: Ignacio Vizzo <ignaciovizzo@gmail.com>

## Problem Description

- On `openvdb::FloatGrid`, some voxel values are `-background` and thus, marked as `inactive. Which makes total sense to me.
- When copying the data to a dense array, the mask for the voxels is lost, which is also not a problem to my eyes.
- When copying back from a dense array to a `openvdb::FloatGrid`, it's checked which values are within a certain `mTolerance` close to the `background` value, and thus, marked as inactive.


To showcase my problem I made a simple `VDB` -> `np` -> `VDB` pipeline, without changing any value or anything...

## Simple Example

<details>
<summary>Python Example</summary>
  
```python
import numpy as np
import pyopenvdb as vdb


def level_set_to_numpy(grid: vdb.FloatGrid) -> np.ndarray:
    shape = grid.evalActiveVoxelDim()
    start = grid.evalActiveVoxelBoundingBox()[0]
    sdf_volume = np.zeros(shape, dtype=np.float32)
    grid.copyToArray(sdf_volume, ijk=start)
    return sdf_volume


# Input VDB, a simple sphere
vdb_grid_in = vdb.createLevelSetSphere(2.0, voxelSize=0.1)
vdb_grid_in.name = "vdb_grid in"

# Covert to dense np array
np_grid = level_set_to_numpy(vdb_grid_in)

# Covert back to a VDB grid
vdb_grid_out = vdb.FloatGrid()
vdb_grid_out.transform = vdb_grid_in.transform
vdb_grid_out.background = vdb_grid_in.background
vdb_grid_out.gridClass = vdb_grid_in.gridClass
vdb_grid_out.name = "vdb_grid out"
vdb_grid_out.copyFromArray(
    np_grid,
    ijk=vdb_grid_in.evalActiveVoxelBoundingBox()[0],
    tolerance=0.0,
)

print("Stats:")
print("Same background?", vdb_grid_in.background == vdb_grid_out.background)
print("Same min value ?", vdb_grid_in.evalMinMax()[0] == vdb_grid_out.evalMinMax()[0])
print("Same max value ?", vdb_grid_in.evalMinMax()[1] == vdb_grid_out.evalMinMax()[1])
print("max[vdb  in] = {:.30}".format(vdb_grid_in.evalMinMax()[1]))
print("max[vdb out] = {:.30}".format(vdb_grid_out.evalMinMax()[1]))
print("min[vdb  in] = {:.30}".format(vdb_grid_in.evalMinMax()[0]))
print("min[vdb out] = {:.30}".format(vdb_grid_out.evalMinMax()[0]))

vdb.write("in.vdb", vdb_grid_in)
vdb.write("out.vdb", vdb_grid_out)
```
</details>

<details>
<summary>Output</summary>

```sh
Stats:
Same background? True
Same min value ? False
Same max value ? True
max[vdb  in] = 0.2978250682353973388671875
max[vdb out] = 0.2978250682353973388671875
min[vdb  in] = -0.2970613539218902587890625
min[vdb out] = -0.300000011920928955078125
```
</details>

## Figures

### Input
![image](https://user-images.githubusercontent.com/21349875/121906150-1d12ef00-cd2b-11eb-8fb7-ee41a0f3197a.png)

### Output
![image](https://user-images.githubusercontent.com/21349875/121906187-27cd8400-cd2b-11eb-9fc2-003e83330ff4.png)

### Cross-section Input
![image](https://user-images.githubusercontent.com/21349875/121906315-49c70680-cd2b-11eb-8109-9545acd7a34e.png)

### Cross-section Output
![image](https://user-images.githubusercontent.com/21349875/121906353-53506e80-cd2b-11eb-95c2-e6b6d8577344.png)

## Analysis

While the volumes represent exactly the same geometry, due to an **unknown error to me** in the `copyFromArray` method (I suspect), some voxel values don't match the target `background` value, meaning that they won't get "pruned" and marked as inactive. In consequence, we end up with a "less sparse volume" since we need to also densely store all those values.

This is the exact same behavior I'm facing on my application, the `background value` is the exact same `32` bits representation value but there are more `active` voxels in the output grid.

Here is another comparison between the output grids, to showcase that the "copy error" gets reflected on the `min` value of the output grid...
![image](https://user-images.githubusercontent.com/21349875/121906776-bb06b980-cd2b-11eb-88ac-473dddcbb1c0.png)

## NOTE

Most of the time this doesn't present an issue, on my sphere example, if you **don't** cut the sphere to manually inspect the values that are inside, you will never notice that there are some errors.

Thanks and sorry for the long explanation!


