### PR TITLE
Add a new CustomInterrupter with weak symbols overriden by Houdini

### DIFF
--- a/openvdb/openvdb/util/NullInterrupter.cc
+++ b/openvdb/openvdb/util/NullInterrupter.cc
@@ -1,0 +1,20 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#include "NullInterrupter.h"
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace util {
+
+// default implementation of custom interrupter is a noop
+
+CustomInterrupter::CustomInterrupter(const char*) { }
+void CustomInterrupter::start(const char*) { }
+void CustomInterrupter::end() { }
+bool CustomInterrupter::wasInterrupted(int) { return false; }
+
+} // namespace util
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb

--- a/openvdb_houdini/openvdb_houdini/CMakeLists.txt
+++ b/openvdb_houdini/openvdb_houdini/CMakeLists.txt
@@ -165,6 +165,7 @@ file(COPY
     GT_GEOPrimCollectVDB.h
     GU_PrimVDB.h
     GU_VDBPointTools.h
+    Interrupter.h
     PointUtils.h
     SOP_NodeVDB.h
     SOP_VDBVerbUtils.h
@@ -183,6 +184,7 @@ add_library(openvdb_houdini SHARED
   GT_GEOPrimCollectVDB.cc
   GU_PrimVDB.cc
   GU_VDBPointTools.cc
+  Interrupter.cc
   ParmFactory.cc
   PointUtils.cc
   SOP_NodeVDB.cc

--- a/openvdb_houdini/openvdb_houdini/GeometryUtil.h
+++ b/openvdb_houdini/openvdb_houdini/GeometryUtil.h
@@ -8,6 +8,7 @@
 #ifndef OPENVDB_HOUDINI_GEOMETRY_UTIL_HAS_BEEN_INCLUDED
 #define OPENVDB_HOUDINI_GEOMETRY_UTIL_HAS_BEEN_INCLUDED
 
+#include "Interrupter.h"
 #include <openvdb/openvdb.h>
 #include <openvdb/tools/MeshToVolume.h> // for openvdb::tools::MeshToVoxelEdgeData
 #include <openvdb/tree/LeafManager.h>
@@ -36,8 +37,6 @@ class OP_Node;
 
 
 namespace openvdb_houdini {
-
-class Interrupter;
 
 
 /// Add geometry to the given detail to indicate the extents of a frustum transform.

--- a/openvdb_houdini/openvdb_houdini/Interrupter.cc
+++ b/openvdb_houdini/openvdb_houdini/Interrupter.cc
@@ -1,0 +1,49 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+//
+/// @file Interrupter.cc
+/// @brief Houdini Interrupter
+
+#include "Interrupter.h"
+#include <UT/UT_Interrupt.h>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace util {
+
+/// Override the CustomInterrupter definitions from the OpenVDB library
+/// with methods that use Houdini @c UT_Interrupt
+/// @sa openvdb/util/NullInterrupter.h
+
+CustomInterrupter::CustomInterrupter(const char* title /*=nullptr*/):
+    mInterrupter(reinterpret_cast<char* const>(UTgetInterrupt())),
+    mRunning(false),
+    mTitle(title ? title : "")
+{
+}
+
+void CustomInterrupter::start(const char* name /*=nullptr*/)
+{
+    if (!mRunning) {
+        mRunning = true;
+        reinterpret_cast<UT_Interrupt* const>(mInterrupter)->opStart(name ? name : mTitle.c_str());
+    }
+}
+
+void CustomInterrupter::end()
+{
+    if (mRunning) {
+        reinterpret_cast<UT_Interrupt* const>(mInterrupter)->opEnd();
+        mRunning = false;
+    }
+}
+
+bool CustomInterrupter::wasInterrupted(int percent /*=-1*/)
+{
+    return reinterpret_cast<UT_Interrupt* const>(mInterrupter)->opInterrupt(percent);
+}
+
+} // namespace util
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb

--- a/openvdb_houdini/openvdb_houdini/Interrupter.h
+++ b/openvdb_houdini/openvdb_houdini/Interrupter.h
@@ -1,0 +1,18 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+//
+/// @file Interrupter.h
+/// @brief Houdini Interrupter
+
+#ifndef OPENVDB_HOUDINI_INTERRUPTER_HAS_BEEN_INCLUDED
+#define OPENVDB_HOUDINI_INTERRUPTER_HAS_BEEN_INCLUDED
+
+#include <openvdb/util/NullInterrupter.h> // for CustomInterrupter
+
+namespace openvdb_houdini {
+
+using Interrupter = openvdb::util::CustomInterrupter;
+
+} // namespace openvdb_houdini
+
+#endif // OPENVDB_HOUDINI_INTERRUPTER_HAS_BEEN_INCLUDED

--- a/openvdb_houdini/openvdb_houdini/PointUtils.h
+++ b/openvdb_houdini/openvdb_houdini/PointUtils.h
@@ -10,6 +10,7 @@
 #ifndef OPENVDB_HOUDINI_POINT_UTILS_HAS_BEEN_INCLUDED
 #define OPENVDB_HOUDINI_POINT_UTILS_HAS_BEEN_INCLUDED
 
+#include "Interrupter.h"
 #include <openvdb/math/Vec3.h>
 #include <openvdb/Types.h>
 #include <openvdb/points/PointDataGrid.h>
@@ -60,10 +61,6 @@ enum POINT_COMPRESSION_TYPE
     COMPRESSION_UNIT_FIXED_POINT_8,
     COMPRESSION_UNIT_FIXED_POINT_16,
 };
-
-
-// forward declaration
-class Interrupter;
 
 
 /// @brief Compute a voxel size from a Houdini detail

--- a/openvdb_houdini/openvdb_houdini/Utils.h
+++ b/openvdb_houdini/openvdb_houdini/Utils.h
@@ -8,10 +8,10 @@
 #ifndef OPENVDB_HOUDINI_UTILS_HAS_BEEN_INCLUDED
 #define OPENVDB_HOUDINI_UTILS_HAS_BEEN_INCLUDED
 
+#include "Interrupter.h"
 #include "GU_PrimVDB.h"
 #include <OP/OP_Node.h> // for OP_OpTypeId
 #include <UT/UT_SharedPtr.h>
-#include <UT/UT_Interrupt.h>
 #include <openvdb/openvdb.h>
 #include <functional>
 #include <type_traits>
@@ -162,43 +162,6 @@ public:
     GU_PrimVDB* operator->() const { return getPrimitive(); }
     //@}
 }; // class VdbPrimIterator
-
-
-////////////////////////////////////////
-
-
-/// @brief Wrapper class that adapts a Houdini @c UT_Interrupt object
-/// for use with OpenVDB library routines
-/// @sa openvdb/util/NullInterrupter.h
-class Interrupter
-{
-public:
-    explicit Interrupter(const char* title = nullptr):
-        mUTI{UTgetInterrupt()}, mRunning{false}, mTitle{title ? title : ""}
-    {}
-    ~Interrupter() { if (mRunning) this->end(); }
-
-    Interrupter(const Interrupter&) = default;
-    Interrupter& operator=(const Interrupter&) = default;
-
-    /// @brief Signal the start of an interruptible operation.
-    /// @param name  an optional descriptive name for the operation
-    void start(const char* name = nullptr) {
-        if (!mRunning) { mRunning = true; mUTI->opStart(name ? name : mTitle.c_str()); }
-    }
-    /// Signal the end of an interruptible operation.
-    void end() { if (mRunning) { mUTI->opEnd(); mRunning = false; } }
-
-    /// @brief Check if an interruptible operation should be aborted.
-    /// @param percent  an optional (when >= 0) percentage indicating
-    ///     the fraction of the operation that has been completed
-    bool wasInterrupted(int percent=-1) { return mUTI->opInterrupt(percent); }
-
-private:
-    UT_Interrupt* mUTI;
-    bool mRunning;
-    std::string mTitle;
-};
 
 
 ////////////////////////////////////////


### PR DESCRIPTION
In the process of trying to introduce explicit instantiation, the interrupters proved to be an issue because `openvdb_houdini::Interrupter` lives in the openvdb_houdini library so no function signatures with this object can be explicitly instantiated in the core library.

Here's an alternative approach - I've added a new CustomInterrupter to the core library that has four methods that are marked weak and I've explicitly overridden them in the Houdini library. This means we can explicitly instantiate templated methods in the base class with these symbols and then replace the symbols in the openvdb_houdini library. An alias keeps the existing functionality with minimal refactoring.

I've tested performance as this removes the ability to inline the `wasInterrupted()` method, however it makes no discernible difference as the UT_Interrupt class that the Interrupter wraps in Houdini does not itself have inlineable methods. As a side note, I also tested with and without an interrupter as a baseline and unless the number of wasInterrupted() calls are _far_ too excessive to be useful (ie every voxel in an inner loop) does the fact that it can be compiled out as a no-op actually provide any noticeable benefit. I honestly don't think it makes sense to continue templating all these methods on an InterrupterT given the additional compile-time and API complexity.

Note there is a mechanism in Windows that provides a similar benefit from what I can understand but I need to dig deeper (https://devblogs.microsoft.com/oldnewthing/20200731-00/?p=104024).