### PR TITLE
Fix prime number in voxel hashing

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -1134,8 +1134,10 @@ public:
 
     /// @brief Return a hash key derived from the existing coordinates.
     /// @details For details on this hash function please see the VDB paper.
+    /// The prime numbers are modified based on the ACM Transactions on Graphics paper:
+    /// "Real-time 3D reconstruction at scale using voxel hashing"
     template<int Log2N = 3 + 4 + 5>
-    __hostdev__ uint32_t hash() const { return ((1 << Log2N) - 1) & (mVec[0] * 73856093 ^ mVec[1] * 19349663 ^ mVec[2] * 83492791); }
+    __hostdev__ uint32_t hash() const { return ((1 << Log2N) - 1) & (mVec[0] * 73856093 ^ mVec[1] * 19349669 ^ mVec[2] * 83492791); }
 
     /// @brief Return the octant of this Coord
     //__hostdev__ size_t octant() const { return (uint32_t(mVec[0])>>31) | ((uint32_t(mVec[1])>>31)<<1) | ((uint32_t(mVec[2])>>31)<<2); }

--- a/openvdb/openvdb/math/Coord.h
+++ b/openvdb/openvdb/math/Coord.h
@@ -224,13 +224,15 @@ public:
 
     /// @brief Return a hash value for this coordinate
     /// @note Log2N is the binary logarithm of the hash table size.
-    /// @details The hash function is taken from the SIGGRAPH paper:
+    /// @details The hash function is originally taken from the SIGGRAPH paper:
     /// "VDB: High-resolution sparse volumes with dynamic topology"
+    /// and the prime numbers are modified based on the ACM Transactions on Graphics paper:
+    /// "Real-time 3D reconstruction at scale using voxel hashing"
     template<int Log2N = 20>
     size_t hash() const
     {
         const uint32_t* vec = reinterpret_cast<const uint32_t*>(mVec.data());
-        return ((1<<Log2N)-1) & (vec[0]*73856093 ^ vec[1]*19349663 ^ vec[2]*83492791);
+        return ((1<<Log2N)-1) & (vec[0]*73856093 ^ vec[1]*19349669 ^ vec[2]*83492791);
     }
 
 private:


### PR DESCRIPTION
Hi!

I found that one of the constants used for hashing is not a prime number as claimed in the paper (19349663=41*471943). Note that this is also the case in the referred publication of [Teschner et al. [2003]](https://matthias-research.github.io/pages/publications/tetraederCollision.pdf).

I replaced it with the next closest prime number which is 19349669, which has been done [here](https://niessnerlab.org/papers/2013/4hashing/niessner2013hashing.pdf) as well.

Best
Benedikt
