### PR TITLE
Support for hollow VDBs

### DIFF
--- a/openvdb/openvdb/tools/LevelSetRebuild.h
+++ b/openvdb/openvdb/tools/LevelSetRebuild.h
@@ -4,13 +4,25 @@
 #ifndef OPENVDB_TOOLS_LEVELSETREBUILD_HAS_BEEN_INCLUDED
 #define OPENVDB_TOOLS_LEVELSETREBUILD_HAS_BEEN_INCLUDED
 
+/// When rebuilding we convert from grid -> mesh -> grid.
+/// The conversion from mesh -> grid will close any internal bubbles.
+/// By using the original grid as an oracle we can set the sign of the
+/// bubbles properly.  Unfortunately, when increasing resolution the 
+/// rasterization of the mesh diverges too far from interpolated original
+/// grid and results in incorrect sign choices.   The likely correct solution
+/// is to use a different approach for rebuilding when resolution is
+/// increasing.
+#define OPENVDB_USE_ORACLE_IN_REBUILD 0
+
 #include <openvdb/Grid.h>
 #include <openvdb/Exceptions.h>
 #include <openvdb/math/Math.h>
 #include <openvdb/math/Transform.h>
+#if OPENVDB_USE_ORACLE_IN_REBUILD
 #include <openvdb/tools/VolumeToMesh.h>
 #include <openvdb/tools/MeshToVolume.h>
 #include <openvdb/tools/Interpolation.h>
+#endif
 #include <openvdb/util/NullInterrupter.h>
 #include <openvdb/util/Util.h>
 #include <openvdb/openvdb.h>
@@ -253,6 +265,7 @@ doLevelSetRebuild(const GridType& grid, typename GridType::ValueType iso,
 
     QuadAndTriangleDataAdapter<Vec3s, Vec4I> mesh(points, primitives);
 
+#if OPENVDB_USE_ORACLE_IN_REBUILD
     auto backToOldGrid = [&xform, &grid](const Coord& coord) -> openvdb::math::Vec3d {
         return grid.transform().worldToIndex(xform->indexToWorld(coord));
     };
@@ -265,14 +278,23 @@ doLevelSetRebuild(const GridType& grid, typename GridType::ValueType iso,
             return value <= 0 ? true : false;
         }
     };
+#endif
 
     if (interrupter) {
         return meshToVolume<GridType>(*interrupter, mesh, *transform, exBandWidth, inBandWidth,
-            DISABLE_RENORMALIZATION, nullptr, interiorTest, EVAL_EVERY_VOXEL);
+            DISABLE_RENORMALIZATION, nullptr
+#if OPENVDB_USE_ORACLE_IN_REBUILD
+            , interiorTest, EVAL_EVERY_VOXEL
+#endif
+            );
     }
 
     return meshToVolume<GridType>(mesh, *transform, exBandWidth, inBandWidth,
-        DISABLE_RENORMALIZATION, nullptr, interiorTest, EVAL_EVERY_VOXEL);
+        DISABLE_RENORMALIZATION, nullptr
+#if OPENVDB_USE_ORACLE_IN_REBUILD
+        , interiorTest, EVAL_EVERY_VOXEL
+#endif
+        );
 }
 
 

--- a/openvdb/openvdb/tools/LevelSetRebuild.h
+++ b/openvdb/openvdb/tools/LevelSetRebuild.h
@@ -7,7 +7,7 @@
 /// When rebuilding we convert from grid -> mesh -> grid.
 /// The conversion from mesh -> grid will close any internal bubbles.
 /// By using the original grid as an oracle we can set the sign of the
-/// bubbles properly.  Unfortunately, when increasing resolution the 
+/// bubbles properly.  Unfortunately, when increasing resolution the
 /// rasterization of the mesh diverges too far from interpolated original
 /// grid and results in incorrect sign choices.   The likely correct solution
 /// is to use a different approach for rebuilding when resolution is

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -78,6 +78,19 @@ enum MeshToVolumeFlags {
 };
 
 
+/// @brief Different staregies how to determine sign of an SDF when using
+/// interior test.
+enum InteriorTestStrategy {
+
+   /// Evaluates interior test at every voxel. This is usefull when we rebuild already
+   /// existing SDF where evaluating previous grid is cheap
+   EVAL_EVERY_VOXEL = 0,
+
+   /// Evaluates interior test at least once per tile and flood fills within the tile.
+   EVAL_EVERY_TILE = 1,
+};
+
+
 /// @brief  Convert polygonal meshes that consist of quads and/or triangles into
 ///         signed or unsigned distance field volumes.
 ///
@@ -108,7 +121,10 @@ enum MeshToVolumeFlags {
 /// @param flags              optional conversion flags defined in @c MeshToVolumeFlags
 /// @param polygonIndexGrid   optional grid output that will contain the closest-polygon
 ///                           index for each voxel in the narrow band region
-template <typename GridType, typename MeshDataAdapter>
+/// @param interiorTest       function `Coord -> Bool` that evaluates to true inside of the
+///                           mesh and false outside, for more see evaluateInteriortest
+/// @param interiorTestStrat  determines how the interiorTest is used, see InteriorTestStrategy
+template <typename GridType, typename MeshDataAdapter, typename InteriorTest = std::nullptr_t>
 typename GridType::Ptr
 meshToVolume(
   const MeshDataAdapter& mesh,
@@ -116,7 +132,9 @@ meshToVolume(
   float exteriorBandWidth = 3.0f,
   float interiorBandWidth = 3.0f,
   int flags = 0,
-  typename GridType::template ValueConverter<Int32>::Type * polygonIndexGrid = nullptr);
+  typename GridType::template ValueConverter<Int32>::Type * polygonIndexGrid = nullptr,
+  InteriorTest interiorTest = nullptr,
+  InteriorTestStrategy interiorTestStrat = EVAL_EVERY_VOXEL);
 
 
 /// @brief  Convert polygonal meshes that consist of quads and/or triangles into
@@ -134,7 +152,10 @@ meshToVolume(
 /// @param flags              optional conversion flags defined in @c MeshToVolumeFlags
 /// @param polygonIndexGrid   optional grid output that will contain the closest-polygon
 ///                           index for each voxel in the active narrow band region
-template <typename GridType, typename MeshDataAdapter, typename Interrupter>
+/// @param interiorTest       function `Coord -> Bool` that evaluates to true inside of the
+///                           mesh and false outside, for more see evaluatInteriorTest
+/// @param interiorTestStrat  determines how the interiorTest is used, see InteriorTestStrategy
+template <typename GridType, typename MeshDataAdapter, typename Interrupter, typename InteriorTest = std::nullptr_t>
 typename GridType::Ptr
 meshToVolume(
     Interrupter& interrupter,
@@ -143,7 +164,9 @@ meshToVolume(
     float exteriorBandWidth = 3.0f,
     float interiorBandWidth = 3.0f,
     int flags = 0,
-    typename GridType::template ValueConverter<Int32>::Type * polygonIndexGrid = nullptr);
+    typename GridType::template ValueConverter<Int32>::Type * polygonIndexGrid = nullptr,
+    InteriorTest interiorTest = nullptr,
+    InteriorTestStrategy interiorTestStrategy = EVAL_EVERY_VOXEL);
 
 
 ////////////////////////////////////////
@@ -3118,8 +3141,166 @@ traceExteriorBoundaries(FloatTreeT& tree)
 
 ////////////////////////////////////////
 
+template <typename T, Index Log2Dim, typename InteriorTest>
+void
+floodFillLeafNode(tree::LeafNode<T,Log2Dim>& leafNode, const InteriorTest& interiorTest) {
 
-template <typename GridType, typename MeshDataAdapter, typename Interrupter>
+    enum VoxelState {
+        NOT_VISITED = 0,
+        POSITIVE = 1,
+        NEGATIVE = 2,
+        NOT_ASSIGNED = 3
+    };
+
+    const auto DIM = leafNode.DIM;
+    const auto SIZE = leafNode.SIZE;
+
+    std::vector<VoxelState> voxelState(SIZE, NOT_VISITED);
+
+    std::vector<std::pair<Index, VoxelState>> offsetStack;
+    offsetStack.reserve(SIZE);
+
+    for (Index offset=0; offset<SIZE; offset++) {
+        const auto value = leafNode.getValue(offset);
+
+        // We do not assign anything for voxel close to the mesh
+        // This condition is aligned with the condition in traceVoxelLine
+        if (abs(value) <= 0.75) {
+            voxelState[offset] = NOT_ASSIGNED;
+        } else if (voxelState[offset] == NOT_VISITED) {
+
+            auto coord = leafNode.offsetToGlobalCoord(offset);
+
+            if (interiorTest(coord)){
+                // Yes we assigne positive values to interior points
+                // this is aligned with how meshToVolume works internally
+                offsetStack.push_back({offset, POSITIVE});
+                voxelState[offset] = POSITIVE;
+            } else {
+                offsetStack.push_back({offset, NEGATIVE});
+                voxelState[offset] = NEGATIVE;
+            }
+
+            while(!offsetStack.empty()){
+
+                auto [off, state] = offsetStack[offsetStack.size()-1];
+                offsetStack.pop_back();
+
+                if (state == NEGATIVE) {
+                    leafNode.setValueOnly(off, -leafNode.getValue(off));
+                }
+
+                // iterate over all neighbours and assign identical state
+                // if they have not been visited and if they are far away
+                // from the mesh (the condition is same as in traceVoxelLine)
+                for (int dim=2; dim>=0; dim--){
+                    for (int i = -1; i <=1; ++(++i)){
+                        int dimIdx = (off >> dim * Log2Dim) % DIM;
+                        auto neighOff = off + (1 << dim * Log2Dim) * i;
+                        if ((0 < dimIdx) &&
+                            (dimIdx < DIM - 1) &&
+                            (voxelState[neighOff] == NOT_VISITED)) {
+
+                            if (abs(leafNode.getValue(neighOff)) <= 0.75) {
+                                voxelState[neighOff] = NOT_ASSIGNED;
+                            } else {
+                                offsetStack.push_back({neighOff, state});
+                                voxelState[neighOff] = state;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+////////////////////////////////////////
+
+/// @brief Sets the sign of voxel values of `tree` based on the `interiorTest`
+///
+/// Inside is set to positive and outside to negative. This is in reverse to the usual
+/// level set convention, but `meshToVolume` uses the opposite convention at certain point.
+///
+/// InteriorTest has to be a function `Coord -> bool` which evaluates true
+/// inside of the mesh and false outside.
+///
+/// Furthermore, InteriorTest does not have to be thread-safe, but it has to be
+/// copy constructible and evaluating different coppy has to be thread-safe.
+///
+///  Example of a interior test
+///
+///  auto acc = tree->getAccessor();
+///
+///  auto test = [acc = grid.getConstAccessor()](const Cood& coord) -> bool {
+///     return acc->get(coord) <= 0 ? true : false;
+///  }
+template <typename FloatTreeT, typename InteriorTest>
+void
+evaluateInteriorTest(FloatTreeT& tree, InteriorTest interiorTest, InteriorTestStrategy interiorTestStrategy)
+{
+    static_assert(std::is_invocable_r<bool, InteriorTest, Coord>::value,
+                 "InteriorTest has to be a function `Coord -> bool`!");
+    static_assert(std::is_copy_constructible_v<InteriorTest>,
+                 "InteriorTest has to be copyable!");
+
+    using LeafT = typename FloatTreeT::LeafNodeType;
+
+    if (interiorTestStrategy == EVAL_EVERY_VOXEL) {
+
+        auto op = [interiorTest](auto& node) {
+            using Node = std::decay_t<decltype(node)>;
+
+            if constexpr (std::is_same_v<Node, LeafT>) {
+
+                for (auto iter = node.beginValueAll(); iter; ++iter) {
+                    if (!interiorTest(iter.getCoord())) {
+                        iter.setValue(-*iter);
+                    }
+                }
+
+            } else {
+                for (auto iter = node.beginChildOff(); iter; ++iter) {
+                    if (!interiorTest(iter.getCoord())) {
+                        iter.setValue(-*iter);
+                    }
+                }
+            }
+        };
+
+        openvdb::tree::NodeManager nodes(tree);
+        nodes.foreachBottomUp(op);
+    }
+
+    if (interiorTestStrategy == EVAL_EVERY_TILE) {
+
+        auto op = [interiorTest](auto& node) {
+            using Node = std::decay_t<decltype(node)>;
+
+            if constexpr (std::is_same_v<Node, LeafT>) {
+                // // leaf node
+                LeafT& leaf = static_cast<LeafT&>(node);
+
+                floodFillLeafNode(leaf, interiorTest);
+
+            } else {
+                for (auto iter = node.beginChildOff(); iter; ++iter) {
+                    if (!interiorTest(iter.getCoord())) {
+                        iter.setValue(-*iter);
+                    }
+                }
+            }
+        };
+
+        openvdb::tree::NodeManager nodes(tree);
+        nodes.foreachBottomUp(op);
+    }
+} // void evaluateInteriorTest()
+
+////////////////////////////////////////
+
+
+template <typename GridType, typename MeshDataAdapter, typename Interrupter, typename InteriorTest>
 typename GridType::Ptr
 meshToVolume(
   Interrupter& interrupter,
@@ -3128,7 +3309,9 @@ meshToVolume(
   float exteriorBandWidth,
   float interiorBandWidth,
   int flags,
-  typename GridType::template ValueConverter<Int32>::Type * polygonIndexGrid)
+  typename GridType::template ValueConverter<Int32>::Type * polygonIndexGrid,
+  InteriorTest interiorTest,
+  InteriorTestStrategy interiorTestStrat)
 {
     using GridTypePtr = typename GridType::Ptr;
     using TreeType = typename GridType::TreeType;
@@ -3241,34 +3424,49 @@ meshToVolume(
 
     if (computeSignedDistanceField) {
 
-        // Determines the inside/outside state for the narrow band of voxels.
-        traceExteriorBoundaries(distTree);
+        /// If interior test is not provided
+        if constexpr (std::is_same_v<InteriorTest, std::nullptr_t>) {
+            // Determines the inside/outside state for the narrow band of voxels.
+            traceExteriorBoundaries(distTree);
+        } else {
+            evaluateInteriorTest(distTree, interiorTest, interiorTestStrat);
+        }
 
-        std::vector<LeafNodeType*> nodes;
-        nodes.reserve(distTree.leafCount());
-        distTree.getNodes(nodes);
+        /// Do not fix intersecting voxels if we have evaluated interior test for every voxel.
+        bool signInitializedForEveryVoxel =
+                /// interior test was provided i.e. not null
+                !std::is_same_v<InteriorTest, std::nullptr_t> &&
+                /// interior test was evaluated for every voxel
+                interiorTestStrat == EVAL_EVERY_VOXEL;
 
-        const tbb::blocked_range<size_t> nodeRange(0, nodes.size());
+        if (!signInitializedForEveryVoxel) {
 
-        using SignOp =
-            mesh_to_volume_internal::ComputeIntersectingVoxelSign<TreeType, MeshDataAdapter>;
+            std::vector<LeafNodeType*> nodes;
+            nodes.reserve(distTree.leafCount());
+            distTree.getNodes(nodes);
 
-        tbb::parallel_for(nodeRange, SignOp(nodes, distTree, indexTree, mesh));
+            const tbb::blocked_range<size_t> nodeRange(0, nodes.size());
 
-        if (interrupter.wasInterrupted(45)) return distGrid;
+            using SignOp =
+                mesh_to_volume_internal::ComputeIntersectingVoxelSign<TreeType, MeshDataAdapter>;
 
-        // Remove voxels created by self intersecting portions of the mesh.
-        if (removeIntersectingVoxels) {
+            tbb::parallel_for(nodeRange, SignOp(nodes, distTree, indexTree, mesh));
 
-            tbb::parallel_for(nodeRange,
-                mesh_to_volume_internal::ValidateIntersectingVoxels<TreeType>(distTree, nodes));
+            if (interrupter.wasInterrupted(45)) return distGrid;
 
-            tbb::parallel_for(nodeRange,
-                mesh_to_volume_internal::RemoveSelfIntersectingSurface<TreeType>(
-                    nodes, distTree, indexTree));
+            // Remove voxels created by self intersecting portions of the mesh.
+            if (removeIntersectingVoxels) {
 
-            tools::pruneInactive(distTree,  /*threading=*/true);
-            tools::pruneInactive(indexTree, /*threading=*/true);
+                tbb::parallel_for(nodeRange,
+                    mesh_to_volume_internal::ValidateIntersectingVoxels<TreeType>(distTree, nodes));
+
+                tbb::parallel_for(nodeRange,
+                    mesh_to_volume_internal::RemoveSelfIntersectingSurface<TreeType>(
+                        nodes, distTree, indexTree));
+
+                tools::pruneInactive(distTree,  /*threading=*/true);
+                tools::pruneInactive(indexTree, /*threading=*/true);
+            }
         }
     }
 
@@ -3421,7 +3619,7 @@ meshToVolume(
 }
 
 
-template <typename GridType, typename MeshDataAdapter>
+template <typename GridType, typename MeshDataAdapter, typename InteriorTest>
 typename GridType::Ptr
 meshToVolume(
   const MeshDataAdapter& mesh,
@@ -3429,7 +3627,9 @@ meshToVolume(
   float exteriorBandWidth,
   float interiorBandWidth,
   int flags,
-  typename GridType::template ValueConverter<Int32>::Type * polygonIndexGrid)
+  typename GridType::template ValueConverter<Int32>::Type * polygonIndexGrid,
+  InteriorTest interiorTest,
+  InteriorTestStrategy interiorTestStrat)
 {
     util::NullInterrupter nullInterrupter;
     return meshToVolume<GridType>(nullInterrupter, mesh, transform,

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -4448,14 +4448,14 @@ createLevelSetBox(const math::BBox<VecType>& bbox,
 #define _FUNCTION(TreeT) \
     Grid<TreeT>::Ptr meshToVolume<Grid<TreeT>>(util::NullInterrupter&, \
         const QuadAndTriangleDataAdapter<Vec3s, Vec3I>&, const openvdb::math::Transform&, \
-        float, float, int, Grid<TreeT>::ValueConverter<Int32>::Type*)
+        float, float, int, Grid<TreeT>::ValueConverter<Int32>::Type*, std::nullptr_t, InteriorTestStrategy)
 OPENVDB_REAL_TREE_INSTANTIATE(_FUNCTION)
 #undef _FUNCTION
 
 #define _FUNCTION(TreeT) \
     Grid<TreeT>::Ptr meshToVolume<Grid<TreeT>>(util::NullInterrupter&, \
         const QuadAndTriangleDataAdapter<Vec3s, Vec4I>&, const openvdb::math::Transform&, \
-        float, float, int, Grid<TreeT>::ValueConverter<Int32>::Type*)
+        float, float, int, Grid<TreeT>::ValueConverter<Int32>::Type*, std::nullptr_t, InteriorTestStrategy)
 OPENVDB_REAL_TREE_INSTANTIATE(_FUNCTION)
 #undef _FUNCTION
 

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -3198,7 +3198,7 @@ floodFillLeafNode(tree::LeafNode<T,Log2Dim>& leafNode, const InteriorTest& inter
                         int dimIdx = (off >> dim * Log2Dim) % DIM;
                         auto neighOff = off + (1 << dim * Log2Dim) * i;
                         if ((0 < dimIdx) &&
-                            (dimIdx < DIM - 1) &&
+                            (dimIdx < (int)DIM - 1) &&
                             (voxelState[neighOff] == NOT_VISITED)) {
 
                             if (abs(leafNode.getValue(neighOff)) <= 0.75) {
@@ -3628,8 +3628,8 @@ meshToVolume(
   float interiorBandWidth,
   int flags,
   typename GridType::template ValueConverter<Int32>::Type * polygonIndexGrid,
-  InteriorTest interiorTest,
-  InteriorTestStrategy interiorTestStrat)
+  InteriorTest /*interiorTest*/,
+  InteriorTestStrategy /*interiorTestStrat*/)
 {
     util::NullInterrupter nullInterrupter;
     return meshToVolume<GridType>(nullInterrupter, mesh, transform,

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -3427,6 +3427,7 @@ meshToVolume(
         /// If interior test is not provided
         if constexpr (std::is_same_v<InteriorTest, std::nullptr_t>) {
             // Determines the inside/outside state for the narrow band of voxels.
+            interiorTest;       // Trigger usage.
             traceExteriorBoundaries(distTree);
         } else {
             evaluateInteriorTest(distTree, interiorTest, interiorTestStrat);

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -3145,6 +3145,18 @@ template <typename T, Index Log2Dim, typename InteriorTest>
 void
 floodFillLeafNode(tree::LeafNode<T,Log2Dim>& leafNode, const InteriorTest& interiorTest) {
 
+    // Floods fills a single leaf node.
+    // Starts with all voxels in NOT_VISITED.
+    // Final result is voxels in either POSITIVE, NEGATIVE, or NOT_ASSIGNED.
+    // Voxels that were categorized as NEGATIVE are negated.
+    // The NOT_ASSIGNED is all voxels within 0.75 of the zero-crossing.
+    //
+    // NOT_VISITED voxels, if outside the 0.75 band, will query the oracle
+    // to get a POSITIVE Or NEGATIVE sign (with interior being POSITIVE!)
+    //
+    // After setting a NOT_VISITED to either POSITIVE or NEGATIVE, an 8-way
+    // depth-first floodfill is done, stopping at either the 0.75 boundary
+    // or visited voxels.
     enum VoxelState {
         NOT_VISITED = 0,
         POSITIVE = 1,

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -3427,7 +3427,7 @@ meshToVolume(
         /// If interior test is not provided
         if constexpr (std::is_same_v<InteriorTest, std::nullptr_t>) {
             // Determines the inside/outside state for the narrow band of voxels.
-            interiorTest;       // Trigger usage.
+            (void) interiorTest;       // Trigger usage.
             traceExteriorBoundaries(distTree);
         } else {
             evaluateInteriorTest(distTree, interiorTest, interiorTestStrat);

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -3177,7 +3177,7 @@ floodFillLeafNode(tree::LeafNode<T,Log2Dim>& leafNode, const InteriorTest& inter
 
         // We do not assign anything for voxel close to the mesh
         // This condition is aligned with the condition in traceVoxelLine
-        if (abs(value) <= 0.75) {
+        if (std::abs(value) <= 0.75) {
             voxelState[offset] = NOT_ASSIGNED;
         } else if (voxelState[offset] == NOT_VISITED) {
 
@@ -3213,7 +3213,7 @@ floodFillLeafNode(tree::LeafNode<T,Log2Dim>& leafNode, const InteriorTest& inter
                             (dimIdx < (int)DIM - 1) &&
                             (voxelState[neighOff] == NOT_VISITED)) {
 
-                            if (abs(leafNode.getValue(neighOff)) <= 0.75) {
+                            if (std::abs(leafNode.getValue(neighOff)) <= 0.75) {
                                 voxelState[neighOff] = NOT_ASSIGNED;
                             } else {
                                 offsetStack.push_back({neighOff, state});

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
@@ -19,6 +19,7 @@
 #include <openvdb/tools/LevelSetUtil.h>
 #include <openvdb/util/Util.h>
 
+#include <UT/UT_Version.h>
 #include <CH/CH_Manager.h>
 #include <PRM/PRM_Parm.h>
 #include <PRM/PRM_SharedFunc.h>

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_From_Polygons.cc
@@ -22,6 +22,9 @@
 #include <CH/CH_Manager.h>
 #include <PRM/PRM_Parm.h>
 #include <PRM/PRM_SharedFunc.h>
+#if UT_VERSION_INT >= 0x14000000        // 20.0 or later
+#include <GU/GU_WindingNumber.h>
+#endif
 
 #include <algorithm> // for std::max()
 #include <sstream>
@@ -396,6 +399,15 @@ newSopOperator(OP_OperatorTable* table)
             " it is closed or watertight.  It is similar to the Minimum"
             " function of the [Node:sop/isooffset] node."));
 
+#if UT_VERSION_INT >= 0x14000000        // 20.0 or later
+    parms.add(hutil::ParmFactory(PRM_TOGGLE, "preserveholes", "Preserve Holes")
+        .setTooltip(
+            "Preserve geometry holes.\n"
+            "When off, generated signed distance field fills any holes of the input mesh. "
+            "Turning this option on prevents this behavior. "
+            "It requires a closed, watertight surface. Otherwise, it can generate invalid signed distance function."));
+#endif
+
     //////////
     // Mesh attribute transfer {Point, Vertex & Primitive}
 
@@ -763,7 +775,9 @@ SOP_OpenVDB_From_Polygons::Cache::cookVDBSop(OP_Context& context)
         const bool unsignedDistanceFieldConversion = bool(evalInt("unsigneddist", 0, time));
         const bool outputFogVolumeGrid = bool(evalInt("buildfog", 0, time));
         const bool outputAttributeGrid = bool(evalInt("attrList", 0, time) > 0);
-
+#if UT_VERSION_INT >= 0x14000000        // 20.0 or later
+        const bool preserveHoles = bool(evalInt("preserveholes", 0, time));
+#endif
 
         if (!outputDistanceField && !outputFogVolumeGrid && !outputAttributeGrid) {
 
@@ -862,6 +876,24 @@ SOP_OpenVDB_From_Polygons::Cache::cookVDBSop(OP_Context& context)
                 hvdb::PrimCpyOp(inputGdp, primList));
         }
 
+#if UT_VERSION_INT >= 0x14000000        // 20.0 or later
+        //////////
+        // Interior test
+
+        GU_WindingNumber3DApprox windingNumber;
+        auto interiorTest = [transform, &windingNumber](const openvdb::Coord &coord) -> bool
+        {
+            auto pt = UTvdbConvert(transform->indexToWorld(coord));
+            auto wn = windingNumber.eval(pt, 2.0);
+            return fabs(wn) >= 0.5 ? true : false;
+        };
+
+        if (preserveHoles) {
+            windingNumber.init(*inputGdp, nullptr, 2);
+        }
+#endif
+
+
         //////////
         // Mesh to volume conversion
 
@@ -879,8 +911,20 @@ SOP_OpenVDB_From_Polygons::Cache::cookVDBSop(OP_Context& context)
             primitiveIndexGrid.reset(new openvdb::Int32Grid(0));
         }
 
-        openvdb::FloatGrid::Ptr grid = openvdb::tools::meshToVolume<openvdb::FloatGrid>(
-            boss.interrupter(), mesh, *transform, exBand, inBand, conversionFlags, primitiveIndexGrid.get());
+        openvdb::FloatGrid::Ptr grid;
+
+#if UT_VERSION_INT >= 0x14000000        // 20.0 or later
+        if (!preserveHoles) {
+            grid = openvdb::tools::meshToVolume<openvdb::FloatGrid>(
+                    boss.interrupter(), mesh, *transform, exBand, inBand, conversionFlags, primitiveIndexGrid.get());
+        } else {
+            grid = openvdb::tools::meshToVolume<openvdb::FloatGrid>(
+                    boss.interrupter(), mesh, *transform, exBand, inBand, conversionFlags, primitiveIndexGrid.get(), interiorTest, openvdb::tools::EVAL_EVERY_TILE);
+        }
+#else
+        grid = openvdb::tools::meshToVolume<openvdb::FloatGrid>(
+                boss.interrupter(), mesh, *transform, exBand, inBand, conversionFlags, primitiveIndexGrid.get());
+#endif
 
         //////////
         // Output

--- a/pendingchanges/hollowmesh.txt
+++ b/pendingchanges/hollowmesh.txt
@@ -3,7 +3,7 @@ OpenVDB:
       new optional arguments to provide an interior test oracle and an
       interior testing methods.  These allow the default
       outside-flood-fill to be replaced if the actual sidedness can be
-      known.
+      known.  Thanks to Tomas Skrivan for this change.
 
       LevelSetRebuild includes disabled code that uses this for
       resampling levelsets - the original grid is used as the true

--- a/pendingchanges/hollowmesh.txt
+++ b/pendingchanges/hollowmesh.txt
@@ -1,0 +1,17 @@
+OpenVDB:
+      openvdb/tools/MeshToVolume's meshToVolume takes two
+      new optional arguments to provide an interior test oracle and an
+      interior testing methods.  These allow the default
+      outside-flood-fill to be replaced if the actual sidedness can be
+      known.
+
+      LevelSetRebuild includes disabled code that uses this for
+      resampling levelsets - the original grid is used as the true
+      sign value.  However, due to differences between
+      polygonalization and trilinear interpolation, it cannot be used
+      directly.  The code is provided so we can learn from this
+      mistake.
+   
+Houdini:
+    - Added Preserve Holes option to VDB From Polygons that uses the
+      fast winding oracle to not collapse holes in polygonal geometry.


### PR DESCRIPTION
From Tomas Skrivan comes this PR for providing hollow vdb support.

The volume-to-mesh gains an optional oracle to determine sign.   Rebuild level set uses this to ensure the rebuilt levelset always matches sign with the input.

From Polygons SOP gains an option to use the winding number to determine sign, enabled in H20 where the winding number is exposed.