### PR TITLE
Minor improvements to some methods in Math.h

### DIFF
--- a/openvdb/openvdb/math/Math.h
+++ b/openvdb/openvdb/math/Math.h
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <cmath>     // for std::ceil(), std::fabs(), std::pow(), std::sqrt(), etc.
 #include <cstdlib>   // for abs(int)
+#include <cstring>   // for memcpy
 #include <random>
 #include <string>
 #include <type_traits> // for std::is_arithmetic
@@ -474,27 +475,25 @@ isRelOrApproxEqual(const bool& a, const bool& b, const bool&, const bool&)
     return (a == b);
 }
 
-
-// Avoid strict aliasing issues by using type punning
-// http://cellperformance.beyond3d.com/articles/2006/06/understanding-strict-aliasing.html
-// Using "casting through a union(2)"
 inline int32_t
-floatToInt32(const float aFloatValue)
+floatToInt32(const float f)
 {
-    union FloatOrInt32 { float floatValue; int32_t int32Value; };
-    const FloatOrInt32* foi = reinterpret_cast<const FloatOrInt32*>(&aFloatValue);
-    return foi->int32Value;
+    // switch to std:bit_cast in C++20
+    static_assert(sizeof(int32_t) == sizeof f, "`float` has an unexpected size.");
+    int32_t ret;
+    std::memcpy(&ret, &f, sizeof(int32_t));
+    return ret;
 }
-
 
 inline int64_t
-doubleToInt64(const double aDoubleValue)
+doubleToInt64(const double d)
 {
-    union DoubleOrInt64 { double doubleValue; int64_t int64Value; };
-    const DoubleOrInt64* dol = reinterpret_cast<const DoubleOrInt64*>(&aDoubleValue);
-    return dol->int64Value;
+    // switch to std:bit_cast in C++20
+    static_assert(sizeof(int64_t) == sizeof d, "`double` has an unexpected size.");
+    int64_t ret;
+    std::memcpy(&ret, &d, sizeof(int64_t));
+    return ret;
 }
-
 
 // aUnitsInLastPlace is the allowed difference between the least significant digits
 // of the numbers' floating point representation
@@ -923,40 +922,36 @@ struct promote {
     using type = typename boost::numeric::conversion_traits<S, T>::supertype;
 };
 
-
 /// @brief Return the index [0,1,2] of the smallest value in a 3D vector.
-/// @note This methods assumes operator[] exists and avoids branching.
-/// @details If two components of the input vector are equal and smaller than the
-/// third component, the largest index of the two is always returned.
-/// If all three vector components are equal the largest index, i.e. 2, is
-/// returned. In other words the return value corresponds to the largest index
-/// of the of the smallest vector components.
+/// @note This methods assumes operator[] exists.
+/// @details The return value corresponds to the largest index of the of
+/// the smallest vector components.
 template<typename Vec3T>
 size_t
 MinIndex(const Vec3T& v)
 {
-    static const size_t hashTable[8] = { 2, 1, 9, 1, 2, 9, 0, 0 };//9 is a dummy value
-    const size_t hashKey =
-        ((v[0] < v[1]) << 2) + ((v[0] < v[2]) << 1) + (v[1] < v[2]);// ?*4+?*2+?*1
-    return hashTable[hashKey];
+    size_t r = 0;
+    for (size_t i = 1; i < 3; ++i) {
+        // largest index (backwards compatibility)
+        if (v[i] <= v[r]) r = i;
+    }
+    return r;
 }
 
-
 /// @brief Return the index [0,1,2] of the largest value in a 3D vector.
-/// @note This methods assumes operator[] exists and avoids branching.
-/// @details If two components of the input vector are equal and larger than the
-/// third component, the largest index of the two is always returned.
-/// If all three vector components are equal the largest index, i.e. 2, is
-/// returned. In other words the return value corresponds to the largest index
-/// of the largest vector components.
+/// @note This methods assumes operator[] exists.
+/// @details The return value corresponds to the largest index of the of
+/// the largest vector components.
 template<typename Vec3T>
 size_t
 MaxIndex(const Vec3T& v)
 {
-    static const size_t hashTable[8] = { 2, 1, 9, 1, 2, 9, 0, 0 };//9 is a dummy value
-    const size_t hashKey =
-        ((v[0] > v[1]) << 2) + ((v[0] > v[2]) << 1) + (v[1] > v[2]);// ?*4+?*2+?*1
-    return hashTable[hashKey];
+    size_t r = 0;
+    for (size_t i = 1; i < 3; ++i) {
+        // largest index (backwards compatibility)
+        if (v[i] >= v[r]) r = i;
+    }
+    return r;
 }
 
 } // namespace math

--- a/openvdb/openvdb/math/Tuple.h
+++ b/openvdb/openvdb/math/Tuple.h
@@ -83,22 +83,33 @@ public:
         }
     }
 
-    T operator[](int i) const {
-        // we'd prefer to use size_t, but can't because gcc3.2 doesn't like
-        // it - it conflicts with child class conversion operators to
-        // pointer types.
-//             assert(i >= 0 && i < SIZE);
+    // @brief  const access to an element in the tuple. The offset idx must be
+    //   an integral type. A copy of the tuple data is returned.
+    template <typename IdxT>
+    T operator[](IdxT i) const {
+        static_assert(std::is_integral<IdxT>::value, "Expected integer type for Tuple[] access.");
+        assert(i >= IdxT(0) && i < IdxT(SIZE));
         return mm[i];
     }
 
-    T& operator[](int i) {
-        // see above for size_t vs int
-//             assert(i >= 0 && i < SIZE);
+    // @brief  non-const access to an element in the tuple. The offset idx must be
+    //   an integral type. A reference to the tuple data is returned.
+    template <typename IdxT>
+    T& operator[](IdxT i) {
+        static_assert(std::is_integral<IdxT>::value, "Expected integer type for Tuple[] access.");
+        assert(i >= IdxT(0) && i < IdxT(SIZE));
         return mm[i];
     }
+
+    // These exist solely to provide backwards compatibility with [] access of
+    // types that were castable to 'int' (such as floating point type). The
+    // above templates allow for any integer type to be used as an offset into
+    // the tuple data.
+    T operator[](int i) const { return this->operator[]<int>(i); }
+    T& operator[](int i) { return this->operator[]<int>(i); }
 
     /// @name Compatibility
-    /// These are mostly for backwards compability with functions that take
+    /// These are mostly for backwards compatibility with functions that take
     /// old-style Vs (which are just arrays).
     //@{
     /// Copies this tuple into an array of a compatible type

--- a/openvdb/openvdb/math/Tuple.h
+++ b/openvdb/openvdb/math/Tuple.h
@@ -85,25 +85,25 @@ public:
 
     // @brief  const access to an element in the tuple. The offset idx must be
     //   an integral type. A copy of the tuple data is returned.
-    template <typename IdxT>
+    template <typename IdxT,
+        typename std::enable_if<std::is_integral<IdxT>::value, bool>::type = true>
     T operator[](IdxT i) const {
-        static_assert(std::is_integral<IdxT>::value, "Expected integer type for Tuple[] access.");
         assert(i >= IdxT(0) && i < IdxT(SIZE));
         return mm[i];
     }
 
     // @brief  non-const access to an element in the tuple. The offset idx must be
     //   an integral type. A reference to the tuple data is returned.
-    template <typename IdxT>
+    template <typename IdxT,
+        typename std::enable_if<std::is_integral<IdxT>::value, bool>::type = true>
     T& operator[](IdxT i) {
-        static_assert(std::is_integral<IdxT>::value, "Expected integer type for Tuple[] access.");
         assert(i >= IdxT(0) && i < IdxT(SIZE));
         return mm[i];
     }
 
     // These exist solely to provide backwards compatibility with [] access of
-    // types that were castable to 'int' (such as floating point type). The
-    // above templates allow for any integer type to be used as an offset into
+    // non-integer types that were castable to 'int' (such as floating point type).
+    // The above templates allow for any integer type to be used as an offset into
     // the tuple data.
     T operator[](int i) const { return this->operator[]<int>(i); }
     T& operator[](int i) { return this->operator[]<int>(i); }


### PR DESCRIPTION
Fixes #1419 

Also removed lookup table implementation of Min/MaxIndex which is about twice as slow as a trivial loop

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>