### PR TITLE
Remove the explicit default assignment operator.

### DIFF
--- a/nanovdb/nanovdb/util/GridStats.h
+++ b/nanovdb/nanovdb/util/GridStats.h
@@ -131,7 +131,6 @@ protected:
             , vector(v)
         {
         }
-        Pair& operator=(const Pair&) = default;
         bool  operator<(const Pair& rhs) const { return scalar < rhs.scalar; }
     } mMin, mMax;
     Extrema& add(const Pair& p)
@@ -162,7 +161,6 @@ public:
         , mMax(b)
     {
     }
-    Extrema& operator=(const Extrema&) = default;
     Extrema& min(const VecT& v)
     {
         Pair tmp(v);

--- a/nanovdb/nanovdb/util/GridStats.h
+++ b/nanovdb/nanovdb/util/GridStats.h
@@ -74,7 +74,6 @@ public:
         , mMax(b)
     {
     }
-    Extrema& operator=(const Extrema&) = default;
     Extrema& min(const ValueT& v)
     {
         if (v < mMin) {


### PR DESCRIPTION
Remove the explicit default assignment operator - if this is specified, so should the copy constructor and move operators, as per rule of five.