### PR TITLE
Add a placeholder in version.h for the URL and revision to be stored

### DIFF
--- a/openvdb/openvdb/version.h.in
+++ b/openvdb/openvdb/version.h.in
@@ -92,6 +92,11 @@
 /// @hideinitializer
 #define OPENVDB_LIBRARY_VERSION_NUMBER ${OPENVDB_PACKED_VERSION}
 
+/// @brief Where this version was compiled from if it comes from a
+/// git repo.
+#define OPENVDB_PACKAGE_URL "@OPENVDB_PACKAGE_URL@"
+#define OPENVDB_PACKAGE_REVISION "@OPENVDB_PACKAGE_REVISION@"
+
 /// @brief The version namespace name for this library version
 /// @hideinitializer
 ///

--- a/openvdb/openvdb/version.h.in
+++ b/openvdb/openvdb/version.h.in
@@ -261,6 +261,8 @@ inline constexpr const char* getLibraryVersionString() { return OPENVDB_LIBRARY_
 inline constexpr const char* getLibraryAbiVersionString() {
     return OPENVDB_LIBRARY_ABI_VERSION_STRING;
 }
+inline constexpr const char* getPackageUrl() { return OPENVDB_PACKAGE_URL; }
+inline constexpr const char* getPackageRevision() { return OPENVDB_PACKAGE_REVISION; }
 
 
 struct VersionId {

--- a/pendingchanges/package_placeholder.txt
+++ b/pendingchanges/package_placeholder.txt
@@ -1,0 +1,4 @@
+Build:
+    - Add a placeholder to inject the specific revision and URL used
+      to build OpenVDB, useful for 3rd party build scripts to publish
+      their exact versions.


### PR DESCRIPTION
When distributing an OpenVDB package that is forked from the official it can be useful to provide the URL and commit hash that was used so people can re-create it or derive from it if they wish.

What we do for USD is have a define that we replace when we download the library from github with our particular URL and revision.  This seems like a useful thing to have in the master branch with the placeholder values, so others can follow a similar protocol if they wish.  If we eventually distribute binaries we may also ensure our binary build process likewise patches this.