### PR TITLE
Sweep out use of M_PI* constants

### DIFF
--- a/doc/examplecode.txt
+++ b/doc/examplecode.txt
@@ -921,7 +921,7 @@ openvdb::Vec3SGrid::Ptr grid = ...;
 
 // Construct the rotation matrix.
 openvdb::math::Mat3s rot45 =
-    openvdb::math::rotation<openvdb::math::Mat3s>(openvdb::math::Y_AXIS, M_PI_4);
+    openvdb::math::rotation<openvdb::math::Mat3s>(openvdb::math::Y_AXIS, openvdb::math::pi<double>()/4.0);
 
 // Apply the functor to all active values.
 openvdb::tools::foreach(grid->beginValueOn(), MatMul(rot45));

--- a/doc/math.txt
+++ b/doc/math.txt
@@ -78,7 +78,7 @@ openvdb::math::Transform::Ptr linearTransform =
 // Rotate the transform by 90 degrees about the X axis.
 // As a result the j-index will now map into the -z physical direction,
 // and the k-index will map to the +y physical direction.
-linearTransform->preRotate(M_PI/2, openvdb::math::X_AXIS);
+linearTransform->preRotate(openvdb::math::pi<double>()/2.0, openvdb::math::X_AXIS);
 @endcode
 
 @subsection sFrustumTransforms Frustum Transforms
@@ -302,7 +302,7 @@ convention of right-multiplication of the matrix against a vector:
 openvdb::math::Mat4d transform = openvdb::math::Mat4d::identity();
 transform.preScale(openvdb::math::Vec3d(2,3,2));
 transform.postTranslate(openvdb::math::Vec3d(1,0,0));
-transform.postRotate(openvdb::math::X_AXIS, M_PI/3.0);
+transform.postRotate(openvdb::math::X_AXIS, openvdb::math::pi<double>()/3.0);
 
 // Location of a point in index space
 openvdb::math::Vec3d indexSpace(1,2,3);

--- a/nanovdb/nanovdb/examples/benchmark/Benchmark.cc
+++ b/nanovdb/nanovdb/examples/benchmark/Benchmark.cc
@@ -31,6 +31,7 @@
 #include <openvdb/tools/RayIntersector.h>
 #include <openvdb/math/Ray.h>
 #include <openvdb/math/Transform.h>
+#include <openvdb/math/Math.h>
 #endif
 
 #if defined(NANOVDB_USE_TBB)
@@ -452,7 +453,7 @@ TEST_F(Benchmark, OpenVDB_CPU)
                                 0.5 * (bbox.max()[2] + bbox.min()[2]));
     const Vec3T          lookat = srcGrid->indexToWorld(center), up(0, -1, 0);
     auto                 eye = [&lookat, &radius](int angle) {
-        const RealT theta = angle * M_PI / 180.0f;
+        const RealT theta = angle * openvdb::math::pi<RealT>() / 180.0f;
         return lookat + radius * Vec3T(sin(theta), 0, cos(theta));
     };
 
@@ -536,7 +537,7 @@ TEST_F(Benchmark, DenseGrid_CPU)
     const auto  bbox = grid->worldBBox();
     const Vec3T lookat(0.5 * (bbox.min() + bbox.max())), up(0, -1, 0);
     auto        eye = [&lookat, &radius](int angle) {
-        const RealT theta = angle * M_PI / 180.0f;
+        const RealT theta = angle * openvdb::math::pi<RealT>() / 180.0f;
         return lookat + radius * Vec3T(sin(theta), 0, cos(theta));
     };
 
@@ -677,7 +678,7 @@ TEST_F(Benchmark, NanoVDB_GPU)
     const auto  bbox = grid->worldBBox();
     const Vec3T lookat(0.5 * (bbox.min() + bbox.max())), up(0, -1, 0);
     auto        eye = [&lookat, &radius](int angle) {
-        const RealT theta = angle * M_PI / 180.0f;
+        const RealT theta = angle * openvdb::math::pi<RealT>() / 180.0f;
         return lookat + radius * Vec3T(sin(theta), 0, cos(theta));
     };
     CameraT *host_camera, *dev_camera;

--- a/nanovdb/nanovdb/unittest/TestOpenVDB.cc
+++ b/nanovdb/nanovdb/unittest/TestOpenVDB.cc
@@ -23,6 +23,7 @@
 #endif
 
 #include <openvdb/openvdb.h>
+#include <openvdb/math/Math.h>
 #include <openvdb/tools/LevelSetSphere.h>
 #include <openvdb/tools/LevelSetPlatonic.h>
 #include <openvdb/tools/Interpolation.h>
@@ -1020,8 +1021,8 @@ inline void genPoints(const int numPoints, std::vector<openvdb::Vec3R>& points)
 {
     openvdb::math::Random01 randNumber(0);
     const int               n = int(std::sqrt(double(numPoints)));
-    const double            xScale = (2.0 * M_PI) / double(n);
-    const double            yScale = M_PI / double(n);
+    const double            xScale = (2.0 * openvdb::math::pi<double>()) / double(n);
+    const double            yScale = openvdb::math::pi<double>() / double(n);
 
     double         x, y, theta, phi;
     openvdb::Vec3R pos;

--- a/openvdb/openvdb/Platform.h
+++ b/openvdb/openvdb/Platform.h
@@ -54,12 +54,6 @@
 
 /// Windows defines
 #ifdef _WIN32
-    // Math constants are not included in <cmath> unless _USE_MATH_DEFINES is
-    // defined on MSVC
-    // https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
-    #ifndef _USE_MATH_DEFINES
-        #define _USE_MATH_DEFINES
-    #endif
     ///Disable the non-portable Windows definitions of min() and max() macros
     #ifndef NOMINMAX
         #define NOMINMAX

--- a/openvdb/openvdb/math/Mat.h
+++ b/openvdb/openvdb/math/Mat.h
@@ -343,11 +343,11 @@ eulerAngles(
     {
     case XYZ_ROTATION:
         if (isApproxEqual(mat[2][0], ValueType(1.0), eps)) {
-            theta = ValueType(M_PI_2);
+            theta = ValueType(math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(mat[1][2], mat[1][1]));
             psi = phi;
         } else if (isApproxEqual(mat[2][0], ValueType(-1.0), eps)) {
-            theta = ValueType(-M_PI_2);
+            theta = ValueType(-math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(mat[1][2], mat[1][1]));
             psi = -phi;
         } else {
@@ -360,11 +360,11 @@ eulerAngles(
         return V(phi, theta, psi);
     case ZXY_ROTATION:
         if (isApproxEqual(mat[1][2], ValueType(1.0), eps)) {
-            theta = ValueType(M_PI_2);
+            theta = ValueType(math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(mat[0][1], mat[0][0]));
             psi = phi;
         } else if (isApproxEqual(mat[1][2], ValueType(-1.0), eps)) {
-            theta = ValueType(-M_PI/2);
+            theta = ValueType(-math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(mat[0][1],mat[2][1]));
             psi = -phi;
         } else {
@@ -378,11 +378,11 @@ eulerAngles(
 
     case YZX_ROTATION:
         if (isApproxEqual(mat[0][1], ValueType(1.0), eps)) {
-            theta = ValueType(M_PI_2);
+            theta = ValueType(math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(mat[2][0], mat[2][2]));
             psi = phi;
         } else if (isApproxEqual(mat[0][1], ValueType(-1.0), eps)) {
-            theta = ValueType(-M_PI/2);
+            theta = ValueType(-math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(mat[2][0], mat[1][0]));
             psi = -phi;
         } else {
@@ -401,7 +401,7 @@ eulerAngles(
             phi = ValueType(0.5 * atan2(mat[1][2], mat[1][1]));
             psi = phi;
         } else if (isApproxEqual(mat[0][0], ValueType(-1.0), eps)) {
-            theta = ValueType(M_PI);
+            theta = ValueType(math::pi<double>());
             psi = ValueType(0.5 * atan2(mat[2][1], -mat[1][1]));
             phi = - psi;
         } else {
@@ -420,7 +420,7 @@ eulerAngles(
             phi = ValueType(0.5 * atan2(mat[0][1], mat[0][0]));
             psi = phi;
         } else if (isApproxEqual(mat[2][2], ValueType(-1.0), eps)) {
-            theta = ValueType(M_PI);
+            theta = ValueType(math::pi<double>());
             phi = ValueType(0.5 * atan2(mat[0][1], mat[0][0]));
             psi = -phi;
         } else {
@@ -435,11 +435,11 @@ eulerAngles(
     case YXZ_ROTATION:
 
         if (isApproxEqual(mat[2][1], ValueType(1.0), eps)) {
-            theta = ValueType(-M_PI_2);
+            theta = ValueType(-math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(-mat[1][0], mat[0][0]));
             psi = phi;
         } else if (isApproxEqual(mat[2][1], ValueType(-1.0), eps)) {
-            theta = ValueType(M_PI_2);
+            theta = ValueType(math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(mat[1][0], mat[0][0]));
             psi = -phi;
         } else {
@@ -454,11 +454,11 @@ eulerAngles(
     case ZYX_ROTATION:
 
         if (isApproxEqual(mat[0][2], ValueType(1.0), eps)) {
-            theta = ValueType(-M_PI_2);
+            theta = ValueType(-math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(-mat[1][0], mat[1][1]));
             psi = phi;
         } else if (isApproxEqual(mat[0][2], ValueType(-1.0), eps)) {
-            theta = ValueType(M_PI_2);
+            theta = ValueType(math::pi<double>() / 2.0);
             phi = ValueType(0.5 * atan2(mat[2][1], mat[2][0]));
             psi = -phi;
         } else {
@@ -473,11 +473,11 @@ eulerAngles(
     case XZY_ROTATION:
 
         if (isApproxEqual(mat[1][0], ValueType(-1.0), eps)) {
-            theta = ValueType(M_PI_2);
+            theta = ValueType(math::pi<double>() / 2.0);
             psi = ValueType(0.5 * atan2(mat[2][1], mat[2][2]));
             phi = -psi;
         } else if (isApproxEqual(mat[1][0], ValueType(1.0), eps)) {
-            theta = ValueType(-M_PI_2);
+            theta = ValueType(-math::pi<double>() / 2.0);
             psi = ValueType(0.5 * atan2(- mat[2][1], mat[2][2]));
             phi = psi;
         } else {

--- a/openvdb/openvdb/tools/RayTracer.h
+++ b/openvdb/openvdb/tools/RayTracer.h
@@ -357,9 +357,9 @@ public:
         , mScaleHeight(frameWidth * double(film.height()) / double(film.width()))
     {
         assert(nearPlane > 0 && farPlane > nearPlane);
-        mScreenToWorld.accumPostRotation(math::X_AXIS, rotation[0] * M_PI / 180.0);
-        mScreenToWorld.accumPostRotation(math::Y_AXIS, rotation[1] * M_PI / 180.0);
-        mScreenToWorld.accumPostRotation(math::Z_AXIS, rotation[2] * M_PI / 180.0);
+        mScreenToWorld.accumPostRotation(math::X_AXIS, rotation[0] * math::pi<double>() / 180.0);
+        mScreenToWorld.accumPostRotation(math::Y_AXIS, rotation[1] * math::pi<double>() / 180.0);
+        mScreenToWorld.accumPostRotation(math::Z_AXIS, rotation[2] * math::pi<double>() / 180.0);
         mScreenToWorld.accumPostTranslation(translation);
         this->initRay(nearPlane, farPlane);
     }
@@ -464,13 +464,13 @@ class PerspectiveCamera: public BaseCamera
     /// focal lenth in mm and the specified aperture in mm.
     static double focalLengthToFieldOfView(double length, double aperture)
     {
-        return 360.0 / M_PI * atan(aperture/(2.0*length));
+        return 360.0 / math::pi<double>() * atan(aperture/(2.0*length));
     }
     /// @brief Return the focal length in mm given a horizontal field of
     /// view in degrees and the specified aperture in mm.
     static double fieldOfViewToFocalLength(double fov, double aperture)
     {
-        return aperture/(2.0*(tan(fov * M_PI / 360.0)));
+        return aperture/(2.0*(tan(fov * math::pi<double>() / 360.0)));
     }
 };// PerspectiveCamera
 

--- a/openvdb/openvdb/tools/ValueTransformer.h
+++ b/openvdb/openvdb/tools/ValueTransformer.h
@@ -78,7 +78,7 @@ namespace tools {
 /// {
 ///     VectorGrid grid = ...;
 ///     tools::foreach(grid.beginValueOn(),
-///         MatMul(math::rotation<math::Mat3s>(math::Y, M_PI_4)));
+///         MatMul(math::rotation<math::Mat3s>(math::Y, openvdb::math::pi<double>()/4.0)));
 /// }
 /// @endcode
 ///

--- a/openvdb/openvdb/unittest/TestGridTransformer.cc
+++ b/openvdb/openvdb/unittest/TestGridTransformer.cc
@@ -60,7 +60,7 @@ TestGridTransformer::transformGrid()
     for (int i = 0; i < 8; ++i) {
         const openvdb::Vec3R
             scale = i & 1 ? openvdb::Vec3R(10, 4, 7.5) : oneVec,
-            rotate = (i & 2 ? openvdb::Vec3R(30, 230, -190) : zeroVec) * (M_PI / 180),
+            rotate = (i & 2 ? openvdb::Vec3R(30, 230, -190) : zeroVec) * (openvdb::math::pi<openvdb::Real>() / 180),
             translate = i & 4 ? openvdb::Vec3R(-5, 0, 10) : zeroVec,
             pivot = i & 8 ? openvdb::Vec3R(0.5, 4, -3.3) : zeroVec;
         openvdb::tools::GridTransformer transformer(pivot, scale, rotate, translate);
@@ -239,7 +239,7 @@ TEST_F(TestGridTransformer, testDecomposition)
         EXPECT_TRUE(!decompose(m, s, r, t));
     }
 
-    const auto rad = [](double deg) { return deg * M_PI / 180.0; };
+    const auto rad = [](double deg) { return deg * openvdb::math::pi<double>() / 180.0; };
 
     const Vec3d ix(1, 0, 0), iy(0, 1, 0), iz(0, 0, 1);
 

--- a/openvdb/openvdb/unittest/TestMaps.cc
+++ b/openvdb/openvdb/unittest/TestMaps.cc
@@ -3,6 +3,7 @@
 
 #include <openvdb/Exceptions.h>
 #include <openvdb/math/Maps.h>
+#include <openvdb/math/Math.h>
 #include <openvdb/util/MapsUtil.h>
 #include "gtest/gtest.h"
 
@@ -35,7 +36,7 @@ TEST_F(TestMaps, testApproxInverse)
     }
     {
         Mat4d rot = Mat4d::identity();
-        rot.setToRotation(X_AXIS, M_PI/4.);
+        rot.setToRotation(X_AXIS, openvdb::math::pi<double>()/4.);
 
         Mat4d rotInv = rot.inverse();
         Mat4d mat = rotInv * singular * rot;
@@ -629,7 +630,7 @@ TEST_F(TestMaps, testJacobians)
         AffineMap affine;
 
         const int n = 10;
-        const double dtheta = M_PI / n;
+        const double dtheta = openvdb::math::pi<double>() / n;
 
         const Vec3d test(1,2,3);
         const Vec3d origin(0,0,0);

--- a/openvdb/openvdb/unittest/TestPointAdvect.cc
+++ b/openvdb/openvdb/unittest/TestPointAdvect.cc
@@ -9,6 +9,7 @@
 #include <openvdb/tools/LevelSetSphere.h>
 #include <openvdb/tools/Composite.h> // csgDifference
 #include <openvdb/tools/MeshToVolume.h> // createLevelSetBox
+#include <openvdb/math/Math.h>
 #include <openvdb/openvdb.h>
 #include <openvdb/Types.h>
 
@@ -389,7 +390,7 @@ TEST_F(TestPointAdvect, testZalesaksDisk)
     for (auto leaf = velocity->tree().beginLeaf(); leaf; ++leaf) {
         for (auto iter = leaf->beginValueOn(); iter; ++iter) {
             Vec3s position = xform->indexToWorld(iter.getCoord().asVec3d());
-            Vec3s vel = (position.cross(Vec3s(0, 0, 1)) * 2.0f * M_PI) / 10.0f;
+            Vec3s vel = (position.cross(Vec3s(0, 0, 1)) * 2.0f * openvdb::math::pi<float>()) / 10.0f;
             iter.setValue(vel);
         }
     }

--- a/openvdb/openvdb/unittest/TestPointConversion.cc
+++ b/openvdb/openvdb/unittest/TestPointConversion.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include <openvdb/io/TempFile.h>
+#include <openvdb/math/Math.h>
 #include <openvdb/points/PointDataGrid.h>
 #include <openvdb/points/PointAttribute.h>
 #include <openvdb/points/PointConversion.h>
@@ -119,8 +120,8 @@ genPoints(const int numPoints, const double scale, const bool stride,
     // init
     openvdb::math::Random01 randNumber(0);
     const int n = int(std::sqrt(double(numPoints)));
-    const double xScale = (2.0 * M_PI) / double(n);
-    const double yScale = M_PI / double(n);
+    const double xScale = (2.0 * openvdb::math::pi<double>()) / double(n);
+    const double yScale = openvdb::math::pi<double>() / double(n);
 
     double x, y, theta, phi;
     openvdb::Vec3f pos;
@@ -1045,9 +1046,9 @@ TEST_F(TestPointConversion, testComputeVoxelSize)
 
         // Rotate by 45 degrees in X, Y, Z
 
-        transform1->postRotate(M_PI / 4.0, math::X_AXIS);
-        transform1->postRotate(M_PI / 4.0, math::Y_AXIS);
-        transform1->postRotate(M_PI / 4.0, math::Z_AXIS);
+        transform1->postRotate(openvdb::math::pi<double>() / 4.0, math::X_AXIS);
+        transform1->postRotate(openvdb::math::pi<double>() / 4.0, math::Y_AXIS);
+        transform1->postRotate(openvdb::math::pi<double>() / 4.0, math::Z_AXIS);
 
         affineMap1 = transform1->constMap<math::AffineMap>();
         EXPECT_TRUE(affineMap1.get());

--- a/openvdb/openvdb/unittest/TestPointCount.cc
+++ b/openvdb/openvdb/unittest/TestPointCount.cc
@@ -4,6 +4,7 @@
 #include <openvdb/points/PointDataGrid.h>
 #include <openvdb/openvdb.h>
 #include <openvdb/io/TempFile.h>
+#include <openvdb/math/Math.h>
 
 #include <openvdb/points/PointGroup.h>
 #include <openvdb/points/PointCount.h>
@@ -595,8 +596,8 @@ genPoints(std::vector<Vec3R>& positions, const int numPoints, const double scale
     // init
     math::Random01 randNumber(0);
     const int n = int(std::sqrt(double(numPoints)));
-    const double xScale = (2.0 * M_PI) / double(n);
-    const double yScale = M_PI / double(n);
+    const double xScale = (2.0 * openvdb::math::pi<double>()) / double(n);
+    const double yScale = openvdb::math::pi<double>() / double(n);
 
     double x, y, theta, phi;
     Vec3R pos;

--- a/openvdb/openvdb/unittest/TestPointDataLeaf.cc
+++ b/openvdb/openvdb/unittest/TestPointDataLeaf.cc
@@ -4,6 +4,7 @@
 #include <openvdb/points/PointDataGrid.h>
 #include <openvdb/openvdb.h>
 #include <openvdb/io/io.h>
+#include <openvdb/math/Math.h>
 
 #include <gtest/gtest.h>
 
@@ -105,8 +106,8 @@ std::vector<openvdb::Vec3R> genPoints(const int numPoints)
     // init
     openvdb::math::Random01 randNumber(0);
     const int n = int(std::sqrt(double(numPoints)));
-    const double xScale = (2.0 * M_PI) / double(n);
-    const double yScale = M_PI / double(n);
+    const double xScale = (2.0 * openvdb::math::pi<double>()) / double(n);
+    const double yScale = openvdb::math::pi<double>() / double(n);
 
     double x, y, theta, phi;
 

--- a/openvdb/openvdb/unittest/TestPrePostAPI.cc
+++ b/openvdb/openvdb/unittest/TestPrePostAPI.cc
@@ -4,6 +4,7 @@
 #include <openvdb/Exceptions.h>
 #include <openvdb/math/Mat4.h>
 #include <openvdb/math/Maps.h>
+#include <openvdb/math/Math.h>
 #include <openvdb/math/Transform.h>
 #include <openvdb/util/MapsUtil.h>
 
@@ -72,9 +73,9 @@ TEST_F(TestPrePostAPI, testMat4Rotate)
     double TOL = 1e-7;
 
     Mat4d rx, ry, rz;
-    const double angle1 = 20. * M_PI / 180.;
-    const double angle2 = 64. * M_PI / 180.;
-    const double angle3 = 125. *M_PI / 180.;
+    const double angle1 = 20. * openvdb::math::pi<double>() / 180.;
+    const double angle2 = 64. * openvdb::math::pi<double>() / 180.;
+    const double angle3 = 125. *openvdb::math::pi<double>() / 180.;
     rx.setToRotation(Vec3d(1,0,0), angle1);
     ry.setToRotation(Vec3d(0,1,0), angle2);
     rz.setToRotation(Vec3d(0,0,1), angle3);
@@ -352,7 +353,7 @@ TEST_F(TestPrePostAPI, testMaps)
         }
     }
     { // pre rotate
-        const double angle1 = 20. * M_PI / 180.;
+        const double angle1 = 20. * openvdb::math::pi<double>() / 180.;
         UniformScaleMap usm;
         UniformScaleTranslateMap ustm;
         ScaleMap sm;
@@ -383,7 +384,7 @@ TEST_F(TestPrePostAPI, testMaps)
         }
     }
     { // post rotate
-        const double angle1 = 20. * M_PI / 180.;
+        const double angle1 = 20. * openvdb::math::pi<double>() / 180.;
         UniformScaleMap usm;
         UniformScaleTranslateMap ustm;
         ScaleMap sm;

--- a/openvdb/openvdb/unittest/TestQuantizedUnitVec.cc
+++ b/openvdb/openvdb/unittest/TestQuantizedUnitVec.cc
@@ -93,8 +93,8 @@ TEST_F(TestQuantizedUnitVec, testQuantization)
     // init
     srand(0);
     const int n = int(std::sqrt(double(numNormals)));
-    const double xScale = (2.0 * M_PI) / double(n);
-    const double yScale = M_PI / double(n);
+    const double xScale = (2.0 * openvdb::math::pi<double>()) / double(n);
+    const double yScale = openvdb::math::pi<double>() / double(n);
 
     double x, y, theta, phi;
     Vec3s n0, n1;

--- a/openvdb/openvdb/unittest/TestQuat.cc
+++ b/openvdb/openvdb/unittest/TestQuat.cc
@@ -46,7 +46,7 @@ TEST_F(TestQuat, testAxisAngle)
 
     Vec3s v(1, 2, 3);
     v.normalize();
-    float a = float(M_PI / 4.f);
+    float a = float(openvdb::math::pi<float>() / 4.f);
 
     Quat<float> q(v,a);
     float b = q.angle();
@@ -177,9 +177,9 @@ TEST_F(TestQuat, testEulerAngles)
         double TOL = 1e-7;
 
         Mat4d rx, ry, rz;
-        const double angle1 = 20. * M_PI / 180.;
-        const double angle2 = 64. * M_PI / 180.;
-        const double angle3 = 125. *M_PI / 180.;
+        const double angle1 = 20. * openvdb::math::pi<double>() / 180.;
+        const double angle2 = 64. * openvdb::math::pi<double>() / 180.;
+        const double angle3 = 125. *openvdb::math::pi<double>() / 180.;
         rx.setToRotation(Vec3d(1,0,0), angle1);
         ry.setToRotation(Vec3d(0,1,0), angle2);
         rz.setToRotation(Vec3d(0,0,1), angle3);
@@ -202,9 +202,9 @@ TEST_F(TestQuat, testEulerAngles)
         double TOL = 1e-7;
 
         Mat4d rx, ry, rz;
-        const double angle1 = 20. * M_PI / 180.;
-        const double angle2 = 64. * M_PI / 180.;
-        const double angle3 = 125. *M_PI / 180.;
+        const double angle1 = 20. * openvdb::math::pi<double>() / 180.;
+        const double angle2 = 64. * openvdb::math::pi<double>() / 180.;
+        const double angle3 = 125. *openvdb::math::pi<double>() / 180.;
         rx.setToRotation(Vec3d(1,0,0), angle1);
         ry.setToRotation(Vec3d(0,1,0), angle2);
         rz.setToRotation(Vec3d(0,0,1), angle3);
@@ -227,9 +227,9 @@ TEST_F(TestQuat, testEulerAngles)
         double TOL = 1e-7;
 
         Mat4d rx, ry, rz;
-        const double angle1 = 20. * M_PI / 180.;
-        const double angle2 = 64. * M_PI / 180.;
-        const double angle3 = 125. *M_PI / 180.;
+        const double angle1 = 20. * openvdb::math::pi<double>() / 180.;
+        const double angle2 = 64. * openvdb::math::pi<double>() / 180.;
+        const double angle3 = 125. *openvdb::math::pi<double>() / 180.;
         rx.setToRotation(Vec3d(1,0,0), angle1);
         ry.setToRotation(Vec3d(0,1,0), angle2);
         rz.setToRotation(Vec3d(0,0,1), angle3);

--- a/openvdb/openvdb/unittest/TestRay.cc
+++ b/openvdb/openvdb/unittest/TestRay.cc
@@ -6,6 +6,7 @@
 #include <openvdb/math/Ray.h>
 #include <openvdb/math/DDA.h>
 #include <openvdb/math/BBox.h>
+#include <openvdb/math/Math.h>
 #include <openvdb/Types.h>
 #include <openvdb/math/Transform.h>
 #include <openvdb/tools/LevelSetSphere.h>
@@ -84,7 +85,7 @@ TEST_F(TestRay, testRay)
     {// test transformation
         math::Transform::Ptr xform = math::Transform::createLinearTransform();
 
-        xform->preRotate(M_PI, math::Y_AXIS );
+        xform->preRotate(openvdb::math::pi<double>(), math::Y_AXIS );
         xform->postTranslate(math::Vec3d(1, 2, 3));
         xform->preScale(Vec3R(0.1, 0.2, 0.4));
 
@@ -124,7 +125,7 @@ TEST_F(TestRay, testRay)
 
         // This is the index to world transform
         math::Transform::Ptr xform = math::Transform::createLinearTransform();
-        xform->postRotate(M_PI, math::Y_AXIS );
+        xform->postRotate(openvdb::math::pi<double>(), math::Y_AXIS );
         xform->postTranslate(math::Vec3d(1, 2, 3));
         xform->postScale(Vec3R(0.1, 0.1, 0.1));//voxel size
 

--- a/openvdb/openvdb/unittest/TestTools.cc
+++ b/openvdb/openvdb/unittest/TestTools.cc
@@ -24,6 +24,7 @@
 #include <openvdb/tools/VolumeAdvect.h>
 #include <openvdb/util/Util.h>
 #include <openvdb/util/CpuTimer.h>
+#include <openvdb/math/Math.h>
 #include <openvdb/math/Stats.h>
 #include "util.h" // for unittest_util::makeSphere()
 #include <gtest/gtest.h>
@@ -1605,8 +1606,8 @@ TEST_F(TestTools, testVectorTransformer)
     Mat4d xform = Mat4d::identity();
     xform.preTranslate(Vec3d(0.1, -2.5, 3));
     xform.preScale(Vec3d(0.5, 1.1, 2));
-    xform.preRotate(math::X_AXIS, 30.0 * M_PI / 180.0);
-    xform.preRotate(math::Y_AXIS, 300.0 * M_PI / 180.0);
+    xform.preRotate(math::X_AXIS, 30.0 * openvdb::math::pi<double>() / 180.0);
+    xform.preRotate(math::Y_AXIS, 300.0 * openvdb::math::pi<double>() / 180.0);
 
     Mat4d invXform = xform.inverse();
     invXform = invXform.transpose();

--- a/openvdb/openvdb/unittest/util.h
+++ b/openvdb/openvdb/unittest/util.h
@@ -102,8 +102,8 @@ inline void genPoints(const int numPoints, std::vector<openvdb::Vec3R>& points)
     // init
     openvdb::math::Random01 randNumber(0);
     const int n = int(std::sqrt(double(numPoints)));
-    const double xScale = (2.0 * M_PI) / double(n);
-    const double yScale = M_PI / double(n);
+    const double xScale = (2.0 * openvdb::math::pi<double>()) / double(n);
+    const double yScale = openvdb::math::pi<double>() / double(n);
 
     double x, y, theta, phi;
     openvdb::Vec3R pos;

--- a/openvdb_cmd/vdb_view/Camera.cc
+++ b/openvdb_cmd/vdb_view/Camera.cc
@@ -3,6 +3,8 @@
 
 #include "Camera.h"
 
+#include <openvdb/math/Math.h>
+
 #include <cmath>
 
 #define GLFW_INCLUDE_GLU
@@ -10,7 +12,7 @@
 
 namespace openvdb_viewer {
 
-const double Camera::sDeg2rad = M_PI / 180.0;
+const double Camera::sDeg2rad = openvdb::math::pi<double>() / 180.0;
 
 
 Camera::Camera()

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Resample.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Resample.cc
@@ -17,6 +17,7 @@
 #include <openvdb_houdini/UT_VDBUtils.h> // for UTvdbGridCast()
 #include <openvdb_houdini/SOP_NodeVDB.h>
 #include <openvdb/openvdb.h>
+#include <openvdb/math/Math.h>
 #include <openvdb/tools/GridTransformer.h>
 #include <openvdb/tools/LevelSetRebuild.h>
 #include <openvdb/tools/VectorTransformer.h> // for transformVectors()
@@ -467,7 +468,7 @@ SOP_OpenVDB_Resample::Cache::cookVDBSop(OP_Context& context)
 
         const openvdb::Vec3R
             translate = evalVec3R("t", time),
-            rotate = (M_PI / 180.0) * evalVec3R("r", time),
+            rotate = (openvdb::math::pi<double>() / 180.0) * evalVec3R("r", time),
             scale = evalVec3R("s", time),
             pivot = evalVec3R("p", time);
         const float

--- a/pendingchanges/msvc_use_math_defines.txt
+++ b/pendingchanges/msvc_use_math_defines.txt
@@ -1,0 +1,7 @@
+Build:
+    - On Windows (MSVC), the _USE_MATH_DEFINES macro is no longer defined when
+    including <openvdb/Platform.h> (or any dependent headers). If you were
+    relying on this in your own project for M_PI, M_PI_2, etc. you can add
+    -D_USE_MATH_DEFINES to your own project compiler options. See
+    https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
+    for more info.


### PR DESCRIPTION
Replace M_PI* constants with openvdb::math::pi<T>(). This allows us to
remove the reliance on having the _USE_MATH_DEFINES macro being defined
prior to any inclusion of cmath/math.h on Windows. This was easily
broken by bad include orders inside openvdb or by users of openvdb.

Signed-off-by: Edward Lam <e4lam@yahoo.com>