### PR TITLE
Synchronization of these files with H19.

### DIFF
--- a/openvdb_houdini/openvdb_houdini/GEO_PrimVDB.cc
+++ b/openvdb_houdini/openvdb_houdini/GEO_PrimVDB.cc
@@ -110,7 +110,7 @@ GEO_PrimVDB::GEO_PrimVDB(GEO_Detail *d, GA_Offset offset)
 {
 }
 
-GEO_PrimVDB::~GEO_PrimVDB() 
+GEO_PrimVDB::~GEO_PrimVDB()
 {
     if (myCEGridIsOwned)
         delete myCEGrid;
@@ -1410,7 +1410,7 @@ GEO_PrimVDB::getCEGrid(bool read, bool write) const
     if (myCEGrid)
         return myCEGrid;
 
-    CE_VDBGrid	*cegrid = new CE_VDBGrid();
+    CE_VDBGrid  *cegrid = new CE_VDBGrid();
 
     try
     {
@@ -1419,9 +1419,9 @@ GEO_PrimVDB::getCEGrid(bool read, bool write) const
     }
     catch (cl::Error &err)
     {
-	CE_Context::reportError(err);
-	delete cegrid;
-	cegrid = 0;
+        CE_Context::reportError(err);
+        delete cegrid;
+        cegrid = 0;
     }
 
     myCEGrid = cegrid;
@@ -1434,12 +1434,12 @@ void
 GEO_PrimVDB::flushCEWriteCaches()
 {
     if (!myCEGrid)
-	return;
+        return;
     if (myCEGridAuthorative)
     {
-	// Write back.
+        // Write back.
         UT_ASSERT(!"Not implemented");
-	myCEGridAuthorative = false;
+        myCEGridAuthorative = false;
     }
 }
 
@@ -1470,7 +1470,7 @@ GEO_PrimVDB::stealCEBuffers(const GA_Primitive *psrc)
 
     src->myCEGrid = 0;
     src->myCEGridAuthorative = false;
-    src->myCEGridIsOwned = true;    
+    src->myCEGridIsOwned = true;
 }
 
 
@@ -3527,8 +3527,8 @@ const char *
 GEO_PrimVDB::getGridName() const
 {
     GA_ROHandleS nameAttr(getParent(), GA_ATTRIB_PRIMITIVE, "name");
-    return nameAttr.isValid() 
-	? static_cast<const char *>(nameAttr.get(getMapOffset())) : "";
+    return nameAttr.isValid()
+   ? static_cast<const char *>(nameAttr.get(getMapOffset())) : "";
 }
 
 
@@ -3800,11 +3800,11 @@ GA_START_INTRINSIC_DEF(GEO_PrimVDB, geo_NUM_INTRINSICS)
             "volumevisuallod", intrinsicVisualLod)
 
     GA_INTRINSIC_METHOD_F(GEO_PrimVDB, geo_INTRINSIC_VOLUMEMINVALUE,
-	 "volumeminvalue", calcMinimum)
+         "volumeminvalue", calcMinimum)
     GA_INTRINSIC_METHOD_F(GEO_PrimVDB, geo_INTRINSIC_VOLUMEMAXVALUE,
-	 "volumemaxvalue", calcMaximum)
+         "volumemaxvalue", calcMaximum)
     GA_INTRINSIC_METHOD_F(GEO_PrimVDB, geo_INTRINSIC_VOLUMEAVGVALUE,
-	 "volumeavgvalue", calcAverage)
+         "volumeavgvalue", calcAverage)
 
     VDB_INTRINSIC_META_STR(GEO_PrimVDB, geo_INTRINSIC_META_GRID_CLASS)
     VDB_INTRINSIC_META_STR(GEO_PrimVDB, geo_INTRINSIC_META_GRID_CREATOR)

--- a/openvdb_houdini/openvdb_houdini/GEO_PrimVDB.h
+++ b/openvdb_houdini/openvdb_houdini/GEO_PrimVDB.h
@@ -756,8 +756,8 @@ private:
 
     GEO_VolumeOptions       myVis;
 
-    mutable CE_VDBGrid			*myCEGrid;
-    mutable bool			 myCEGridAuthorative;
+    mutable CE_VDBGrid                  *myCEGrid;
+    mutable bool                         myCEGridAuthorative;
     mutable bool                         myCEGridIsOwned;
 
     AtomicUniqueId          myUniqueId;

--- a/openvdb_houdini/openvdb_houdini/GEO_VDBTranslator.cc
+++ b/openvdb_houdini/openvdb_houdini/GEO_VDBTranslator.cc
@@ -130,7 +130,13 @@ GEO_VDBTranslator::fileStat(const char *filename, GA_Stat &stat, uint /*level*/)
 
             meta_minbbox = stats->getMetadata<openvdb::Vec3IMetadata>("file_bbox_min");
             meta_maxbbox = stats->getMetadata<openvdb::Vec3IMetadata>("file_bbox_max");
-            if (meta_minbbox && meta_maxbbox)
+            // empty vdbs have invalid bounding boxes, and often very
+            // huge ones, so we intentionally skip them here.
+	    if (meta_minbbox && meta_maxbbox &&
+                meta_minbbox->value().x() <= meta_maxbbox->value().x() &&
+                meta_minbbox->value().y() <= meta_maxbbox->value().y() &&
+                meta_minbbox->value().z() <= meta_maxbbox->value().z()
+                )
             {
                 UT_Vector3              minv, maxv;
                 minv = UTvdbConvert(meta_minbbox->value());

--- a/openvdb_houdini/openvdb_houdini/GEO_VDBTranslator.cc
+++ b/openvdb_houdini/openvdb_houdini/GEO_VDBTranslator.cc
@@ -132,7 +132,7 @@ GEO_VDBTranslator::fileStat(const char *filename, GA_Stat &stat, uint /*level*/)
             meta_maxbbox = stats->getMetadata<openvdb::Vec3IMetadata>("file_bbox_max");
             // empty vdbs have invalid bounding boxes, and often very
             // huge ones, so we intentionally skip them here.
-	    if (meta_minbbox && meta_maxbbox &&
+            if (meta_minbbox && meta_maxbbox &&
                 meta_minbbox->value().x() <= meta_maxbbox->value().x() &&
                 meta_minbbox->value().y() <= meta_maxbbox->value().y() &&
                 meta_minbbox->value().z() <= meta_maxbbox->value().z()

--- a/openvdb_houdini/openvdb_houdini/GU_PrimVDB.cc
+++ b/openvdb_houdini/openvdb_houdini/GU_PrimVDB.cc
@@ -1908,13 +1908,15 @@ setAttr(GEO_Detail& geo, GA_AttributeOwner owner, GA_Offset elem,
     using RWHandleT = typename MetaAttrT::RWHandleT;
     using TupleT = typename MetaAttrT::TupleT;
 
-    /// @todo If there is an existing attribute with the given name but
-    /// a different type, this will replace the old attribute with a new one.
-    /// See GA_ReuseStrategy for alternative behaviors.
-    GA_RWAttributeRef attrRef = geo.addTuple(MetaAttrT::theStorage, owner, name, MetaAttrT::theTupleSize);
-    if (attrRef.isInvalid()) return;
-
-    RWHandleT handle(attrRef.getAttribute());
+    // Try to bind the type, if fails, then create a tuple.
+    RWHandleT handle(&geo, owner, name, MetaAttrT::theTupleSize);
+    if (!handle.isValid())
+    {
+        geo.addTuple(MetaAttrT::theStorage, owner, name, MetaAttrT::theTupleSize);
+        handle.bind(&geo, owner, name, MetaAttrT::theTupleSize);
+        if (!handle.isValid())
+            return;
+    }
 
     const MetadataT& meta = static_cast<const MetadataT&>(meta_base);
     switch (MetaAttrT::theTupleSize) {
@@ -1935,10 +1937,14 @@ static void
 setStrAttr(GEO_Detail& geo, GA_AttributeOwner owner, GA_Offset elem,
     const char* name, const openvdb::Metadata& meta_base)
 {
-    GA_RWAttributeRef attrRef = geo.addStringTuple(owner, name, 1);
-    if (attrRef.isInvalid()) return;
-
-    GA_RWHandleS handle(attrRef.getAttribute());
+    GA_RWHandleS handle(&geo, owner, name);
+    if (!handle.isValid())
+    {
+        geo.addStringTuple(owner, name, 1);
+        handle.bind(&geo, owner, name);
+        if (!handle.isValid())
+            return;
+    }
 
     const MetadataT& meta = static_cast<const MetadataT&>(meta_base);
     handle.set(elem, 0, MetaTuple<const char*, MetadataT, 0>::get(meta));
@@ -1953,10 +1959,15 @@ setMatAttr(GEO_Detail& geo, GA_AttributeOwner owner, GA_Offset elem,
     using RWHandleT = typename MetaAttrT::RWHandleT;
     using TupleT = typename MetaAttrT::TupleT;
 
-    GA_RWAttributeRef attrRef = geo.addTuple(MetaAttrT::theStorage, owner, name, MetaAttrT::theTupleSize);
-    if (attrRef.isInvalid()) return;
-
-    RWHandleT handle(attrRef.getAttribute());
+    // Try to bind the type, if fails, then create a tuple.
+    RWHandleT handle(&geo, owner, name, MetaAttrT::theTupleSize);
+    if (!handle.isValid())
+    {
+        geo.addTuple(MetaAttrT::theStorage, owner, name, MetaAttrT::theTupleSize);
+        handle.bind(&geo, owner, name, MetaAttrT::theTupleSize);
+        if (!handle.isValid())
+            return;
+    }
 
     const MetadataT& meta = static_cast<const MetadataT&>(meta_base);
 


### PR DESCRIPTION
This includes CE grid support (From 18.5 but last sync Nano wasn't official
yet)

The one real change (which isn't just FYI/reference) is to GEO_VDBTranslator
to ignore empty vdbs when building bounding boxes.  We were enlarging
the final stat by the min/max of the bbox, but for invalid boxes that
obviously will be wrong.  This showed up as the File SOP load-as-info
giving huge bounding boxes if an empty vdb was present.

Signed-off-by: jlait <jlait@andorra.sidefx.com>