### PR TITLE
Move find_package for Blosc, TBB, IlmBase and Log4CPlus up to root CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -742,6 +742,68 @@ determine the ABI number. You may set this to force a given ABI number.]=] FORCE
 
 ##########################################################################
 
+# Collect and configure lib dependencies
+
+if (OPENVDB_BUILD_CORE)
+  find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbb)
+  if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_TBB_VERSION)
+    if(${Tbb_VERSION} VERSION_LESS FUTURE_MINIMUM_TBB_VERSION)
+      message(DEPRECATION "Support for TBB versions < ${FUTURE_MINIMUM_TBB_VERSION} "
+        "is deprecated and will be removed.")
+    endif()
+  endif()
+
+  if(USE_IMATH_HALF)
+    find_package(IlmBase ${MINIMUM_ILMBASE_VERSION} REQUIRED COMPONENTS Half)
+    if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_ILMBASE_VERSION)
+      if(${IlmBase_VERSION} VERSION_LESS FUTURE_MINIMUM_ILMBASE_VERSION)
+        message(DEPRECATION "Support for IlmBase versions < ${FUTURE_MINIMUM_ILMBASE_VERSION} "
+          "is deprecated and will be removed.")
+      endif()
+    endif()
+  endif()
+
+  if(USE_LOG4CPLUS)
+    # Find Log4CPlus libraries
+    find_package(Log4cplus ${MINIMUM_LOG4CPLUS_VERSION} REQUIRED)
+  endif()
+
+  if(USE_BLOSC)
+    # Find Blosc libraries
+    find_package(Blosc ${MINIMUM_BLOSC_VERSION} REQUIRED)
+    if(Blosc_FOUND AND Blosc_VERSION VERSION_GREATER MINIMUM_BLOSC_VERSION)
+      message(WARNING "The version of Blosc located is greater than ${MINIMUM_BLOSC_VERSION}. "
+        "There have been reported issues with using later versions of Blosc with OpenVDB. "
+        "OpenVDB has been tested fully against Blosc ${MINIMUM_BLOSC_VERSION}, it is "
+        "recommended that you use this version where possible."
+      )
+    endif()
+  else()
+    message(WARNING "Blosc support is disabled. It is strongly recommended to "
+      "enable blosc for optimal builds of OpenVDB and to support compatible "
+      "serialization of other OpenVDB installations."
+    )
+  endif()
+
+  if(USE_BLOSC OR USE_ZLIB)
+    if(USE_STATIC_DEPENDENCIES)
+      set(_ZLIB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+      if(WIN32)
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+      else()
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+      endif()
+    endif()
+    find_package(ZLIB ${MINIMUM_ZLIB_VERSION} REQUIRED)
+    if(USE_STATIC_DEPENDENCIES)
+      set(CMAKE_FIND_LIBRARY_SUFFIXES ${_ZLIB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+      unset(_ZLIB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
+    endif()
+  endif()
+endif()
+
+##########################################################################
+
 if(OPENVDB_BUILD_CORE)
   add_subdirectory(openvdb/openvdb)
 endif()

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -127,62 +127,6 @@ if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_BOOST_VERSION)
   endif()
 endif()
 
-find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbb)
-if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_TBB_VERSION)
-  if(${Tbb_VERSION} VERSION_LESS FUTURE_MINIMUM_TBB_VERSION)
-    message(DEPRECATION "Support for TBB versions < ${FUTURE_MINIMUM_TBB_VERSION} "
-      "is deprecated and will be removed.")
-  endif()
-endif()
-
-if(USE_IMATH_HALF)
-  find_package(IlmBase ${MINIMUM_ILMBASE_VERSION} REQUIRED COMPONENTS Half)
-  if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_ILMBASE_VERSION)
-    if(${IlmBase_VERSION} VERSION_LESS FUTURE_MINIMUM_ILMBASE_VERSION)
-      message(DEPRECATION "Support for IlmBase versions < ${FUTURE_MINIMUM_ILMBASE_VERSION} "
-        "is deprecated and will be removed.")
-    endif()
-  endif()
-endif()
-
-if(USE_LOG4CPLUS)
-  # Find Log4CPlus libraries
-  find_package(Log4cplus ${MINIMUM_LOG4CPLUS_VERSION} REQUIRED)
-endif()
-
-if(USE_BLOSC)
-  # Find Blosc libraries
-  find_package(Blosc ${MINIMUM_BLOSC_VERSION} REQUIRED)
-  if(Blosc_FOUND AND Blosc_VERSION VERSION_GREATER MINIMUM_BLOSC_VERSION)
-    message(WARNING "The version of Blosc located is greater than ${MINIMUM_BLOSC_VERSION}. "
-      "There have been reported issues with using later versions of Blosc with OpenVDB. "
-      "OpenVDB has been tested fully against Blosc ${MINIMUM_BLOSC_VERSION}, it is "
-      "recommended that you use this version where possible."
-    )
-  endif()
-else()
-  message(WARNING "Blosc support is disabled. It is strongly recommended to "
-    "enable blosc for optimal builds of OpenVDB and to support compatible "
-    "serialization of other OpenVDB installations."
-  )
-endif()
-
-if(USE_BLOSC OR USE_ZLIB)
-  if(USE_STATIC_DEPENDENCIES)
-    set(_ZLIB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
-    if(WIN32)
-      set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
-    else()
-      set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-    endif()
-  endif()
-  find_package(ZLIB ${MINIMUM_ZLIB_VERSION} REQUIRED)
-  if(USE_STATIC_DEPENDENCIES)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${_ZLIB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
-    unset(_ZLIB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
-  endif()
-endif()
-
 if(UNIX)
   find_package(Threads REQUIRED)
 endif()


### PR DESCRIPTION
Our Houdini CI has been failing for almost a week now and along with it any other PRs we've submitted since then:

https://github.com/AcademySoftwareFoundation/openvdb/actions/workflows/houdini.yml?query=event%3Aschedule

I would guess it's somehow related to #1055 based on the timing of when other PRs have been merged, but it's not clear to me what in this PR might have caused these failures to suddenly start to happen.

On investigating, I noticed that the RPATH for the python module pyopenvdb.so did not include the Houdini dsolib directories where libblosc.so was intended to have been retrieved from. A little more digging led me to realize that the variable `Blosc_LIBRARY_DIRS` was being read from (https://github.com/AcademySoftwareFoundation/openvdb/blob/master/openvdb/openvdb/python/CMakeLists.txt#L264) but only set in the find_package call in the core library (https://github.com/AcademySoftwareFoundation/openvdb/blob/master/openvdb/openvdb/CMakeLists.txt#L155). As variables in CMake only propagate from parent to child and these two CMakeLists are essentially siblings (they're both invoked by an add_subdirectory call in the root CMakeLists), this wasn't working.

The change I'm making here is simply to move the find_package calls for Blosc, TBB, IlmBase and Log4CPlus up into the root CMakeLists which fixes the problem. I couldn't move the Boost find_package call because it relies on the `OPENVDB_CORE_SHARED` variable that comes from the core library CMakeLists. This is also a problem for the cmd and unittests CMakeLists hence why I opted to move the find_package instead of calling it again from each CMakeLists that requires it, though I'm open to better solutions.