### PR TITLE
The vdbPrimsToRemove in MergeOp is shared across threads,

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Merge.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Merge.cc
@@ -20,6 +20,7 @@
 
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_Version.h>
+#include <UT/UT_ConcurrentVector.h>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -297,7 +298,7 @@ struct MergeOp
     StringRemapType opRemap;
     std::deque<GU_PrimVDB*> vdbPrims;
     std::deque<const GU_PrimVDB*> constVdbPrims;
-    std::deque<GU_PrimVDB*> vdbPrimsToRemove;
+    UT_ConcurrentVector<GU_PrimVDB *> vdbPrimsToRemove;
     PrimitiveNumberMap primNumbers;
 
     explicit MergeOp(openvdb::util::NullInterrupter& _interrupt): self(nullptr), interrupt(_interrupt) { }

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Merge.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Merge.cc
@@ -298,7 +298,7 @@ struct MergeOp
     StringRemapType opRemap;
     std::deque<GU_PrimVDB*> vdbPrims;
     std::deque<const GU_PrimVDB*> constVdbPrims;
-    UT_ConcurrentVector<GU_PrimVDB *> vdbPrimsToRemove;
+    UT_ConcurrentVector<GU_PrimVDB*> vdbPrimsToRemove;
     PrimitiveNumberMap primNumbers;
 
     explicit MergeOp(openvdb::util::NullInterrupter& _interrupt): self(nullptr), interrupt(_interrupt) { }

--- a/pendingchanges/vdbmerge_fix.txt
+++ b/pendingchanges/vdbmerge_fix.txt
@@ -1,0 +1,3 @@
+Houdini:
+    - Fix race condition in OpenVDB Merge SOP that could cause crashes
+      or merged VDBs to not be deleted.


### PR DESCRIPTION
The vdbPrimsToRemove in MergeOp is shared across threads,
so calling push_back resulted in race conditions and the prims
occasionally not being deleted or the std::dequeue becoming
corrupt and crashing.

Made the simplest change of just switching to a UT_ConcurrentVector
that wraps the tbb structure.

A more correct change would be to return vdbPrimsToRemove like we
do the outputgrids so we could explicitly gather them without locking,
this would also avoid this unseen action at distance.

Signed-off-by: jlait <jlait@andorra.sidefx.com>