### PR TITLE
CMake updates:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,8 @@ Disable CMakes default system search paths when locating dependencies. When enab
 its default system search routine if it cannot find a dependency with the provided settings. When disabled, only
 paths provided through the Xxx_ROOT, supported XXX_INCLUDEDIR/XXX_LIBRARYDIR variables or the SYSTEM_LIBRARY_PATHS
 list will be searched.]=] OFF)
-option(OPENVDB_USE_DEPRECATED_ABI_6 "Bypass minimum ABI requirement checks" OFF)
 option(OPENVDB_USE_DEPRECATED_ABI_7 "Bypass minimum ABI requirement checks" OFF)
+option(OPENVDB_USE_DEPRECATED_ABI_8 "Bypass minimum ABI requirement checks" OFF)
 option(OPENVDB_USE_FUTURE_ABI_10 "Bypass future ABI check" OFF)
 option(OPENVDB_FUTURE_DEPRECATION "Generate messages for upcoming deprecation" ON)
 option(OPENVDB_ENABLE_UNINSTALL "Adds a CMake uninstall target." ON)
@@ -209,8 +209,28 @@ if(USE_AX)
   endif()
 endif()
 
+if(OPENVDB_BUILD_HOUDINI_PLUGIN OR OPENVDB_BUILD_HOUDINI_ABITESTS)
+  set(USE_HOUDINI ON)
+endif()
+
+if(OPENVDB_BUILD_MAYA_PLUGIN)
+  set(USE_MAYA ON)
+endif()
+
+if(USE_MAYA AND USE_HOUDINI)
+  # @todo technically this is possible so long as library versions match
+  # exactly but it's difficult to validate and dangerous
+  message(FATAL_ERROR "Cannot build both Houdini and Maya plugins against "
+    "the same core dependencies. Plugins must be compiled separately to "
+    "ensure the required DCC dependencies are met.")
+endif()
+
 ###### Deprecated options
 
+if(OPENVDB_CODE_COVERAGE)
+  message(FATAL_ERROR "The OPENVDB_CODE_COVERAGE option  has been removed. Choose instead the unique"
+      "build type -DCMAKE_BUILD_TYPE=coverage")
+endif()
 if(OPENVDB_BUILD_HOUDINI_SOPS)
   message(FATAL_ERROR "The OPENVDB_BUILD_HOUDINI_SOPS option has been removed. Use OPENVDB_BUILD_HOUDINI_PLUGIN.")
 endif()
@@ -221,142 +241,33 @@ endif()
 # Various root level CMake options which are marked as advanced
 
 mark_as_advanced(
+  CONCURRENT_MALLOC
+  DISABLE_CMAKE_SEARCH_PATHS
+  DISABLE_DEPENDENCY_VERSION_CHECKS
+  OPENVDB_BUILD_HOUDINI_ABITESTS
   OPENVDB_CXX_STRICT
   OPENVDB_ENABLE_RPATH
-  USE_HOUDINI
-  USE_MAYA
-  USE_LOG4CPLUS
-  USE_IMATH_HALF
-  USE_CCACHE
-  OPENVDB_BUILD_HOUDINI_ABITESTS
-  DISABLE_DEPENDENCY_VERSION_CHECKS
-  DISABLE_CMAKE_SEARCH_PATHS
-  OPENVDB_USE_DEPRECATED_ABI_6
-  OPENVDB_USE_DEPRECATED_ABI_7
-  OPENVDB_USE_FUTURE_ABI_10
   OPENVDB_FUTURE_DEPRECATION
-  CONCURRENT_MALLOC
-  USE_COLORED_OUTPUT
-  SYSTEM_LIBRARY_PATHS
   OPENVDB_SIMD
+  OPENVDB_USE_DEPRECATED_ABI_7
+  OPENVDB_USE_DEPRECATED_ABI_8
+  OPENVDB_USE_FUTURE_ABI_10
+  SYSTEM_LIBRARY_PATHS
+  USE_CCACHE
+  USE_COLORED_OUTPUT
+  USE_HOUDINI
+  USE_IMATH_HALF
+  USE_LOG4CPLUS
+  USE_MAYA
 )
-
-# Configure minimum version requirements - some are treated specially and fall
-# outside of the DISABLE_DEPENDENCY_VERSION_CHECKS catch
-set(MINIMUM_CXX_STANDARD 14)
-
-# @note  ABI always enforced so the correct deprecation messages are available.
-# OPENVDB_USE_DEPRECATED_ABI_<VERSION> should be used to circumvent this
-set(MINIMUM_OPENVDB_ABI_VERSION 6)
-set(FUTURE_MINIMUM_OPENVDB_ABI_VERSION 8)
-set(FUTURE_OPENVDB_ABI_VERSION 10)
-
-if(NOT DISABLE_DEPENDENCY_VERSION_CHECKS)
-  # @note  Currently tracking CY2020 of the VFX platform where available
-  set(MINIMUM_GCC_VERSION 6.3.1)
-  set(MINIMUM_CLANG_VERSION 3.8)
-  set(MINIMUM_ICC_VERSION 17)
-  set(MINIMUM_MSVC_VERSION 19.10)
-
-  set(MINIMUM_BOOST_VERSION 1.70)
-  set(MINIMUM_ILMBASE_VERSION 2.4)
-  set(MINIMUM_OPENEXR_VERSION 2.4)
-  set(MINIMUM_ZLIB_VERSION 1.2.7)
-  set(MINIMUM_TBB_VERSION 2019.0)
-  set(MINIMUM_LLVM_VERSION 7.0.0)
-  set(MINIMUM_BLOSC_VERSION 1.5.0)
-
-  set(MINIMUM_PYTHON_VERSION 2.7) # @warning should be 3.7.x, but H18.5+ can still be used with 2.7.x
-  set(MINIMUM_NUMPY_VERSION 1.14.0)
-
-  set(MINIMUM_GOOGLETEST_VERSION 1.10)
-  set(MINIMUM_GLFW_VERSION 3.1)
-  set(MINIMUM_LOG4CPLUS_VERSION 1.1.2)
-  set(MINIMUM_HOUDINI_VERSION 18.5)
-
-  # These always promote warnings rather than errors
-  set(MINIMUM_MAYA_VERSION 2017)
-  set(MINIMUM_DOXYGEN_VERSION 1.8.8)
-endif()
-
-# VFX 21 deprecations to transition to MINIMUM_* variables in OpenVDB 10.0.0
-
-# No compiler upgrades planned
-set(FUTURE_MINIMUM_GCC_VERSION 9.3.1)
-set(FUTURE_MINIMUM_ICC_VERSION 19)
-# set(FUTURE_MINIMUM_MSVC_VERSION 19.10)
-
-# set(FUTURE_MINIMUM_CMAKE_VERSION 3.18)
-# set(FUTURE_MINIMUM_ILMBASE_VERSION 2.4)
-# set(FUTURE_MINIMUM_OPENEXR_VERSION 2.4)
-set(FUTURE_MINIMUM_BOOST_VERSION 1.73)
-set(FUTURE_MINIMUM_BLOSC_VERSION 1.17.0)
-set(FUTURE_MINIMUM_TBB_VERSION 2020.2)
-set(FUTURE_MINIMUM_PYTHON_VERSION 3.7)
-set(FUTURE_MINIMUM_NUMPY_VERSION 1.17.0)
-# set(FUTURE_MINIMUM_HOUDINI_VERSION 18.5)
-set(FUTURE_MINIMUM_LLVM_VERSION 10.0.0)
 
 #########################################################################
 
-# General CMake and CXX settings
+# Configure MINIMUM and FUTURE_MINIMUM version variables
 
-if(FUTURE_MINIMUM_CMAKE_VERSION)
-  if(${CMAKE_VERSION} VERSION_LESS ${FUTURE_MINIMUM_CMAKE_VERSION})
-    message(DEPRECATION "Support for CMake versions < ${FUTURE_MINIMUM_CMAKE_VERSION} "
-      "is deprecated and will be removed.")
-  endif()
-endif()
+include(cmake/config/OpenVDBVersions.cmake)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD ${MINIMUM_CXX_STANDARD} CACHE STRING
-    "The C++ standard whose features are requested to build OpenVDB components." FORCE)
-elseif(CMAKE_CXX_STANDARD LESS ${MINIMUM_CXX_STANDARD})
-  message(FATAL_ERROR "Provided C++ Standard is less than the supported minimum."
-    "Required is at least \"${MINIMUM_CXX_STANDARD}\" (found ${CMAKE_CXX_STANDARD})")
-endif()
-
-# Configure MS Runtime
-
-if(WIN32 AND CMAKE_MSVC_RUNTIME_LIBRARY)
-  message(STATUS "CMAKE_MSVC_RUNTIME_LIBRARY set to target ${CMAKE_MSVC_RUNTIME_LIBRARY}")
-
-  # Configure Boost library varient on Windows
-  if(NOT Boost_USE_STATIC_RUNTIME)
-    set(Boost_USE_STATIC_RUNTIME OFF)
-    if(CMAKE_MSVC_RUNTIME_LIBRARY STREQUAL MultiThreaded OR
-       CMAKE_MSVC_RUNTIME_LIBRARY STREQUAL MultiThreadedDebug)
-      set(Boost_USE_STATIC_RUNTIME ON)
-    endif()
-  endif()
-  if(NOT Boost_USE_DEBUG_RUNTIME)
-    set(Boost_USE_DEBUG_RUNTIME OFF)
-    if(CMAKE_MSVC_RUNTIME_LIBRARY STREQUAL MultiThreadedDebugDLL OR
-       CMAKE_MSVC_RUNTIME_LIBRARY STREQUAL MultiThreadedDebug)
-      set(Boost_USE_DEBUG_RUNTIME ON)
-    endif()
-  endif()
-endif()
-
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
-if(OPENVDB_ENABLE_RPATH)
-  # Configure rpath for installation base on the following:
-  # https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
-  set(CMAKE_SKIP_BUILD_RPATH FALSE)
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-  # @todo make relocatable?
-  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-endif()
-
-# For CMake's find Threads module which brings in pthread - This flag
-# forces the compiler -pthread flag vs -lpthread
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+#########################################################################
 
 enable_testing()
 
@@ -382,26 +293,6 @@ if(OPENVDB_INSTALL_CMAKE_MODULES)
     cmake/OpenVDBUtils.cmake
   )
   install(FILES ${OPENVDB_CMAKE_MODULES} DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OpenVDB)
-endif()
-
-# Configure DCC installation if necessary
-
-if(OPENVDB_BUILD_HOUDINI_PLUGIN OR
-   OPENVDB_BUILD_HOUDINI_ABITESTS)
-  set(USE_HOUDINI ON)
-endif()
-
-if(OPENVDB_BUILD_MAYA_PLUGIN)
-  set(USE_MAYA ON)
-endif()
-
-if(USE_MAYA AND USE_HOUDINI)
-  # @todo technically this is possible so long as library versions match
-  # exactly but it's difficult to validate and dangerous
-  message(FATAL_ERROR "Cannot build both Houdini and Maya plugins against "
-    "the same core dependencies. Plugins must be compiled separately to "
-    "ensure the required DCC dependencies are met."
-  )
 endif()
 
 # Configure component dependencies by loading the Houdini/Maya setup
@@ -457,31 +348,11 @@ if(USE_CCACHE)
   endif()
 endif()
 
-# Build type configuration
+#########################################################################
 
-if(OPENVDB_CODE_COVERAGE)
-  message(DEPRECATION "The OPENVDB_CODE_COVERAGE option is deprecated. Choose instead the unique"
-    "build type -DCMAKE_BUILD_TYPE=coverage")
-  set(CMAKE_BUILD_TYPE coverage)
-endif()
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
+# Configure general CMake and CXX settings
 
-include(cmake/config/OpenVDBBuildTypes.cmake)
-
-if(CMAKE_BUILD_TYPE EQUAL coverage)
-  # use .gcno extension instead of .cc.gcno
-  # @note This is an undocumented internal cmake var and does not work
-  # with multi config generators
-  set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
-endif()
-
-# CMAKE_BUILD_TYPE is ignored for multi config generators i.e. MSVS
-get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-if(NOT _isMultiConfig)
-  message(STATUS "CMake Build Type: ${CMAKE_BUILD_TYPE}")
-endif()
+include(cmake/config/OpenVDBCXX.cmake)
 
 #########################################################################
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -155,8 +155,8 @@ set -x
 # Note:
 # - all sub binary options are always on and can be toggles with: OPENVDB_BUILD_BINARIES=ON/OFF
 cmake \
-    -DOPENVDB_USE_DEPRECATED_ABI_6=ON \
     -DOPENVDB_USE_DEPRECATED_ABI_7=ON \
+    -DOPENVDB_USE_DEPRECATED_ABI_8=ON \
     -DOPENVDB_BUILD_VDB_PRINT=ON \
     -DOPENVDB_BUILD_VDB_LOD=ON \
     -DOPENVDB_BUILD_VDB_RENDER=ON \

--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -333,9 +333,7 @@ endif()
 # Explicitly configure the OpenVDB ABI version depending on the Houdini
 # version.
 
-if(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.0)
-  set(OPENVDB_HOUDINI_ABI 6)
-elseif(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.5)
+if(Houdini_VERSION_MAJOR_MINOR VERSION_EQUAL 18.5)
   set(OPENVDB_HOUDINI_ABI 7)
 else()
   find_file(_houdini_openvdb_version_file "openvdb/version.h"

--- a/cmake/config/OpenVDBVersions.cmake
+++ b/cmake/config/OpenVDBVersions.cmake
@@ -1,0 +1,69 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: MPL-2.0
+#
+#[=======================================================================[
+
+  Current and future version requirements for all OpenVDB dependencies,
+  including compilers, language features and OpenVDB's ABI.
+
+#]=======================================================================]
+
+cmake_minimum_required(VERSION 3.15)
+
+###############################################################################
+
+# Configure minimum version requirements - some are treated specially and fall
+# outside of the DISABLE_DEPENDENCY_VERSION_CHECKS catch
+set(MINIMUM_CXX_STANDARD 14)
+
+# @note  ABI always enforced so the correct deprecation messages are available.
+# OPENVDB_USE_DEPRECATED_ABI_<VERSION> should be used to circumvent this
+set(MINIMUM_OPENVDB_ABI_VERSION 7)
+set(FUTURE_MINIMUM_OPENVDB_ABI_VERSION 9)
+set(FUTURE_OPENVDB_ABI_VERSION 10)
+
+if(NOT DISABLE_DEPENDENCY_VERSION_CHECKS)
+  # @note  Currently tracking CY2020 of the VFX platform where available
+  set(MINIMUM_GCC_VERSION 6.3.1)
+  set(MINIMUM_CLANG_VERSION 3.8)
+  set(MINIMUM_ICC_VERSION 17)
+  set(MINIMUM_MSVC_VERSION 19.10)
+
+  set(MINIMUM_BOOST_VERSION 1.70)
+  set(MINIMUM_ILMBASE_VERSION 2.4)
+  set(MINIMUM_OPENEXR_VERSION 2.4)
+  set(MINIMUM_ZLIB_VERSION 1.2.7)
+  set(MINIMUM_TBB_VERSION 2019.0)
+  set(MINIMUM_LLVM_VERSION 7.0.0)
+  set(MINIMUM_BLOSC_VERSION 1.5.0)
+
+  set(MINIMUM_PYTHON_VERSION 2.7) # @warning should be 3.7.x, but H18.5+ can still be used with 2.7.x
+  set(MINIMUM_NUMPY_VERSION 1.17.0)
+
+  set(MINIMUM_GOOGLETEST_VERSION 1.10)
+  set(MINIMUM_GLFW_VERSION 3.1)
+  set(MINIMUM_LOG4CPLUS_VERSION 1.1.2)
+  set(MINIMUM_HOUDINI_VERSION 18.5)
+
+  # These always promote warnings rather than errors
+  set(MINIMUM_MAYA_VERSION 2017)
+  set(MINIMUM_DOXYGEN_VERSION 1.8.8)
+endif()
+
+# VFX 21 deprecations to transition to MINIMUM_* variables in OpenVDB 10.0.0
+
+set(FUTURE_MINIMUM_GCC_VERSION 9.3.1)
+set(FUTURE_MINIMUM_ICC_VERSION 19)
+# set(FUTURE_MINIMUM_MSVC_VERSION 19.10)
+
+set(FUTURE_MINIMUM_CXX_STANDARD 17)
+set(FUTURE_MINIMUM_CMAKE_VERSION 3.18)
+#set(FUTURE_MINIMUM_ILMBASE_VERSION 2.4) # Minimum is already 2.4
+#set(FUTURE_MINIMUM_OPENEXR_VERSION 2.4) # Minimum is already 2.4
+set(FUTURE_MINIMUM_BOOST_VERSION 1.73)
+set(FUTURE_MINIMUM_BLOSC_VERSION 1.17.0)
+set(FUTURE_MINIMUM_TBB_VERSION 2020.2)
+set(FUTURE_MINIMUM_PYTHON_VERSION 3.7)
+set(FUTURE_MINIMUM_NUMPY_VERSION 1.19.0)
+set(FUTURE_MINIMUM_HOUDINI_VERSION 19.0)
+set(FUTURE_MINIMUM_LLVM_VERSION 10.0.0)

--- a/nanovdb/nanovdb/util/NanoToOpenVDB.h
+++ b/nanovdb/nanovdb/util/NanoToOpenVDB.h
@@ -132,14 +132,7 @@ NanoToOpenVDB<T>::operator()(const NanoGrid<T>& grid, int /*verbose*/)
     for (uint32_t i=0; i<data->mTableSize; ++i) {
         auto *tile = data->tile(i);
         if (tile->isChild()) {
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
             root.addChild( this->process( data->getChild(tile)) );
-#else// hack since RootNode::addChild is not available in older versions
-            root.addTile(tile->origin(), root.background(), false);//dummy tile
-            auto it = root.beginChildAll();
-            while(it.getCoord() != tile->origin()) ++it;// find tile
-            it.setChild(this->process( data->getChild(tile)) );//replace tile with child
-#endif
         } else {
             root.addTile(tile->origin(), tile->value, tile->state);
         }

--- a/nanovdb/nanovdb/util/OpenToNanoVDB.h
+++ b/nanovdb/nanovdb/util/OpenToNanoVDB.h
@@ -513,14 +513,7 @@ GridHandle<BufferT> OpenToNanoVDB<OpenBuildT,  NanoBuildT,  OracleT, BufferT>::
     mArray0.clear();
     mArray1.clear();
     mArray2.clear();
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     std::vector<uint32_t> nodeCount = openTree.nodeCount();
-#else
-    std::vector<uint32_t> nodeCount(openTree.treeDepth());
-    for (auto it = openTree.cbeginNode(); it; ++it) {
-        ++(nodeCount[it.getDepth()]);
-    }
-#endif
     mArray0.reserve(nodeCount[0]);
     mArray1.reserve(nodeCount[1]);
     mArray2.reserve(nodeCount[2]);

--- a/openvdb/openvdb/Grid.h
+++ b/openvdb/openvdb/Grid.h
@@ -99,7 +99,6 @@ public:
     /// transform are deep copies of this grid's and whose tree is default-constructed.
     virtual GridBase::Ptr copyGridWithNewTree() const = 0;
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     /// @brief Return a new grid of the same type as this grid whose tree and transform
     /// is shared with this grid and whose metadata is provided as an argument.
     virtual GridBase::ConstPtr copyGridReplacingMetadata(const MetaMap& meta) const = 0;
@@ -113,7 +112,6 @@ public:
     /// @throw ValueError if the transform pointer is null
     virtual GridBase::ConstPtr copyGridReplacingMetadataAndTransform(const MetaMap& meta,
         math::Transform::Ptr xform) const = 0;
-#endif
 
     /// Return a new grid whose metadata, transform and tree are deep copies of this grid's.
     virtual GridBase::Ptr deepCopyGrid() const = 0;
@@ -485,11 +483,9 @@ protected:
     /// @brief Initialize with an identity linear transform.
     GridBase(): mTransform(math::Transform::createLinearTransform()) {}
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     /// @brief Initialize with metadata and a transform.
     /// @throw ValueError if the transform pointer is null
     GridBase(const MetaMap& meta, math::Transform::Ptr xform);
-#endif
 
     /// @brief Deep copy another grid's metadata and transform.
     GridBase(const GridBase& other): MetaMap(other), mTransform(other.mTransform->copy()) {}
@@ -675,7 +671,6 @@ public:
     /// @name Copying
     /// @{
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     /// @brief Return a new grid of the same type as this grid whose tree and transform
     /// is shared with this grid and whose metadata is provided as an argument.
     ConstPtr copyReplacingMetadata(const MetaMap& meta) const;
@@ -703,7 +698,6 @@ public:
     /// @throw ValueError if the transform pointer is null
     GridBase::ConstPtr copyGridReplacingMetadataAndTransform(const MetaMap& meta,
         math::Transform::Ptr xform) const override;
-#endif
 
     /// @brief Return a new grid whose metadata, transform and tree are deep copies of this grid's.
     Ptr deepCopy() const { return Ptr(new Grid(*this)); }
@@ -988,10 +982,8 @@ tools::minMax(grid->tree()). Use threaded = false for serial execution")
 
 
 private:
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     /// Deep copy metadata, but share tree and transform.
     Grid(TreePtrType tree, const MetaMap& meta, math::Transform::Ptr xform);
-#endif
 
     /// Helper function for use with registerGrid()
     static GridBase::Ptr factory() { return Grid::create(); }
@@ -1190,14 +1182,12 @@ struct HasMultiPassIO<Grid<TreeType>> {
 
 ////////////////////////////////////////
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
 inline GridBase::GridBase(const MetaMap& meta, math::Transform::Ptr xform)
     : MetaMap(meta)
     , mTransform(xform)
 {
     if (!xform) OPENVDB_THROW(ValueError, "Transform pointer is null");
 }
-#endif
 
 template<typename GridType>
 inline typename GridType::Ptr
@@ -1275,7 +1265,6 @@ inline Grid<TreeT>::Grid(TreePtrType tree): mTree(tree)
 }
 
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
 template<typename TreeT>
 inline Grid<TreeT>::Grid(TreePtrType tree, const MetaMap& meta, math::Transform::Ptr xform):
     GridBase(meta, xform),
@@ -1283,7 +1272,6 @@ inline Grid<TreeT>::Grid(TreePtrType tree, const MetaMap& meta, math::Transform:
 {
     if (!tree) OPENVDB_THROW(ValueError, "Tree pointer is null");
 }
-#endif
 
 
 template<typename TreeT>
@@ -1366,7 +1354,6 @@ Grid<TreeT>::copy() const
 }
 
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
 template<typename TreeT>
 inline typename Grid<TreeT>::ConstPtr
 Grid<TreeT>::copyReplacingMetadata(const MetaMap& meta) const
@@ -1392,7 +1379,6 @@ Grid<TreeT>::copyReplacingMetadataAndTransform(const MetaMap& meta,
     TreePtrType treePtr = ConstPtrCast<TreeT>(this->constTreePtr());
     return ConstPtr{new Grid<TreeT>{treePtr, meta, xform}};
 }
-#endif
 
 
 template<typename TreeT>
@@ -1427,7 +1413,6 @@ Grid<TreeT>::copyGrid() const
     return this->copy();
 }
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
 template<typename TreeT>
 inline GridBase::ConstPtr
 Grid<TreeT>::copyGridReplacingMetadata(const MetaMap& meta) const
@@ -1449,7 +1434,6 @@ Grid<TreeT>::copyGridReplacingMetadataAndTransform(const MetaMap& meta,
 {
     return this->copyReplacingMetadataAndTransform(meta, xform);
 }
-#endif
 
 template<typename TreeT>
 inline GridBase::Ptr

--- a/openvdb/openvdb/openvdb.cc
+++ b/openvdb/openvdb/openvdb.cc
@@ -14,21 +14,21 @@
 #include <blosc.h>
 #endif
 
-#if OPENVDB_ABI_VERSION_NUMBER < 6
-    #error ABI <= 5 is no longer supported
+#if OPENVDB_ABI_VERSION_NUMBER <= 6
+    #error ABI <= 6 is no longer supported
 #endif
 
 // If using an OPENVDB_ABI_VERSION_NUMBER that has been deprecated, issue an
 // error directive. This can be optionally suppressed by defining:
 //   OPENVDB_USE_DEPRECATED_ABI_<VERSION>=ON.
-#ifndef OPENVDB_USE_DEPRECATED_ABI_6
-    #if OPENVDB_ABI_VERSION_NUMBER == 6
-        #error ABI = 6 is deprecated, CMake option OPENVDB_USE_DEPRECATED_ABI_6 suppresses this error
-    #endif
-#endif
 #ifndef OPENVDB_USE_DEPRECATED_ABI_7
     #if OPENVDB_ABI_VERSION_NUMBER == 7
         #error ABI = 7 is deprecated, CMake option OPENVDB_USE_DEPRECATED_ABI_7 suppresses this error
+    #endif
+#endif
+#ifndef OPENVDB_USE_DEPRECATED_ABI_8
+    #if OPENVDB_ABI_VERSION_NUMBER == 8
+        #error ABI = 8 is deprecated, CMake option OPENVDB_USE_DEPRECATED_ABI_8 suppresses this error
     #endif
 #endif
 

--- a/openvdb/openvdb/points/AttributeArray.cc
+++ b/openvdb/openvdb/points/AttributeArray.cc
@@ -51,7 +51,6 @@ AttributeArray::ScopedRegistryLock::ScopedRegistryLock()
 // AttributeArray implementation
 
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
 AttributeArray::AttributeArray(const AttributeArray& rhs)
     : AttributeArray(rhs, tbb::spin_mutex::scoped_lock(rhs.mMutex))
 {
@@ -59,9 +58,6 @@ AttributeArray::AttributeArray(const AttributeArray& rhs)
 
 
 AttributeArray::AttributeArray(const AttributeArray& rhs, const tbb::spin_mutex::scoped_lock&)
-#else
-AttributeArray::AttributeArray(const AttributeArray& rhs)
-#endif
     : mIsUniform(rhs.mIsUniform)
     , mFlags(rhs.mFlags)
     , mUsePagedRead(rhs.mUsePagedRead)

--- a/openvdb/openvdb/points/AttributeArray.h
+++ b/openvdb/openvdb/points/AttributeArray.h
@@ -366,9 +366,7 @@ private:
         bool rangeChecking = true);
 
 protected:
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     AttributeArray(const AttributeArray& rhs, const tbb::spin_mutex::scoped_lock&);
-#endif
 
     /// @brief Specify whether this attribute has a constant stride or not.
     void setConstantStride(bool state);
@@ -544,7 +542,7 @@ public:
     /// Default constructor, always constructs a uniform attribute.
     explicit TypedAttributeArray(Index n = 1, Index strideOrTotalSize = 1, bool constantStride = true,
         const ValueType& uniformValue = zeroVal<ValueType>());
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
+
     /// Deep copy constructor.
     /// @note This method is thread-safe (as of ABI=7) for concurrently reading from the
     /// source attribute array while being deep-copied. Specifically, this means that the
@@ -555,12 +553,7 @@ public:
     /// Deep copy constructor.
     OPENVDB_DEPRECATED_MESSAGE("Use copy-constructor without unused bool parameter")
     TypedAttributeArray(const TypedAttributeArray&, bool /*unused*/);
-#else
-    /// Deep copy constructor.
-    /// @note This method is not thread-safe for reading or writing, use
-    /// TypedAttributeArray::copy() to ensure thread-safety when reading concurrently.
-    TypedAttributeArray(const TypedAttributeArray&, bool uncompress = false);
-#endif
+
     /// Deep copy assignment operator.
     /// @note this operator is thread-safe.
     TypedAttributeArray& operator=(const TypedAttributeArray&);
@@ -762,9 +755,7 @@ protected:
 private:
     friend class ::TestAttributeArray;
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     TypedAttributeArray(const TypedAttributeArray&, const tbb::spin_mutex::scoped_lock&);
-#endif
 
     /// Load data from memory-mapped file.
     inline void doLoad() const;
@@ -1132,7 +1123,6 @@ TypedAttributeArray<ValueType_, Codec_>::TypedAttributeArray(
 }
 
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
 template<typename ValueType_, typename Codec_>
 TypedAttributeArray<ValueType_, Codec_>::TypedAttributeArray(const TypedAttributeArray& rhs)
     : TypedAttributeArray(rhs, tbb::spin_mutex::scoped_lock(rhs.mMutex))
@@ -1144,11 +1134,6 @@ template<typename ValueType_, typename Codec_>
 TypedAttributeArray<ValueType_, Codec_>::TypedAttributeArray(const TypedAttributeArray& rhs,
     const tbb::spin_mutex::scoped_lock& lock)
     : AttributeArray(rhs, lock)
-#else
-template<typename ValueType_, typename Codec_>
-TypedAttributeArray<ValueType_, Codec_>::TypedAttributeArray(const TypedAttributeArray& rhs, bool)
-    : AttributeArray(rhs)
-#endif
     , mSize(rhs.mSize)
     , mStrideOrTotalSize(rhs.mStrideOrTotalSize)
 {
@@ -1259,9 +1244,6 @@ template<typename ValueType_, typename Codec_>
 AttributeArray::Ptr
 TypedAttributeArray<ValueType_, Codec_>::copy() const
 {
-#if OPENVDB_ABI_VERSION_NUMBER < 7
-    tbb::spin_mutex::scoped_lock lock(mMutex);
-#endif
     return AttributeArray::Ptr(new TypedAttributeArray<ValueType, Codec>(*this));
 }
 

--- a/openvdb/openvdb/tree/Tree.h
+++ b/openvdb/openvdb/tree/Tree.h
@@ -109,12 +109,10 @@ public:
     virtual Index treeDepth() const = 0;
     /// Return the number of leaf nodes.
     virtual Index32 leafCount() const = 0;
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     /// Return a vector with node counts. The number of nodes of type NodeType
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
     virtual std::vector<Index32> nodeCount() const = 0;
-#endif
     /// Return the number of non-leaf nodes.
     virtual Index32 nonLeafCount() const = 0;
     /// Return the number of active voxels stored in leaf nodes.
@@ -336,7 +334,6 @@ public:
     Index treeDepth() const override { return DEPTH; }
     /// Return the number of leaf nodes.
     Index32 leafCount() const override { return mRoot.leafCount(); }
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     /// Return a vector with node counts. The number of nodes of type NodeType
     /// is given as element NodeType::LEVEL in the return vector. Thus, the size
     /// of this vector corresponds to the height (or depth) of this tree.
@@ -346,7 +343,6 @@ public:
         mRoot.nodeCount( vec );
         return vec;// Named Return Value Optimization
     }
-#endif
     /// Return the number of non-leaf nodes.
     Index32 nonLeafCount() const override { return mRoot.nonLeafCount(); }
     /// Return the number of active voxels stored in leaf nodes.
@@ -2093,14 +2089,8 @@ Tree<RootNodeType>::print(std::ostream& os, int verboseLevel) const
         maxVal = extrema.max();
     }
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     const auto nodeCount = this->nodeCount();//fast
     const Index32 leafCount = nodeCount.front();// leaf is the first element
-#else
-    std::vector<Index64> nodeCount(dims.size());
-    for (NodeCIter it = cbeginNode(); it; ++it) ++(nodeCount[it.getDepth()]);//slow
-    const Index64 leafCount = *nodeCount.rbegin();// leaf is the last element
-#endif
     assert(dims.size() == nodeCount.size());
 
     Index64 totalNodeCount = 0;
@@ -2110,11 +2100,7 @@ Tree<RootNodeType>::print(std::ostream& os, int verboseLevel) const
     os << "    Root(1 x " << mRoot.getTableSize() << ")";
     if (dims.size() >= 2) {
         for (size_t i = 1, N = dims.size() - 1; i < N; ++i) {
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
             os << ", Internal(" << util::formattedInt(nodeCount[N - i]);
-#else
-            os << ", Internal(" << util::formattedInt(nodeCount[i]);
-#endif
             os << " x " << (1 << dims[i]) << "^3)";
         }
         os << ", Leaf(" << util::formattedInt(leafCount);

--- a/openvdb/openvdb/unittest/TestGrid.cc
+++ b/openvdb/openvdb/unittest/TestGrid.cc
@@ -84,10 +84,8 @@ public:
 
     openvdb::Index treeDepth() const override { return 0; }
     openvdb::Index leafCount() const override { return 0; }
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     std::vector<openvdb::Index32> nodeCount() const override
         { return std::vector<openvdb::Index32>(DEPTH, 0); }
-#endif
     openvdb::Index nonLeafCount() const override { return 0; }
     openvdb::Index64 activeVoxelCount() const override { return 0UL; }
     openvdb::Index64 inactiveVoxelCount() const override { return 0UL; }
@@ -266,7 +264,6 @@ TEST_F(TestGrid, testCopyGrid)
     ASSERT_DOUBLES_EXACTLY_EQUAL(fillValue1, tree1.getValue(changeCoord));
     ASSERT_DOUBLES_EXACTLY_EQUAL(1.0f, tree2.getValue(changeCoord));
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     // shallow-copy a const grid but supply a new transform and meta map
     EXPECT_EQ(1.0, grid1->transform().voxelSize().x());
     EXPECT_EQ(size_t(0), grid1->metaCount());
@@ -285,7 +282,6 @@ TEST_F(TestGrid, testCopyGrid)
     EXPECT_EQ(size_t(1), grid3->metaCount());
     EXPECT_EQ(Index(2), tree3.leafCount());
     EXPECT_EQ(long(3), constGrid1->constTreePtr().use_count());
-#endif
 }
 
 

--- a/openvdb/openvdb/unittest/TestNodeVisitor.cc
+++ b/openvdb/openvdb/unittest/TestNodeVisitor.cc
@@ -12,7 +12,6 @@ class TestNodeVisitor: public ::testing::Test
 };
 
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
 struct NodeCountOp
 {
     template <typename NodeT>
@@ -45,7 +44,6 @@ TEST_F(TestNodeVisitor, testNodeCount)
         EXPECT_EQ(nodeCount1[i], nodeCount2[i]);
     }
 }
-#endif // OPENVDB_ABI_VERSION_NUMBER >= 7
 
 
 template <typename TreeT>
@@ -114,7 +112,6 @@ TEST_F(TestNodeVisitor, testDepthFirst)
 }
 
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
 template <typename TreeT>
 struct StoreOriginsOp
 {
@@ -176,7 +173,6 @@ TEST_F(TestNodeVisitor, testOriginArray)
 
     EXPECT_EQ(idx, origins.size());
 }
-#endif // OPENVDB_ABI_VERSION_NUMBER >= 7
 
 
 template <typename TreeType>

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -2763,7 +2763,6 @@ TEST_F(TestTree, testStealNode)
     }
 }
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
 TEST_F(TestTree, testNodeCount)
 {
     //openvdb::util::CpuTimer timer;// use for benchmark test
@@ -2791,7 +2790,6 @@ TEST_F(TestTree, testNodeCount)
     EXPECT_EQ(tree.leafCount(), nodeCount2.front());// leaf nodes
     for (size_t i=0; i<nodeCount2.size(); ++i) EXPECT_EQ( nodeCount1[i], nodeCount2[i]);
 }
-#endif
 
 TEST_F(TestTree, testRootNode)
 {

--- a/openvdb/openvdb/version.h.in
+++ b/openvdb/openvdb/version.h.in
@@ -173,15 +173,15 @@
 // directive. This can be suppressed by defining OPENVDB_USE_DEPRECATED_ABI_<VERSION>.
 // Note that, whilst the VDB CMake does not allow this option to be hit,
 // it exists to propagate this message to downstream targets
-#ifndef OPENVDB_USE_DEPRECATED_ABI_6
-    #if OPENVDB_ABI_VERSION_NUMBER == 6
-        PRAGMA(message("NOTE: ABI = 6 is deprecated, define OPENVDB_USE_DEPRECATED_ABI_6 "
-            "to suppress this message"))
-    #endif
-#endif
 #ifndef OPENVDB_USE_DEPRECATED_ABI_7
     #if OPENVDB_ABI_VERSION_NUMBER == 7
         PRAGMA(message("NOTE: ABI = 7 is deprecated, define OPENVDB_USE_DEPRECATED_ABI_7 "
+            "to suppress this message"))
+    #endif
+#endif
+#ifndef OPENVDB_USE_DEPRECATED_ABI_8
+    #if OPENVDB_ABI_VERSION_NUMBER == 8
+        PRAGMA(message("NOTE: ABI = 8 is deprecated, define OPENVDB_USE_DEPRECATED_ABI_8 "
             "to suppress this message"))
     #endif
 #endif

--- a/openvdb_houdini/openvdb_houdini/ParmFactory.h
+++ b/openvdb_houdini/openvdb_houdini/ParmFactory.h
@@ -404,11 +404,7 @@ public:
         ParmList& parms, OP_OperatorTable& table, OpFlavor flavor = SOP);
 
     /// Register the operator.
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     virtual ~OpFactory();
-#else
-    ~OpFactory();
-#endif
 
     OpFactory(const OpFactory&) = delete;
     OpFactory& operator=(const OpFactory&) = delete;

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_LOD.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_LOD.cc
@@ -188,7 +188,6 @@ struct MultiResGridFractionalOp
         } else {
             const size_t levels = openvdb::math::Ceil(level) + 1;
             const GridType* gridPtr = &grid;
-#if OPENVDB_ABI_VERSION_NUMBER >= 7 // Grid::copyReplacingMetadata() only available in ABI>=7
             // if grid already has MultiResGrid_Level metadata with type int64, remove it
             typename GridType::ConstPtr newGridPtr;
             auto meta = grid.template getMetadata<openvdb::Int64Metadata>("MultiResGrid_Level");
@@ -200,7 +199,6 @@ struct MultiResGridFractionalOp
                 newGridPtr = grid.copyReplacingMetadata(metaMap);
                 gridPtr = newGridPtr.get();
             }
-#endif
             openvdb::tools::MultiResGrid<TreeT> mrg( levels, *gridPtr );
             outputGrid = mrg.template createGrid<Order>( level );
         }
@@ -223,7 +221,6 @@ struct MultiResGridRangeOp
         if ( end > 0.0f ) {
             const size_t levels = openvdb::math::Ceil(end) + 1;
             const GridType* gridPtr = &grid;
-#if OPENVDB_ABI_VERSION_NUMBER >= 7 // Grid::copyReplacingMetadata() only available in ABI>=7
             // if grid already has MultiResGrid_Level metadata with type int64, remove it
             typename GridType::ConstPtr newGridPtr;
             auto meta = grid.template getMetadata<openvdb::Int64Metadata>("MultiResGrid_Level");
@@ -235,7 +232,6 @@ struct MultiResGridRangeOp
                 newGridPtr = grid.copyReplacingMetadata(metaMap);
                 gridPtr = newGridPtr.get();
             }
-#endif
             openvdb::tools::MultiResGrid<TreeT> mrg( levels, *gridPtr );
 
             // inclusive range
@@ -260,7 +256,6 @@ struct MultiResGridIntegerOp
     {
         using TreeT = typename GridType::TreeType;
         const GridType* gridPtr = &grid;
-#if OPENVDB_ABI_VERSION_NUMBER >= 7 // Grid::copyReplacingMetadata() only available in ABI>=7
         // if grid already has MultiResGrid_Level metadata with type float, remove it
         typename GridType::ConstPtr newGridPtr;
         auto meta = grid.template getMetadata<openvdb::FloatMetadata>("MultiResGrid_Level");
@@ -272,7 +267,6 @@ struct MultiResGridIntegerOp
             newGridPtr = grid.copyReplacingMetadata(metaMap);
             gridPtr = newGridPtr.get();
         }
-#endif
         openvdb::tools::MultiResGrid<TreeT> mrg( levels, *gridPtr );
         outputGrids = mrg.grids();
     }

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Visualize.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Visualize.cc
@@ -1844,15 +1844,7 @@ TreeVisualizer::allocateOffsetArrays(const GridType& grid)
 {
     // allocate offsets per node arrays - no zero value initialization
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 7
     const auto nodeCounts = grid.tree().nodeCount();
-#else
-    // Tree::nodeCount() was only added in ABI=7, so use a NodeIterator with an earlier ABI
-    std::vector<openvdb::Index32> nodeCounts(grid.tree().treeDepth());
-    for (auto it = grid.tree().cbeginNode(); it; ++it) {
-        ++(nodeCounts[it.getLevel()]);
-    }
-#endif
 
     for (const auto& count : nodeCounts) {
         mPointOffsets.emplace_back(new size_t[count]);


### PR DESCRIPTION
    - Removed deprecated options, code paths and ABI 6
    - Deprecated ABI 8
    - Moved MINIMUM version defines to cmake/config/OpenVDBVersions.cmake
    - Renamed OpenVDBBuildTypes.cmake to OpenVDBCXX.cmake
    - Moved other CMake CXX options to OpenVDBCXX.cmake
    - Added deprecation warnings for C++14, CMake and Houdini

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>