### PR TITLE
Sweep out use of labs() from openvdb/Math.h

### DIFF
--- a/openvdb/openvdb/math/Math.h
+++ b/openvdb/openvdb/math/Math.h
@@ -307,11 +307,9 @@ SmoothUnitStep(Type x, Type min, Type max)
 inline int32_t Abs(int32_t i) { return abs(i); }
 inline int64_t Abs(int64_t i)
 {
-#ifdef _MSC_VER
-    return (i < int64_t(0) ? -i : i);
-#else
-    return labs(i);
-#endif
+    static_assert(sizeof(decltype(std::abs(i))) == sizeof(int64_t),
+                  "std::abs(int64) broken");
+    return std::abs(i);
 }
 inline float Abs(float x) { return std::fabs(x); }
 inline double Abs(double x) { return std::fabs(x); }
@@ -517,7 +515,7 @@ isUlpsEqual(const double aLeft, const double aRight, const int64_t aUnitsInLastP
         longRight = INT64_C(0x8000000000000000) - longRight;
     }
 
-    int64_t difference = labs(longLeft - longRight);
+    int64_t difference = Abs(longLeft - longRight);
     return (difference <= aUnitsInLastPlace);
 }
 

--- a/openvdb/openvdb/math/Math.h
+++ b/openvdb/openvdb/math/Math.h
@@ -304,7 +304,7 @@ SmoothUnitStep(Type x, Type min, Type max)
 
 //@{
 /// Return the absolute value of the given quantity.
-inline int32_t Abs(int32_t i) { return abs(i); }
+inline int32_t Abs(int32_t i) { return std::abs(i); }
 inline int64_t Abs(int64_t i)
 {
     static_assert(sizeof(decltype(std::abs(i))) == sizeof(int64_t),
@@ -534,7 +534,7 @@ isUlpsEqual(const float aLeft, const float aRight, const int32_t aUnitsInLastPla
         intRight = 0x80000000 - intRight;
     }
 
-    int32_t difference = abs(intLeft - intRight);
+    int32_t difference = Abs(intLeft - intRight);
     return (difference <= aUnitsInLastPlace);
 }
 


### PR DESCRIPTION
On Windows, labs() uses long which is int32_t instead of int64_t so we
were silently casting down in math::isUlpsEqual(). Since C++11, there
have been proper overloads of std::abs() for both long and long long
provided by `<cstdlib>` so just use that instead.

Signed-off-by: Edward Lam <edward@sidefx.com>