### PR TITLE
VDB Activate SOP for no good reason bailed out as soon as a non-vdb was found

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Activate.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Activate.cc
@@ -604,7 +604,7 @@ SOP_VDBActivate::Cache::cookVDBSop(OP_Context &context)
         GA_FOR_ALL_GROUP_PRIMITIVES(gdp, group, prim)
         {
             if (!(prim->getPrimitiveId() & GEO_PrimTypeCompat::GEOPRIMVDB))
-                break;
+                continue;
 
             GEO_PrimVDB *vdb = UTverify_cast<GEO_PrimVDB *>(prim);
             vdb->makeGridUnique();

--- a/pendingchanges/vdbactivate_continue.txt
+++ b/pendingchanges/vdbactivate_continue.txt
@@ -1,0 +1,3 @@
+Houdini:
+    - VDB Activate SOP no longer stops at the first non-VDB primitive,
+      but instead just skips such primitives.


### PR DESCRIPTION
The correct thing is just to ignore these prims.
