### PR TITLE
Fixed a crash on Android in the StreamState static instance constructor

### DIFF
--- a/openvdb/openvdb/io/Archive.h
+++ b/openvdb/openvdb/io/Archive.h
@@ -192,6 +192,20 @@ private:
     bool mEnableGridStats;
 }; // class Archive
 
+
+namespace internal {
+
+/// @brief Global registration of stream state.
+/// @note This is called from @c openvdb::initialize, so there is
+/// no need to call it directly.
+void initialize();
+
+/// @brief Global deregistration of stream state.
+/// @note This is called from @c openvdb::uninitialize, so there is
+/// no need to call it directly.
+void uninitialize();
+
+} // namespace internal
 } // namespace io
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb

--- a/openvdb/openvdb/openvdb.cc
+++ b/openvdb/openvdb/openvdb.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include "openvdb.h"
+#include "io/Archive.h"
 #include "io/DelayedLoadMetadata.h"
 #include "points/PointDataGrid.h"
 #include "tools/PointIndexGrid.h"
@@ -66,6 +67,9 @@ initialize()
 
     logging::initialize();
 
+    // Register stream state.
+    io::internal::initialize();
+
     // Register metadata.
     Metadata::clearRegistry();
     MetaTypes::foreach<RegisterMeta>();
@@ -127,6 +131,7 @@ __pragma(warning(default:1711))
     GridBase::clearRegistry();
     math::MapRegistry::clear();
     points::internal::uninitialize();
+    io::internal::uninitialize();
 
 #ifdef OPENVDB_USE_BLOSC
     // We don't want to destroy Blosc, because it might have been


### PR DESCRIPTION
I built OpenVDB for Android as a shared library and it seemed to crash every time when it was loaded. Further investigation showed that it crashes in the static initialization of the `sStreamState` [instance](https://github.com/AcademySoftwareFoundation/openvdb/blob/5cb821242f833d78fbd9506c9d5e20e4c7280f32/openvdb/openvdb/io/Archive.cc#L79-L103). The class has a non-trivial constructor which makes calls to `xalloc()`, `iword()` and `pword()` as can be seen [here](https://github.com/AcademySoftwareFoundation/openvdb/blob/5cb821242f833d78fbd9506c9d5e20e4c7280f32/openvdb/openvdb/io/Archive.cc#L112-L118). These functions crash on Android when called from static initializers when the library is being loaded.

The fix is to delay initialization of `sStreamState` object and do it from the `openvdb::initialize()` function.