### PR TITLE
CMake Object Libraries

### DIFF
--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -593,31 +593,6 @@ endif()
 
 ##########################################################################
 
-# @todo CMake >= 3.12, use an object library to consolidate shared/static
-# builds. There are limitations with earlier versions of CMake when used with
-# imported targets.
-
-if(OPENVDB_CORE_SHARED)
-  add_library(openvdb_shared SHARED ${OPENVDB_LIBRARY_SOURCE_FILES})
-endif()
-
-if(OPENVDB_CORE_STATIC)
-  add_library(openvdb_static STATIC ${OPENVDB_LIBRARY_SOURCE_FILES})
-endif()
-
-# Alias either the shared or static library to the generic OpenVDB
-# target. Dependent components should use this target to build against
-# such that they are always able to find a valid build of OpenVDB
-
-if(OPENVDB_CORE_SHARED)
-  add_library(openvdb ALIAS openvdb_shared)
-else()
-  add_library(openvdb ALIAS openvdb_static)
-endif()
-
-
-##########################################################################
-
 # Configure (static and shared lib) C flags
 
 # Private defines (not inherited by dependent projects)
@@ -642,54 +617,36 @@ endif()
 
 ##########################################################################
 
-# Configure static build
+# Configure object library
 
-if(OPENVDB_CORE_STATIC)
-  target_include_directories(openvdb_static
-    PUBLIC ../ ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/openvdb
-    PRIVATE .
-  )
+add_library(openvdb_obj OBJECT ${OPENVDB_LIBRARY_SOURCE_FILES})
 
-  target_compile_definitions(openvdb_static
-    PUBLIC ${OPENVDB_CORE_PUBLIC_DEFINES} -DOPENVDB_STATICLIB
-    PRIVATE ${OPENVDB_CORE_PRIVATE_DEFINES}
-  )
+target_include_directories(openvdb_obj
+  PUBLIC ../ ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/openvdb
+  PRIVATE .
+)
 
-  target_link_libraries(openvdb_static
-    PUBLIC ${OPENVDB_CORE_DEPENDENT_LIBS}
-  )
+target_compile_definitions(openvdb_obj
+  PUBLIC ${OPENVDB_CORE_PUBLIC_DEFINES} -DOPENVDB_DLL
+  PRIVATE ${OPENVDB_CORE_PRIVATE_DEFINES}
+)
 
-  set_target_properties(openvdb_static
-    PROPERTIES OUTPUT_NAME ${OPENVDB_STATIC_LIBRARY_NAME})
+target_link_libraries(openvdb_obj
+  PUBLIC ${OPENVDB_CORE_DEPENDENT_LIBS}
+)
 
-  if(MSVC)
-    if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
-      # NOTE: MSVC_RUNTIME_LIBRARY does not propagate to targets, so
-      # also add it explicitly as a compile option
-      set_target_properties(openvdb_static PROPERTIES
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-      target_compile_options(openvdb_static PUBLIC
-        "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/MT$<$<CONFIG:Debug>:d>>")
-    endif()
-    set_target_properties(openvdb_static PROPERTIES PREFIX "lib")
-  endif()
-endif()
+##########################################################################
 
-# Configure shared build
+# Configure shared library
 
 if(OPENVDB_CORE_SHARED)
+  add_library(openvdb_shared SHARED $<TARGET_OBJECTS:openvdb_obj>)
+
   target_include_directories(openvdb_shared
-    PUBLIC ../ ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/openvdb
-    PRIVATE .
+    PUBLIC $<TARGET_PROPERTY:openvdb_obj,INCLUDE_DIRECTORIES>
   )
-
-  target_compile_definitions(openvdb_shared
-    PUBLIC ${OPENVDB_CORE_PUBLIC_DEFINES} -DOPENVDB_DLL
-    PRIVATE ${OPENVDB_CORE_PRIVATE_DEFINES}
-  )
-
   target_link_libraries(openvdb_shared
-    PUBLIC ${OPENVDB_CORE_DEPENDENT_LIBS}
+    PUBLIC $<TARGET_PROPERTY:openvdb_obj,LINK_LIBRARIES>
   )
 
   set_target_properties(openvdb_shared
@@ -708,6 +665,76 @@ if(OPENVDB_CORE_SHARED)
         "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/MD$<$<CONFIG:Debug>:d>>")
     endif()
   endif()
+endif()
+
+##########################################################################
+
+# Configure static library
+
+if(OPENVDB_CORE_STATIC)
+  if(WIN32)
+    # configure static library object library for Windows
+    add_library(openvdb_obj_win_static OBJECT ${OPENVDB_LIBRARY_SOURCE_FILES})
+
+    target_include_directories(openvdb_obj_win_static
+      PUBLIC ../ ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/openvdb
+      PRIVATE .
+    )
+
+    target_compile_definitions(openvdb_obj_win_static
+      PUBLIC ${OPENVDB_CORE_PUBLIC_DEFINES} -DOPENVDB_STATICLIB
+      PRIVATE ${OPENVDB_CORE_PRIVATE_DEFINES}
+    )
+
+    target_link_libraries(openvdb_obj_win_static
+      PUBLIC ${OPENVDB_CORE_DEPENDENT_LIBS}
+    )
+
+    add_library(openvdb_static STATIC $<TARGET_OBJECTS:openvdb_obj_win_static>)
+
+    target_include_directories(openvdb_static
+      PUBLIC $<TARGET_PROPERTY:openvdb_obj_win_static,INCLUDE_DIRECTORIES>
+    )
+    target_link_libraries(openvdb_static
+      PUBLIC $<TARGET_PROPERTY:openvdb_obj_win_static,LINK_LIBRARIES>
+    )
+  else()
+    add_library(openvdb_static STATIC $<TARGET_OBJECTS:openvdb_obj>)
+
+    target_include_directories(openvdb_static
+      PUBLIC $<TARGET_PROPERTY:openvdb_obj,INCLUDE_DIRECTORIES>
+    )
+    target_link_libraries(openvdb_static
+      PUBLIC $<TARGET_PROPERTY:openvdb_obj,LINK_LIBRARIES>
+    )
+  endif()
+
+  set_target_properties(openvdb_static
+    PROPERTIES OUTPUT_NAME ${OPENVDB_STATIC_LIBRARY_NAME})
+
+  if(MSVC)
+    if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
+      # NOTE: MSVC_RUNTIME_LIBRARY does not propagate to targets, so
+      # also add it explicitly as a compile option
+      set_target_properties(openvdb_static PROPERTIES
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+      target_compile_options(openvdb_static PUBLIC
+        "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/MT$<$<CONFIG:Debug>:d>>")
+    endif()
+    set_target_properties(openvdb_static PROPERTIES PREFIX "lib")
+  endif()
+endif()
+
+##########################################################################
+
+# Alias either the shared or static library to the generic OpenVDB
+# target. Dependent components should use this target to build against
+# such that they are always able to find a valid build of OpenVDB
+
+if(OPENVDB_CORE_SHARED)
+  add_library(openvdb ALIAS openvdb_shared)
+else()
+  add_library(openvdb ALIAS openvdb_static)
 endif()
 
 ##########################################################################

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -183,7 +183,7 @@ else()
   )
 endif()
 
-add_executable(vdb_test ${UNITTEST_SOURCE_FILES})
+add_library(vdb_test_obj OBJECT ${UNITTEST_SOURCE_FILES})
 
 # Blosc and ZLib are hidden dependencies for the core library
 # (not exposed in headers), so we need to manually link them in
@@ -210,6 +210,14 @@ if(USE_BLOSC OR OpenVDB_USES_BLOSC OR USE_ZLIB OR OpenVDB_USES_ZLIB)
   endif()
   list(APPEND OPENVDB_CORE_DEPENDENT_LIBS ZLIB::ZLIB)
 endif()
+
+# Propagate interface include directories from the dependencies to the object library
+
+foreach(DEP ${OPENVDB_TEST_DEPENDENT_LIBS})
+  target_include_directories(vdb_test_obj PUBLIC $<TARGET_PROPERTY:${DEP},INTERFACE_INCLUDE_DIRECTORIES>)
+endforeach()
+
+add_executable(vdb_test $<TARGET_OBJECTS:vdb_test_obj>)
 
 target_link_libraries(vdb_test ${OPENVDB_TEST_DEPENDENT_LIBS})
 add_test(NAME vdb_unit_test COMMAND $<TARGET_FILE:vdb_test> -v)

--- a/openvdb_cmd/vdb_print/CMakeLists.txt
+++ b/openvdb_cmd/vdb_print/CMakeLists.txt
@@ -13,7 +13,16 @@ project(VDBPrint LANGUAGES CXX)
 include(GNUInstallDirs)
 
 set(SOURCE_FILES main.cc)
-add_executable(vdb_print ${SOURCE_FILES})
+add_library(vdb_print_obj OBJECT ${SOURCE_FILES})
+
+# Propagate interface include directories from the dependencies to the object library
+
+foreach(DEP ${OPENVDB_BINARIES_DEPENDENT_LIBS})
+  target_include_directories(vdb_print_obj PUBLIC $<TARGET_PROPERTY:${DEP},INTERFACE_INCLUDE_DIRECTORIES>)
+endforeach()
+
+add_executable(vdb_print $<TARGET_OBJECTS:vdb_print_obj>)
+
 target_link_libraries(vdb_print ${OPENVDB_BINARIES_DEPENDENT_LIBS})
 
 install(TARGETS vdb_print RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This is a work-in-progress draft of implementing CMake object libraries which we previously couldn't do until we were using at least CMake 3.12. It wasn't as easy as I had hoped, so looking for early feedback that this is the correct approach and then I'll tackle the rest of the library. This has two main goals:

* To avoid compiling the same object files for both static and shared libraries which is wasteful (doesn't apply to Windows).
* To remove the synchronization points after each target, so that all source file compilation can happen concurrently. This avoids multiple long tails of compilation happening for each target to result in faster overall compilation throughput.