### PR TITLE
And HIP support for NanoVDB

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -161,8 +161,8 @@ typedef unsigned long long uint64_t;
 
 #endif // __CUDACC_RTC__
 
-#ifdef __CUDACC__
-// Only define __hostdev__ when using NVIDIA CUDA compiler
+#if defined(__CUDACC__) || defined(__HIP__)
+// Only define __hostdev__ when using NVIDIA CUDA or HIP compiler
 #define __hostdev__ __host__ __device__
 #else
 #define __hostdev__
@@ -611,7 +611,7 @@ struct Delta<double>
 /// Maximum floating-point values
 template<typename T>
 struct Maximum;
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP__)
 template<>
 struct Maximum<int>
 {
@@ -1176,10 +1176,10 @@ using Vec3f = Vec3<float>;
 using Vec3i = Vec3<int>;
 
 /// @brief Return a single precision floating-point vector of this coordinate
-Vec3f Coord::asVec3s() const { return Vec3f(float(mVec[0]), float(mVec[1]), float(mVec[2])); }
+__hostdev__ inline Vec3f Coord::asVec3s() const { return Vec3f(float(mVec[0]), float(mVec[1]), float(mVec[2])); }
 
 /// @brief Return a double precision floating-point vector of this coordinate
-Vec3d Coord::asVec3d() const { return Vec3d(double(mVec[0]), double(mVec[1]), double(mVec[2])); }
+__hostdev__ inline Vec3d Coord::asVec3d() const { return Vec3d(double(mVec[0]), double(mVec[1]), double(mVec[2])); }
 
 // ----------------------------> Vec4 <--------------------------------------
 
@@ -2042,7 +2042,7 @@ struct Map
 }; // Map
 
 template<typename Mat4T>
-void Map::set(const Mat4T& mat, const Mat4T& invMat, double taper)
+__hostdev__ void Map::set(const Mat4T& mat, const Mat4T& invMat, double taper)
 {
     float * mf = mMatF, *vf = mVecF;
     float*  mif = mInvMatF;
@@ -2486,7 +2486,7 @@ private:
 }; // Class Grid
 
 template<typename TreeT>
-int Grid<TreeT>::findBlindDataForSemantic(GridBlindDataSemantic semantic) const
+__hostdev__ int Grid<TreeT>::findBlindDataForSemantic(GridBlindDataSemantic semantic) const
 {
     for (uint32_t i = 0, n = this->blindDataCount(); i < n; ++i)
         if (this->blindMetaData(i).mSemantic == semantic)
@@ -2671,7 +2671,7 @@ private:
 }; // Tree class
 
 template<typename RootT>
-void Tree<RootT>::extrema(ValueType& min, ValueType& max) const
+__hostdev__ void Tree<RootT>::extrema(ValueType& min, ValueType& max) const
 {
     min = this->root().minimum();
     max = this->root().maximum();
@@ -3880,7 +3880,7 @@ private:
 }; // LeafNode class
 
 template<typename ValueT, typename CoordT, template<uint32_t> class MaskT, uint32_t LOG2DIM>
-inline void LeafNode<ValueT, CoordT, MaskT, LOG2DIM>::updateBBox()
+__hostdev__ inline void LeafNode<ValueT, CoordT, MaskT, LOG2DIM>::updateBBox()
 {
     static_assert(LOG2DIM == 3, "LeafNode::updateBBox: only supports LOGDIM = 3!");
     if (!this->isActive()) return;

--- a/nanovdb/nanovdb/util/SampleFromVoxels.h
+++ b/nanovdb/nanovdb/util/SampleFromVoxels.h
@@ -22,7 +22,7 @@
 #define NANOVDB_SAMPLE_FROM_VOXELS_H_HAS_BEEN_INCLUDED
 
 // Only define __hostdev__ when compiling as NVIDIA CUDA
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIP__)
 #define __hostdev__ __host__ __device__
 #else
 #include <cmath> // for floor
@@ -136,7 +136,7 @@ private:
 
 template<typename TreeOrAccT>
 template<typename Vec3T>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 0, true>::operator()(const Vec3T& xyz) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 0, true>::operator()(const Vec3T& xyz) const
 {
     const CoordT ijk = Round<CoordT>(xyz);
     if (ijk != mPos) {
@@ -147,7 +147,7 @@ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 0, true>::operator()
 }
 
 template<typename TreeOrAccT>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 0, true>::operator()(const CoordT& ijk) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 0, true>::operator()(const CoordT& ijk) const
 {
     if (ijk != mPos) {
         mPos = ijk;
@@ -158,7 +158,7 @@ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 0, true>::operator()
 
 template<typename TreeOrAccT>
 template<typename Vec3T>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 0, false>::operator()(const Vec3T& xyz) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 0, false>::operator()(const Vec3T& xyz) const
 {
     return mAcc.getValue(Round<CoordT>(xyz));
 }
@@ -195,7 +195,7 @@ public:
 }; // TrilinearSamplerBase
 
 template<typename TreeOrAccT>
-void TrilinearSampler<TreeOrAccT>::stencil(CoordT& ijk, ValueT (&v)[2][2][2]) const
+__hostdev__ void TrilinearSampler<TreeOrAccT>::stencil(CoordT& ijk, ValueT (&v)[2][2][2]) const
 {
     v[0][0][0] = mAcc.getValue(ijk); // i, j, k
 
@@ -224,7 +224,7 @@ void TrilinearSampler<TreeOrAccT>::stencil(CoordT& ijk, ValueT (&v)[2][2][2]) co
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-typename TreeOrAccT::ValueType TrilinearSampler<TreeOrAccT>::sample(const Vec3T<RealT> &uvw, const ValueT (&v)[2][2][2])
+__hostdev__ typename TreeOrAccT::ValueType TrilinearSampler<TreeOrAccT>::sample(const Vec3T<RealT> &uvw, const ValueT (&v)[2][2][2])
 {
 #if 0
   auto lerp = [](ValueT a, ValueT b, ValueT w){ return fma(w, b-a, a); };// = w*(b-a) + a
@@ -239,7 +239,7 @@ typename TreeOrAccT::ValueType TrilinearSampler<TreeOrAccT>::sample(const Vec3T<
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-Vec3T<typename TreeOrAccT::ValueType> TrilinearSampler<TreeOrAccT>::gradient(const Vec3T<RealT> &uvw, const ValueT (&v)[2][2][2])
+__hostdev__ Vec3T<typename TreeOrAccT::ValueType> TrilinearSampler<TreeOrAccT>::gradient(const Vec3T<RealT> &uvw, const ValueT (&v)[2][2][2])
 {
     static_assert(is_floating_point<ValueT>::value, "TrilinearSampler::gradient requires a floating-point type");
 #if 0
@@ -270,7 +270,7 @@ Vec3T<typename TreeOrAccT::ValueType> TrilinearSampler<TreeOrAccT>::gradient(con
 }
 
 template<typename TreeOrAccT>
-bool TrilinearSampler<TreeOrAccT>::zeroCrossing(const ValueT (&v)[2][2][2])
+__hostdev__ bool TrilinearSampler<TreeOrAccT>::zeroCrossing(const ValueT (&v)[2][2][2])
 {
     static_assert(is_floating_point<ValueT>::value, "TrilinearSampler::zeroCrossing requires a floating-point type");
     const bool less = v[0][0][0] < ValueT(0);
@@ -363,21 +363,21 @@ public:
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, true>::operator()(Vec3T<RealT> xyz) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, true>::operator()(Vec3T<RealT> xyz) const
 {
     this->cache(xyz);
     return BaseT::sample(xyz, mVal);
 }
 
 template<typename TreeOrAccT>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, true>::operator()(const CoordT &ijk) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, true>::operator()(const CoordT &ijk) const
 {
     return  ijk == mPos ? mVal[0][0][0] : BaseT::mAcc.getValue(ijk);
 }
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-Vec3T<typename TreeOrAccT::ValueType> SampleFromVoxels<TreeOrAccT, 1, true>::gradient(Vec3T<RealT> xyz) const
+__hostdev__ Vec3T<typename TreeOrAccT::ValueType> SampleFromVoxels<TreeOrAccT, 1, true>::gradient(Vec3T<RealT> xyz) const
 {
     this->cache(xyz);
     return BaseT::gradient(xyz, mVal);
@@ -393,7 +393,7 @@ __hostdev__ bool SampleFromVoxels<TreeOrAccT, 1, true>::zeroCrossing(Vec3T<RealT
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-void SampleFromVoxels<TreeOrAccT, 1, true>::cache(Vec3T<RealT>& xyz) const
+__hostdev__ void SampleFromVoxels<TreeOrAccT, 1, true>::cache(Vec3T<RealT>& xyz) const
 {
     CoordT ijk = Floor<CoordT>(xyz);
     if (ijk != mPos) {
@@ -406,7 +406,7 @@ void SampleFromVoxels<TreeOrAccT, 1, true>::cache(Vec3T<RealT>& xyz) const
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, false>::operator()(Vec3T<RealT> xyz) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, false>::operator()(Vec3T<RealT> xyz) const
 {
     ValueT val[2][2][2];
     CoordT ijk = Floor<CoordT>(xyz);
@@ -418,7 +418,7 @@ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, false>::operator(
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, false>::operator()(Vec3T<RealT> xyz) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, false>::operator()(Vec3T<RealT> xyz) const
 {
     auto lerp = [](ValueT a, ValueT b, RealT w) { return a + ValueT(w) * (b - a); };
 
@@ -463,7 +463,7 @@ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 1, false>::operator(
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-inline Vec3T<typename TreeOrAccT::ValueType> SampleFromVoxels<TreeOrAccT, 1, false>::gradient(Vec3T<RealT> xyz) const
+__hostdev__ inline Vec3T<typename TreeOrAccT::ValueType> SampleFromVoxels<TreeOrAccT, 1, false>::gradient(Vec3T<RealT> xyz) const
 {
     ValueT val[2][2][2];
     CoordT ijk = Floor<CoordT>(xyz);
@@ -473,7 +473,7 @@ inline Vec3T<typename TreeOrAccT::ValueType> SampleFromVoxels<TreeOrAccT, 1, fal
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-bool SampleFromVoxels<TreeOrAccT, 1, false>::zeroCrossing(Vec3T<RealT> xyz) const
+__hostdev__ bool SampleFromVoxels<TreeOrAccT, 1, false>::zeroCrossing(Vec3T<RealT> xyz) const
 {
     ValueT val[2][2][2];
     CoordT ijk = Floor<CoordT>(xyz);
@@ -510,7 +510,7 @@ public:
 }; // TriquadraticSamplerBase
 
 template<typename TreeOrAccT>
-void TriquadraticSampler<TreeOrAccT>::stencil(const CoordT &ijk, ValueT (&v)[3][3][3]) const
+__hostdev__ void TriquadraticSampler<TreeOrAccT>::stencil(const CoordT &ijk, ValueT (&v)[3][3][3]) const
 {
     CoordT p(ijk[0] - 1, 0, 0);
     for (int dx = 0; dx < 3; ++dx, ++p[0]) {
@@ -526,7 +526,7 @@ void TriquadraticSampler<TreeOrAccT>::stencil(const CoordT &ijk, ValueT (&v)[3][
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-typename TreeOrAccT::ValueType TriquadraticSampler<TreeOrAccT>::sample(const Vec3T<RealT> &uvw, const ValueT (&v)[3][3][3])
+__hostdev__ typename TreeOrAccT::ValueType TriquadraticSampler<TreeOrAccT>::sample(const Vec3T<RealT> &uvw, const ValueT (&v)[3][3][3])
 {
     auto kernel = [](const ValueT* value, double weight)->ValueT {
         return weight * (weight * (0.5f * (value[0] + value[2]) - value[1]) +
@@ -545,7 +545,7 @@ typename TreeOrAccT::ValueType TriquadraticSampler<TreeOrAccT>::sample(const Vec
 }
 
 template<typename TreeOrAccT>
-bool TriquadraticSampler<TreeOrAccT>::zeroCrossing(const ValueT (&v)[3][3][3])
+__hostdev__ bool TriquadraticSampler<TreeOrAccT>::zeroCrossing(const ValueT (&v)[3][3][3])
 {
     static_assert(is_floating_point<ValueT>::value, "TrilinearSampler::zeroCrossing requires a floating-point type");
     const bool less = v[0][0][0] < ValueT(0);
@@ -624,14 +624,14 @@ public:
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 2, true>::operator()(Vec3T<RealT> xyz) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 2, true>::operator()(Vec3T<RealT> xyz) const
 {
     this->cache(xyz);
     return BaseT::sample(xyz, mVal);
 }
 
 template<typename TreeOrAccT>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 2, true>::operator()(const CoordT &ijk) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 2, true>::operator()(const CoordT &ijk) const
 {
     return  ijk == mPos ? mVal[1][1][1] : BaseT::mAcc.getValue(ijk);
 }
@@ -646,7 +646,7 @@ __hostdev__ bool SampleFromVoxels<TreeOrAccT, 2, true>::zeroCrossing(Vec3T<RealT
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-void SampleFromVoxels<TreeOrAccT, 2, true>::cache(Vec3T<RealT>& xyz) const
+__hostdev__ void SampleFromVoxels<TreeOrAccT, 2, true>::cache(Vec3T<RealT>& xyz) const
 {
     CoordT ijk = Floor<CoordT>(xyz);
     if (ijk != mPos) {
@@ -657,7 +657,7 @@ void SampleFromVoxels<TreeOrAccT, 2, true>::cache(Vec3T<RealT>& xyz) const
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 2, false>::operator()(Vec3T<RealT> xyz) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 2, false>::operator()(Vec3T<RealT> xyz) const
 {
     ValueT val[3][3][3];
     CoordT ijk = Floor<CoordT>(xyz);
@@ -667,7 +667,7 @@ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 2, false>::operator(
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-bool SampleFromVoxels<TreeOrAccT, 2, false>::zeroCrossing(Vec3T<RealT> xyz) const
+__hostdev__ bool SampleFromVoxels<TreeOrAccT, 2, false>::zeroCrossing(Vec3T<RealT> xyz) const
 {
     ValueT val[3][3][3];
     CoordT ijk = Floor<CoordT>(xyz);
@@ -710,7 +710,7 @@ public:
 }; // TricubicSampler
 
 template<typename TreeOrAccT>
-void TricubicSampler<TreeOrAccT>::stencil(const CoordT& ijk, ValueT (&C)[64]) const
+__hostdev__ void TricubicSampler<TreeOrAccT>::stencil(const CoordT& ijk, ValueT (&C)[64]) const
 {
     auto fetch = [&](int i, int j, int k) -> ValueT& { return C[((i + 1) << 4) + ((j + 1) << 2) + k + 1]; };
 
@@ -929,7 +929,7 @@ public:
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 3, true>::operator()(Vec3T<RealT> xyz) const
+__hostdev__ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 3, true>::operator()(Vec3T<RealT> xyz) const
 {
     this->cache(xyz);
     return BaseT::sample(xyz, mC);
@@ -937,7 +937,7 @@ typename TreeOrAccT::ValueType SampleFromVoxels<TreeOrAccT, 3, true>::operator()
 
 template<typename TreeOrAccT>
 template<typename RealT, template<typename...> class Vec3T>
-void SampleFromVoxels<TreeOrAccT, 3, true>::cache(Vec3T<RealT>& xyz) const
+__hostdev__ void SampleFromVoxels<TreeOrAccT, 3, true>::cache(Vec3T<RealT>& xyz) const
 {
     CoordT ijk = Floor<CoordT>(xyz);
     if (ijk != mPos) {


### PR DESCRIPTION
We are using HIP in Blender/Cycles for AMD GPU rendering, and some small changes are needed to make NanoVDB work.
https://github.com/ROCm-Developer-Tools/HIP

* Use host/device qualifiers when either `__CUDACC__` or `__HIP__` is defined
* Add `__hostdev__` to method definitions outside the class body. CUDA only needs them in the class body declaration, but HIP needs both.

This makes using the NanoVDB headers as part of HIP C++ code work. It does not add support for HIP to the examples. That would be a much bigger change and likely add much code duplication.