### PR TITLE
Remove unused tbb/task.h include to avoid deprecation warnings

### DIFF
--- a/openvdb/openvdb/tools/PointAdvect.h
+++ b/openvdb/openvdb/tools/PointAdvect.h
@@ -21,7 +21,6 @@
 
 #include <tbb/blocked_range.h>             // threading
 #include <tbb/parallel_for.h>              // threading
-#include <tbb/task.h>                      // for cancel
 
 #include <vector>
 


### PR DESCRIPTION
Signed-off-by: Edward Lam <edward@sidefx.com>