### PR TITLE
Fix NanoVDB build errors with HIP on Linux

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -1877,7 +1877,7 @@ __hostdev__ static inline uint32_t FindLowestOn(uint64_t v)
 {
     NANOVDB_ASSERT(v);
 #if (defined(__CUDA_ARCH__) || defined(__HIP__)) && defined(NANOVDB_USE_INTRINSICS)
-    return __ffsll(v);
+    return __ffsll(static_cast<unsigned long long int>(v));
 #elif defined(_MSC_VER) && defined(NANOVDB_USE_INTRINSICS)
     unsigned long index;
     _BitScanForward64(&index, v);
@@ -2592,7 +2592,7 @@ public:
     ///
     /// @note This method is only defined for IndexGrid = NanoGrid<ValueIndex>
     template <typename T = BuildType>
-    __hostdev__ typename enable_if<is_same<T, ValueIndex>::value, uint64_t>::type valueCount() const {return DataType::mData1;}
+    __hostdev__ typename enable_if<is_same<T, ValueIndex>::value, const uint64_t&>::type valueCount() const {return DataType::mData1;}
 
     /// @brief Return a const reference to the tree
     __hostdev__ const TreeT& tree() const { return *reinterpret_cast<const TreeT*>(this->treePtr()); }


### PR DESCRIPTION
For reference:
```
openvdb/include/nanovdb/NanoVDB.h:1880:12: error: call to '__ffsll' is ambiguous
    return __ffsll(v);
           ^~~~~~~
/opt/rocm-5.3.2/include/hip/amd_detail/amd_device_functions.h:69:39: note: candidate function
__device__ static inline unsigned int __ffsll(unsigned long long int input) {
                                      ^
/opt/rocm-5.3.2/include/hip/amd_detail/amd_device_functions.h:77:39: note: candidate function
__device__ static inline unsigned int __ffsll(long long int input) {
                                      ^
openvdb/include/nanovdb/NanoVDB.h:5567:61: warning: returning reference to local temporary object [-Wreturn-stack-address]
    __hostdev__ const uint64_t& valueCount() const { return mGrid.valueCount(); }
                                                            ^~~~~~~~~~~~~~~~~~
```