### PR TITLE
Fix typo in cmake/FindOpenVDB.cmake to handle the QUIET argument of find_package() correctly

### DIFF
--- a/cmake/FindOpenVDB.cmake
+++ b/cmake/FindOpenVDB.cmake
@@ -433,7 +433,7 @@ if(NOT _OPENVDB_HAS_NEW_VERSION_HEADER)
   endif()
 endif()
 
-if(NOT OpenVDB_FIND_QUIET)
+if(NOT OpenVDB_FIND_QUIETLY)
   if(NOT OpenVDB_ABI)
     message(WARNING "Unable to determine OpenVDB ABI version from OpenVDB "
       "installation. The library major version \"${OpenVDB_MAJOR_VERSION}\" "


### PR DESCRIPTION
I've changed `OpenVDB_FIND_QUIET` to `OpenVDB_FIND_QUIETLY`. It fixes a typo, as the [docs](https://cmake.org/cmake/help/latest/command/find_package.html) say that:

> When loading a find module or package configuration file find_package defines variables to provide information about the call arguments (and restores their original state before returning):
> 
> ...
> 
> \<PackageName\>_FIND_QUIETLY
> True if QUIET option was given

