### PR TITLE
FindTBB: also search for `tbb/version.h`

### DIFF
--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -163,7 +163,7 @@ list(APPEND _TBB_INCLUDE_SEARCH_DIRS
 )
 
 # Look for a standard tbb header file.
-find_path(Tbb_INCLUDE_DIR tbb/tbb_stddef.h
+find_path(Tbb_INCLUDE_DIR NAMES tbb/version.h tbb/tbb_stddef.h
   ${_FIND_TBB_ADDITIONAL_OPTIONS}
   PATHS ${_TBB_INCLUDE_SEARCH_DIRS}
   PATH_SUFFIXES ${CMAKE_INSTALL_INCLUDEDIR} include


### PR DESCRIPTION
The `tbb_stddef.h` header no longer exists. In environments with older
TBB installations laying around beside newer TBB installations, the
newer TBB ends up being found except for the include directory because
the `find_file` finds the old TBB's `tbb_stddef.h` header which doesn't
match the new prefix. Instead, also search for `tbb/version.h` to allow
the fallback `oneapi/` version extraction end up working.