### PR TITLE
Fix Segfault in Projection Mode of VDB Advect Points SOP

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Advect_Points.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Advect_Points.cc
@@ -1019,7 +1019,7 @@ SOP_OpenVDB_Advect_Points::Cache::cookVDBSop(OP_Context& context)
             case PROPAGATION_TYPE_PROJECTION:
             {
                 Projection projection(parms, boss.interrupter());
-                hvdb::GEOvdbApply<hvdb::Vec3GridTypes>(*parms.mVelPrim, projection);
+                hvdb::GEOvdbApply<hvdb::Vec3GridTypes>(*parms.mCptPrim, projection);
                 break;
             }
             case PROPAGATION_TYPE_UNKNOWN: break;

--- a/pendingchanges/projectioncrash.txt
+++ b/pendingchanges/projectioncrash.txt
@@ -1,0 +1,2 @@
+Houdini:
+    - Fix a bug in the projection mode of the Advect Points SOP that was causing a segfault.


### PR DESCRIPTION
When I made the changes to switch from `GEOvdbProcessTypedGrid` to `GEOvdbApply`, I accidentally introduced this bug in the projection mode of the VDB Advect Points SOP:

https://github.com/AcademySoftwareFoundation/openvdb/pull/591/files#diff-3da92c28c566b6736ba31e46a2c8a84a00c8beada13f7c3cda90de1782014874R1022

This change fixes the bug so that this mode no longer crashes.

@jmlait 