### PR TITLE
RPATH and Houdini improvements

### DIFF
--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -96,7 +96,7 @@ jobs:
         -j ${{ matrix.config.j }}
         --build-type=${{ matrix.config.build }}
         --components="${{ matrix.config.components }}"
-        --cargs=\"-DOPENVDB_BUILD_HOUDINI_ABITESTS=ON -DOPENVDB_HOUDINI_INSTALL_PREFIX=/tmp -DDISABLE_DEPENDENCY_VERSION_CHECKS=${{ matrix.config.disable_checks }}\"
+        --cargs=\"-DDISABLE_CMAKE_SEARCH_PATHS=ON -DOPENVDB_BUILD_HOUDINI_ABITESTS=ON -DOPENVDB_HOUDINI_INSTALL_PREFIX=/tmp -DDISABLE_DEPENDENCY_VERSION_CHECKS=${{ matrix.config.disable_checks }}\"
     - name: test
       run: cd build && ctest -V
       # Final check to make sure the cache still exists

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -76,12 +76,14 @@ jobs:
         restore-keys: vdb-v3-houdini${{ matrix.config.hou }}-
     - name: validate_houdini
       run: test -f "hou/hou.tar.gz"
-      # Make sure the cache is copied, not moved, as the cache action always posts the cache
+      # Make sure the cache is copied, not moved, as the cache action always posts the cache.
+      # Also make sure that the unpacked install is NOT in the root of the OpenVDB checkout
+      # otherwise CMake's install RPATHs wil not work correctly.
     - name: install_houdini
       run: |
-        mkdir houdini_install
-        cp hou/hou.tar.gz houdini_install/hou.tar.gz
-        cd houdini_install && tar -xzf hou.tar.gz && cd -
+        mkdir $HOME/houdini_install
+        cp hou/hou.tar.gz $HOME/houdini_install/hou.tar.gz
+        cd $HOME/houdini_install && tar -xzf hou.tar.gz && cd -
     - name: install_cmake
       run: ./ci/install_cmake.sh 3.12.0
     - name: install_gtest
@@ -89,7 +91,7 @@ jobs:
     - name: build
       shell: bash
       run: >
-        cd houdini_install/hou && source houdini_setup_bash && cd - &&
+        cd $HOME/houdini_install/hou && source houdini_setup_bash && cd - &&
         ./ci/build.sh -v
         -j ${{ matrix.config.j }}
         --build-type=${{ matrix.config.build }}

--- a/.github/workflows/houdini_cache_update.yml
+++ b/.github/workflows/houdini_cache_update.yml
@@ -29,7 +29,7 @@ jobs:
         if: steps.check.outputs.HOUDINI_SECRETS != 'true'
         run: echo "HOUDINI_CLIENT_ID and HOUDINI_SECRET_KEY GitHub Action Secrets needs to be set to install Houdini builds"
 
-  houdini18_5:
+  linux_houdini18_5:
     needs: [checksecret]
     if: >
       ${{ needs.checksecret.outputs.HOUDINI_SECRETS == 'true' ||
@@ -59,7 +59,7 @@ jobs:
         ./ci/build.sh -v
         --build-type=Release
         --components="core,hou,bin,python,test,axcore,axbin,axtest"
-        --cargs=\"-DOPENVDB_BUILD_HOUDINI_ABITESTS=ON -DOPENVDB_HOUDINI_INSTALL_PREFIX=/tmp\"
+        --cargs=\"-DDISABLE_CMAKE_SEARCH_PATHS=ON -DOPENVDB_BUILD_HOUDINI_ABITESTS=ON -DOPENVDB_HOUDINI_INSTALL_PREFIX=/tmp\"
     - name: test
       run: cd build && ctest -V
     - name: write_houdini_cache
@@ -68,7 +68,7 @@ jobs:
         path: hou
         key: vdb-v3-houdini18_5-${{ hashFiles('hou/hou.tar.gz') }}
 
-  houdini18_0:
+  linux_houdini18_0:
     needs: [checksecret]
     if: >
       ${{ needs.checksecret.outputs.HOUDINI_SECRETS == 'true' ||
@@ -98,7 +98,7 @@ jobs:
         ./ci/build.sh -v
         --build-type=Release
         --components="core,hou,bin,python,test,axcore,axbin,axtest"
-        --cargs=\"-DOPENVDB_BUILD_HOUDINI_ABITESTS=ON -DOPENVDB_HOUDINI_INSTALL_PREFIX=/tmp\"
+        --cargs=\"-DDISABLE_CMAKE_SEARCH_PATHS=ON -DOPENVDB_BUILD_HOUDINI_ABITESTS=ON -DOPENVDB_HOUDINI_INSTALL_PREFIX=/tmp\"
     - name: test
       run: cd build && ctest -V
     - name: write_houdini_cache

--- a/.github/workflows/houdini_cache_update.yml
+++ b/.github/workflows/houdini_cache_update.yml
@@ -47,15 +47,15 @@ jobs:
       run: ./ci/download_houdini.sh 18.5 ON
     - name: install_houdini
       run: |
-        mkdir houdini_install
-        cp hou/hou.tar.gz houdini_install/hou.tar.gz
-        cd houdini_install && tar -xzf hou.tar.gz && cd -
+        mkdir $HOME/houdini_install
+        cp hou/hou.tar.gz $HOME/houdini_install/hou.tar.gz
+        cd $HOME/houdini_install && tar -xzf hou.tar.gz && cd -
     - name: install_gtest
       run: ./ci/install_gtest.sh 1.10.0
     - name: build
       shell: bash
       run: >
-        cd houdini_install/hou && source houdini_setup_bash && cd - &&
+        cd $HOME/houdini_install/hou && source houdini_setup_bash && cd - &&
         ./ci/build.sh -v
         --build-type=Release
         --components="core,hou,bin,python,test,axcore,axbin,axtest"
@@ -86,15 +86,15 @@ jobs:
       run: ./ci/download_houdini.sh 18.0 ON
     - name: install_houdini
       run: |
-        mkdir houdini_install
-        cp hou/hou.tar.gz houdini_install/hou.tar.gz
-        cd houdini_install && tar -xzf hou.tar.gz && cd -
+        mkdir $HOME/houdini_install
+        cp hou/hou.tar.gz $HOME/houdini_install/hou.tar.gz
+        cd $HOME/houdini_install && tar -xzf hou.tar.gz && cd -
     - name: install_gtest
       run: ./ci/install_gtest.sh 1.10.0
     - name: build
       shell: bash
       run: >
-        cd houdini_install/hou && source houdini_setup_bash && cd - &&
+        cd $HOME/houdini_install/hou && source houdini_setup_bash && cd - &&
         ./ci/build.sh -v
         --build-type=Release
         --components="core,hou,bin,python,test,axcore,axbin,axtest"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,8 @@ if(OPENVDB_ENABLE_RPATH)
   set(CMAKE_SKIP_BUILD_RPATH FALSE)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  # @todo make relocatable?
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 endif()
 
 # For CMake's find Threads module which brings in pthread - This flag

--- a/ci/install_cmake.sh
+++ b/ci/install_cmake.sh
@@ -3,16 +3,13 @@
 set -ex
 
 CMAKE_VERSION="$1"
+CMAKE_PACKAGE=cmake-${CMAKE_VERSION}-Linux-x86_64
 
-git clone https://github.com/Kitware/CMake.git
-cd CMake
+wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_PACKAGE}.tar.gz
 
-if [ "$CMAKE_VERSION" != "latest" ]; then
-    git checkout tags/v${CMAKE_VERSION} -b v${CMAKE_VERSION}
-fi
+tar -xf ${CMAKE_PACKAGE}.tar.gz
+cp ${CMAKE_PACKAGE}/bin/* /usr/local/bin/
+cp -r ${CMAKE_PACKAGE}/share/* /usr/local/share/
 
-mkdir build
-cd build
-cmake ../.
-make -j4
-make install
+rm -rf ${CMAKE_PACKAGE}
+rm -rf ${CMAKE_PACKAGE}.tar.gz

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -188,18 +188,53 @@ if(UNIX)
 endif()
 
 # Set deps. Note that the order here is important. If we're building against
-# Houdini 17.5 we must include IlmBase deps first to ensure the users chosen
-# namespaced headers are correctly prioritized. Otherwise other include paths
-# from shared installs (including houdini) may pull in the wrong headers
+# Houdini 17.5 or later we must include IlmBase deps first to ensure the users
+# chosen namespaced headers are correctly prioritized. Otherwise other include
+# paths from shared installs (including houdini) may pull in the wrong headers
 
-set(OPENVDB_CORE_DEPENDENT_LIBS
-  Boost::iostreams
-  Boost::system
-)
+set(OPENVDB_CORE_DEPENDENT_LIBS "")
 
 if(USE_IMATH_HALF)
   list(APPEND OPENVDB_CORE_DEPENDENT_LIBS IlmBase::Half)
 endif()
+
+# We then choose to pull in TBB. If building aganst Houdini, TBB should
+# always be pulled from there (we should always be using the version of TBB
+# shipped with Houdini).
+
+list(APPEND OPENVDB_CORE_DEPENDENT_LIBS TBB::tbb)
+
+if(USE_LOG4CPLUS)
+  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Log4cplus::log4cplus)
+endif()
+
+# @todo blosc and zlib should be hidden (privately linked in):
+# See FindOpenVDB.cmake
+# @warning If building against Houdini these should be picked up from the
+# Houdini installation. If a custom version of EXR is in use, be careful
+# that zlib/blosc headers/libs are not also in the same location e.g.
+# /usr/local
+
+if(USE_BLOSC)
+  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Blosc::blosc)
+endif()
+
+if(USE_BLOSC OR USE_ZLIB)
+  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS ZLIB::ZLIB)
+endif()
+
+if(UNIX)
+  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Threads::Threads)
+endif()
+
+# Pull in Boost last as houdini's boost (hboost) is fully namespaced and libs
+# are renamed too. Boost can be pulled in at any time, but do it last so that,
+# if it's in a shared place (like /usr/local) it doesn't accidently pull in
+# other headers.
+
+list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
+  Boost::iostreams
+  Boost::system)
 
 if(WIN32)
   # Boost headers contain #pragma commands on Windows which causes Boost
@@ -212,27 +247,6 @@ if(WIN32)
         Boost::disable_autolinking  # add -DBOOST_ALL_NO_LIB
       )
   endif()
-endif()
-
-if(USE_LOG4CPLUS)
-  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Log4cplus::log4cplus)
-endif()
-
-# @todo blosc and zlib should be hidden (privately linked in):
-# See FindOpenVDB.cmake
-
-if(USE_BLOSC)
-  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Blosc::blosc)
-endif()
-
-if(USE_BLOSC OR USE_ZLIB)
-  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS ZLIB::ZLIB)
-endif()
-
-list(APPEND OPENVDB_CORE_DEPENDENT_LIBS TBB::tbb)
-
-if(UNIX)
-  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Threads::Threads)
 endif()
 
 ##########################################################################

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -546,23 +546,7 @@ if(OPENVDB_CORE_SHARED)
     PROPERTIES
       OUTPUT_NAME ${OPENVDB_SHARED_LIBRARY_NAME}
       SOVERSION ${OpenVDB_MAJOR_VERSION}.${OpenVDB_MINOR_VERSION}
-      VERSION ${OpenVDB_MAJOR_VERSION}.${OpenVDB_MINOR_VERSION}.${OpenVDB_PATCH_VERSION}
-  )
-
-  if(OPENVDB_ENABLE_RPATH)
-    # @todo There is probably a better way to do this for imported targets
-    list(APPEND RPATHS
-      ${Boost_LIBRARY_DIRS}
-      ${IlmBase_LIBRARY_DIRS}
-      ${Log4cplus_LIBRARY_DIRS}
-      ${Blosc_LIBRARY_DIRS}
-      ${Tbb_LIBRARY_DIRS}
-    )
-    list(REMOVE_DUPLICATES RPATHS)
-    set_target_properties(openvdb_shared
-      PROPERTIES INSTALL_RPATH "${RPATHS}"
-    )
-  endif()
+      VERSION ${OpenVDB_MAJOR_VERSION}.${OpenVDB_MINOR_VERSION}.${OpenVDB_PATCH_VERSION})
 
   if(MSVC)
     if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)

--- a/openvdb/openvdb/cmd/CMakeLists.txt
+++ b/openvdb/openvdb/cmd/CMakeLists.txt
@@ -52,29 +52,6 @@ endif()
 
 ##########################################################################
 
-# rpath handling
-
-set(RPATHS "")
-if(OPENVDB_ENABLE_RPATH)
-  # @todo There is probably a better way to do this for imported targets
-  list(APPEND RPATHS
-    ${Boost_LIBRARY_DIRS}
-    ${IlmBase_LIBRARY_DIRS}
-    ${Log4cplus_LIBRARY_DIRS}
-    ${Blosc_LIBRARY_DIRS}
-    ${Tbb_LIBRARY_DIRS}
-  )
-  if(OPENVDB_BUILD_CORE)
-    list(APPEND RPATHS ${CMAKE_INSTALL_FULL_LIBDIR})
-  else()
-    list(APPEND RPATHS ${OpenVDB_LIBRARY_DIRS})
-  endif()
-
-  list(REMOVE_DUPLICATES RPATHS)
-endif()
-
-##########################################################################
-
 ##### VDB binaries
 
 #### vdb_print
@@ -83,12 +60,6 @@ if(OPENVDB_BUILD_VDB_PRINT)
   set(VDB_PRINT_SOURCE_FILES openvdb_print.cc)
   add_executable(vdb_print ${VDB_PRINT_SOURCE_FILES})
   target_link_libraries(vdb_print ${OPENVDB_BINARIES_DEPENDENT_LIBS})
-
-  if(OPENVDB_ENABLE_RPATH)
-    set_target_properties(vdb_print
-      PROPERTIES INSTALL_RPATH "${RPATHS}"
-    )
-  endif()
 
   install(TARGETS vdb_print RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
@@ -101,12 +72,6 @@ if(OPENVDB_BUILD_VDB_LOD)
   set(VDB_LOD_SOURCE_FILES  openvdb_lod.cc)
   add_executable(vdb_lod ${VDB_LOD_SOURCE_FILES})
   target_link_libraries(vdb_lod ${OPENVDB_BINARIES_DEPENDENT_LIBS})
-
-  if(OPENVDB_ENABLE_RPATH)
-    set_target_properties(vdb_lod
-      PROPERTIES INSTALL_RPATH "${RPATHS}"
-    )
-  endif()
 
   install(TARGETS vdb_lod RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
@@ -143,20 +108,6 @@ if(OPENVDB_BUILD_VDB_RENDER)
     if(OPENEXR_USE_STATIC_LIBS OR (${ILMBASE_LIB_TYPE} STREQUAL STATIC_LIBRARY))
       target_compile_definitions(vdb_render  PUBLIC -DOPENVDB_OPENEXR_STATICLIB)
     endif()
-  endif()
-
-  if(OPENVDB_ENABLE_RPATH)
-    set(OPENVDB_RENDER_RPATHS)
-    list(APPEND OPENVDB_RENDER_RPATHS
-      ${OpenEXR_LIBRARY_DIRS}
-      ${RPATHS}
-    )
-    list(REMOVE_DUPLICATES OPENVDB_RENDER_RPATHS)
-
-    set_target_properties(vdb_render
-      PROPERTIES INSTALL_RPATH "${OPENVDB_RENDER_RPATHS}"
-    )
-    unset(OPENVDB_RENDER_RPATHS)
   endif()
 
   install(TARGETS vdb_render RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -199,12 +150,6 @@ if(OPENVDB_BUILD_VDB_VIEW)
   endif()
 
   target_compile_definitions(vdb_view PRIVATE -DGL_GLEXT_PROTOTYPES=1)
-
-  if(OPENVDB_ENABLE_RPATH)
-    set_target_properties(vdb_view
-      PROPERTIES INSTALL_RPATH "${RPATHS}"
-    )
-  endif()
 
   install(TARGETS vdb_view RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/openvdb/openvdb/python/CMakeLists.txt
+++ b/openvdb/openvdb/python/CMakeLists.txt
@@ -254,30 +254,6 @@ if(USE_NUMPY)
   target_compile_definitions(pyopenvdb PUBLIC "-DPY_OPENVDB_USE_NUMPY")
 endif()
 
-if(OPENVDB_ENABLE_RPATH)
-  # @todo There is probably a better way to do this for imported targets
-  set(RPATHS "")
-  list(APPEND RPATHS
-    ${Boost_LIBRARY_DIRS}
-    ${IlmBase_LIBRARY_DIRS}
-    ${Log4cplus_LIBRARY_DIRS}
-    ${Blosc_LIBRARY_DIRS}
-    ${Tbb_LIBRARY_DIRS}
-    ${Python_LIBRARY_DIRS}
-  )
-  if(OPENVDB_BUILD_CORE)
-    list(APPEND RPATHS ${CMAKE_INSTALL_FULL_LIBDIR})
-  else()
-    list(APPEND RPATHS ${OpenVDB_LIBRARY_DIRS})
-  endif()
-
-  list(REMOVE_DUPLICATES RPATHS)
-  set_target_properties(pyopenvdb
-    PROPERTIES INSTALL_RPATH "${RPATHS}"
-  )
-  unset(RPATHS)
-endif()
-
 set(PYTHON_PUBLIC_INCLUDE_NAMES
   pyopenvdb.h
 )

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -211,28 +211,4 @@ target_link_libraries(vdb_test
   ${OPENVDB_TEST_DEPENDENT_LIBS}
 )
 
-if(OPENVDB_ENABLE_RPATH)
-  set(RPATHS "")
-  # @todo There is probably a better way to do this for imported targets
-  list(APPEND RPATHS
-    ${Boost_LIBRARY_DIRS}
-    ${IlmBase_LIBRARY_DIRS}
-    ${Log4cplus_LIBRARY_DIRS}
-    ${Blosc_LIBRARY_DIRS}
-    ${Tbb_LIBRARY_DIRS}
-    ${Gtest_LIBRARY_DIRS}
-  )
-  if(OPENVDB_BUILD_CORE)
-    list(APPEND RPATHS ${CMAKE_INSTALL_FULL_LIBDIR})
-  else()
-    list(APPEND RPATHS ${OpenVDB_LIBRARY_DIRS})
-  endif()
-
-  list(REMOVE_DUPLICATES RPATHS)
-
-  set_target_properties(vdb_test
-    PROPERTIES INSTALL_RPATH "${RPATHS}"
-  )
-endif()
-
 add_test(vdb_unit_test vdb_test -v)

--- a/openvdb_ax/openvdb_ax/CMakeLists.txt
+++ b/openvdb_ax/openvdb_ax/CMakeLists.txt
@@ -310,22 +310,6 @@ if(OPENVDB_AX_SHARED)
       VERSION ${OpenVDB_MAJOR_VERSION}.${OpenVDB_MINOR_VERSION}.${OpenVDB_PATCH_VERSION}
     )
 
-  if(OPENVDB_ENABLE_RPATH)
-    # @todo There is probably a better way to do this for imported targets
-    list(APPEND RPATHS
-      ${Boost_LIBRARY_DIRS}
-      ${IlmBase_LIBRARY_DIRS}
-      ${Log4cplus_LIBRARY_DIRS}
-      ${Blosc_LIBRARY_DIRS}
-      ${Tbb_LIBRARY_DIRS}
-      ${LLVM_LIBRARY_DIRS}
-    )
-    list(REMOVE_DUPLICATES RPATHS)
-    set_target_properties(openvdb_ax_shared
-      PROPERTIES INSTALL_RPATH "${RPATHS}"
-    )
-  endif()
-
   target_link_libraries(openvdb_ax_shared PUBLIC ${OPENVDB_AX_CORE_DEPENDENT_LIBS})
 endif()
 

--- a/openvdb_ax/openvdb_ax/cmd/CMakeLists.txt
+++ b/openvdb_ax/openvdb_ax/cmd/CMakeLists.txt
@@ -42,27 +42,4 @@ set(VDB_AX_SOURCE_FILES openvdb_ax.cc)
 add_executable(vdb_ax ${VDB_AX_SOURCE_FILES})
 target_link_libraries(vdb_ax ${OPENVDB_BINARIES_DEPENDENT_LIBS})
 
-if(OPENVDB_ENABLE_RPATH)
-  set(RPATHS "")
-  # @todo There is probably a better way to do this for imported targets
-  list(APPEND RPATHS
-    ${Boost_LIBRARY_DIRS}
-    ${IlmBase_LIBRARY_DIRS}
-    ${Log4cplus_LIBRARY_DIRS}
-    ${Blosc_LIBRARY_DIRS}
-    ${Tbb_LIBRARY_DIRS}
-  )
-  if(OPENVDB_BUILD_AX)
-    list(APPEND RPATHS ${CMAKE_INSTALL_FULL_LIBDIR})
-  else()
-    list(APPEND RPATHS ${OpenVDB_LIBRARY_DIRS})
-  endif()
-
-  list(REMOVE_DUPLICATES RPATHS)
-  set_target_properties(vdb_ax
-    PROPERTIES INSTALL_RPATH "${RPATHS}"
-  )
-  unset(RPATHS)
-endif()
-
 install(TARGETS vdb_ax RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/openvdb_houdini/openvdb_houdini/CMakeLists.txt
+++ b/openvdb_houdini/openvdb_houdini/CMakeLists.txt
@@ -202,31 +202,6 @@ target_link_libraries(openvdb_houdini PUBLIC
 
 target_compile_definitions(openvdb_houdini PRIVATE "-DOPENVDB_HOUDINI_PRIVATE")
 
-if(OPENVDB_ENABLE_RPATH)
-  # @todo There is probably a better way to do this for imported targets
-  set(RPATHS "")
-  list(APPEND RPATHS
-    ${Boost_LIBRARY_DIRS}
-    ${IlmBase_LIBRARY_DIRS}
-    ${Log4cplus_LIBRARY_DIRS}
-    ${Blosc_LIBRARY_DIRS}
-    ${Tbb_LIBRARY_DIRS}
-  )
-  if(OPENVDB_BUILD_CORE)
-    list(APPEND RPATHS ${CMAKE_INSTALL_FULL_LIBDIR})
-  else()
-    list(APPEND RPATHS ${OpenVDB_LIBRARY_DIRS})
-  endif()
-
-  list(REMOVE_DUPLICATES RPATHS)
-
-  set_target_properties(openvdb_houdini
-    PROPERTIES INSTALL_RPATH "${RPATHS}"
-  )
-  unset(RPATHS)
-endif()
-
-
 set_target_properties(openvdb_houdini
   PROPERTIES
     OUTPUT_NAME openvdb_houdini
@@ -357,25 +332,6 @@ foreach(DSO_NAME ${OPENVDB_DSO_NAMES})
     PREFIX ""
     TAGINFO ""
   )
-
-  # Configure rpaths
-  # Encode the path to libopenvdb.so into plugins, and because some
-  # plugins might depend on Houdini libraries that are not linked into
-  # hython (among other tools), encode the Houdini library path as well.
-
-  if(OPENVDB_ENABLE_RPATH)
-    set(RPATHS)
-    if(OPENVDB_BUILD_CORE)
-      list(APPEND RPATHS ${CMAKE_INSTALL_FULL_LIBDIR})
-    else()
-      list(APPEND RPATHS ${OpenVDB_LIBRARY_DIRS})
-    endif()
-    list(APPEND RPATHS ${OPENVDB_HOUDINI_LIB_INSTALL_PREFIX})
-    list(REMOVE_DUPLICATES RPATHS)
-    set_target_properties(${DSO_NAME}
-      PROPERTIES INSTALL_RPATH "${RPATHS}"
-    )
-  endif()
 
   add_dependencies(openvdb_houdini_dsos ${DSO_NAME})
 endforeach()

--- a/openvdb_maya/openvdb_maya/CMakeLists.txt
+++ b/openvdb_maya/openvdb_maya/CMakeLists.txt
@@ -133,21 +133,6 @@ set_target_properties(openvdb_maya
   OUTPUT_NAME OpenVDB
 )
 
-if(OPENVDB_ENABLE_RPATH)
-  set(RPATHS "")
-  if(OPENVDB_BUILD_CORE)
-    list(APPEND RPATHS ${CMAKE_INSTALL_FULL_LIBDIR})
-  else()
-    list(APPEND RPATHS ${OpenVDB_LIBRARY_DIRS})
-  endif()
-
-  list(REMOVE_DUPLICATES RPATHS)
-  set_target_properties(openvdb_maya
-    PROPERTIES INSTALL_RPATH "${RPATHS}"
-  )
-  unset(RPATHS)
-endif()
-
 #########################################################################
 
 install(TARGETS openvdb_maya


### PR DESCRIPTION
 - Removed explicit RPATHs in favour of CMake's automatic behaviour
 - Changed the Houdini CI to extract the Houdini install outside the OpenVDB root source to fix CMake install RPATHs being ignored
 - Changed the include order for VDB dependencies to better resolve issues where system libraries would conflict
 - Download CMake rather than building from source (saves ~5min)


