### PR TITLE
Rename label of menu item for clipping by geometry

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Clip.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Clip.cc
@@ -85,7 +85,7 @@ newSopOperator(OP_OperatorTable* table)
     parms.add(hutil::ParmFactory(PRM_STRING, "clipper", "Clip To")
         .setChoiceListItems(PRM_CHOICELIST_SINGLE, {
             "camera",   "Camera",
-            "geometry", "Geometry",
+            "geometry", "Geometry Bounding Box",
             "mask",     "Mask VDB"
         })
         .setDefault("geometry")


### PR DESCRIPTION
This makes it clear it is a bounding box clip, not a geometry clip.  Matches upcoming 19.5 rename.
