### PR TITLE
added nanovdb::getExtrema

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,10 @@ OpenVDB Version History
 
 Version 9.1.1 - In development
 
+    New features:
+    - Added nanovdb::getExtrema, which computes the min/max of all the values
+      in a NanoVDB grid that intersects a specified index bounding box.
+
 Version 9.1.0 - June 9, 2022
 
     Bug Fixes:

--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -7,6 +7,11 @@
 <B>Version 9.1.1</B> - <I>In development</I>
 
 @par
+New features:
+- Added nanovdb::getExtrema, which computes the min/max of all the values
+  in a NanoVDB grid that intersects a specified index bounding box.
+
+@par
 <B>Version 9.1.0</B> - <I>June 9, 2022</I>
 
 @par

--- a/nanovdb/nanovdb/util/NodeManager.h
+++ b/nanovdb/nanovdb/util/NodeManager.h
@@ -94,6 +94,7 @@ public:
     RootT* root() { return mRoot; }
 
     /// @brief Return the number of tree nodes at the specified level
+    /// @details 0 is leaf, 1 is lower internal, 2 is upper internal and 3 is root
     uint64_t nodeCount(int level) const { return mNodeCount[level]; }
 
     /// @brief Return the i'th leaf node

--- a/nanovdb/nanovdb/util/OpenToNanoVDB.h
+++ b/nanovdb/nanovdb/util/OpenToNanoVDB.h
@@ -698,17 +698,17 @@ NanoTree<NanoBuildT>* OpenToNanoVDB<OpenBuildT,  NanoBuildT,  OracleT, BufferT>:
 
 #if 1// count active tiles and voxels
 
-    // Count number of active leaf level tiles
+    // Count number of active tiles in the lower internal nodes
     data->mTileCount[0] = reduce(mArray1, uint32_t(0), [&](auto &r, uint32_t sum){
         for (auto i=r.begin(); i!=r.end(); ++i) sum += mArray1[i].node->getValueMask().countOn();
         return sum;}, std::plus<uint32_t>());
 
-    // Count number of active lower internal node tiles
+    // Count number of active tiles in the upper internal nodes
     data->mTileCount[1] = reduce(mArray2, uint32_t(0), [&](auto &r, uint32_t sum){
         for (auto i=r.begin(); i!=r.end(); ++i) sum += mArray2[i].node->getValueMask().countOn();
         return sum;}, std::plus<uint32_t>());
 
-    // Count number of active upper internal node tiles
+    // Count number of active tile in the root node
     uint32_t sum = 0;
     for (auto it = openTree.root().cbeginValueOn(); it; ++it) ++sum;
     data->mTileCount[2] = sum;


### PR DESCRIPTION
Signed-off-by: Ken <ken.museth@gmail.com>

Added an efficient method to compute the extrema values, i.e. min/max, of all the values in a NanoVDB grid that intersects a specified index bounding box.

Also improved documentation and fixed an index-bug in nanovdb::Tree:: activeTileCount