### PR TITLE
Auto detect OpenVDB API for houdini-19+

### DIFF
--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -335,12 +335,31 @@ if(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.0)
   set(OPENVDB_HOUDINI_ABI 6)
 elseif(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.5)
   set(OPENVDB_HOUDINI_ABI 7)
-elseif(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 19.0)
-  set(OPENVDB_HOUDINI_ABI 8)
 else()
-  message(WARNING "Unknown version of Houdini, assuming OpenVDB ABI=8, "
-    "but if this not correct, the CMake flag -DOPENVDB_HOUDINI_ABI=<N> can override this value.")
-  set(OPENVDB_HOUDINI_ABI 8)
+  find_file(_houdini_openvdb_version_file "openvdb/version.h"
+    PATHS ${HOUDINI_INCLUDE_DIR}
+    NO_DEFAULT_PATH
+    NO_PACKAGE_ROOT_PATH
+    NO_CMAKE_PATH
+    NO_CMAKE_ENVIRONMENT_PATH
+    NO_SYSTEM_ENVIRONMENT_PATH
+    NO_CMAKE_SYSTEM_PATH)
+  if(NOT ${_houdini_openvdb_version_file} EQUAL "_houdini_openvdb_version_file-NOTFOUND")
+    file(STRINGS ${_houdini_openvdb_version_file} _houdini_openvdb_version)
+    foreach(line ${_houdini_openvdb_version})
+      if(line MATCHES "^#define OPENVDB_ABI_VERSION_NUMBER ([0-9]+)$")
+        set(OPENVDB_HOUDINI_ABI ${CMAKE_MATCH_1})
+        break()
+      endif()
+    endforeach()
+    unset(_houdini_openvdb_version)
+  endif()
+  unset(_houdini_openvdb_version_file)
+  if(NOT OPENVDB_HOUDINI_ABI)
+    message(WARNING "Unknown version of Houdini, assuming OpenVDB ABI=${OpenVDB_MAJOR_VERSION}, "
+      "but if this not correct, the CMake flag -DOPENVDB_HOUDINI_ABI=<N> can override this value.")
+    set(OPENVDB_HOUDINI_ABI ${OpenVDB_MAJOR_VERSION})
+  endif()
 endif()
 
 # ------------------------------------------------------------------------

--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -339,7 +339,7 @@ else()
   find_file(_houdini_openvdb_version_file "openvdb/version.h"
     PATHS ${HOUDINI_INCLUDE_DIR}
     NO_DEFAULT_PATH)
-  if(NOT ${_houdini_openvdb_version_file} EQUAL "_houdini_openvdb_version_file-NOTFOUND")
+  if(NOT ${_houdini_openvdb_version_file})
     file(STRINGS ${_houdini_openvdb_version_file} _houdini_openvdb_version)
     foreach(line ${_houdini_openvdb_version})
       if(line MATCHES "^#define OPENVDB_ABI_VERSION_NUMBER ([0-9]+)$")

--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -341,7 +341,7 @@ else()
   find_file(_houdini_openvdb_version_file "openvdb/version.h"
     PATHS ${HOUDINI_INCLUDE_DIR}
     NO_DEFAULT_PATH)
-  if(NOT ${_houdini_openvdb_version_file})
+  if(_houdini_openvdb_version_file)
     OPENVDB_VERSION_FROM_HEADER("${_houdini_openvdb_version_file}"
       ABI OPENVDB_HOUDINI_ABI)
   endif()

--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -77,6 +77,8 @@ may be provided to tell this module where to look.
 
 cmake_minimum_required(VERSION 3.15)
 
+# Include utility functions for version information
+include(${CMAKE_CURRENT_LIST_DIR}/OpenVDBUtils.cmake)
 
 set(_FIND_HOUDINI_ADDITIONAL_OPTIONS "")
 if(DISABLE_CMAKE_SEARCH_PATHS)
@@ -340,14 +342,8 @@ else()
     PATHS ${HOUDINI_INCLUDE_DIR}
     NO_DEFAULT_PATH)
   if(NOT ${_houdini_openvdb_version_file})
-    file(STRINGS ${_houdini_openvdb_version_file} _houdini_openvdb_version)
-    foreach(line ${_houdini_openvdb_version})
-      if(line MATCHES "^#define OPENVDB_ABI_VERSION_NUMBER ([0-9]+)$")
-        set(OPENVDB_HOUDINI_ABI ${CMAKE_MATCH_1})
-        break()
-      endif()
-    endforeach()
-    unset(_houdini_openvdb_version)
+    OPENVDB_VERSION_FROM_HEADER("${_houdini_openvdb_version_file}"
+      ABI OPENVDB_HOUDINI_ABI)
   endif()
   unset(_houdini_openvdb_version_file)
   if(NOT OPENVDB_HOUDINI_ABI)

--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -338,12 +338,7 @@ elseif(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.5)
 else()
   find_file(_houdini_openvdb_version_file "openvdb/version.h"
     PATHS ${HOUDINI_INCLUDE_DIR}
-    NO_DEFAULT_PATH
-    NO_PACKAGE_ROOT_PATH
-    NO_CMAKE_PATH
-    NO_CMAKE_ENVIRONMENT_PATH
-    NO_SYSTEM_ENVIRONMENT_PATH
-    NO_CMAKE_SYSTEM_PATH)
+    NO_DEFAULT_PATH)
   if(NOT ${_houdini_openvdb_version_file} EQUAL "_houdini_openvdb_version_file-NOTFOUND")
     file(STRINGS ${_houdini_openvdb_version_file} _houdini_openvdb_version)
     foreach(line ${_houdini_openvdb_version})


### PR DESCRIPTION
During cmake configuration if `Houdini_VERSION_MAJOR_MINOR` is greater than or equal to 19.0 it will extract the ABI version number from `openvdb/version.h` shipped with Houdini.

If it fails it will use the similar fallback as before, except it will use `OpenVDB_MAJOR_VERSION` instead of hardcoded `8`.

Signed-off-by: Fredrik Salomonsson <fredriks@d2.com>