### PR TITLE
Update v8.2 branch to use new houdini caches

### DIFF
--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -59,21 +59,22 @@ jobs:
     strategy:
       matrix:
         config:
-          # build against VFX Ref 2018 even though it's unsupported, just to make sure that we test Boost 1.61
-          - { cxx: clang++, image: '2018', hou: '18_0', j: '2', build: 'Release', components: 'core,hou,bin,python,test,axcore,axbin,axtest', disable_checks: 'ON' }
-          - { cxx: clang++, image: '2019', hou: '18_0', j: '2', build: 'Release', components: 'core,hou,bin,python,test,axcore,axbin,axtest', disable_checks: 'OFF' }
           - { cxx: clang++, image: '2020', hou: '18_5', j: '2', build: 'Release', components: 'core,hou,bin,python,test,axcore,axbin,axtest', disable_checks: 'OFF' }
           - { cxx: clang++, image: '2020', hou: '18_5', j: '2', build: 'Debug', components: 'core,hou', disable_checks: 'OFF' }
           - { cxx: g++,     image: '2020', hou: '18_5', j: '1', build: 'Release', components: 'core,hou', disable_checks: 'OFF' }
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
+    - name: timestamp
+      id: timestamp
+      shell: bash
+      run: echo "::set-output name=timestamp::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
     - name: fetch_houdini
       uses: actions/cache@v2
       with:
         path: hou
-        key: vdb-v3-houdini${{ matrix.config.hou }}-${{ hashFiles('hou/hou.tar.gz') }}
-        restore-keys: vdb-v3-houdini${{ matrix.config.hou }}-
+        key: dummy-houdini${{ matrix.config.hou }}-${{ steps.timestamp.outputs.timestamp }}
+        restore-keys: vdb-v4-houdini${{ matrix.config.hou }}-
     - name: validate_houdini
       run: test -f "hou/hou.tar.gz"
       # Make sure the cache is copied, not moved, as the cache action always posts the cache.
@@ -99,6 +100,6 @@ jobs:
         --cargs=\"-DDISABLE_CMAKE_SEARCH_PATHS=ON -DOPENVDB_BUILD_HOUDINI_ABITESTS=ON -DOPENVDB_HOUDINI_INSTALL_PREFIX=/tmp -DDISABLE_DEPENDENCY_VERSION_CHECKS=${{ matrix.config.disable_checks }}\"
     - name: test
       run: cd build && ctest -V
-      # Final check to make sure the cache still exists
-    - name: validate_houdini
-      run: test -f "hou/hou.tar.gz"
+      # Delete the houdini tarball so that this dummy cache occupies no space
+    - name: delete_hou
+      run: rm -f hou/hou.tar.gz

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -74,7 +74,7 @@ jobs:
       with:
         path: hou
         key: dummy-houdini${{ matrix.config.hou }}-${{ steps.timestamp.outputs.timestamp }}
-        restore-keys: vdb-v4-houdini${{ matrix.config.hou }}-
+        restore-keys: vdb-v5-houdini${{ matrix.config.hou }}-
     - name: validate_houdini
       run: test -f "hou/hou.tar.gz"
       # Make sure the cache is copied, not moved, as the cache action always posts the cache.


### PR DESCRIPTION
This updates the cache keys, adds the dummy cache workflow and eliminates H18.0 builds as we no longer store Houdini 18.0 caches.