### PR TITLE
Fix clamp bug in VDB Visualize SOP

### DIFF
--- a/pendingchanges/vdb_visualize_clamp.txt
+++ b/pendingchanges/vdb_visualize_clamp.txt
@@ -1,0 +1,2 @@
+Houdini:
+    Fix bug in VDB Visualize SOP where color values that exceed the range wrap around instead of being clamped.


### PR DESCRIPTION
When displaying voxels or points as colors, the input value is not being clamped to the range, so it wraps around. This fixes that by applying the clamp before evaluating the UT_Ramp.