### PR TITLE
Explicit Instantiation Unit Test

### DIFF
--- a/openvdb/openvdb/math/Mat.h
+++ b/openvdb/openvdb/math/Mat.h
@@ -278,8 +278,8 @@ rotation(const Vec3<typename MatType::value_type> &_axis, typename MatType::valu
     Vec3<T> axis(_axis.unit());
 
     // compute trig properties of angle:
-    T c(cos(double(angle)));
-    T s(sin(double(angle)));
+    T c(static_cast<T>(cos(double(angle))));
+    T s(static_cast<T>(sin(double(angle))));
     T t(1 - c);
 
     MatType result;
@@ -593,9 +593,9 @@ rotation(
                 result[i][j] = static_cast<T>(
                     a * u[i] * u[j] + b * v[i] * v[j] + c * v[j] * u[i]);
         }
-        result[0][0] += 1.0;
-        result[1][1] += 1.0;
-        result[2][2] += 1.0;
+        result[0][0] = static_cast<T>(result[0][0] + 1.0);
+        result[1][1] = static_cast<T>(result[1][1] + 1.0);
+        result[2][2] = static_cast<T>(result[2][2] + 1.0);
 
         if(MatType::numColumns() == 4) padMat4(result);
         return result;

--- a/openvdb/openvdb/math/Mat3.h
+++ b/openvdb/openvdb/math/Mat3.h
@@ -259,7 +259,7 @@ public:
 
     /// Set the matrix as cross product of the given vector
     void setSkew(const Vec3<T> &v)
-    {*this = skew(v);}
+    {*this = skew<Mat3>(v);}
 
     /// @brief Set this matrix to the rotation matrix specified by the quaternion
     /// @details The quaternion is normalized and used to construct the matrix.

--- a/openvdb/openvdb/math/Mat4.h
+++ b/openvdb/openvdb/math/Mat4.h
@@ -557,7 +557,7 @@ public:
 
         } else {
             invertible = true;
-            detA = 1.0 / detA;
+            detA = static_cast<T>(1.0 / detA);
 
             //
             // Calculate A^-1
@@ -599,7 +599,7 @@ public:
                     invertible = false;
 
                 } else {
-                    h = 1.0 / h;
+                    h = static_cast<T>(1.0 / h);
 
                     //
                     // Calculate h, g, and f
@@ -1282,8 +1282,8 @@ bool Mat4<T>::invert(Mat4<T> &inverse, T tolerance) const
 
         // scale row i
         for (int k = 0; k < 4; ++k) {
-            temp[i][k] /= pivot;
-            inverse[i][k] /= pivot;
+            temp[i][k] = static_cast<T>(temp[i][k] / pivot);
+            inverse[i][k] = static_cast<T>(inverse[i][k] / pivot);
         }
 
         // eliminate in rows below i
@@ -1292,8 +1292,8 @@ bool Mat4<T>::invert(Mat4<T> &inverse, T tolerance) const
             if (!isExactlyEqual(t, 0.0)) {
                 // subtract scaled row i from row j
                 for (int k = 0; k < 4; ++k) {
-                    temp[j][k] -= temp[i][k] * t;
-                    inverse[j][k] -= inverse[i][k] * t;
+                    temp[j][k] -= static_cast<T>(temp[i][k] * t);
+                    inverse[j][k] -= static_cast<T>(inverse[i][k] * t);
                 }
             }
         }
@@ -1306,7 +1306,7 @@ bool Mat4<T>::invert(Mat4<T> &inverse, T tolerance) const
 
             if (!isExactlyEqual(t, 0.0)) {
                 for (int k = 0; k < 4; ++k) {
-                    inverse[j][k] -= inverse[i][k]*t;
+                    inverse[j][k] -= static_cast<T>(inverse[i][k]*t);
                 }
             }
         }

--- a/openvdb/openvdb/math/Quat.h
+++ b/openvdb/openvdb/math/Quat.h
@@ -565,8 +565,8 @@ public:
 
     friend Quat slerp<>(const Quat &q1, const Quat &q2, T t, T tolerance);
 
-    void write(std::ostream& os) const { os.write(static_cast<char*>(&mm), sizeof(T) * 4); }
-    void read(std::istream& is) { is.read(static_cast<char*>(&mm), sizeof(T) * 4); }
+    void write(std::ostream& os) const { os.write(reinterpret_cast<const char*>(&mm), sizeof(T) * 4); }
+    void read(std::istream& is) { is.read(reinterpret_cast<char*>(&mm), sizeof(T) * 4); }
 
 protected:
     T mm[4];

--- a/openvdb/openvdb/math/Quat.h
+++ b/openvdb/openvdb/math/Quat.h
@@ -500,7 +500,7 @@ public:
     /// this = normalized this
     Quat unit() const
     {
-        T d = sqrt(mm[0]*mm[0] + mm[1]*mm[1] + mm[2]*mm[2] + mm[3]*mm[3]);
+        T d = static_cast<T>(sqrt(mm[0]*mm[0] + mm[1]*mm[1] + mm[2]*mm[2] + mm[3]*mm[3]));
         if( isExactlyEqual(d , T(0.0) ) )
             OPENVDB_THROW(ArithmeticError,
                 "Normalizing degenerate quaternion");

--- a/openvdb/openvdb/math/Vec2.h
+++ b/openvdb/openvdb/math/Vec2.h
@@ -250,7 +250,8 @@ public:
     Vec2<T> unitSafe() const
     {
         T l2 = lengthSqr();
-        return l2 ? *this/static_cast<T>(sqrt(l2)) : Vec2<T>(1,0);
+        const bool nonZero = (l2 != zeroVal<T>());
+        return nonZero ? *this/static_cast<T>(sqrt(l2)) : Vec2<T>(1,0);
     }
 
     /// Multiply each element of this vector by @a scalar.

--- a/openvdb/openvdb/math/Vec3.h
+++ b/openvdb/openvdb/math/Vec3.h
@@ -395,7 +395,8 @@ public:
     Vec3<T> unitSafe() const
     {
         T l2 = lengthSqr();
-        return l2 ? *this / static_cast<T>(sqrt(l2)) : Vec3<T>(1, 0 ,0);
+        const bool nonZero = (l2 != zeroVal<T>());
+        return nonZero ? *this / static_cast<T>(sqrt(l2)) : Vec3<T>(1, 0 ,0);
     }
 
     // Number of cols, rows, elements

--- a/openvdb/openvdb/math/Vec4.h
+++ b/openvdb/openvdb/math/Vec4.h
@@ -293,7 +293,8 @@ public:
     Vec4<T> unitSafe() const
     {
         T l2 = lengthSqr();
-        return l2 ? *this / static_cast<T>(sqrt(l2)) : Vec4<T>(1, 0, 0, 0);
+        const bool nonZero = (l2 != zeroVal<T>());
+        return nonZero ? *this / static_cast<T>(sqrt(l2)) : Vec4<T>(1, 0, 0, 0);
     }
 
     /// Multiply each element of this vector by @a scalar.

--- a/openvdb/openvdb/points/PointDataGrid.h
+++ b/openvdb/openvdb/points/PointDataGrid.h
@@ -625,27 +625,27 @@ public:
 
     using ValueOnIter = typename BaseLeaf::template ValueIter<
         MaskOnIterator, PointDataLeafNode, const ValueType, ValueOn>;
-    using ValueOnCIter = typename BaseLeaf::template ValueIter<
+    using ValueOnCIter = typename BaseLeaf::template ConstValueIter<
         MaskOnIterator, const PointDataLeafNode, const ValueType, ValueOn>;
     using ValueOffIter = typename BaseLeaf::template ValueIter<
         MaskOffIterator, PointDataLeafNode, const ValueType, ValueOff>;
-    using ValueOffCIter = typename BaseLeaf::template ValueIter<
+    using ValueOffCIter = typename BaseLeaf::template ConstValueIter<
         MaskOffIterator,const PointDataLeafNode,const ValueType,ValueOff>;
     using ValueAllIter = typename BaseLeaf::template ValueIter<
         MaskDenseIterator, PointDataLeafNode, const ValueType, ValueAll>;
-    using ValueAllCIter = typename BaseLeaf::template ValueIter<
+    using ValueAllCIter = typename BaseLeaf::template ConstValueIter<
         MaskDenseIterator,const PointDataLeafNode,const ValueType,ValueAll>;
     using ChildOnIter = typename BaseLeaf::template ChildIter<
         MaskOnIterator, PointDataLeafNode, ChildOn>;
-    using ChildOnCIter = typename BaseLeaf::template ChildIter<
+    using ChildOnCIter = typename BaseLeaf::template ConstChildIter<
         MaskOnIterator, const PointDataLeafNode, ChildOn>;
     using ChildOffIter = typename BaseLeaf::template ChildIter<
         MaskOffIterator, PointDataLeafNode, ChildOff>;
-    using ChildOffCIter = typename BaseLeaf::template ChildIter<
+    using ChildOffCIter = typename BaseLeaf::template ConstChildIter<
         MaskOffIterator, const PointDataLeafNode, ChildOff>;
     using ChildAllIter = typename BaseLeaf::template DenseIter<
         PointDataLeafNode, ValueType, ChildAll>;
-    using ChildAllCIter = typename BaseLeaf::template DenseIter<
+    using ChildAllCIter = typename BaseLeaf::template ConstDenseIter<
         const PointDataLeafNode, const ValueType, ChildAll>;
 
     using IndexVoxelIter    = IndexIter<ValueVoxelCIter, NullFilter>;

--- a/openvdb/openvdb/tools/PointIndexGrid.h
+++ b/openvdb/openvdb/tools/PointIndexGrid.h
@@ -1583,27 +1583,27 @@ protected:
 public:
     using ValueOnIter = typename BaseLeaf::template ValueIter<
         MaskOnIterator, PointIndexLeafNode, const ValueType, ValueOn>;
-    using ValueOnCIter = typename BaseLeaf::template ValueIter<
+    using ValueOnCIter = typename BaseLeaf::template ConstValueIter<
         MaskOnIterator, const PointIndexLeafNode, const ValueType, ValueOn>;
     using ValueOffIter = typename BaseLeaf::template ValueIter<
         MaskOffIterator, PointIndexLeafNode, const ValueType, ValueOff>;
-    using ValueOffCIter = typename BaseLeaf::template ValueIter<
+    using ValueOffCIter = typename BaseLeaf::template ConstValueIter<
         MaskOffIterator,const PointIndexLeafNode,const ValueType, ValueOff>;
     using ValueAllIter = typename BaseLeaf::template ValueIter<
         MaskDenseIterator, PointIndexLeafNode, const ValueType, ValueAll>;
-    using ValueAllCIter = typename BaseLeaf::template ValueIter<
+    using ValueAllCIter = typename BaseLeaf::template ConstValueIter<
         MaskDenseIterator,const PointIndexLeafNode,const ValueType, ValueAll>;
     using ChildOnIter = typename BaseLeaf::template ChildIter<
         MaskOnIterator, PointIndexLeafNode, ChildOn>;
-    using ChildOnCIter = typename BaseLeaf::template ChildIter<
+    using ChildOnCIter = typename BaseLeaf::template ConstChildIter<
         MaskOnIterator, const PointIndexLeafNode, ChildOn>;
     using ChildOffIter = typename BaseLeaf::template ChildIter<
         MaskOffIterator, PointIndexLeafNode, ChildOff>;
-    using ChildOffCIter = typename BaseLeaf::template ChildIter<
+    using ChildOffCIter = typename BaseLeaf::template ConstChildIter<
         MaskOffIterator, const PointIndexLeafNode, ChildOff>;
     using ChildAllIter = typename BaseLeaf::template DenseIter<
         PointIndexLeafNode, ValueType, ChildAll>;
-    using ChildAllCIter = typename BaseLeaf::template DenseIter<
+    using ChildAllCIter = typename BaseLeaf::template ConstDenseIter<
         const PointIndexLeafNode, const ValueType, ChildAll>;
 
 #define VMASK_ this->getValueMask()

--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -137,11 +137,25 @@ protected:
             return *(this->parent().getChildNode(pos));
         }
 
-        // Note: setItem() can't be called on const iterators.
-        void setItem(Index pos, const ChildT& c) const { this->parent().resetChildNode(pos, &c); }
+        void setItem(Index pos, ChildT& c) const { this->parent().resetChildNode(pos, &c); }
 
-        // Note: modifyItem() isn't implemented, since it's not useful for child node pointers.
+       // Note: modifyItem() isn't implemented, since it's not useful for child node pointers.
     };// ChildIter
+
+    template<typename NodeT, typename ChildT, typename MaskIterT, typename TagT>
+    struct ConstChildIter: public SparseIteratorBase<
+        MaskIterT, ConstChildIter<NodeT, ChildT, MaskIterT, TagT>, NodeT, ChildT>
+    {
+        ConstChildIter() {}
+        ConstChildIter(const MaskIterT& iter, NodeT* parent): SparseIteratorBase<
+            MaskIterT, ConstChildIter<NodeT, ChildT, MaskIterT, TagT>, NodeT, ChildT>(iter, parent) {}
+
+        ChildT& getItem(Index pos) const
+        {
+            assert(this->parent().isChildMaskOn(pos));
+            return *(this->parent().getChildNode(pos));
+        }
+    };// ConstChildIter
 
     // Sparse iterator that visits tile values of an InternalNode
     template<typename NodeT, typename ValueT, typename MaskIterT, typename TagT>
@@ -152,18 +166,27 @@ protected:
         ValueIter(const MaskIterT& iter, NodeT* parent): SparseIteratorBase<
             MaskIterT, ValueIter<NodeT, ValueT, MaskIterT, TagT>, NodeT, ValueT>(iter, parent) {}
 
-        const ValueT& getItem(Index pos) const { return this->parent().mNodes[pos].getValue(); }
+        ValueT& getItem(Index pos) const { return this->parent().mNodes[pos].getValue(); }
 
-        // Note: setItem() can't be called on const iterators.
         void setItem(Index pos, const ValueT& v) const { this->parent().mNodes[pos].setValue(v); }
 
-        // Note: modifyItem() can't be called on const iterators.
         template<typename ModifyOp>
         void modifyItem(Index pos, const ModifyOp& op) const
         {
             op(this->parent().mNodes[pos].getValue());
         }
     };// ValueIter
+
+    template<typename NodeT, typename ValueT, typename MaskIterT, typename TagT>
+    struct ConstValueIter: public SparseIteratorBase<
+        MaskIterT, ConstValueIter<NodeT, ValueT, MaskIterT, TagT>, NodeT, ValueT>
+    {
+        ConstValueIter() {}
+        ConstValueIter(const MaskIterT& iter, NodeT* parent): SparseIteratorBase<
+            MaskIterT, ConstValueIter<NodeT, ValueT, MaskIterT, TagT>, NodeT, ValueT>(iter, parent) {}
+
+        ValueT& getItem(Index pos) const { return this->parent().mNodes[pos].getValue(); }
+    };// ConstValueIter
 
     // Dense iterator that visits both tiles and child nodes of an InternalNode
     template<typename NodeT, typename ChildT, typename ValueT, typename TagT>
@@ -201,21 +224,44 @@ protected:
         }
     };// DenseIter
 
+    template<typename NodeT, typename ChildT, typename ValueT, typename TagT>
+    struct ConstDenseIter: public DenseIteratorBase<
+        MaskDenseIterator, ConstDenseIter<NodeT, ChildT, ValueT, TagT>, NodeT, ChildT, ValueT>
+    {
+        using BaseT = DenseIteratorBase<MaskDenseIterator, ConstDenseIter, NodeT, ChildT, ValueT>;
+        using NonConstValueT = typename BaseT::NonConstValueType;
+
+        ConstDenseIter() {}
+        ConstDenseIter(const MaskDenseIterator& iter, NodeT* parent):
+            DenseIteratorBase<MaskDenseIterator, ConstDenseIter, NodeT, ChildT, ValueT>(iter, parent) {}
+
+        bool getItem(Index pos, ChildT*& child, ValueT& value) const
+        {
+            if (this->parent().isChildMaskOn(pos)) {
+                child = this->parent().getChildNode(pos);
+                return true;
+            }
+            child = nullptr;
+            value = this->parent().mNodes[pos].getValue();
+            return false;
+        }
+    };// ConstDenseIter
+
 public:
     // Iterators (see Iterator.h for usage)
     using ChildOnIter = ChildIter<InternalNode, ChildNodeType, MaskOnIterator, ChildOn>;
-    using ChildOnCIter = ChildIter<const InternalNode,const ChildNodeType,MaskOnIterator,ChildOn>;
+    using ChildOnCIter = ConstChildIter<const InternalNode,const ChildNodeType,MaskOnIterator,ChildOn>;
     using ChildOffIter = ValueIter<InternalNode, const ValueType, MaskOffIterator, ChildOff>;
-    using ChildOffCIter = ValueIter<const InternalNode,const ValueType,MaskOffIterator,ChildOff>;
+    using ChildOffCIter = ConstValueIter<const InternalNode,const ValueType,MaskOffIterator,ChildOff>;
     using ChildAllIter = DenseIter<InternalNode, ChildNodeType, ValueType, ChildAll>;
-    using ChildAllCIter = DenseIter<const InternalNode,const ChildNodeType, ValueType, ChildAll>;
+    using ChildAllCIter = ConstDenseIter<const InternalNode,const ChildNodeType, ValueType, ChildAll>;
 
     using ValueOnIter = ValueIter<InternalNode, const ValueType, MaskOnIterator, ValueOn>;
-    using ValueOnCIter = ValueIter<const InternalNode, const ValueType, MaskOnIterator, ValueOn>;
+    using ValueOnCIter = ConstValueIter<const InternalNode, const ValueType, MaskOnIterator, ValueOn>;
     using ValueOffIter = ValueIter<InternalNode, const ValueType, MaskOffIterator, ValueOff>;
-    using ValueOffCIter = ValueIter<const InternalNode,const ValueType,MaskOffIterator,ValueOff>;
+    using ValueOffCIter = ConstValueIter<const InternalNode,const ValueType,MaskOffIterator,ValueOff>;
     using ValueAllIter = ValueIter<InternalNode, const ValueType, MaskOffIterator, ValueAll>;
-    using ValueAllCIter = ValueIter<const InternalNode,const ValueType,MaskOffIterator,ValueAll>;
+    using ValueAllCIter = ConstValueIter<const InternalNode,const ValueType,MaskOffIterator,ValueAll>;
 
     ChildOnCIter  cbeginChildOn()  const { return ChildOnCIter(mChildMask.beginOn(), this); }
     ChildOffCIter cbeginChildOff() const { return ChildOffCIter(mChildMask.beginOff(), this); }

--- a/openvdb/openvdb/tree/LeafBuffer.h
+++ b/openvdb/openvdb/tree/LeafBuffer.h
@@ -449,6 +449,19 @@ private:
 template<Index Log2Dim> const bool LeafBuffer<bool, Log2Dim>::sOn = true;
 template<Index Log2Dim> const bool LeafBuffer<bool, Log2Dim>::sOff = false;
 
+
+////////////////////////////////////////
+
+
+template<typename T, Index Log2Dim>
+inline std::ostream&
+operator<<(std::ostream& os, const LeafBuffer<T, Log2Dim>& buf)
+{
+    for (Index32 i = 0, N = buf.size(); i < N; ++i) os << buf.data()[i] << ", ";
+    return os;
+}
+
+
 } // namespace tree
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -1994,14 +1994,6 @@ LeafNode<T, Log2Dim>::doVisit2(NodeT& self, OtherChildAllIterT& otherIter,
 ////////////////////////////////////////
 
 
-template<typename T, Index Log2Dim>
-inline std::ostream&
-operator<<(std::ostream& os, const typename LeafNode<T, Log2Dim>::Buffer& buf)
-{
-    for (Index32 i = 0, N = buf.size(); i < N; ++i) os << buf.mData[i] << ", ";
-    return os;
-}
-
 } // namespace tree
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -215,26 +215,38 @@ protected:
         ValueIter() {}
         ValueIter(const MaskIterT& iter, NodeT* parent): BaseT(iter, parent) {}
 
-        ValueT& getItem(Index pos) const { return this->parent().getValue(pos); }
-        ValueT& getValue() const { return this->parent().getValue(this->pos()); }
+        const ValueT& getItem(Index pos) const { return this->parent().getValue(pos); }
+        const ValueT& getValue() const { return this->parent().getValue(this->pos()); }
 
-        // Note: setItem() can't be called on const iterators.
         void setItem(Index pos, const ValueT& value) const
         {
             this->parent().setValueOnly(pos, value);
         }
-        // Note: setValue() can't be called on const iterators.
         void setValue(const ValueT& value) const
         {
             this->parent().setValueOnly(this->pos(), value);
         }
 
-        // Note: modifyItem() can't be called on const iterators.
         template<typename ModifyOp>
         void modifyItem(Index n, const ModifyOp& op) const { this->parent().modifyValue(n, op); }
-        // Note: modifyValue() can't be called on const iterators.
         template<typename ModifyOp>
         void modifyValue(const ModifyOp& op) const { this->parent().modifyValue(this->pos(), op); }
+    };
+
+    template<typename MaskIterT, typename NodeT, typename ValueT, typename TagT>
+    struct ConstValueIter:
+        // Derives from SparseIteratorBase, but can also be used as a dense iterator,
+        // if MaskIterT is a dense mask iterator type.
+        public SparseIteratorBase<
+            MaskIterT, ConstValueIter<MaskIterT, NodeT, ValueT, TagT>, NodeT, ValueT>
+    {
+        using BaseT = SparseIteratorBase<MaskIterT, ConstValueIter, NodeT, ValueT>;
+
+        ConstValueIter() {}
+        ConstValueIter(const MaskIterT& iter, NodeT* parent): BaseT(iter, parent) {}
+
+        ValueT& getItem(Index pos) const { return this->parent().getValue(pos); }
+        ValueT& getValue() const { return this->parent().getValue(this->pos()); }
     };
 
     /// Leaf nodes have no children, so their child iterators have no get/set accessors.
@@ -245,6 +257,15 @@ protected:
         ChildIter() {}
         ChildIter(const MaskIterT& iter, NodeT* parent): SparseIteratorBase<
             MaskIterT, ChildIter<MaskIterT, NodeT, TagT>, NodeT, ValueType>(iter, parent) {}
+    };
+
+    template<typename MaskIterT, typename NodeT, typename TagT>
+    struct ConstChildIter:
+        public SparseIteratorBase<MaskIterT, ConstChildIter<MaskIterT, NodeT, TagT>, NodeT, ValueType>
+    {
+        ConstChildIter() {}
+        ConstChildIter(const MaskIterT& iter, NodeT* parent): SparseIteratorBase<
+            MaskIterT, ConstChildIter<MaskIterT, NodeT, TagT>, NodeT, ValueType>(iter, parent) {}
     };
 
     template<typename NodeT, typename ValueT, typename TagT>
@@ -264,29 +285,43 @@ protected:
             return false; // no child
         }
 
-        // Note: setItem() can't be called on const iterators.
-        //void setItem(Index pos, void* child) const {}
-
-        // Note: unsetItem() can't be called on const iterators.
         void unsetItem(Index pos, const ValueT& value) const
         {
             this->parent().setValueOnly(pos, value);
         }
     };
 
+    template<typename NodeT, typename ValueT, typename TagT>
+    struct ConstDenseIter: public DenseIteratorBase<
+        MaskDenseIterator, ConstDenseIter<NodeT, ValueT, TagT>, NodeT, /*ChildT=*/void, ValueT>
+    {
+        using BaseT = DenseIteratorBase<MaskDenseIterator, ConstDenseIter, NodeT, void, ValueT>;
+        using NonConstValueT = typename BaseT::NonConstValueType;
+
+        ConstDenseIter() {}
+        ConstDenseIter(const MaskDenseIterator& iter, NodeT* parent): BaseT(iter, parent) {}
+
+        bool getItem(Index pos, void*& child, NonConstValueT& value) const
+        {
+            value = this->parent().getValue(pos);
+            child = nullptr;
+            return false; // no child
+        }
+    };
+
 public:
     using ValueOnIter = ValueIter<MaskOnIterator, LeafNode, const ValueType, ValueOn>;
-    using ValueOnCIter = ValueIter<MaskOnIterator, const LeafNode, const ValueType, ValueOn>;
+    using ValueOnCIter = ConstValueIter<MaskOnIterator, const LeafNode, const ValueType, ValueOn>;
     using ValueOffIter = ValueIter<MaskOffIterator, LeafNode, const ValueType, ValueOff>;
-    using ValueOffCIter = ValueIter<MaskOffIterator,const LeafNode,const ValueType,ValueOff>;
+    using ValueOffCIter = ConstValueIter<MaskOffIterator,const LeafNode,const ValueType,ValueOff>;
     using ValueAllIter = ValueIter<MaskDenseIterator, LeafNode, const ValueType, ValueAll>;
-    using ValueAllCIter = ValueIter<MaskDenseIterator,const LeafNode,const ValueType,ValueAll>;
+    using ValueAllCIter = ConstValueIter<MaskDenseIterator,const LeafNode,const ValueType,ValueAll>;
     using ChildOnIter = ChildIter<MaskOnIterator, LeafNode, ChildOn>;
     using ChildOnCIter = ChildIter<MaskOnIterator, const LeafNode, ChildOn>;
     using ChildOffIter = ChildIter<MaskOffIterator, LeafNode, ChildOff>;
     using ChildOffCIter = ChildIter<MaskOffIterator, const LeafNode, ChildOff>;
     using ChildAllIter = DenseIter<LeafNode, ValueType, ChildAll>;
-    using ChildAllCIter = DenseIter<const LeafNode, const ValueType, ChildAll>;
+    using ChildAllCIter = ConstDenseIter<const LeafNode, const ValueType, ChildAll>;
 
     ValueOnCIter  cbeginValueOn() const { return ValueOnCIter(mValueMask.beginOn(), this); }
     ValueOnCIter   beginValueOn() const { return ValueOnCIter(mValueMask.beginOn(), this); }
@@ -848,9 +883,9 @@ protected:
     friend struct ValueIter<MaskOnIterator, LeafNode, ValueType, ValueOn>;
     friend struct ValueIter<MaskOffIterator, LeafNode, ValueType, ValueOff>;
     friend struct ValueIter<MaskDenseIterator, LeafNode, ValueType, ValueAll>;
-    friend struct ValueIter<MaskOnIterator, const LeafNode, ValueType, ValueOn>;
-    friend struct ValueIter<MaskOffIterator, const LeafNode, ValueType, ValueOff>;
-    friend struct ValueIter<MaskDenseIterator, const LeafNode, ValueType, ValueAll>;
+    friend struct ConstValueIter<MaskOnIterator, const LeafNode, const ValueType, ValueOn>;
+    friend struct ConstValueIter<MaskOffIterator, const LeafNode, const ValueType, ValueOff>;
+    friend struct ConstValueIter<MaskDenseIterator, const LeafNode, const ValueType, ValueAll>;
 
     // Allow iterators to call mask accessor methods (see below).
     /// @todo Make mask accessors public?

--- a/openvdb/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/openvdb/tree/LeafNodeBool.h
@@ -585,17 +585,28 @@ protected:
         const bool& getItem(Index pos) const { return this->parent().getValue(pos); }
         const bool& getValue() const { return this->getItem(this->pos()); }
 
-        // Note: setItem() can't be called on const iterators.
         void setItem(Index pos, bool value) const { this->parent().setValueOnly(pos, value); }
-        // Note: setValue() can't be called on const iterators.
         void setValue(bool value) const { this->setItem(this->pos(), value); }
 
-        // Note: modifyItem() can't be called on const iterators.
         template<typename ModifyOp>
         void modifyItem(Index n, const ModifyOp& op) const { this->parent().modifyValue(n, op); }
-        // Note: modifyValue() can't be called on const iterators.
         template<typename ModifyOp>
         void modifyValue(const ModifyOp& op) const { this->modifyItem(this->pos(), op); }
+    };
+
+    template<typename MaskIterT, typename NodeT, typename ValueT>
+    struct ConstValueIter:
+        // Derives from SparseIteratorBase, but can also be used as a dense iterator,
+        // if MaskIterT is a dense mask iterator type.
+        public SparseIteratorBase<MaskIterT, ConstValueIter<MaskIterT, NodeT, ValueT>, NodeT, ValueT>
+    {
+        using BaseT = SparseIteratorBase<MaskIterT, ConstValueIter, NodeT, ValueT>;
+
+        ConstValueIter() {}
+        ConstValueIter(const MaskIterT& iter, NodeT* parent): BaseT(iter, parent) {}
+
+        const bool& getItem(Index pos) const { return this->parent().getValue(pos); }
+        const bool& getValue() const { return this->getItem(this->pos()); }
     };
 
     /// Leaf nodes have no children, so their child iterators have no get/set accessors.
@@ -606,6 +617,15 @@ protected:
         ChildIter() {}
         ChildIter(const MaskIterT& iter, NodeT* parent): SparseIteratorBase<
             MaskIterT, ChildIter<MaskIterT, NodeT>, NodeT, bool>(iter, parent) {}
+    };
+
+    template<typename MaskIterT, typename NodeT>
+    struct ConstChildIter:
+        public SparseIteratorBase<MaskIterT, ConstChildIter<MaskIterT, NodeT>, NodeT, bool>
+    {
+        ConstChildIter() {}
+        ConstChildIter(const MaskIterT& iter, NodeT* parent): SparseIteratorBase<
+            MaskIterT, ConstChildIter<MaskIterT, NodeT>, NodeT, bool>(iter, parent) {}
     };
 
     template<typename NodeT, typename ValueT>
@@ -625,26 +645,40 @@ protected:
             return false; // no child
         }
 
-        // Note: setItem() can't be called on const iterators.
-        //void setItem(Index pos, void* child) const {}
-
-        // Note: unsetItem() can't be called on const iterators.
         void unsetItem(Index pos, const ValueT& val) const {this->parent().setValueOnly(pos, val);}
+    };
+
+    template<typename NodeT, typename ValueT>
+    struct ConstDenseIter: public DenseIteratorBase<
+        MaskDenseIter, ConstDenseIter<NodeT, ValueT>, NodeT, /*ChildT=*/void, ValueT>
+    {
+        using BaseT = DenseIteratorBase<MaskDenseIter, ConstDenseIter, NodeT, void, ValueT>;
+        using NonConstValueT = typename BaseT::NonConstValueType;
+
+        ConstDenseIter() {}
+        ConstDenseIter(const MaskDenseIter& iter, NodeT* parent): BaseT(iter, parent) {}
+
+        bool getItem(Index pos, void*& child, NonConstValueT& value) const
+        {
+            value = this->parent().getValue(pos);
+            child = nullptr;
+            return false; // no child
+        }
     };
 
 public:
     using ValueOnIter = ValueIter<MaskOnIter, LeafNode, const bool>;
-    using ValueOnCIter = ValueIter<MaskOnIter, const LeafNode, const bool>;
+    using ValueOnCIter = ConstValueIter<MaskOnIter, const LeafNode, const bool>;
     using ValueOffIter = ValueIter<MaskOffIter, LeafNode, const bool>;
-    using ValueOffCIter = ValueIter<MaskOffIter, const LeafNode, const bool>;
+    using ValueOffCIter = ConstValueIter<MaskOffIter, const LeafNode, const bool>;
     using ValueAllIter = ValueIter<MaskDenseIter, LeafNode, const bool>;
-    using ValueAllCIter = ValueIter<MaskDenseIter, const LeafNode, const bool>;
+    using ValueAllCIter = ConstValueIter<MaskDenseIter, const LeafNode, const bool>;
     using ChildOnIter = ChildIter<MaskOnIter, LeafNode>;
     using ChildOnCIter = ChildIter<MaskOnIter, const LeafNode>;
     using ChildOffIter = ChildIter<MaskOffIter, LeafNode>;
     using ChildOffCIter = ChildIter<MaskOffIter, const LeafNode>;
     using ChildAllIter = DenseIter<LeafNode, bool>;
-    using ChildAllCIter = DenseIter<const LeafNode, const bool>;
+    using ChildAllCIter = ConstDenseIter<const LeafNode, const bool>;
 
     ValueOnCIter  cbeginValueOn() const { return ValueOnCIter(mValueMask.beginOn(), this); }
     ValueOnCIter   beginValueOn() const { return ValueOnCIter(mValueMask.beginOn(), this); }
@@ -737,9 +771,9 @@ private:
     friend struct ValueIter<MaskOnIter, LeafNode, bool>;
     friend struct ValueIter<MaskOffIter, LeafNode, bool>;
     friend struct ValueIter<MaskDenseIter, LeafNode, bool>;
-    friend struct ValueIter<MaskOnIter, const LeafNode, bool>;
-    friend struct ValueIter<MaskOffIter, const LeafNode, bool>;
-    friend struct ValueIter<MaskDenseIter, const LeafNode, bool>;
+    friend struct ConstValueIter<MaskOnIter, const LeafNode, const bool>;
+    friend struct ConstValueIter<MaskOffIter, const LeafNode, const bool>;
+    friend struct ConstValueIter<MaskDenseIter, const LeafNode, const bool>;
 
     //@{
     /// Allow iterators to call mask accessor methods (see below).

--- a/openvdb/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/openvdb/tree/LeafNodeMask.h
@@ -593,17 +593,28 @@ protected:
         const bool& getItem(Index pos) const { return this->parent().getValue(pos); }
         const bool& getValue() const { return this->getItem(this->pos()); }
 
-        // Note: setItem() can't be called on const iterators.
         void setItem(Index pos, bool value) const { this->parent().setValueOnly(pos, value); }
-        // Note: setValue() can't be called on const iterators.
         void setValue(bool value) const { this->setItem(this->pos(), value); }
 
-        // Note: modifyItem() can't be called on const iterators.
         template<typename ModifyOp>
         void modifyItem(Index n, const ModifyOp& op) const { this->parent().modifyValue(n, op); }
-        // Note: modifyValue() can't be called on const iterators.
         template<typename ModifyOp>
         void modifyValue(const ModifyOp& op) const { this->modifyItem(this->pos(), op); }
+    };
+
+    template<typename MaskIterT, typename NodeT, typename ValueT>
+    struct ConstValueIter:
+        // Derives from SparseIteratorBase, but can also be used as a dense iterator,
+        // if MaskIterT is a dense mask iterator type.
+        public SparseIteratorBase<MaskIterT, ConstValueIter<MaskIterT, NodeT, ValueT>, NodeT, ValueT>
+    {
+        using BaseT = SparseIteratorBase<MaskIterT, ConstValueIter, NodeT, ValueT>;
+
+        ConstValueIter() {}
+        ConstValueIter(const MaskIterT& iter, NodeT* parent): BaseT(iter, parent) {}
+
+        const bool& getItem(Index pos) const { return this->parent().getValue(pos); }
+        const bool& getValue() const { return this->getItem(this->pos()); }
     };
 
     /// Leaf nodes have no children, so their child iterators have no get/set accessors.
@@ -614,6 +625,15 @@ protected:
         ChildIter() {}
         ChildIter(const MaskIterT& iter, NodeT* parent): SparseIteratorBase<
             MaskIterT, ChildIter<MaskIterT, NodeT>, NodeT, bool>(iter, parent) {}
+    };
+
+    template<typename MaskIterT, typename NodeT>
+    struct ConstChildIter:
+        public SparseIteratorBase<MaskIterT, ConstChildIter<MaskIterT, NodeT>, NodeT, bool>
+    {
+        ConstChildIter() {}
+        ConstChildIter(const MaskIterT& iter, NodeT* parent): SparseIteratorBase<
+            MaskIterT, ConstChildIter<MaskIterT, NodeT>, NodeT, bool>(iter, parent) {}
     };
 
     template<typename NodeT, typename ValueT>
@@ -633,26 +653,41 @@ protected:
             return false; // no child
         }
 
-        // Note: setItem() can't be called on const iterators.
-        //void setItem(Index pos, void* child) const {}
-
         // Note: unsetItem() can't be called on const iterators.
         void unsetItem(Index pos, const ValueT& val) const {this->parent().setValueOnly(pos, val);}
     };
 
+    template<typename NodeT, typename ValueT>
+    struct ConstDenseIter: public DenseIteratorBase<
+        MaskDenseIter, ConstDenseIter<NodeT, ValueT>, NodeT, /*ChildT=*/void, ValueT>
+    {
+        using BaseT = DenseIteratorBase<MaskDenseIter, ConstDenseIter, NodeT, void, ValueT>;
+        using NonConstValueT = typename BaseT::NonConstValueType;
+
+        ConstDenseIter() {}
+        ConstDenseIter(const MaskDenseIter& iter, NodeT* parent): BaseT(iter, parent) {}
+
+        bool getItem(Index pos, void*& child, NonConstValueT& value) const
+        {
+            value = this->parent().getValue(pos);
+            child = nullptr;
+            return false; // no child
+        }
+    };
+
 public:
     using ValueOnIter = ValueIter<MaskOnIter, LeafNode, const bool>;
-    using ValueOnCIter = ValueIter<MaskOnIter, const LeafNode, const bool>;
+    using ValueOnCIter = ConstValueIter<MaskOnIter, const LeafNode, const bool>;
     using ValueOffIter = ValueIter<MaskOffIter, LeafNode, const bool>;
-    using ValueOffCIter = ValueIter<MaskOffIter, const LeafNode, const bool>;
+    using ValueOffCIter = ConstValueIter<MaskOffIter, const LeafNode, const bool>;
     using ValueAllIter = ValueIter<MaskDenseIter, LeafNode, const bool>;
-    using ValueAllCIter = ValueIter<MaskDenseIter, const LeafNode, const bool>;
+    using ValueAllCIter = ConstValueIter<MaskDenseIter, const LeafNode, const bool>;
     using ChildOnIter = ChildIter<MaskOnIter, LeafNode>;
     using ChildOnCIter = ChildIter<MaskOnIter, const LeafNode>;
     using ChildOffIter = ChildIter<MaskOffIter, LeafNode>;
     using ChildOffCIter = ChildIter<MaskOffIter, const LeafNode>;
     using ChildAllIter = DenseIter<LeafNode, bool>;
-    using ChildAllCIter = DenseIter<const LeafNode, const bool>;
+    using ChildAllCIter = ConstDenseIter<const LeafNode, const bool>;
 
     ValueOnCIter  cbeginValueOn() const { return ValueOnCIter(mBuffer.mData.beginOn(), this); }
     ValueOnCIter   beginValueOn() const { return ValueOnCIter(mBuffer.mData.beginOn(), this); }
@@ -743,9 +778,9 @@ private:
     friend struct ValueIter<MaskOnIter, LeafNode, bool>;
     friend struct ValueIter<MaskOffIter, LeafNode, bool>;
     friend struct ValueIter<MaskDenseIter, LeafNode, bool>;
-    friend struct ValueIter<MaskOnIter, const LeafNode, bool>;
-    friend struct ValueIter<MaskOffIter, const LeafNode, bool>;
-    friend struct ValueIter<MaskDenseIter, const LeafNode, bool>;
+    friend struct ConstValueIter<MaskOnIter, const LeafNode, const bool>;
+    friend struct ConstValueIter<MaskOffIter, const LeafNode, const bool>;
+    friend struct ConstValueIter<MaskDenseIter, const LeafNode, const bool>;
 
     //@{
     /// Allow iterators to call mask accessor methods (see below).

--- a/openvdb/openvdb/tree/RootNode.h
+++ b/openvdb/openvdb/tree/RootNode.h
@@ -167,7 +167,6 @@ private:
     static ChildType&       getChild(const MapIter& i) { return *(i->second.child); }
     static const ChildType& getChild(const MapCIter& i) { return *(i->second.child); }
     static ChildType&       stealChild(const MapIter& i, const Tile& t) {return i->second.steal(t);}
-    static const ChildType& stealChild(const MapCIter& i,const Tile& t) {return i->second.steal(t);}
 
     static bool isChild(const MapCIter& i)   { return i->second.isChild(); }
     static bool isChild(const MapIter& i)    { return i->second.isChild(); }

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -89,6 +89,7 @@ else()
     TestDivergence.cc
     TestDoubleMetadata.cc
     TestExceptions.cc
+    TestExplicitInstantiation.cc
     TestFastSweeping.cc
     TestFile.cc
     TestFilter.cc

--- a/openvdb/openvdb/unittest/TestExplicitInstantiation.cc
+++ b/openvdb/openvdb/unittest/TestExplicitInstantiation.cc
@@ -1,0 +1,89 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#include <openvdb/openvdb.h>
+#include <openvdb/points/PointDataGrid.h>
+#include <openvdb/tools/PointIndexGrid.h>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+
+namespace math {
+
+// explicit template instantiation of math classes
+
+template class BBox<Vec3f>;
+template class Mat3<float>;
+template class Mat4<float>;
+template class Quat<float>;
+template class Vec2<float>;
+template class Vec3<float>;
+template class Vec4<float>;
+
+} // namespace math
+
+namespace tree {
+
+// explicit template instantiation of LeafBuffer
+
+template class LeafBuffer<float, 3>;
+template class LeafBuffer<int64_t, 3>;
+template class LeafBuffer<Vec3f, 3>;
+template class LeafBuffer<bool, 3>;
+
+// explicit template instantiation of LeafNode
+
+template class LeafNode<float, 3>;
+template class LeafNode<int64_t, 3>;
+template class LeafNode<Vec3f, 3>;
+template class LeafNode<bool, 3>;
+template class LeafNode<ValueMask, 3>;
+
+// explicit template instantiation of InternalNode
+
+template class InternalNode<LeafNode<float, 3>, 4>;
+template class InternalNode<InternalNode<LeafNode<float, 3>, 4>, 5>;
+
+// explicit template instantiation of RootNode
+
+template class RootNode<InternalNode<InternalNode<LeafNode<float, 3>, 4>, 5>>;
+
+// explicit template instantiation of Tree
+
+template class Tree<RootNode<InternalNode<InternalNode<LeafNode<float, 3>, 4>, 5>>>;
+
+// explicit template instantiation of LeafManager and NodeManagers
+
+template class LeafManager<FloatTree>;
+template class NodeManager<FloatTree>;
+template class DynamicNodeManager<FloatTree>;
+
+// explicit template instantiation of ValueAccessor
+
+template class ValueAccessor3<FloatTree>;
+
+} // namespace tree
+
+namespace points {
+
+// explicit template instantiation of PointDataLeafNode
+
+template class PointDataLeafNode<PointDataIndex32, 3>;
+
+} // namespace points
+
+namespace tools {
+
+// explicit template instantiation of PointIndexLeafNode
+
+template struct PointIndexLeafNode<PointIndex32, 3>;
+
+} // namespace tools
+
+// explicit template instantiation of Grid
+
+template class Grid<FloatTree>;
+
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb


### PR DESCRIPTION
This PR adds a new unit test that performs explicit template instantiation for many of the most common math and tree classes. As the explicit template instantiation does a full instantiation of all methods, this catches errors in the VDB API that have not been noticed because they either haven't been instantiated by anything in the OpenVDB library or reported by any of our users who have attempted to call them. One simple example is `RootNode::stealChild(const MapCIter& i, ...)` - attempting to call this method results in a compile error as you cannot steal data from a const iterator. 

The biggest change here is introducing `ConstValueIter`, `ConstChildIter` and `ConstDenseIter`. Currently, non-const base iterators are used even for const iterators (such as `using ValueOnCIter = typename BaseLeaf::template ValueIter<...>`) with a comment not to call these methods (such as `// Note: setItem() can't be called on const iterators.`). This change could also be implemented using SFINAE, but I felt introducing new iterators was cleaner.

Here's the summary of changes to get this new unit test to compile:

* New ConstValueIter, ConstChildIter and ConstDenseIter classes - the same as the non-const iterators but with no `setItem()` or `modifyItem()` calls, rewire all RootNode, InternalNode and LeafNode iterator aliases for const iterators.
* Move `operator<<(ostream&)` method for LeafNode buffer into LeafBuffer and use public method to access data.
* Remove `RootNode::stealChild(const MapCIter& i, ...)` method.
* Add `RootNode::probeLeaf(const Coord&)` definition, which was previously declared but not defined.
* Fix compile error in Quat `read(ostream&)` and `write(istream&)` by using reinterpret_cast instead of static_cast.
* Fix compile error in `Mat3::setSkew()` by passing correct template parameter.
* Fix lots of float conversion warnings in Mat, Mat4 and Quat by using static_cast.
* Fix warning in `VecT::unitSafe()` where it was treating a float value as a bool instead of comparing with zero.

Ultimately, I expect we would probably remove this unit test (as it's not really a unit test, but a compile test) when we introduce proper explicit template instantiation as part of the library, but this at least tests that no new errors are introduced in the interim.

