### PR TITLE
Remove a simple warning about missing template keyword

### DIFF
--- a/openvdb/openvdb/tools/PointIndexGrid.h
+++ b/openvdb/openvdb/tools/PointIndexGrid.h
@@ -1427,7 +1427,7 @@ public:
     bool operator!=(const PointIndexLeafNode& other) const { return !(other == *this); }
 
     template<MergePolicy Policy> void merge(const PointIndexLeafNode& rhs) {
-        BaseLeaf::merge<Policy>(rhs);
+        BaseLeaf::template merge<Policy>(rhs);
     }
     template<MergePolicy Policy> void merge(const ValueType& tileValue, bool tileActive) {
          BaseLeaf::template merge<Policy>(tileValue, tileActive);


### PR DESCRIPTION
Fixes GCC 12 warning:

openvdb/tools/PointIndexGrid.h:1430:9: error: expected primary-expression before 'template'
 1430 |         template BaseLeaf::merge<Policy>(rhs);
      |         ^~~~~~~~