### PR TITLE
Fix bug with VDB LOD SOP Chaining

### DIFF
--- a/pendingchanges/vdblod_metadata.txt
+++ b/pendingchanges/vdblod_metadata.txt
@@ -1,0 +1,2 @@
+Houdini:
+    * Fix bug to allow VDB LOD SOPs to be chained together.


### PR DESCRIPTION
The VDB LOD SOP can output grids with either int64 or float metadata with the same name ("MultiResGrid_Level") depending on the mode used. This fix is to address an issue reported in production where it's not possible to chain two VDB LOD SOPs with different modes. You can replicate by using one VDB LOD SOP with mode == "single level" and another connected to it with mode == "LOD Pyramid" or vice-versa.

In this case, it now checks whether the metadata already exists on the input grid and is of an incompatible type and then drops that metadata before calling the MultiResGrid code.

Note that I only fixed for ABI>=7 because we're soon to remove support for older ABIs / Houdini versions anyway.