### PR TITLE
Introduce ccache to Linux release builds

### DIFF
--- a/.github/workflows/ax.yml
+++ b/.github/workflows/ax.yml
@@ -51,6 +51,7 @@ jobs:
       image: aswf/ci-openvdb:${{ matrix.config.image }}
     env:
       CXX: ${{ matrix.config.cxx }}
+      CCACHE_DIR: /tmp/ccache
     strategy:
       matrix:
         config:
@@ -78,7 +79,6 @@ jobs:
           restore-keys: linux-ax${{ matrix.config.image }}-${{ matrix.config.cxx }}-
       - name: build
         run: >
-          CCACHE_DIR=/tmp/ccache
           ./ci/build.sh -v
           -j ${{ matrix.config.j }}
           --build-type=${{ matrix.config.build }}
@@ -90,7 +90,6 @@ jobs:
       - name: build
         if: matrix.config.components == 'core'
         run: >
-          CCACHE_DIR=/tmp/ccache
           ./ci/build.sh -v
           -j ${{ matrix.config.j }}
           --build-type=${{ matrix.config.build }}
@@ -104,7 +103,7 @@ jobs:
       - name: ccache_clean
         if: matrix.config.build == 'Release'
         shell: bash
-        run: CCACHE_DIR=/tmp/ccache ccache --evict-older-than 1d
+        run: ccache --evict-older-than 1d
 
   macos-ax:
     if: |

--- a/.github/workflows/ax.yml
+++ b/.github/workflows/ax.yml
@@ -63,8 +63,22 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+      - name: timestamp
+        id: timestamp
+        shell: bash
+        run: echo "::set-output name=timestamp::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        # don't use ccache for debug builds
+        if: matrix.config.build == 'Release'
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: linux-ax${{ matrix.config.image }}-${{ matrix.config.cxx }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: linux-ax${{ matrix.config.image }}-${{ matrix.config.cxx }}-
       - name: build
         run: >
+          CCACHE_DIR=/tmp/ccache
           ./ci/build.sh -v
           -j ${{ matrix.config.j }}
           --build-type=${{ matrix.config.build }}
@@ -76,6 +90,7 @@ jobs:
       - name: build
         if: matrix.config.components == 'core'
         run: >
+          CCACHE_DIR=/tmp/ccache
           ./ci/build.sh -v
           -j ${{ matrix.config.j }}
           --build-type=${{ matrix.config.build }}
@@ -85,6 +100,11 @@ jobs:
         run: cd build && ctest -V
       - name: test_doxygen_examples
         run: ./ci/extract_test_examples.sh
+      # Keep ccache light by stripping out any caches not accessed in the last day
+      - name: ccache_clean
+        if: matrix.config.build == 'Release'
+        shell: bash
+        run: CCACHE_DIR=/tmp/ccache ccache --evict-older-than 1d
 
   macos-ax:
     if: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
       image: aswf/ci-openvdb:${{ matrix.config.image }}
     env:
       CXX: ${{ matrix.config.cxx }}
+      CCACHE_DIR: /tmp/ccache
     strategy:
       matrix:
         config:
@@ -91,7 +92,6 @@ jobs:
       run: ./ci/install_gtest.sh 1.10.0
     - name: build
       run: >
-        CCACHE_DIR=/tmp/ccache
         ./ci/build.sh -v
         --build-type=${{ matrix.config.build }}
         --components=\"core,python,bin,test\"
@@ -107,7 +107,7 @@ jobs:
     - name: ccache_clean
       if: matrix.config.build == 'Release'
       shell: bash
-      run: CCACHE_DIR=/tmp/ccache ccache --evict-older-than 1d
+      run: ccache --evict-older-than 1d
 
   windows:
     # Windows CI. Tests static and dynamic builds with MT and MD respectively.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,24 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
+    - name: timestamp
+      id: timestamp
+      shell: bash
+      run: echo "::set-output name=timestamp::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+    - name: ccache
+      # don't use ccache for debug builds
+      if: matrix.config.build == 'Release'
+      id: ccache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/ccache
+        key: linux-vfx${{ matrix.config.image }}-abi${{ matrix.config.abi }}-${{ matrix.config.cxx }}-${{ steps.timestamp.outputs.timestamp }}
+        restore-keys: linux-vfx${{ matrix.config.image }}-abi${{ matrix.config.abi }}-${{ matrix.config.cxx }}-
     - name: install_gtest
       run: ./ci/install_gtest.sh 1.10.0
     - name: build
       run: >
+        CCACHE_DIR=/tmp/ccache
         ./ci/build.sh -v
         --build-type=${{ matrix.config.build }}
         --components=\"core,python,bin,test\"
@@ -89,6 +103,11 @@ jobs:
       run: |
         cd build && ctest -V
         cd - && ./ci/test_install.sh
+    # Keep ccache light by stripping out any caches not accessed in the last day
+    - name: ccache_clean
+      if: matrix.config.build == 'Release'
+      shell: bash
+      run: CCACHE_DIR=/tmp/ccache ccache --evict-older-than 1d
 
   windows:
     # Windows CI. Tests static and dynamic builds with MT and MD respectively.

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -69,6 +69,19 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
+    - name: timestamp
+      id: timestamp
+      shell: bash
+      run: echo "::set-output name=timestamp::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+    - name: ccache
+      # don't use ccache for debug builds
+      if: matrix.config.build == 'Release'
+      id: ccache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/ccache
+        key: linux-vfx-hou${{ matrix.config.hou }}-${{ matrix.config.image }}-${{ matrix.config.cxx }}-${{ steps.timestamp.outputs.timestamp }}
+        restore-keys: linux-vfx-hou${{ matrix.config.hou }}-${{ matrix.config.image }}-${{ matrix.config.cxx }}-
     - name: fetch_houdini
       uses: actions/cache@v2
       with:
@@ -93,6 +106,7 @@ jobs:
       shell: bash
       run: >
         cd $HOME/houdini_install/hou && source houdini_setup_bash && cd - &&
+        CCACHE_DIR=/tmp/ccache
         ./ci/build.sh -v
         -j ${{ matrix.config.j }}
         --build-type=${{ matrix.config.build }}
@@ -100,6 +114,11 @@ jobs:
         --cargs=\"-DDISABLE_CMAKE_SEARCH_PATHS=ON -DOPENVDB_BUILD_HOUDINI_ABITESTS=ON -DOPENVDB_HOUDINI_INSTALL_PREFIX=/tmp -DDISABLE_DEPENDENCY_VERSION_CHECKS=${{ matrix.config.disable_checks }}\"
     - name: test
       run: cd build && ctest -V
+    # Keep ccache light by stripping out any caches not accessed in the last day
+    - name: ccache_clean
+      if: matrix.config.build == 'Release'
+      shell: bash
+      run: CCACHE_DIR=/tmp/ccache ccache --evict-older-than 1d
       # Final check to make sure the cache still exists
     - name: validate_houdini
       run: test -f "hou/hou.tar.gz"

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -60,6 +60,7 @@ jobs:
       image: aswf/ci-base:${{ matrix.config.image }}
     env:
       CXX: ${{ matrix.config.cxx }}
+      CCACHE_DIR: /tmp/ccache
     strategy:
       matrix:
         config:
@@ -106,7 +107,6 @@ jobs:
       shell: bash
       run: >
         cd $HOME/houdini_install/hou && source houdini_setup_bash && cd - &&
-        CCACHE_DIR=/tmp/ccache
         ./ci/build.sh -v
         -j ${{ matrix.config.j }}
         --build-type=${{ matrix.config.build }}
@@ -118,7 +118,7 @@ jobs:
     - name: ccache_clean
       if: matrix.config.build == 'Release'
       shell: bash
-      run: CCACHE_DIR=/tmp/ccache ccache --evict-older-than 1d
+      run: ccache --evict-older-than 1d
       # Final check to make sure the cache still exists
     - name: validate_houdini
       run: test -f "hou/hou.tar.gz"


### PR DESCRIPTION
This introduces ccache to Linux release builds including AX and Houdini (12 jobs in total). An identical (re)build now takes around 12 hours less cumulatively and costs 692MB in disk space. 