### PR TITLE
Deprecate string grids

### DIFF
--- a/openvdb/openvdb/openvdb.cc
+++ b/openvdb/openvdb/openvdb.cc
@@ -97,7 +97,12 @@ initialize()
     DoubleGrid::registerGrid();
     Int32Grid::registerGrid();
     Int64Grid::registerGrid();
+    // @note String grids types are deprecated but we still register them
+    //   as supported serializable types for backward compatibility. This
+    //   will likely be removed in a future major version
+OPENVDB_NO_DEPRECATION_WARNING_BEGIN
     StringGrid::registerGrid();
+OPENVDB_NO_DEPRECATION_WARNING_END
     Vec3IGrid::registerGrid();
     Vec3SGrid::registerGrid();
     Vec3DGrid::registerGrid();

--- a/openvdb/openvdb/openvdb.h
+++ b/openvdb/openvdb/openvdb.h
@@ -25,7 +25,6 @@ using FloatTree    = tree::Tree4<float,       5, 4, 3>::Type;
 using Int32Tree    = tree::Tree4<int32_t,     5, 4, 3>::Type;
 using Int64Tree    = tree::Tree4<int64_t,     5, 4, 3>::Type;
 using MaskTree     = tree::Tree4<ValueMask,   5, 4, 3>::Type;
-using StringTree   = tree::Tree4<std::string, 5, 4, 3>::Type;
 using UInt32Tree   = tree::Tree4<uint32_t,    5, 4, 3>::Type;
 using Vec2DTree    = tree::Tree4<Vec2d,       5, 4, 3>::Type;
 using Vec2ITree    = tree::Tree4<Vec2i,       5, 4, 3>::Type;
@@ -46,7 +45,6 @@ using FloatGrid    = Grid<FloatTree>;
 using Int32Grid    = Grid<Int32Tree>;
 using Int64Grid    = Grid<Int64Tree>;
 using MaskGrid     = Grid<MaskTree>;
-using StringGrid   = Grid<StringTree>;
 using Vec3DGrid    = Grid<Vec3DTree>;
 using Vec3IGrid    = Grid<Vec3ITree>;
 using Vec3SGrid    = Grid<Vec3STree>;
@@ -61,6 +59,18 @@ OPENVDB_API void initialize();
 
 /// Global deregistration of basic types
 OPENVDB_API void uninitialize();
+
+
+// Deprecated types
+/// @note  Customizing the type of a VDB tree to an arbitrary class is still
+///  supported however std::string Trees will, in the future, no longer be
+///  provided as a native type by OpenVDB.
+using StringTree OPENVDB_DEPRECATED_MESSAGE("Support for std::string Trees "
+    "as a native type will be dropped in future versions. Please feedback with any concerns.")
+    = tree::Tree4<std::string, 5, 4, 3>::Type;
+using StringGrid OPENVDB_DEPRECATED_MESSAGE("Support for std::string Grids "
+    "as a native type will be dropped in future versions. Please feedback with any concerns.")
+    = Grid<tree::Tree4<std::string, 5, 4, 3>::Type>;
 
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb

--- a/openvdb/openvdb/unittest/TestInit.cc
+++ b/openvdb/openvdb/unittest/TestInit.cc
@@ -45,7 +45,9 @@ TEST_F(TestInit, test)
     EXPECT_TRUE(DoubleGrid::isRegistered());
     EXPECT_TRUE(Int32Grid::isRegistered());
     EXPECT_TRUE(Int64Grid::isRegistered());
+OPENVDB_NO_DEPRECATION_WARNING_BEGIN
     EXPECT_TRUE(StringGrid::isRegistered());
+OPENVDB_NO_DEPRECATION_WARNING_END
     EXPECT_TRUE(Vec3IGrid::isRegistered());
     EXPECT_TRUE(Vec3SGrid::isRegistered());
     EXPECT_TRUE(Vec3DGrid::isRegistered());
@@ -76,7 +78,9 @@ TEST_F(TestInit, test)
     EXPECT_TRUE(!DoubleGrid::isRegistered());
     EXPECT_TRUE(!Int32Grid::isRegistered());
     EXPECT_TRUE(!Int64Grid::isRegistered());
+OPENVDB_NO_DEPRECATION_WARNING_BEGIN
     EXPECT_TRUE(!StringGrid::isRegistered());
+OPENVDB_NO_DEPRECATION_WARNING_END
     EXPECT_TRUE(!Vec3IGrid::isRegistered());
     EXPECT_TRUE(!Vec3SGrid::isRegistered());
     EXPECT_TRUE(!Vec3DGrid::isRegistered());

--- a/openvdb/openvdb/unittest/TestPointScatter.cc
+++ b/openvdb/openvdb/unittest/TestPointScatter.cc
@@ -81,14 +81,6 @@ TEST_F(TestPointScatter, testUniformPointScatter)
         EXPECT_EQ(total, pointCount(points->tree()));
     }
     {
-        StringGrid grid;
-        grid.sparseFill(boxBounds, "", /*active*/true);
-        auto points = points::uniformPointScatter(grid, total);
-        EXPECT_EQ(Index32(8), points->tree().leafCount());
-        EXPECT_EQ(Index64(27), points->activeVoxelCount());
-        EXPECT_EQ(total, pointCount(points->tree()));
-    }
-    {
         Vec3DGrid grid;
         grid.sparseFill(boxBounds, Vec3d(), /*active*/true);
         auto points = points::uniformPointScatter(grid, total);
@@ -309,14 +301,6 @@ TEST_F(TestPointScatter, testDenseUniformPointScatter)
     {
         MaskGrid grid;
         grid.sparseFill(boxBounds, /*maskBuffer*/true);
-        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
-        EXPECT_EQ(Index32(8), points->tree().leafCount());
-        EXPECT_EQ(Index64(27), points->activeVoxelCount());
-        EXPECT_EQ(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
-    }
-    {
-        StringGrid grid;
-        grid.sparseFill(boxBounds, "", /*active*/true);
         auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
         EXPECT_EQ(Index32(8), points->tree().leafCount());
         EXPECT_EQ(Index64(27), points->activeVoxelCount());

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -552,44 +552,6 @@ evalMinMaxTest<openvdb::BoolTree>()
     EXPECT_EQ(true, maxVal);
 }
 
-/// Specialization for string trees
-template<>
-void
-evalMinMaxTest<openvdb::StringTree>()
-{
-    const std::string
-        echidna("echidna"), loris("loris"), pangolin("pangolin");
-
-    openvdb::StringTree tree(/*background=*/loris);
-
-    // No set voxels (defaults to min = max = zero)
-    std::string minVal, maxVal;
-    tree.evalMinMax(minVal, maxVal);
-    EXPECT_EQ(std::string(), minVal);
-    EXPECT_EQ(std::string(), maxVal);
-
-    // Only one set voxel
-    tree.setValue(openvdb::Coord(0, 0, 0), pangolin);
-    minVal.clear(); maxVal.clear();
-    tree.evalMinMax(minVal, maxVal);
-    EXPECT_EQ(pangolin, minVal);
-    EXPECT_EQ(pangolin, maxVal);
-
-    // Multiple set voxels, single value
-    tree.setValue(openvdb::Coord(-10, -10, -10), pangolin);
-    minVal.clear(); maxVal.clear();
-    tree.evalMinMax(minVal, maxVal);
-    EXPECT_EQ(pangolin, minVal);
-    EXPECT_EQ(pangolin, maxVal);
-
-    // Multiple set voxels, multiple values
-    tree.setValue(openvdb::Coord(10, 10, 10), echidna);
-    minVal.clear(); maxVal.clear();
-    tree.evalMinMax(minVal, maxVal);
-    EXPECT_EQ(echidna, minVal);
-    EXPECT_EQ(pangolin, maxVal);
-}
-
 /// Specialization for Coord trees
 template<>
 void
@@ -632,7 +594,6 @@ TEST_F(TestTree, testEvalMinMax)
     evalMinMaxTest<openvdb::Int32Tree>();
     evalMinMaxTest<openvdb::Vec3STree>();
     evalMinMaxTest<openvdb::Vec2ITree>();
-    evalMinMaxTest<openvdb::StringTree>();
     evalMinMaxTest<openvdb::Coord>();
 }
 

--- a/openvdb/openvdb/unittest/TestTreeIterators.cc
+++ b/openvdb/openvdb/unittest/TestTreeIterators.cc
@@ -435,6 +435,8 @@ TEST_F(TestTreeIterators, testModifyValue)
         //tree.cbeginValueOn().modifyValue(Local::negate);
     }
     {
+        // @note  StringTree types as native types are deprecated, but we can
+        //   still test tool functionality with them
         typedef openvdb::tree::Tree4<std::string, DIM2, DIM1, DIM0>::Type StringTree323f;
 
         StringTree323f tree(/*background=*/"");

--- a/openvdb_ax/openvdb_ax/test/compiler/TestVolumeExecutable.cc
+++ b/openvdb_ax/openvdb_ax/test/compiler/TestVolumeExecutable.cc
@@ -575,6 +575,7 @@ TestVolumeExecutable::testActiveTileStreaming()
 
     // test spatially varying voxelization for string grids which use specialized implementations
     {
+OPENVDB_NO_DEPRECATION_WARNING_BEGIN
         openvdb::StringGrid grid;
         grid.setName("test");
         openvdb::StringTree& tree = grid.tree();
@@ -625,6 +626,7 @@ TestVolumeExecutable::testActiveTileStreaming()
             if (coord.x() == 0) CPPUNIT_ASSERT_EQUAL(*it, std::string("bar"));
             else                CPPUNIT_ASSERT_EQUAL(*it, std::string("foo"));
         });
+OPENVDB_NO_DEPRECATION_WARNING_END
     }
 
     // test streaming with an OFF iterator (no streaming behaviour) and an ALL iterator (streaming behaviour for ON values only)

--- a/pendingchanges/deprecate_string_grids.txt
+++ b/pendingchanges/deprecate_string_grids.txt
@@ -1,0 +1,2 @@
+Deprecations:
+  - StringGrid and StringTrees are deprecated.


### PR DESCRIPTION
Based on the conversation here https://github.com/AcademySoftwareFoundation/openvdb/blob/master/tsc/meetings/2021-04-20.md, deprecate `StringTree` and `StringGrid` aliases. They current cause segmentation faults on read so the aim would be to eventually deprecate them as natively supported serializable types but continue to support the their template instantiation for intermediate storage. 