### PR TITLE
Fixed a build issue with AX on 32 bit platforms

### DIFF
--- a/openvdb_ax/openvdb_ax/codegen/Types.h
+++ b/openvdb_ax/openvdb_ax/codegen/Types.h
@@ -198,8 +198,8 @@ struct LLVMType<void>
     }
 };
 
-/// @note void* implemented as signed int_t* to match clang IR generation
-template <> struct LLVMType<void*> : public LLVMType<int_t<sizeof(void*)>::type*> {};
+/// @note void* implemented as signed int8_t* to match clang IR generation
+template <> struct LLVMType<void*> : public LLVMType<int8_t*> {};
 template <> struct LLVMType<openvdb::math::half>
 {
     // @note LLVM has a special representation of half types. Don't alias to

--- a/pendingchanges/ax32fix.txt
+++ b/pendingchanges/ax32fix.txt
@@ -1,0 +1,3 @@
+Build:
+ - Fixed a build issue with AX on 32bit platforms.
+ [Reported by Mathieu Malaterre]


### PR DESCRIPTION
IR void* is always i8* regardless

Signed-off-by: Nick Avramoussis <4256455+Idclip@users.noreply.github.com>