### PR TITLE
Remove unnecessary boost system dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The following provides basic installation examples for the core OpenVDB library.
 
 ```bash
 apt-get install -y libboost-iostreams-dev
-apt-get install -y libboost-system-dev
 apt-get install -y libtbb-dev
 apt-get install -y libblosc-dev
 ```
@@ -84,7 +83,6 @@ vcpkg install zlib:x64-windows
 vcpkg install blosc:x64-windows
 vcpkg install tbb:x64-windows
 vcpkg install boost-iostreams:x64-windows
-vcpkg install boost-system:x64-windows
 vcpkg install boost-any:x64-windows
 vcpkg install boost-algorithm:x64-windows
 vcpkg install boost-uuid:x64-windows

--- a/ci/install_windows.sh
+++ b/ci/install_windows.sh
@@ -4,4 +4,4 @@ set -ex
 
 vcpkg update
 vcpkg install zlib libpng openexr tbb gtest blosc glfw3 glew \
-    boost-iostreams boost-system boost-any boost-uuid boost-interprocess boost-algorithm
+    boost-iostreams boost-any boost-uuid boost-interprocess boost-algorithm

--- a/cmake/FindOpenVDB.cmake
+++ b/cmake/FindOpenVDB.cmake
@@ -496,7 +496,7 @@ if(NOT OPENVDB_USE_STATIC_LIBS AND NOT Boost_USE_STATIC_LIBS)
   set(Boost_USE_STATIC_LIBS OFF)
 endif()
 
-find_package(Boost REQUIRED COMPONENTS iostreams system)
+find_package(Boost REQUIRED COMPONENTS iostreams)
 
 # Add deps for pyopenvdb
 # @todo track for numpy
@@ -671,10 +671,7 @@ endif()
 # namespaced headers are correctly prioritized. Otherwise other include paths
 # from shared installs (including houdini) may pull in the wrong headers
 
-set(_OPENVDB_VISIBLE_DEPENDENCIES
-  Boost::iostreams
-  Boost::system
-)
+set(_OPENVDB_VISIBLE_DEPENDENCIES Boost::iostreams)
 
 if(OpenVDB_USES_IMATH_HALF)
   list(APPEND _OPENVDB_VISIBLE_DEPENDENCIES $<TARGET_NAME_IF_EXISTS:IlmBase::Half> $<TARGET_NAME_IF_EXISTS:Imath::Imath>)

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -259,7 +259,7 @@ Package        | Description                                                    
 -------------- | --------------------------------------------------------------- | ------------------ |
 CMake          | Cross-platform family of tools designed to help build software  | All                |
 C++14 Compiler | Matching Houdini compiler and version                           | All                |
-Boost          | Components: system, iostreams, python, thread                   | All                |
+Boost          | Components: iostreams, python, thread                           | All                |
 GoogleTest     | A unit testing framework module for C++                         | Unit Tests         |
 CppUnit        | A unit testing framework module for C++                         | Unit Tests (AX)    |
 GLFW           | Simple API for OpenGL development                               | OpenVDB View       |
@@ -348,7 +348,7 @@ Package        | Description                                                    
 -------------- | ---------------------------------------------------------------   | -------------------------------- |
 CMake          | Cross-platform family of tools designed to help build software    | All                              |
 C++14 Compiler | Matching Houdini compiler and version                             | All                              |
-Boost          | Components: system, iostreams, python, thread                     | All                              |
+Boost          | Components: iostreams, python, thread                             | All                              |
 ZLIB           | Compression library for disk serialization compression            | All                              |
 Blosc          | Recommended dependency for improved disk compression              | All*                             |
 GoogleTest     | A unit testing framework module for C++                           | Unit Tests                       |

--- a/doc/dependencies.txt
+++ b/doc/dependencies.txt
@@ -35,18 +35,18 @@ Reference Platform, but for those that do, their specified versions are
 
 @section depComponents OpenVDB Components
 
-Component               | Requirements                                                     | Optional
------------------------ | ---------------------------------------------------------------- | --------
-OpenVDB Core Library    | CMake, C++14 compiler, TBB::tbb, Boost::system, Boost::iostream  | Blosc, ZLib, Log4cplus, IlmBase::Half
-OpenVDB Print           | Core Library dependencies                                        | -
-OpenVDB LOD             | Core Library dependencies                                        | -
-OpenVDB Render          | Core Library dependencies                                        | OpenEXR, IlmBase, libpng
-OpenVDB View            | Core Library dependencies, OpenGL, GLFW3, GLEW*                  | -
-OpenVDB Python          | Core Library dependencies, Python, Boost::python                 | Boost::numpy, NumPy
-OpenVDB AX              | Core Library dependencies, LLVM                                  | Bison, Flex
-NanoVDB                 | -                                                                | Core Library, CUDA, TBB, Blosc, ZLib
-OpenVDB UnitTests       | Core Library dependencies, GoogleTest                            | CppUnit**
-OpenVDB Documentation   | Doxygen                                                          | -
+Component               | Requirements                                      | Optional
+----------------------- | ------------------------------------------------- | --------
+OpenVDB Core Library    | CMake, C++14 compiler, TBB::tbb, Boost::iostream  | Blosc, ZLib, Log4cplus, IlmBase::Half
+OpenVDB Print           | Core Library dependencies                         | -
+OpenVDB LOD             | Core Library dependencies                         | -
+OpenVDB Render          | Core Library dependencies                         | OpenEXR, IlmBase, libpng
+OpenVDB View            | Core Library dependencies, OpenGL, GLFW3, GLEW*   | -
+OpenVDB Python          | Core Library dependencies, Python, Boost::python  | Boost::numpy, NumPy
+OpenVDB AX              | Core Library dependencies, LLVM                   | Bison, Flex
+NanoVDB                 | -                                                 | Core Library, CUDA, TBB, Blosc, ZLib
+OpenVDB UnitTests       | Core Library dependencies, GoogleTest             | CppUnit**
+OpenVDB Documentation   | Doxygen                                           | -
 
  - @b * GLEW is only required for building the vdb_view binary on Windows.
  - @b ** CppUnit is only required for building the AX unit tests.
@@ -66,7 +66,7 @@ IlmBase        | 2.2**   | 2.3         | Used half precision floating points and
 OpenEXR        | 2.2**   | 2.3         | EXR serialization support                                         | Y       | Y        | http://www.openexr.com
 TBB            | 2018    | 2018        | Threading Building Blocks - template library for task parallelism | Y       | Y        | https://www.threadingbuildingblocks.org
 ZLIB           | 1.2.7   | Latest      | Compression library for disk serialization compression            | Y       | Y        | https://www.zlib.net
-Boost          | 1.66    | 1.66        | Components: system, iostreams, python, numpy                      | Y       | Y        | https://www.boost.org
+Boost          | 1.66    | 1.66        | Components: iostreams, python, numpy                              | Y       | Y        | https://www.boost.org
 LLVM           | 6.0.0   | 8.0.0       | Target-independent code generation                                | Y       | Y        | https://llvm.org/
 Bison          | 3.0.0   | 3.0.5       | General-purpose parser generator                                  | Y       | Y        | https://www.gnu.org/software/gcc
 Flex           | 2.6     | 2.6.4       | Fast lexical analyzer generator                                   | Y       | Y        | https://github.com/westes/flex
@@ -135,7 +135,6 @@ methods or the [manual installation](@ref depManInstall) options.
 apt-get install cmake                   # CMake
 apt-get install libtbb-dev              # TBB
 apt-get install zlibc                   # zlib
-apt-get install libboost-system-dev     # Boost::system
 apt-get install libboost-iostreams-dev  # Boost::iostream
 apt-get install libblosc-dev            # Blosc
 # AX

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -117,7 +117,7 @@ if(OPENVDB_CORE_SHARED AND NOT Boost_USE_STATIC_LIBS)
   set(Boost_USE_STATIC_LIBS OFF)
 endif()
 
-find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS iostreams system)
+find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS iostreams)
 if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_BOOST_VERSION)
   # The X.Y.Z boost version value isn't available until CMake 3.14
   set(FULL_BOOST_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
@@ -250,9 +250,7 @@ endif()
 # if it's in a shared place (like /usr/local) it doesn't accidently pull in
 # other headers.
 
-list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
-  Boost::iostreams
-  Boost::system)
+list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Boost::iostreams)
 
 if(WIN32)
   # Boost headers contain #pragma commands on Windows which causes Boost

--- a/openvdb/openvdb/unittest/TestStreamCompression.cc
+++ b/openvdb/openvdb/unittest/TestStreamCompression.cc
@@ -19,7 +19,6 @@
 #include <boost/interprocess/mapped_region.hpp>
 #include <boost/iostreams/device/array.hpp>
 #include <boost/iostreams/stream.hpp>
-#include <boost/system/error_code.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/version.hpp> // for BOOST_VERSION


### PR DESCRIPTION
This library dependency was not being used anywhere, and therefore
adding an additional dependency to the whole build system for no reason.

Signed-off-by: Ignacio Vizzo <ignaciovizzo@gmail.com>