### PR TITLE
Fix SOP OpenVDB Extrapolate: expand SDF narrow band with 0 dilate value

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Version 9.0.0 - In development
     - A new HoudiniInterrupter has been added that derives from the
       NullInterrupter and the Interrupter is now deprecated. All the SOPs have
       been updated to use the new HoudiniInterrupter.
+    - Add a sanitizer in SOP OpenVDB Extrapolate when expanding a narrow-band
+      level-set with a dilation value of 0, which will result in no operation.
 
     Build:
     - As of this release, VFX Reference Platform 2019 is no longer supported.

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Extrapolate.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Extrapolate.cc
@@ -662,6 +662,13 @@ SOP_OpenVDB_Extrapolate::Cache::process(
                 return false;
             }
 
+            // no-operation if dilation is < 1
+            if (parms.mDilate < 1) {
+                std::string msg = "Expand SDF narrow-band with dilate value < 1 results in no-op.";
+                addMessage(SOP_MESSAGE, msg.c_str());
+                return false;
+            }
+
             const NearestNeighbors nn =
                 (parms.mPattern == "NN18") ? NN_FACE_EDGE : ((parms.mPattern == "NN26") ? NN_FACE_EDGE_VERTEX : NN_FACE);
             parms.mNewFSGrid = dilateSdf(*fsGrid, parms.mDilate, nn, parms.mNSweeps, parms.mSweepingDomain);


### PR DESCRIPTION
Fixing an issue raised by @jmlait in an email: if we try to dilate an SDF with dilate parameter = 0, it should result in no-op. Thank you for catching this, @jmlait.