### PR TITLE
replaced sprintf with snprintf to prevent future bufferoverflow

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -161,7 +161,7 @@ typedef unsigned long long uint64_t;
 #include <stdint.h> //    for types like int32_t etc
 #include <stddef.h> //    for size_t type
 #include <cassert> //     for assert
-#include <cstdio> //      for sprinf
+#include <cstdio> //      for snprintf
 #include <cmath> //       for sqrt and fma
 #include <limits> //      for numeric_limits
 #include <utility>//      for std::move
@@ -673,8 +673,8 @@ public:
 #ifndef __CUDACC_RTC__
     const char* c_str() const
     {
-        char *buffer = (char*)malloc(4 + 1 + 4 + 1 + 4 + 1);// xxxx.xxxx.xxxx\n
-        sprintf(buffer, "%d.%d.%d", this->getMajor(), this->getMinor(), this->getPatch());
+        char *buffer = (char*)malloc(4 + 1 + 4 + 1 + 4 + 1);// xxxx.xxxx.xxxx\0
+        snprintf(buffer, 4 + 1 + 4 + 1 + 4 + 1, "%d.%d.%d", this->getMajor(), this->getMinor(), this->getPatch()); // Prevents overflows by enforcing a fixed size of buffer
         return buffer;
     }
 #endif
@@ -5688,7 +5688,7 @@ void writeUncompressedGrid(StreamT &os, const void *buffer)
       if (*(const uint32_t*)(grid+24) >= *(const uint32_t*)(grid+28) - 1) break;
       grid += gridSize;
     }
-}
+}// writeUncompressedGrid
 
 /// @brief  write multiple NanoVDB grids to a single file, without compression.
 template<typename GridHandleT, template<typename...> class VecT>
@@ -5709,7 +5709,7 @@ void writeUncompressedGrids(const char* fileName, const VecT<GridHandleT>& handl
         fprintf(stderr, "nanovdb::writeUncompressedGrids: Unable to open file \"%s\"for output\n",fileName); exit(EXIT_FAILURE);
     }
     for (auto &handle : handles) writeUncompressedGrid(os, handle.data());
-}
+}// writeUncompressedGrids
 
 /// @brief read all uncompressed grids from a stream and return their handles.
 ///
@@ -5741,7 +5741,7 @@ VecT<GridHandleT> readUncompressedGrids(StreamT& is, const typename GridHandleT:
     }
   }
   return handles;
-}
+}// readUncompressedGrids
 
 /// @brief Read a multiple un-compressed NanoVDB grids from a file and return them as a vector.
 template<typename GridHandleT, template<typename...> class VecT>
@@ -5767,7 +5767,7 @@ VecT<GridHandleT> readUncompressedGrids(const char *fileName, const typename Gri
     fprintf(stderr, "nanovdb::readUncompressedGrids: Unable to open file \"%s\"for input\n",fileName); exit(EXIT_FAILURE);
   }
   return readUncompressedGrids<GridHandleT, StreamT, VecT>(is, buffer);
-}
+}// readUncompressedGrids
 
 } // namespace io
 

--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -122,7 +122,7 @@
 
 #define NANOVDB_MAJOR_VERSION_NUMBER 32 // reflects changes to the ABI and hence also the file format
 #define NANOVDB_MINOR_VERSION_NUMBER 4 //  reflects changes to the API but not ABI
-#define NANOVDB_PATCH_VERSION_NUMBER 0 //  reflects changes that does not affect the ABI or API
+#define NANOVDB_PATCH_VERSION_NUMBER 1 //  reflects changes that does not affect the ABI or API
 
 // This replaces a Coord key at the root level with a single uint64_t
 #define USE_SINGLE_ROOT_KEY

--- a/nanovdb/nanovdb/PNanoVDB.h
+++ b/nanovdb/nanovdb/PNanoVDB.h
@@ -632,7 +632,7 @@ PNANOVDB_FORCE_INLINE float pnanovdb_read_half(pnanovdb_buf_t buf, pnanovdb_addr
 
 #define PNANOVDB_MAJOR_VERSION_NUMBER 32// reflects changes to the ABI
 #define PNANOVDB_MINOR_VERSION_NUMBER  4// reflects changes to the API but not ABI
-#define PNANOVDB_PATCH_VERSION_NUMBER  0// reflects bug-fixes with no ABI or API changes
+#define PNANOVDB_PATCH_VERSION_NUMBER  1// reflects bug-fixes with no ABI or API changes
 
 #define PNANOVDB_GRID_TYPE_UNKNOWN 0
 #define PNANOVDB_GRID_TYPE_FLOAT 1

--- a/pendingchanges/nanovdb.txt
+++ b/pendingchanges/nanovdb.txt
@@ -19,3 +19,4 @@ Bug Fixes:
     - Fixed a bug in nanovdb::HostBuffer that could produce crashes due to misaligned CPU memory allocations.
     - Fixed bug related to uninitialized memory in nanovdb::Grid which could confuse CRC32 checksum validation.
     - Fixed bugs related to the use of intrinsic functions for fast bit-counting in nanovdb.
+    - Fixed a potential security vulnerability in NanoVDB.h related to buffer overflow exploits.


### PR DESCRIPTION
Signed-off-by: Ken Museth <ken.museth@gmail.com>

Fixed a potential security vulnerability in NanoVDB.h related to buffer overflow exploits

sprintf is deprecated in C++17 since it's prone to buffer overflow, which is a serious security risk. This PR replaces sprintf in NanoVDB.h with snprintf which avoids buffer overflow by explicitly defining the maximum number characters written to the buffer.