### PR TITLE
Remove deprecated virtual methods from AttributeArray for ABI=10

### DIFF
--- a/doc/changes.txt
+++ b/doc/changes.txt
@@ -1010,8 +1010,7 @@ API changes:
 - @vdblink{tools::VolumeToMesh::pointList(),VolumeToMesh::pointList} and
   @vdblink{tools::VolumeToMesh::polygonPoolList(),VolumeToMesh::polygonPoolList}
   now return a std::unique_ptr instead of a boost::scoped_array.
-- @vdblink::points::AttributeArray::copyUncompressed() AttributeArray::copyUncompressed@endlink
-  is now deprecated.
+- AttributeArray::copyUncompressed is now deprecated.
 
 @par
 Python:
@@ -1342,9 +1341,8 @@ Improvements:
   @vdblink::points::AttributeArray AttributeArray@endlink now errors.
 - Updated point deletion to use faster batch copying for ABI=6+.
 - Methods relating to in-memory Blosc compression for
-  @vdblink::points::AttributeArray::compress() AttributeArray@endlink
-  now do nothing and have been marked deprecated resulting in memory savings
-  for ABI=6+.
+  AttributeArray::compress() now do nothing and have been marked deprecated
+  resulting in memory savings for ABI=6+.
 
 @par
 Bug fixes:
@@ -1365,8 +1363,8 @@ API changes:
 - Removed a number of methods that were deprecated in version&nbsp;5.0.0 or
   earlier.
 - Removed the experimental @b ValueAccessor::newSetValue method.
-- Deprecated @vdblink::points::AttributeArray::compress()
-  AttributeArray@endlink methods relating to in-memory Blosc compression.
+- Deprecated AttributeArray::compress() methods relating to in-memory Blosc
+  compression.
 
 @par
 Houdini:

--- a/openvdb/openvdb/points/AttributeArray.h
+++ b/openvdb/openvdb/points/AttributeArray.h
@@ -144,11 +144,13 @@ public:
     /// Return a copy of this attribute.
     virtual AttributeArray::Ptr copy() const = 0;
 
+#if OPENVDB_ABI_VERSION_NUMBER < 10
     /// Return a copy of this attribute.
 #ifndef _MSC_VER
     OPENVDB_DEPRECATED_MESSAGE("In-memory compression no longer supported, use AttributeArray::copy() instead")
 #endif
     virtual AttributeArray::Ptr copyUncompressed() const = 0;
+#endif
 
     /// Return the number of elements in this array.
     /// @note This does not count each data element in a strided array
@@ -225,12 +227,14 @@ public:
     template<typename ValueType>
     bool hasValueType() const { return this->type().first == typeNameAsString<ValueType>(); }
 
+#if OPENVDB_ABI_VERSION_NUMBER < 10
     /// @brief Set value at given index @a n from @a sourceIndex of another @a sourceArray.
     // Windows does not allow base classes to be easily deprecated.
 #ifndef _MSC_VER
     OPENVDB_DEPRECATED_MESSAGE("Use copyValues() with source-target index pairs")
 #endif
     virtual void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) = 0;
+#endif
 
     /// @brief Copy values into this array from a source array to a target array
     /// as referenced by an iterator.
@@ -273,6 +277,7 @@ public:
     /// Compact the existing array to become uniform if all values are identical
     virtual bool compact() = 0;
 
+#if OPENVDB_ABI_VERSION_NUMBER < 10
     // Windows does not allow base classes to be deprecated
 #ifndef _MSC_VER
     OPENVDB_DEPRECATED_MESSAGE("Previously this compressed the attribute array, now it does nothing")
@@ -283,6 +288,7 @@ public:
     OPENVDB_DEPRECATED_MESSAGE("Previously this uncompressed the attribute array, now it does nothing")
 #endif
     virtual bool decompress() = 0;
+#endif
 
     /// @brief   Specify whether this attribute should be hidden (e.g., from UI or iterators).
     /// @details This is useful if the attribute is used for blind data or as scratch space
@@ -558,9 +564,11 @@ public:
     /// while being copied using this copy-constructor in another thread.
     /// It is not thread-safe for write.
     TypedAttributeArray(const TypedAttributeArray&);
+#if OPENVDB_ABI_VERSION_NUMBER < 10
     /// Deep copy constructor.
     OPENVDB_DEPRECATED_MESSAGE("Use copy-constructor without unused bool parameter")
     TypedAttributeArray(const TypedAttributeArray&, bool /*unused*/);
+#endif
 
     /// Deep copy assignment operator.
     /// @note this operator is thread-safe.
@@ -576,10 +584,12 @@ public:
     /// @note This method is thread-safe.
     AttributeArray::Ptr copy() const override;
 
+#if OPENVDB_ABI_VERSION_NUMBER < 10
     /// Return a copy of this attribute.
     /// @note This method is thread-safe.
     OPENVDB_DEPRECATED_MESSAGE("In-memory compression no longer supported, use AttributeArray::copy() instead")
     AttributeArray::Ptr copyUncompressed() const override;
+#endif
 
     /// Return a new attribute array of the given length @a n and @a stride with uniform value zero.
     static Ptr create(Index n, Index strideOrTotalSize = 1, bool constantStride = true,
@@ -680,9 +690,11 @@ public:
     /// (assumes in-core)
     static void setUnsafe(AttributeArray* array, const Index n, const ValueType& value);
 
+#if OPENVDB_ABI_VERSION_NUMBER < 10
     /// Set value at given index @a n from @a sourceIndex of another @a sourceArray
     OPENVDB_DEPRECATED_MESSAGE("Use copyValues() with source-target index pairs")
     void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) override;
+#endif
 
     /// Return @c true if this array is stored as a single uniform value.
     bool isUniform() const override { return mIsUniform; }
@@ -706,12 +718,14 @@ public:
     /// Non-member equivalent to fill() that static_casts array to this TypedAttributeArray
     static void fill(AttributeArray* array, const ValueType& value);
 
+#if OPENVDB_ABI_VERSION_NUMBER < 10
     /// Compress the attribute array.
     OPENVDB_DEPRECATED_MESSAGE("Previously this compressed the attribute array, now it does nothing")
     bool compress() override;
     /// Uncompress the attribute array.
     OPENVDB_DEPRECATED_MESSAGE("Previously this uncompressed the attribute array, now it does nothing")
     bool decompress() override;
+#endif
 
     /// Read attribute data from a stream.
     void read(std::istream&) override;
@@ -776,10 +790,14 @@ private:
     /// Load data from memory-mapped file.
     inline void doLoad() const;
     /// Load data from memory-mapped file (unsafe as this function is not protected by a mutex).
+#if OPENVDB_ABI_VERSION_NUMBER >= 10
+    inline void doLoadUnsafe() const;
+#else
     /// @param compression parameter no longer used
     inline void doLoadUnsafe(const bool compression = true) const;
     /// Compress in-core data assuming mutex is locked
     inline bool compressUnsafe();
+#endif
 
     /// Toggle out-of-core state
     inline void setOutOfCore(const bool);
@@ -1264,13 +1282,14 @@ TypedAttributeArray<ValueType_, Codec_>::copy() const
 }
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 10
 template<typename ValueType_, typename Codec_>
 AttributeArray::Ptr
 TypedAttributeArray<ValueType_, Codec_>::copyUncompressed() const
 {
     return this->copy();
 }
-
+#endif
 
 template<typename ValueType_, typename Codec_>
 size_t
@@ -1485,6 +1504,7 @@ TypedAttributeArray<ValueType_, Codec_>::setUnsafe(AttributeArray* array, const 
 }
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 10
 template<typename ValueType_, typename Codec_>
 void
 TypedAttributeArray<ValueType_, Codec_>::set(Index n, const AttributeArray& sourceArray, const Index sourceIndex)
@@ -1496,6 +1516,7 @@ TypedAttributeArray<ValueType_, Codec_>::set(Index n, const AttributeArray& sour
 
     this->set(n, sourceValue);
 }
+#endif
 
 
 template<typename ValueType_, typename Codec_>
@@ -1591,6 +1612,7 @@ TypedAttributeArray<ValueType_, Codec_>::fill(AttributeArray* array, const Value
 }
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 10
 template<typename ValueType_, typename Codec_>
 inline bool
 TypedAttributeArray<ValueType_, Codec_>::compress()
@@ -1613,6 +1635,7 @@ TypedAttributeArray<ValueType_, Codec_>::decompress()
 {
     return false;
 }
+#endif
 
 
 template<typename ValueType_, typename Codec_>
@@ -1950,7 +1973,11 @@ TypedAttributeArray<ValueType_, Codec_>::writePagedBuffers(compression::PagedOut
 
 template<typename ValueType_, typename Codec_>
 void
+#if OPENVDB_ABI_VERSION_NUMBER >= 10
+TypedAttributeArray<ValueType_, Codec_>::doLoadUnsafe() const
+#else
 TypedAttributeArray<ValueType_, Codec_>::doLoadUnsafe(const bool /*compression*/) const
+#endif
 {
     if (!(this->isOutOfCore())) return;
 

--- a/pendingchanges/removed_deprecated_virtual.txt
+++ b/pendingchanges/removed_deprecated_virtual.txt
@@ -1,0 +1,2 @@
+    ABI changes:
+    - Removed deprecated virtual methods from AttributeArray.


### PR DESCRIPTION
These methods have long been deprecated, but being virtual they have to be removed only on an ABI bump.