### PR TITLE
Add -DUSE_PKGCONFIG=OFF when building on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,6 @@ git clone git@github.com:AcademySoftwareFoundation/openvdb.git
 cd openvdb
 mkdir build
 cd build
-cmake -DCMAKE_TOOLCHAIN_FILE=<PATH_TO_VCPKG>\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -A x64 ..
+cmake -DCMAKE_TOOLCHAIN_FILE=<PATH_TO_VCPKG>\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DUSE_PKGCONFIG=OFF -A x64 ..
 cmake --build . --parallel 4 --config Release --target install
 ```


### PR DESCRIPTION
When using vcpkg, pkg-config is not needed.
(The instruction as they are currently do not build on a fresh Windows since there is no pkg-config)