### PR TITLE
fixed a bug in nanovdb/util/HostBuffer.h

### DIFF
--- a/nanovdb/nanovdb/util/HostBuffer.h
+++ b/nanovdb/nanovdb/util/HostBuffer.h
@@ -387,10 +387,10 @@ inline HostBuffer::HostBuffer(uint64_t size) : mPool(nullptr), mSize(size), mDat
 
 inline HostBuffer::HostBuffer(HostBuffer&& other) : mPool(other.mPool), mSize(other.mSize), mData(other.mData)
 {
-    if (mPool) {
+    if (mPool && mSize != 0) {
         mPool->replace(&other, this);
-        other.mPool.reset();
     }
+    other.mPool.reset();
     other.mSize = 0;
     other.mData = nullptr;
 }


### PR DESCRIPTION
Signed-off-by: Ken <ken.museth@gmail.com>

Fixed a bug related to a failing unit-test on Windows debug-build reported by @Idclip . It's related to the move constructor for nanovdb::HostBuffer