### PR TITLE
Fix terse static assert error when building with C++14 on Windows

### DIFF
--- a/openvdb/openvdb/tree/ValueAccessor.h
+++ b/openvdb/openvdb/tree/ValueAccessor.h
@@ -872,7 +872,8 @@ public:
     using LeafNodeType = typename NodeType::LeafNodeType;
     using CoordLimits = std::numeric_limits<Int32>;
 
-    static_assert(std::is_same<NodeType, LeafNodeType>::value);
+    static_assert(std::is_same<NodeType, LeafNodeType>::value,
+        "cache item node type is not leaf node type");
 
     CacheItem(TreeCacheT& parent)
         : mParent(&parent)


### PR DESCRIPTION
USD defaults to C++14, which leads to a build error when using OpenVDB 10 because terse static asserts are a C++17 feature.

Signed-off-by: Brecht Van Lommel <brecht@blender.org>