### PR TITLE
Fix VS2019/VS2022 compiler error in Morphology.h

### DIFF
--- a/openvdb/openvdb/tools/Morphology.h
+++ b/openvdb/openvdb/tools/Morphology.h
@@ -655,7 +655,7 @@ void Morphology<TreeType>::dilateVoxels(const size_t iter,
             // For each node, dilate the mask into itself and neighboring leaf nodes.
             // If the node was originally dense (all active), steal/replace it so
             // subsequent iterations are faster
-            manager.foreach([&](LeafT& leaf, const size_t idx) {
+            manager.foreach([&](auto& leaf, const size_t idx) {
                 // original bit-mask of current leaf node
                 const MaskType& oldMask = nodeMasks[idx];
                 const bool dense = oldMask.isOn();


### PR DESCRIPTION
For some unknown reason MSVC /permissive- has problems with correctly
inferring the LeafT here due to it being used with different types in
the same function. Changing it from LeafT to auto instead allows it
to compile.

Signed-off-by: Edward Lam <e4lam@yahoo.com>