### PR TITLE
Switch to using the static asserts.

### DIFF
--- a/nanovdb/nanovdb/util/GridChecksum.h
+++ b/nanovdb/nanovdb/util/GridChecksum.h
@@ -178,7 +178,7 @@ template <typename ValueT>
 void GridChecksum::operator()(const NanoGrid<ValueT> &grid, ChecksumMode mode)
 {
     // Validate the assumed memory layout
-#if 1
+#if 0
     NANOVDB_ASSERT(NANOVDB_OFFSETOF(GridData, mMagic)    ==  0);
     NANOVDB_ASSERT(NANOVDB_OFFSETOF(GridData, mChecksum) ==  8);
     NANOVDB_ASSERT(NANOVDB_OFFSETOF(GridData, mVersion)  == 16);


### PR DESCRIPTION
The comment mentions that they have compiler warnings, but with clang 15 we now get compiler warnings for trying to do differences with nullptr.
