### PR TITLE
Various AX improvements

### DIFF
--- a/openvdb_ax/openvdb_ax/ast/Parse.cc
+++ b/openvdb_ax/openvdb_ax/ast/Parse.cc
@@ -36,11 +36,14 @@ extern void axerror (openvdb::ax::ast::Tree**, char const *s) {
 }
 
 openvdb::ax::ast::Tree::ConstPtr
-openvdb::ax::ast::parse(const char* code, openvdb::ax::Logger& logger)
+openvdb::ax::ast::parse(const char* code,
+    openvdb::ax::Logger& logger)
 {
     std::lock_guard<std::mutex> lock(sInitMutex);
     axlog = &logger; // for lexer errs
     logger.setSourceCode(code);
+
+    const size_t err = logger.errors();
 
     // reset all locations
     axlloc.first_line = axlloc.last_line = 1;
@@ -55,6 +58,8 @@ openvdb::ax::ast::parse(const char* code, openvdb::ax::Logger& logger)
     openvdb::ax::ast::Tree::ConstPtr ptr(const_cast<const openvdb::ax::ast::Tree*>(tree));
 
     ax_delete_buffer(buffer);
+
+    if (logger.errors() > err) ptr.reset();
 
     logger.setSourceTree(ptr);
     return ptr;

--- a/openvdb_ax/openvdb_ax/ast/Parse.h
+++ b/openvdb_ax/openvdb_ax/ast/Parse.h
@@ -23,14 +23,19 @@ namespace OPENVDB_VERSION_NAME {
 namespace ax {
 namespace ast {
 
-/// @brief  Construct an abstract syntax tree from a code snippet. If the code is
-///         not well formed, as defined by the AX grammar, this will simply return
-///         nullptr, with the logger collecting the errors.
+/// @brief   Construct an abstract syntax tree from a code snippet.
+/// @details This method parses the provided null terminated code snippet and
+///   attempts to construct a complete abstract syntax tree (AST) which can be
+///   passed to the AX Compiler. If the code is not well formed (as defined by
+///   the AX grammar) a nullptr is returned and instances of any errors
+///   encoutered are stored to the provided logger.
 /// @note   The returned AST is const as the logger uses this to determine line
-///         and column numbers of errors/warnings in later stages. If you need to
-///         modify the tree, take a copy.
+///   and column numbers of errors/warnings in later stages. If you need to
+///   modify the tree, take a copy.
 ///
-/// @return A shared pointer to a valid const AST, or nullptr if errored.
+/// @return A shared pointer to a valid const AST. Can be a nullptr on error.
+/// @todo  In the future it may be useful for ::parse to return as much of
+///   the valid AST that exists.
 ///
 /// @param code    The code to parse
 /// @param logger  The logger to collect syntax errors
@@ -38,14 +43,15 @@ namespace ast {
 OPENVDB_AX_API openvdb::ax::ast::Tree::ConstPtr
 parse(const char* code, ax::Logger& logger);
 
-/// @brief  Construct an abstract syntax tree from a code snippet.
-///         A runtime exception will be thrown with the first syntax error.
+/// @brief   Construct an abstract syntax tree from a code snippet.
+/// @details A runtime exception will be thrown with the first syntax error.
 ///
 /// @return A shared pointer to a valid AST.
 ///
 /// @param code The code to parse
 ///
-OPENVDB_AX_API openvdb::ax::ast::Tree::Ptr parse(const char* code);
+OPENVDB_AX_API openvdb::ax::ast::Tree::Ptr
+parse(const char* code);
 
 } // namespace ast
 } // namespace ax

--- a/openvdb_ax/openvdb_ax/ax.cc
+++ b/openvdb_ax/openvdb_ax/ax.cc
@@ -3,7 +3,6 @@
 
 #include "ax.h"
 #include "ast/AST.h"
-#include "compiler/Logger.h"
 #include "compiler/Compiler.h"
 #include "compiler/PointExecutable.h"
 #include "compiler/VolumeExecutable.h"
@@ -27,23 +26,16 @@ namespace ax {
 
 void run(const char* ax, openvdb::GridBase& grid, const AttributeBindings& bindings)
 {
-    // Construct a logger that will output errors to cerr and suppress warnings
-    openvdb::ax::Logger logger;
     // Construct a generic compiler
     openvdb::ax::Compiler compiler;
-    // Parse the provided code and produce an abstract syntax tree
-    // @note  Throws with parser errors if invalid. Parsable code does not
-    //        necessarily equate to compilable code
-    const openvdb::ax::ast::Tree::ConstPtr
-        ast = openvdb::ax::ast::parse(ax, logger);
-    if (!ast) return;
 
     if (grid.isType<points::PointDataGrid>()) {
         // Compile for Point support and produce an executable
         // @note  Throws compiler errors on invalid code. On success, returns
         //        the executable which can be used multiple times on any inputs
         const openvdb::ax::PointExecutable::Ptr exe =
-            compiler.compile<openvdb::ax::PointExecutable>(*ast, logger);
+            compiler.compile<openvdb::ax::PointExecutable>(ax);
+        assert(exe);
 
         //Set the attribute bindings
         exe->setAttributeBindings(bindings);
@@ -56,7 +48,9 @@ void run(const char* ax, openvdb::GridBase& grid, const AttributeBindings& bindi
         // @note  Throws compiler errors on invalid code. On success, returns
         //        the executable which can be used multiple times on any inputs
         const openvdb::ax::VolumeExecutable::Ptr exe =
-            compiler.compile<openvdb::ax::VolumeExecutable>(*ast, logger);
+            compiler.compile<openvdb::ax::VolumeExecutable>(ax);
+        assert(exe);
+
         // Set the attribute bindings
         exe->setAttributeBindings(bindings);
         // Execute on the provided numerical grid
@@ -78,23 +72,17 @@ void run(const char* ax, openvdb::GridPtrVec& grids, const AttributeBindings& bi
                 "a single invocation of ax::run()");
         }
     }
-    // Construct a logger that will output errors to cerr and suppress warnings
-    openvdb::ax::Logger logger;
     // Construct a generic compiler
     openvdb::ax::Compiler compiler;
-    // Parse the provided code and produce an abstract syntax tree
-    // @note  Throws with parser errors if invalid. Parsable code does not
-    //        necessarily equate to compilable code
-    const openvdb::ax::ast::Tree::ConstPtr
-        ast = openvdb::ax::ast::parse(ax, logger);
-    if (!ast) return;
 
     if (points) {
         // Compile for Point support and produce an executable
         // @note  Throws compiler errors on invalid code. On success, returns
         //        the executable which can be used multiple times on any inputs
         const openvdb::ax::PointExecutable::Ptr exe =
-            compiler.compile<openvdb::ax::PointExecutable>(*ast, logger);
+            compiler.compile<openvdb::ax::PointExecutable>(ax);
+        assert(exe);
+
         //Set the attribute bindings
         exe->setAttributeBindings(bindings);
         // Execute on the provided points individually
@@ -108,7 +96,9 @@ void run(const char* ax, openvdb::GridPtrVec& grids, const AttributeBindings& bi
         // @note  Throws compiler errors on invalid code. On success, returns
         //        the executable which can be used multiple times on any inputs
         const openvdb::ax::VolumeExecutable::Ptr exe =
-            compiler.compile<openvdb::ax::VolumeExecutable>(*ast, logger);
+            compiler.compile<openvdb::ax::VolumeExecutable>(ax);
+        assert(exe);
+
         //Set the attribute bindings
         exe->setAttributeBindings(bindings);
         // Execute on the provided volumes

--- a/openvdb_ax/openvdb_ax/codegen/ComputeGenerator.cc
+++ b/openvdb_ax/openvdb_ax/codegen/ComputeGenerator.cc
@@ -138,9 +138,8 @@ bool ComputeGenerator::generate(const ast::Tree& tree)
 
     // if traverse is false, log should have error, but can error
     // without stopping traversal, so check both
-
-    const bool result = this->traverse(&tree) && !mLog.hasError();
-    if (!result) return false;
+    const size_t err = mLog.errors();
+    if (!this->traverse(&tree) || (mLog.errors() > err)) return false;
 
     // free strings at terminating blocks
 

--- a/openvdb_ax/openvdb_ax/codegen/PointComputeGenerator.cc
+++ b/openvdb_ax/openvdb_ax/codegen/PointComputeGenerator.cc
@@ -840,7 +840,8 @@ AttributeRegistry::Ptr PointComputeGenerator::generate(const ast::Tree& tree)
     // full code generation
     // errors can stop traversal, but dont always, so check the log
 
-    if (!this->traverse(&tree) || mLog.hasError()) return nullptr;
+    const size_t err = mLog.errors();
+    if (!this->traverse(&tree) || (mLog.errors() > err)) return nullptr;
 
     // insert free calls for any strings
 

--- a/openvdb_ax/openvdb_ax/codegen/VolumeComputeGenerator.cc
+++ b/openvdb_ax/openvdb_ax/codegen/VolumeComputeGenerator.cc
@@ -362,7 +362,8 @@ AttributeRegistry::Ptr VolumeComputeGenerator::generate(const ast::Tree& tree)
     // full code generation
     // errors can stop traversal, but dont always, so check the log
 
-    if (!this->traverse(&tree) || mLog.hasError()) return nullptr;
+    const size_t err = mLog.errors();
+    if (!this->traverse(&tree) || (mLog.errors() > err)) return nullptr;
 
     // insert free calls for any strings
 

--- a/openvdb_ax/openvdb_ax/compiler/Compiler.cc
+++ b/openvdb_ax/openvdb_ax/compiler/Compiler.cc
@@ -463,13 +463,15 @@ bool initializeGlobalFunctions(const codegen::FunctionRegistry& registry,
     return count == logger.errors();
 }
 
-void verifyTypedAccesses(const ast::Tree& tree, openvdb::ax::Logger& logger)
+bool verifyTypedAccesses(const ast::Tree& tree, openvdb::ax::Logger& logger)
 {
     // verify the attributes and external variables requested in the syntax tree
     // only have a single type. Note that the executer will also throw a runtime
     // error if the same attribute is accessed with different types, but as that's
     // currently not a valid state on a PointDataGrid, error in compilation as well
     // @todo - introduce a framework for supporting custom preprocessors
+
+    const size_t errs = logger.errors();
 
     std::unordered_map<std::string, std::string> nameType;
 
@@ -504,6 +506,8 @@ void verifyTypedAccesses(const ast::Tree& tree, openvdb::ax::Logger& logger)
         };
 
     ast::visitNodeType<ast::ExternalVariable>(tree, externalOp);
+
+    return logger.errors() == errs;
 }
 
 inline void
@@ -682,6 +686,12 @@ Compiler::compile(const ast::Tree& tree,
         CustomData::Ptr data,
         Logger& logger)
 {
+    // @todo  Not technically necessary for volumes but does the
+    //   executer/bindings handle this?
+    if (!verifyTypedAccesses(tree, logger)) {
+        return nullptr;
+    }
+
     // initialize the module and execution engine - the latter isn't needed
     // for IR generation but we leave the creation of the TM to the EE.
 
@@ -768,8 +778,6 @@ Compiler::compile<PointExecutable>(const ast::Tree& syntaxTree,
     PointDefaultModifier modifier;
     modifier.traverse(tree.get());
 
-    verifyTypedAccesses(*tree, logger);
-
     const std::vector<std::string> functionNames {
         codegen::PointKernelBufferRange::getDefaultName(),
         codegen::PointKernelAttributeArray::getDefaultName()
@@ -786,8 +794,6 @@ Compiler::compile<VolumeExecutable>(const ast::Tree& syntaxTree,
                                     const CustomData::Ptr customData)
 {
     using GenT = codegen::codegen_internal::VolumeComputeGenerator;
-
-    verifyTypedAccesses(syntaxTree, logger);
 
     const std::vector<std::string> functionNames {
         // codegen::VolumeKernelValue::getDefaultName(), // currently unused directly

--- a/openvdb_ax/openvdb_ax/compiler/Compiler.h
+++ b/openvdb_ax/openvdb_ax/compiler/Compiler.h
@@ -120,14 +120,16 @@ public:
             [&errors] (const std::string& error) {
                 errors.emplace_back(error + "\n");
             },
-            // ignore warnings
-            [] (const std::string&) {}
+            [] (const std::string&) {} // ignore warnings
         );
         const ast::Tree::ConstPtr syntaxTree = ast::parse(code.c_str(), logger);
-        typename ExecutableT::Ptr exe;
-        if (syntaxTree) {
-            exe = this->compile<ExecutableT>(*syntaxTree, logger, data);
+        if (!errors.empty()) {
+            std::ostringstream os;
+            for (const auto& e : errors) os << e << "\n";
+            OPENVDB_THROW(AXSyntaxError, os.str());
         }
+        assert(syntaxTree);
+        typename ExecutableT::Ptr exe = this->compile<ExecutableT>(*syntaxTree, logger, data);
         if (!errors.empty()) {
             std::ostringstream os;
             for (const auto& e : errors) os << e << "\n";
@@ -153,8 +155,7 @@ public:
             [&errors] (const std::string& error) {
                 errors.emplace_back(error + "\n");
             },
-            // ignore warnings
-            [] (const std::string&) {}
+            [] (const std::string&) {} // ignore warnings
         );
         auto exe = compile<ExecutableT>(syntaxTree, logger, data);
         if (!errors.empty()) {

--- a/openvdb_ax/openvdb_ax/compiler/Logger.h
+++ b/openvdb_ax/openvdb_ax/compiler/Logger.h
@@ -51,6 +51,9 @@ namespace ax {
 ///   parsing, to allow resolution of code locations when they are not
 ///   explicitly available. The Logger also stores a pointer to the AST Tree
 ///   that these nodes belong to and the code used to create it.
+///
+/// @warning  The logger is not thread safe. A unique instance of the Logger
+///   should be used for unique invocations of ax pipelines.
 class OPENVDB_AX_API Logger
 {
 public:
@@ -75,14 +78,14 @@ public:
     ///   associated code location.
     /// @param message The error message
     /// @param lineCol The line/column number of the offending code
-    /// @return true if non-fatal and can continue to capture future messages.
+    /// @return true if can continue to capture future messages.
     bool error(const std::string& message, const CodeLocation& lineCol = CodeLocation(0,0));
 
     /// @brief Log a compiler error using the offending AST node. Used in AST
     ///   traversal.
     /// @param message The error message
     /// @param node The offending AST node causing the error
-    /// @return true if non-fatal and can continue to capture future messages.
+    /// @return true if can continue to capture future messages.
     bool error(const std::string& message, const ax::ast::Node* node);
 
     /// @brief Log a compiler warning and its offending code location. If the
@@ -90,14 +93,14 @@ public:
     ///   associated code location.
     /// @param message The warning message
     /// @param lineCol The line/column number of the offending code
-    /// @return true if non-fatal and can continue to capture future messages.
+    /// @return true if can continue to capture future messages.
     bool warning(const std::string& message, const CodeLocation& lineCol = CodeLocation(0,0));
 
     /// @brief Log a compiler warning using the offending AST node. Used in AST
     ///   traversal.
     /// @param message The warning message
     /// @param node The offending AST node causing the warning
-    /// @return true if non-fatal and can continue to capture future messages.
+    /// @return true if can continue to capture future messages.
     bool warning(const std::string& message, const ax::ast::Node* node);
 
     ///
@@ -130,7 +133,9 @@ public:
     bool getWarningsAsErrors() const;
 
     /// @brief Sets the maximum number of errors that are allowed before
-    ///   compilation should exit
+    ///   compilation should exit.
+    /// @note The logger will continue to increment the error counter beyond
+    ///   this value but, once reached, it will not invoke the error callback.
     /// @param maxErrors The number of allowed errors
     void setMaxErrors(const size_t maxErrors = 0);
     /// @brief Returns the number of allowed errors
@@ -194,8 +199,8 @@ private:
 
     friend class ::TestLogger;
 
-    std::function<void(const std::string&)> mErrorOutput;
-    std::function<void(const std::string&)> mWarningOutput;
+    OutputFunction mErrorOutput;
+    OutputFunction mWarningOutput;
 
     size_t mNumErrors;
     size_t mNumWarnings;

--- a/openvdb_ax/openvdb_ax/test/backend/TestLogger.cc
+++ b/openvdb_ax/openvdb_ax/test/backend/TestLogger.cc
@@ -249,5 +249,7 @@ TestLogger::testMaxErrors()
     CPPUNIT_ASSERT(logger.error(message, location));
     CPPUNIT_ASSERT(!logger.error(message, location));
     CPPUNIT_ASSERT(!logger.error(message, location));
+    // setMaxErrors doesn't limit the error counter
+    CPPUNIT_ASSERT_EQUAL(size_t(3), logger.errors());
 }
 

--- a/openvdb_ax/openvdb_ax/test/compiler/TestPointExecutable.cc
+++ b/openvdb_ax/openvdb_ax/test/compiler/TestPointExecutable.cc
@@ -200,7 +200,7 @@ TestPointExecutable::testCompilerCases()
         // with string only
         CPPUNIT_ASSERT(static_cast<bool>(compiler->compile<openvdb::ax::PointExecutable>("int i;")));
         CPPUNIT_ASSERT_THROW(compiler->compile<openvdb::ax::PointExecutable>("i;"), openvdb::AXCompilerError);
-        CPPUNIT_ASSERT_THROW(compiler->compile<openvdb::ax::PointExecutable>("i"), openvdb::AXCompilerError);
+        CPPUNIT_ASSERT_THROW(compiler->compile<openvdb::ax::PointExecutable>("i"), openvdb::AXSyntaxError);
         // with AST only
         auto ast = openvdb::ax::ast::parse("i;");
         CPPUNIT_ASSERT_THROW(compiler->compile<openvdb::ax::PointExecutable>(*ast), openvdb::AXCompilerError);

--- a/openvdb_ax/openvdb_ax/test/compiler/TestVolumeExecutable.cc
+++ b/openvdb_ax/openvdb_ax/test/compiler/TestVolumeExecutable.cc
@@ -768,7 +768,7 @@ TestVolumeExecutable::testCompilerCases()
         // with string only
         CPPUNIT_ASSERT(static_cast<bool>(compiler->compile<openvdb::ax::VolumeExecutable>("int i;")));
         CPPUNIT_ASSERT_THROW(compiler->compile<openvdb::ax::VolumeExecutable>("i;"), openvdb::AXCompilerError);
-        CPPUNIT_ASSERT_THROW(compiler->compile<openvdb::ax::VolumeExecutable>("i"), openvdb::AXCompilerError);
+        CPPUNIT_ASSERT_THROW(compiler->compile<openvdb::ax::VolumeExecutable>("i"), openvdb::AXSyntaxError);
         // with AST only
         auto ast = openvdb::ax::ast::parse("i;");
         CPPUNIT_ASSERT_THROW(compiler->compile<openvdb::ax::VolumeExecutable>(*ast), openvdb::AXCompilerError);

--- a/openvdb_ax/openvdb_ax/test/frontend/TestSyntaxFailures.cc
+++ b/openvdb_ax/openvdb_ax/test/frontend/TestSyntaxFailures.cc
@@ -261,6 +261,7 @@ static const std::vector<StrWrapper> tests {
     "if + a;",
     "a + if(true) {};",
     "{} + {};",
+    "{} int",
     "~ + !;",
     "+ + -;",
     "; + ;",
@@ -567,7 +568,24 @@ static const std::vector<StrWrapper> tests {
     "|;",
     ",;",
     "!;",
-    "\\;"
+    "\\;",
+
+    // Test right associativity. These symbols are defined with %right in the
+    // parser which forces partial creation of ASTs. ::parse should ensure
+    // that these cases still produce invalid AST ptrs.
+    "{} ?",
+    "{} :",
+    "{} =",
+    "{} +=",
+    "{} -=",
+    "{} /=",
+    "{} *=",
+    "{} %=",
+    "{} |=",
+    "{} &=",
+    "{} ^=",
+    "{} <<=",
+    "{} >>="
 };
 
 }
@@ -587,7 +605,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestSyntaxFailures);
 
 void TestSyntaxFailures::testSyntax()
 {
-    // Quickly check the above doesn't have multiple occurance
+    // Quickly check the above doesn't have multiple occurrence
     // store multiple in a hash map
     const auto hash = [](const StrWrapper* s) {
         return std::hash<std::string>()(s->first);
@@ -611,5 +629,3 @@ void TestSyntaxFailures::testSyntax()
 
     TEST_SYNTAX_FAILS(tests);
 }
-
-

--- a/openvdb_ax/openvdb_ax/test/util.h
+++ b/openvdb_ax/openvdb_ax/test/util.h
@@ -11,6 +11,7 @@
 #define OPENVDB_AX_UNITTEST_UTIL_HAS_BEEN_INCLUDED
 
 #include <openvdb_ax/ast/AST.h>
+#include <openvdb_ax/ast/PrintTree.h>
 #include <openvdb_ax/ast/Parse.h>
 #include <openvdb_ax/ast/Tokens.h>
 #include <openvdb_ax/compiler/Logger.h>
@@ -34,7 +35,7 @@
         const std::string& code = test.first; \
         openvdb::ax::ast::Tree::ConstPtr tree = openvdb::ax::ast::parse(code.c_str(), logger);\
         std::stringstream str; \
-        CPPUNIT_ASSERT_MESSAGE(ERROR_MSG("Unexpected parsing error(s)\n", str.str()), tree); \
+        CPPUNIT_ASSERT_MESSAGE(ERROR_MSG("Unexpected parsing error(s)\n", str.str()), tree && !logger.hasError()); \
     } \
 } \
 
@@ -45,7 +46,7 @@
         logger.clear();\
         const std::string& code = test.first; \
         openvdb::ax::ast::Tree::ConstPtr tree = openvdb::ax::ast::parse(code.c_str(), logger);\
-        CPPUNIT_ASSERT_MESSAGE(ERROR_MSG("Expected parsing error", code), logger.hasError()); \
+        CPPUNIT_ASSERT_MESSAGE(ERROR_MSG("Expected parsing error", code), !tree && logger.hasError()); \
     } \
 } \
 

--- a/pendingchanges/ax_fixes.txt
+++ b/pendingchanges/ax_fixes.txt
@@ -1,0 +1,4 @@
+Bug Fixes:
+    - Fixed a regression in ax::run which wouldn't propagate exceptions
+    - Fixed a bug where ax::ast::parse could return a partially constructed but invalid AST on failure
+    - Fixed AX logger exit handling in ax::Compiler::compile and ax::ast::parse


### PR DESCRIPTION
 - Fixed a regression in ax::run which wouldn't propagate exceptions
 - Improved logger exit handling in the compiler
 - Improved the behaviour of ax::parse for invalid ASTs

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>