### PR TITLE
Updating CI for CY2022 Reference Platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cxx: clang++, image: '2019', abi: '6', build: 'Release' }
           - { cxx: clang++, image: '2020', abi: '7', build: 'Release' }
           - { cxx: clang++, image: '2021', abi: '8', build: 'Release' }
           - { cxx: clang++, image: '2021', abi: '9', build: 'Release' }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         config:
           - { cxx: clang++, image: '2020', abi: '7', build: 'Release' }
           - { cxx: clang++, image: '2021', abi: '8', build: 'Release' }
-          - { cxx: clang++, image: '2021', abi: '9', build: 'Release' }
+          - { cxx: clang++, image: '2022-clang10', abi: '9', build: 'Release' }
           - { cxx: clang++, image: '2021', abi: '8', build: 'Debug'   }
           - { cxx: g++,     image: '2020', abi: '7', build: 'Release' }
           - { cxx: g++,     image: '2021', abi: '8', build: 'Release' }

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -35,17 +35,12 @@ jobs:
     strategy:
       matrix:
         config:
-          # build against VFX Ref 2018 even though it's unsupported, just to make sure that we test Boost 1.61
-          - { cxx: clang++, image: '2018', hou: '18_0', build: 'Release', extras: 'ON', disable_checks: 'ON' }
-          - { cxx: clang++, image: '2019', hou: '18_0', build: 'Release', extras: 'ON', disable_checks: 'OFF' }
           - { cxx: clang++, image: '2020', hou: '18_5', build: 'Release', extras: 'ON', disable_checks: 'OFF' }
           - { cxx: clang++, image: '2020', hou: '18_5', build: 'Debug',   extras: 'OFF', disable_checks: 'OFF' }
           - { cxx: g++,     image: '2020', hou: '18_5', build: 'Release', extras: 'OFF', disable_checks: 'OFF' }
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
-    - name: install_cmake
-      run: ./ci/install_cmake.sh 3.12.0
     - name: install_gtest
       run: ./ci/install_gtest.sh 1.10.0
     - name: fetch_houdini

--- a/.github/workflows/houdini_cache_update.yml
+++ b/.github/workflows/houdini_cache_update.yml
@@ -34,27 +34,3 @@ jobs:
       with:
         path: hou
         key: vdb1-houdini18_5-${{ hashFiles('hou/hou.tar.gz') }}
-
-  houdini18_0:
-    runs-on: ubuntu-latest
-    env:
-      CXX: clang++
-    container:
-      image: aswf/ci-base:2019
-    steps:
-    - uses: actions/checkout@v2
-    - name: download_houdini
-      run: ./ci/download_houdini.sh 18.0 ON ON ${{ secrets.HOUDINI_CLIENT_ID }} ${{ secrets.HOUDINI_SECRET_KEY }}
-    - name: install_houdini
-      run: ./ci/install_houdini.sh
-    - name: install_gtest
-      run: ./ci/install_gtest.sh 1.10.0
-    - name: build
-      run: ./ci/build_houdini.sh Release ON
-    - name: test
-      run: ./ci/test.sh
-    - name: write_houdini_cache
-      uses: actions/cache@v2
-      with:
-        path: hou
-        key: vdb1-houdini18_0-${{ hashFiles('hou/hou.tar.gz') }}


### PR DESCRIPTION
This also officially drops CI support for Houdini 18.0.