### PR TITLE
Fix mDelta initialization for NanoVDB DDA

### DIFF
--- a/nanovdb/nanovdb/util/HDDA.h
+++ b/nanovdb/nanovdb/util/HDDA.h
@@ -239,11 +239,11 @@ public:
             } else if (inv[axis] > 0) {
                 mStep[axis] = Dim;
                 mNext[axis] = (mT0 + (mVoxel[axis] + Dim - pos[axis]) * inv[axis]);
-                mDelta[axis] = inv[axis];
+                mDelta[axis] = mStep[axis]* inv[axis];
             } else {
                 mStep[axis] = -Dim;
                 mNext[axis] = mT0 + (mVoxel[axis] - pos[axis]) * inv[axis];
-                mDelta[axis] = -inv[axis];
+                mDelta[axis] = mStep[axis] * inv[axis];
             }
         }
     }


### PR DESCRIPTION
Hi! It seems that the way `mDelta` is currently initialized for `nanovdb::DDA` doesn't take the step size `Dim` into account. This would cause a mismatch between `mStep` and `mDelta` and thus incorrect `step` updates, whenever `Dim` is strictly greater than 1.

I changed the computation of `mDelta` to align with that in `openvdb::math::DDA`.