### PR TITLE
Use modern GA_Detail::createDetached*Group() API

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Points_Convert.cc
@@ -806,7 +806,7 @@ SOP_OpenVDB_Points_Convert::Cache::cookVDBSop(OP_Context& context)
 
         // Unpack any packed primitives
 
-        std::unique_ptr<GA_PrimitiveGroup> packgroup(ptGeo->newDetachedPrimitiveGroup());
+        GA_PrimitiveGroupUPtr packgroup = ptGeo->createDetachedPrimitiveGroup();
 
         for (GA_Iterator it(ptGeo->getPrimitiveRange()); !it.atEnd(); ++it) {
             GA_Offset offset = *it;


### PR DESCRIPTION
... instead of the unsafe newDetachedPrimitiveGroup() that will be deprecated in a future Houdini version.

Signed-off-by: Edward Lam <e4lam@yahoo.com>