### PR TITLE
Use fabsf() for single-precision absolute value

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -859,7 +859,7 @@ __hostdev__ inline T Abs(T x)
 template<>
 __hostdev__ inline float Abs(float x)
 {
-    return fabs(x);
+    return fabsf(x);
 }
 
 template<>


### PR DESCRIPTION
Overloads of `fabs()` for both `double` and `float` are only available from C++'s <cmath> header, not the C <math.h> header.

Every other math function already correctly used the non-overloaded function name; this was the only outlier. While NanoVDB is written in C++, this change helps avoid requiring C++ headers to be included, which significantly affect compilation time, especially for projects performing just-in-time compilation at runtime.