### PR TITLE
Addresses warning in vdb point: integer conversion resulted in truncation

### DIFF
--- a/openvdb/openvdb/points/AttributeSet.h
+++ b/openvdb/openvdb/points/AttributeSet.h
@@ -38,7 +38,7 @@ using GroupType = uint8_t;
 class OPENVDB_API AttributeSet
 {
 public:
-    enum { INVALID_POS = std::numeric_limits<size_t>::max() };
+    enum AttributePositionLabel : size_t { INVALID_POS = std::numeric_limits<size_t>::max() };
 
     using Ptr                   = std::shared_ptr<AttributeSet>;
     using ConstPtr              = std::shared_ptr<const AttributeSet>;


### PR DESCRIPTION
I'm submitting this PR on behalf of a collegaue, C. Horvath. He reported a warning/error for VS2022:
`
C:\Users\chorvath\.conan\data\openvdb\10.0.0\blackencino\latest\package\f3f00aaf06c8145a4df169b78bec8a0b1e526438\include\openvdb\points\AttributeSet.h(41): warning #69-D: integer conversion resulted in truncation
`
Because in the absence of an integer base type the `enum` `INVALID_POS` defaults to an int, the truncation becomes a negative number. He proposed this solution. Another solution will be to make `INVALID_POS` to be a `static constexpr size_t`. 