### PR TITLE
Set ABI=8 as default for Houdini and lock H18.5 to ABI=7

### DIFF
--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -145,6 +145,8 @@ elseif(MINIMUM_HOUDINI_VERSION)
   endif()
 endif()
 
+set(Houdini_VERSION_MAJOR_MINOR "${Houdini_VERSION_MAJOR}.${Houdini_VERSION_MINOR}")
+
 find_package(PackageHandleStandardArgs)
 find_package_handle_standard_args(Houdini
   REQUIRED_VARS _houdini_install_root Houdini_FOUND
@@ -329,14 +331,12 @@ endif()
 # Explicitly configure the OpenVDB ABI version depending on the Houdini
 # version.
 
-if(Houdini_VERSION VERSION_LESS 17)
-  set(OPENVDB_HOUDINI_ABI 4)
-elseif(Houdini_VERSION VERSION_LESS 18)
-  set(OPENVDB_HOUDINI_ABI 5)
-elseif(Houdini_VERSION VERSION_LESS 18.5)
+if(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.0)
   set(OPENVDB_HOUDINI_ABI 6)
-else()
+elseif(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.5)
   set(OPENVDB_HOUDINI_ABI 7)
+else()
+  set(OPENVDB_HOUDINI_ABI 8)
 endif()
 
 # ------------------------------------------------------------------------

--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -336,6 +336,8 @@ if(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.0)
 elseif(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.5)
   set(OPENVDB_HOUDINI_ABI 7)
 else()
+  message(WARNING "Unknown version of Houdini, assuming OpenVDB ABI=8, "
+    "but if this not correct, the CMake flag -DOPENVDB_HOUDINI_ABI=<N> can override this value.")
   set(OPENVDB_HOUDINI_ABI 8)
 endif()
 

--- a/pendingchanges/houdini_abi8.txt
+++ b/pendingchanges/houdini_abi8.txt
@@ -1,0 +1,2 @@
+Houdini:
+    - The default OpenVDB ABI is now 8 for Houdini versions > 18.5.


### PR DESCRIPTION
As reported by @plattfot in issue #1172.

I've slightly tweaked the logic here so that it compares with the major.minor version of Houdini and thus doesn't require us to make any assumptions about which version of Houdini that SideFX might ship next, so that we can opt to extend this as soon as we enter a new calendar year.