### PR TITLE
Fix: Memory alignment in nanovdb_GridData

### DIFF
--- a/nanovdb/cmd/viewer/code/CNanoVDB.h
+++ b/nanovdb/cmd/viewer/code/CNanoVDB.h
@@ -424,6 +424,8 @@ CNANOVDB_DECLARE_STRUCT_BEGIN(nanovdb_GridData)
     uint64_t         mChecksum; // 8B. Checksum of grid buffer.
     uint32_t         mMajor;// 4B. major version number.
     uint32_t         mFlags; // 4B. flags for grid.
+    uint32_t         mGridIndex;// 4B. Index of this grid in the buffer
+    uint32_t         mGridCount; // 4B. Total number of grids in the buffer
     uint64_t         mGridSize; // 8B. byte count of entire grid buffer.
     uint32_t         mGridName[256/4]; // 256B
     nanovdb_Map      mMap; // 264B. affine transformation between index and world space in both single and double precision


### PR DESCRIPTION
The fields mGridIndex and mGridCount are missing in the struct, which leads to an 8 bit memory missalignment with the C++ data in the buffer of gridhandler->data().
This caused invalid data in mMap, as it is defined, after the missalignmented happened. Artefacts of this bug could be seen in the OpenCL version of the viewer.

For reference see the struct GridData in NanoVDB.h(line 2131-2148).