### PR TITLE
Add option to disable symbol export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ option(OPENVDB_FUTURE_DEPRECATION "Generate messages for upcoming deprecation" O
 option(OPENVDB_ENABLE_UNINSTALL "Adds a CMake uninstall target." ON)
 option(USE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." OFF)
 option(USE_PKGCONFIG "Use pkg-config to search for dependent libraries." ON)
+option(OPENVDB_NO_SYMBOL_EXPORT "Disable symbol visibility for OPENVDB_API functions" OFF)
 
 set(SYSTEM_LIBRARY_PATHS "" CACHE STRING [=[
 A global list of library paths to additionally use into when searching for dependencies.]=])
@@ -206,6 +207,7 @@ mark_as_advanced(
   USE_COLORED_OUTPUT
   SYSTEM_LIBRARY_PATHS
   OPENVDB_SIMD
+  OPENVDB_NO_SYMBOL_EXPORT
 )
 
 # Configure minimum version requirements - some are treated specially and fall
@@ -623,6 +625,13 @@ if(OPENVDB_SIMD STREQUAL "AVX")
 elseif(OPENVDB_SIMD STREQUAL "SSE42")
   add_compile_options(-msse4.2)
   add_definitions(-DOPENVDB_USE_SSE42)
+endif()
+
+if(OPENVDB_NO_SYMBOL_EXPORT)
+  if( (NOT DEFINED OPENVDB_CORE_SHARED) OR (OPENVDB_CORE_SHARED) )
+    message(FATAL_ERROR "Only use OPENVDB_NO_SYMBOL_EXPORT when OPENVDB_CORE_SHARED is disabled.")
+  endif()
+  add_definitions(-DOPENVDB_NO_SYMBOL_EXPORT)
 endif()
 
 #########################################################################

--- a/openvdb/openvdb/Platform.h
+++ b/openvdb/openvdb/Platform.h
@@ -214,18 +214,23 @@
 #ifdef OPENVDB_IMPORT
 #undef OPENVDB_IMPORT
 #endif
-#ifdef __GNUC__
-    #define OPENVDB_EXPORT __attribute__((visibility("default")))
-    #define OPENVDB_IMPORT __attribute__((visibility("default")))
-#endif
-#ifdef _WIN32
-    #ifdef OPENVDB_DLL
-        #define OPENVDB_EXPORT __declspec(dllexport)
-        #define OPENVDB_IMPORT __declspec(dllimport)
-    #else
-        #define OPENVDB_EXPORT
-        #define OPENVDB_IMPORT
+#ifndef OPENVDB_NO_SYMBOL_EXPORT
+    #ifdef __GNUC__
+        #define OPENVDB_EXPORT __attribute__((visibility("default")))
+        #define OPENVDB_IMPORT __attribute__((visibility("default")))
     #endif
+    #ifdef _WIN32
+        #ifdef OPENVDB_DLL
+            #define OPENVDB_EXPORT __declspec(dllexport)
+            #define OPENVDB_IMPORT __declspec(dllimport)
+        #else
+            #define OPENVDB_EXPORT
+            #define OPENVDB_IMPORT
+        #endif
+    #endif
+#else
+    #define OPENVDB_EXPORT
+    #define OPENVDB_IMPORT
 #endif
 
 /// All classes and public free standing functions must be explicitly marked


### PR DESCRIPTION
By default non-windows builds of openvdb export all
symbols marked with OPENVDB_API in the code.
This is almost always the correct approach; however when
distributing a shared library that uses openvdb in a
context where users of that library might also use different
versions of openvdb (including in development versions with
the same ABI) it can cause symbol collisions in the process.

This changes adds a CMake option and compiler define
OPENVDB_NO_SYMBOL_EXPORT, which removes the "default" visibility
for OPENVDB_API symbols.

In effect this imitates the windows static symbol export behavior
for non-windows static builds.

This only makes sense when building openvdb
 - as a static library (a shared library built with this flag
 would be unusable)
 - with symbols hidden (without this the symbols would have
 "default" visibility anyway)

Signed-off-by: Tristan Barback <tristan.barback@autodesk.com>