### PR TITLE
Fix all the int-in-bool-context warnings with GCC9

### DIFF
--- a/openvdb/openvdb/tools/Composite.h
+++ b/openvdb/openvdb/tools/Composite.h
@@ -796,9 +796,14 @@ compMul(GridOrTreeT& aTree, GridOrTreeT& bTree)
 {
     using Adapter = TreeAdapter<GridOrTreeT>;
     using TreeT = typename Adapter::TreeType;
+    using ValueT = typename GridOrTreeT::ValueType;
     struct Local {
         static inline void op(CombineArgs<typename TreeT::ValueType>& args) {
-            args.setResult(args.a() * args.b());
+            if constexpr(std::is_same<ValueT, bool>::value) {
+                args.setResult(args.a() && args.b());
+            } else {
+                args.setResult(args.a() * args.b());
+            }
         }
     };
     Adapter::tree(aTree).combineExtended(Adapter::tree(bTree), Local::op, /*prune=*/false);

--- a/openvdb/openvdb/tools/Filter.h
+++ b/openvdb/openvdb/tools/Filter.h
@@ -507,10 +507,14 @@ Filter<GridT, MaskT, InterruptT>::Avg<Axis>::operator()(Coord xyz)
     ValueType sum = zeroVal<ValueType>();
     Int32 &i = xyz[Axis], j = i + width;
     for (i -= width; i <= j; ++i) filter_internal::accum(sum, acc.getValue(xyz));
-    OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
-    ValueType value = static_cast<ValueType>(sum * frac);
-    OPENVDB_NO_TYPE_CONVERSION_WARNING_END
-    return value;
+    if constexpr(std::is_same<ValueType, bool>::value) {
+        return sum && frac > 0.0f;
+    } else {
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+        ValueType value = static_cast<ValueType>(sum * frac);
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+        return value;
+    }
 }
 
 

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Diagnostics.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Diagnostics.cc
@@ -1186,7 +1186,7 @@ struct TestCollection
 
             if (mTest.testMinimumBandWidth) {
 
-                if (std::is_floating_point<ValueType>::value) {
+                if constexpr (std::is_floating_point<ValueType>::value) {
                     const ValueType width = ValueType(mTest.minBandWidth) * ValueType(voxelSize);
 
                     AbsLessThan<ValueType> test(width);

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_LOD.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_LOD.cc
@@ -322,7 +322,7 @@ SOP_OpenVDB_LOD::Cache::cookVDBSop(OP_Context& context)
                     continue;
                 }
 
-                hvdb::GEOvdbApply<hvdb::VolumeGridTypes>(**it, op);
+                hvdb::GEOvdbApply<hvdb::NumericGridTypes>(**it, op);
 
                 if (boss.wasInterrupted()) return error();
 
@@ -358,7 +358,7 @@ SOP_OpenVDB_LOD::Cache::cookVDBSop(OP_Context& context)
                     continue;
                 }
 
-                hvdb::GEOvdbApply<hvdb::VolumeGridTypes>(**it, op);
+                hvdb::GEOvdbApply<hvdb::NumericGridTypes>(**it, op);
 
                 if (boss.wasInterrupted()) return error();
 
@@ -383,7 +383,7 @@ SOP_OpenVDB_LOD::Cache::cookVDBSop(OP_Context& context)
                     continue;
                 }
 
-                hvdb::GEOvdbApply<hvdb::VolumeGridTypes>(**it, op);
+                hvdb::GEOvdbApply<hvdb::NumericGridTypes>(**it, op);
 
                 if (boss.wasInterrupted()) return error();
 

--- a/pendingchanges/fix_int_in_bool_warnings.txt
+++ b/pendingchanges/fix_int_in_bool_warnings.txt
@@ -1,0 +1,2 @@
+Improvements:
+- Fix int-in-bool-context GCC9+ warnings by switching to use constexpr if.


### PR DESCRIPTION
The int-in-bool-context warnings are everywhere with GCC9, this PR uses lots of constexpr to try and fix them all.

One thing to note is that this also disables Bool Grids from being used in the VDB LOD SOP - I'm unsure if that's the correct thing to do, but seems to me that the prolong/restrict operations don't mean much in a bool context?