### PR TITLE
Fixed guard for NanoVDB CountOn for Windows builds

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -1773,7 +1773,7 @@ __hostdev__ static inline uint32_t FindHighestOn(uint64_t v)
 NANOVDB_HOSTDEV_DISABLE_WARNING
 __hostdev__ inline uint32_t CountOn(uint64_t v)
 {
-#if defined(_MSC_VER) && defined(_M_X64)
+#if defined(_MSC_VER) && defined(_M_X64) && defined(NANOVDB_USE_INTRINSICS)
     v = __popcnt64(v);
 #elif (defined(__GNUC__) || defined(__clang__))
     v = __builtin_popcountll(v);


### PR DESCRIPTION
The header for `__popcnt64` is not included unless `NANOVDB_USE_INTRINSICS` is on