### PR TITLE
Fix Unit Tests when Delayed Loading is Disabled

### DIFF
--- a/openvdb/openvdb/unittest/TestCount.cc
+++ b/openvdb/openvdb/unittest/TestCount.cc
@@ -239,6 +239,7 @@ TEST_F(TestCount, testMemUsage)
     EXPECT_EQ(expectedMaxMem, inCoreMemUsage);
     EXPECT_EQ(expectedMaxMem, memUsageIfLoaded);
 
+#ifdef OPENVDB_USE_DELAYED_LOADING
     // Write out the grid and read it in with delay-loading. Check the
     // expected memory usage values.]
 
@@ -279,6 +280,7 @@ TEST_F(TestCount, testMemUsage)
     std::remove(filename.c_str());
 
     openvdb::uninitialize();
+#endif
 }
 
 

--- a/openvdb/openvdb/unittest/TestPointConversion.cc
+++ b/openvdb/openvdb/unittest/TestPointConversion.cc
@@ -255,9 +255,7 @@ TEST_F(TestPointConversion, testPointConversion)
 
     // read/write grid to a temp file
 
-    io::TempFile file;
-    const std::string filename = file.filename();
-
+    const std::string filename = "testPointConversion.vdb";
     io::File fileOut(filename);
 
     GridCPtrVec grids;
@@ -409,7 +407,6 @@ TEST_F(TestPointConversion, testPointConversion)
         EXPECT_NEAR(position.buffer()[i*2].z(), pointData[i].position.z(), /*tolerance=*/1e-6);
     }
 
-    file.close();
     std::remove(filename.c_str());
 }
 

--- a/openvdb/openvdb/unittest/TestPointCount.cc
+++ b/openvdb/openvdb/unittest/TestPointCount.cc
@@ -288,8 +288,7 @@ TEST_F(TestPointCount, testGroup)
 
         // write out grid to a temp file
         {
-            io::TempFile file;
-            filename = file.filename();
+            filename = "testPointCount1.vdb";
             io::File fileOut(filename);
             GridCPtrVec grids{grid};
             fileOut.write(grids);
@@ -524,8 +523,7 @@ TEST_F(TestPointCount, testOffsets)
 
     // write out grid to a temp file
     {
-        io::TempFile file;
-        filename = file.filename();
+        const std::string filename = "testPointCount1.vdb";
         io::File fileOut(filename);
         GridCPtrVec grids{grid};
         fileOut.write(grids);

--- a/openvdb/openvdb/unittest/TestPointCount.cc
+++ b/openvdb/openvdb/unittest/TestPointCount.cc
@@ -523,7 +523,7 @@ TEST_F(TestPointCount, testOffsets)
 
     // write out grid to a temp file
     {
-        const std::string filename = "testPointCount1.vdb";
+        filename = "testPointCount1.vdb";
         io::File fileOut(filename);
         GridCPtrVec grids{grid};
         fileOut.write(grids);

--- a/openvdb/openvdb/unittest/TestPointRasterizeFrustum.cc
+++ b/openvdb/openvdb/unittest/TestPointRasterizeFrustum.cc
@@ -2153,7 +2153,9 @@ TEST_F(TestPointRasterizeFrustum, testStreaming)
 
     auto leaf = points->tree().cbeginLeaf();
     EXPECT_TRUE(leaf);
+#ifdef OPENVDB_USE_DELAYED_LOADING
     EXPECT_TRUE(leaf->buffer().isOutOfCore());
+#endif
 
     using Rasterizer = FrustumRasterizer<PointDataGrid>;
     using Settings = FrustumRasterizerSettings;
@@ -2324,10 +2326,12 @@ TEST_F(TestPointRasterizeFrustum, testStreaming)
     auto points2 = points->deepCopy();
     points2->setTransform(transform);
 
+#ifdef OPENVDB_USE_DELAYED_LOADING
     // verify both grids are out-of-core
 
     EXPECT_TRUE(points->tree().cbeginLeaf()->buffer().isOutOfCore());
     EXPECT_TRUE(points2->tree().cbeginLeaf()->buffer().isOutOfCore());
+#endif
 
 #ifndef ONLY_RASTER_FLOAT
     // memory tests


### PR DESCRIPTION
Fixes the extra lite weekly build which is building and evaluating the unit tests with delayed loading disabled.