### PR TITLE
Introduced Anisotropic Surfacing Kernels and PCA methods

### DIFF
--- a/openvdb/openvdb/math/Mat.h
+++ b/openvdb/openvdb/math/Mat.h
@@ -213,8 +213,8 @@ MatType
 rotation(Axis axis, typename MatType::value_type angle)
 {
     using T = typename MatType::value_type;
-    T c = static_cast<T>(cos(angle));
-    T s = static_cast<T>(sin(angle));
+    T c = static_cast<T>(std::cos(angle));
+    T s = static_cast<T>(std::sin(angle));
 
     MatType result;
     result.setIdentity();
@@ -256,9 +256,9 @@ rotation(const Vec3<typename MatType::value_type> &_axis, typename MatType::valu
     Vec3<T> axis(_axis.unit());
 
     // compute trig properties of angle:
-    T c(cos(double(angle)));
-    T s(sin(double(angle)));
-    T t(1 - c);
+    const T c = static_cast<T>(std::cos(double(angle)));
+    const T s = static_cast<T>(std::sin(double(angle)));
+    const T t = T(1) - c;
 
     MatType result;
     // handle diagonal elements

--- a/openvdb/openvdb/math/Mat3.h
+++ b/openvdb/openvdb/math/Mat3.h
@@ -680,7 +680,7 @@ pivot(int i, int j, Mat3<T>& S, Vec3<T>& D, Mat3<T>& Q)
 
     double Sjj_minus_Sii = D[j] - D[i];
 
-    if (fabs(Sjj_minus_Sii) * (10*math::Tolerance<T>::value()) > fabs(Sij)) {
+    if (std::abs(Sjj_minus_Sii) * (10*math::Tolerance<T>::value()) > std::abs(Sij)) {
         tan_of_theta = Sij / Sjj_minus_Sii;
     } else {
         /// pivot on Sij
@@ -688,40 +688,40 @@ pivot(int i, int j, Mat3<T>& S, Vec3<T>& D, Mat3<T>& Q)
 
         if (cotan_of_2_theta < 0.) {
             tan_of_theta =
-                -1./(sqrt(1. + cotan_of_2_theta*cotan_of_2_theta) - cotan_of_2_theta);
+                -1./(std::sqrt(1. + cotan_of_2_theta*cotan_of_2_theta) - cotan_of_2_theta);
         } else {
             tan_of_theta =
-                1./(sqrt(1. + cotan_of_2_theta*cotan_of_2_theta) + cotan_of_2_theta);
+                1./(std::sqrt(1. + cotan_of_2_theta*cotan_of_2_theta) + cotan_of_2_theta);
         }
     }
 
-    cosin_of_theta = 1./sqrt( 1. + tan_of_theta * tan_of_theta);
+    cosin_of_theta = 1./std::sqrt( 1. + tan_of_theta * tan_of_theta);
     sin_of_theta = cosin_of_theta * tan_of_theta;
     z = tan_of_theta * Sij;
     S(i,j) = 0;
-    D[i] -= z;
-    D[j] += z;
+    D[i] -= T(z);
+    D[j] += T(z);
     for (int k = 0; k < i; ++k) {
         temp = S(k,i);
-        S(k,i) = cosin_of_theta * temp - sin_of_theta * S(k,j);
-        S(k,j)= sin_of_theta * temp + cosin_of_theta * S(k,j);
+        S(k,i) = T(cosin_of_theta * temp - sin_of_theta * S(k,j));
+        S(k,j) = T(sin_of_theta * temp + cosin_of_theta * S(k,j));
     }
     for (int k = i+1; k < j; ++k) {
         temp = S(i,k);
-        S(i,k) = cosin_of_theta * temp - sin_of_theta * S(k,j);
-        S(k,j) = sin_of_theta * temp + cosin_of_theta * S(k,j);
+        S(i,k) = T(cosin_of_theta * temp - sin_of_theta * S(k,j));
+        S(k,j) = T(sin_of_theta * temp + cosin_of_theta * S(k,j));
     }
     for (int k = j+1; k < n; ++k) {
         temp = S(i,k);
-        S(i,k) = cosin_of_theta * temp - sin_of_theta * S(j,k);
-        S(j,k) = sin_of_theta * temp + cosin_of_theta * S(j,k);
+        S(i,k) = T(cosin_of_theta * temp - sin_of_theta * S(j,k));
+        S(j,k) = T(sin_of_theta * temp + cosin_of_theta * S(j,k));
     }
     for (int k = 0; k < n; ++k)
-        {
-            temp = Q(k,i);
-            Q(k,i) = cosin_of_theta * temp - sin_of_theta*Q(k,j);
-            Q(k,j) = sin_of_theta * temp + cosin_of_theta*Q(k,j);
-        }
+    {
+        temp = Q(k,i);
+        Q(k,i) = T(cosin_of_theta * temp - sin_of_theta * Q(k,j));
+        Q(k,j) = T(sin_of_theta * temp + cosin_of_theta * Q(k,j));
+    }
 }
 
 } // namespace mat3_internal
@@ -758,7 +758,7 @@ diagonalizeSymmetricMatrix(const Mat3<T>& input, Mat3<T>& Q, Vec3<T>& D,
         double er = 0;
         for (int i = 0; i < n; ++i) {
             for (int j = i+1; j < n; ++j) {
-                er += fabs(S(i,j));
+                er += std::abs(S(i,j));
             }
         }
         if (std::abs(er) < math::Tolerance<T>::value()) {
@@ -773,12 +773,12 @@ diagonalizeSymmetricMatrix(const Mat3<T>& input, Mat3<T>& Q, Vec3<T>& D,
         for (int i = 0; i < n; ++i) {
             for (int j = i+1; j < n; ++j){
 
-                if ( fabs(D[i]) * (10*math::Tolerance<T>::value()) > fabs(S(i,j))) {
+                if ( std::abs(D[i]) * (10*math::Tolerance<T>::value()) > std::abs(S(i,j))) {
                     /// value too small to pivot on
                     S(i,j) = 0;
                 }
-                if (fabs(S(i,j)) > max_element) {
-                    max_element = fabs(S(i,j));
+                if (std::abs(S(i,j)) > max_element) {
+                    max_element = std::abs(S(i,j));
                     ip = i;
                     jp = j;
                 }

--- a/openvdb/openvdb/points/AttributeArray.h
+++ b/openvdb/openvdb/points/AttributeArray.h
@@ -886,9 +886,6 @@ private:
     template <bool IsUnknownCodec>
     typename std::enable_if<!IsUnknownCodec, ValueType>::type get(Index index) const;
 
-    // local copy of AttributeArray (to preserve compression)
-    AttributeArray::Ptr mLocalArray;
-
     Index mStrideOrTotalSize;
     Index mSize;
     bool mCollapseOnDestruction;

--- a/openvdb/openvdb/points/PointRasterizeSDF.h
+++ b/openvdb/openvdb/points/PointRasterizeSDF.h
@@ -257,6 +257,10 @@ struct SmoothSphereSettings
     ///   larger than the point radius. Both this and the `radiusScale`
     ///   parameters are given in world space units and are applied to every
     ///   point to generate a surface mask.
+    /// @warning  If this value is less than the sum of the maximum particle
+    ///   radius and the half band width, the exterior half band width may be
+    ///   smaller than desired. In these cases, consider running a levelset
+    ///   renormalize or a levelset rebuild.
     Real searchRadius = 1.0;
 };
 

--- a/openvdb/openvdb/points/PointRasterizeSDF.h
+++ b/openvdb/openvdb/points/PointRasterizeSDF.h
@@ -5,37 +5,62 @@
 ///
 /// @file PointRasterizeSDF.h
 ///
-/// @brief Transfer schemes for rasterizing point positional and radius data to
-///  signed distance fields with optional closest point attribute transfers.
-///  All methods support arbitrary target linear transformations, fixed or
-///  varying point radius, filtering of point data and arbitrary types for
-///  attribute transferring.
+/// @brief Various transfer schemes for rasterizing point positions and radius
+///  data to signed distance fields with optional closest point attribute
+///  transfers. All methods support arbitrary target linear transformations,
+///  fixed or varying point radius, filtering of point data and arbitrary types
+///  for attribute transferring.
 ///
-/// @details There are two main transfer implementations; rasterizeSpheres and
-///  rasterizeSmoothSpheres. The prior performs trivial narrow band stamping
-///  of spheres for each point, where as the latter calculates an averaged
-///  position of influence per voxel as described in:
-///    [Animating Sand as a Fluid - Zhu Bridson 05].
+/// @details There are currently three main transfer implementations:
 ///
-///  rasterizeSpheres() is an extremely fast and efficient way to produce both a
-///  valid symmetrical narrow band level set and transfer attributes using
-///  closest point lookups.
+/// - Rasterize Spheres
 ///
-///  rasterizeSmoothSpheres() produces smoother, more blended connections
-///  between points which is ideal for generating a more artistically pleasant
-///  surface directly from point distributions. It aims to avoid typical post
-///  filtering operations used to smooth surface volumes. Note however that
-///  rasterizeSmoothSpheres may not necessarily produce a *symmetrical* narrow
-///  band level set; the exterior band may be smaller than desired depending on
-///  the search radius. The surface can be rebuilt or resized if necessary.
-///  The same closet point algorithm is used to transfer attributes.
+///     Performs trivial narrow band stamping of spheres for each point. This
+///     is an extremely fast and efficient way to produce both a valid
+///     symmetrical narrow band level set and transfer attributes using closest
+///     point lookups.
 ///
-///  In general, it is recommended to consider post rebuilding/renormalizing the
-///  generated surface using either tools::levelSetRebuild() or
+/// - Rasterize Smooth Spheres
+///
+///     Calculates an averaged position of influence per voxel as described in:
+///       [Animating Sand as a Fluid - Zhu Bridson 2005].
+///
+///     This technique produces smoother, more blended connections between
+///     points which is ideal for generating a more artistically pleasant
+///     surface directly from point distributions. It aims to avoid typical
+///     post filtering operations used to smooth surface volumes. Note however
+///     that this method may not necessarily produce a *symmetrical* narrow
+///     band level set; the exterior band may be smaller than desired depending
+///     on the search radius - the surface can be rebuilt or resized if
+///     necessary. The same closet point algorithm is used to transfer
+///     attributes.
+///
+/// - Rasterize Ellipsoids.
+///
+///     Rasterizes anisotropic ellipses for each point by analyzing point
+///     neighborhood distributions, as described in:
+///       [Reconstructing Surfaces of Particle-Based Fluids Using Anisotropic
+///        Kernel - Yu Turk 2010].
+///
+///     This method uses the rotation and affine matrix attributes built from
+///     the points::pca() method which model these elliptical distributions
+///     using principal component analysis. The ellipses create a much tighter,
+///     more fitted surface that better represents the convex hull of the point
+///     set. This technique also allows point to smoothly blend from their
+///     computed ellipse back to a canonical sphere, as well as allowing
+///     isolated points to be rasterized with their own radius scale. Although
+///     the rasterization step of this pipeline is relatively fast, it is still
+///     the slowest of all three methods and depends on the somewhat expensive
+///     points::pca() method. Still, this technique can be far superior at
+///     producing fluid surfaces where thin sheets (waterfalls) or sharp edges
+///     (wave breaks) are desirable.
+///
+///
+///  In general, it is recommended to consider post rebuilding/renormalizing
+///  the generated surface using either tools::levelSetRebuild() or
 ///  tools::LevelSetTracker::normalize() tools::LevelSetTracker::resize().
 ///
 /// @note These methods use the framework provided in PointTransfer.h
-///
 
 #ifndef OPENVDB_POINTS_RASTERIZE_SDF_HAS_BEEN_INCLUDED
 #define OPENVDB_POINTS_RASTERIZE_SDF_HAS_BEEN_INCLUDED
@@ -50,6 +75,7 @@
 #include <openvdb/tools/ValueTransformer.h>
 #include <openvdb/thread/Threading.h>
 #include <openvdb/util/NullInterrupter.h>
+#include <openvdb/points/PrincipalComponentAnalysis.h>
 
 #include <unordered_map>
 
@@ -61,305 +87,225 @@ OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
 namespace points {
 
-/// @brief Narrow band sphere stamping with a uniform radius.
-/// @details Rasterizes points into a level set using basic sphere stamping with
-///   a uniform radius. The radius parameter is given in world space units and
-///   is applied to every point to generate a fixed surface mask and consequent
-///   distance values.
-/// @param points       the point data grid to rasterize
-/// @param radius       the world space radius of every point
-/// @param halfband     the half band width
-/// @param transform    the target transform for the surface
-/// @param filter       a filter to apply to points
-/// @param interrupter  optional interrupter
-/// @return The signed distance field.
-template <typename PointDataGridT,
-    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
-    typename FilterT = NullFilter,
-    typename InterrupterT = util::NullInterrupter>
-typename SdfT::Ptr
-rasterizeSpheres(const PointDataGridT& points,
-             const Real radius,
-             const Real halfband = LEVEL_SET_HALF_WIDTH,
-             math::Transform::Ptr transform = nullptr,
-             const FilterT& filter = NullFilter(),
-             InterrupterT* interrupter = nullptr);
-
-/// @brief Narrow band sphere stamping with a varying radius.
-/// @details Rasterizes points into a level set using basic sphere stamping with
-///   a variable radius. The radius string parameter expects a point attribute
-///   of type RadiusT to exist.
-/// @param points       the point data grid to rasterize
-/// @param radius       the name of the radius attribute
-/// @param scale        an optional scale to apply to each per point radius
-/// @param halfband     the half band width
-/// @param transform    the target transform for the surface
-/// @param filter       a filter to apply to points
-/// @param interrupter  optional interrupter
-/// @return The signed distance field.
-template <typename PointDataGridT,
-    typename RadiusT = float,
-    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
-    typename FilterT = NullFilter,
-    typename InterrupterT = util::NullInterrupter>
-typename SdfT::Ptr
-rasterizeSpheres(const PointDataGridT& points,
-             const std::string& radius,
-             const Real scale = 1.0,
-             const Real halfband = LEVEL_SET_HALF_WIDTH,
-             math::Transform::Ptr transform = nullptr,
-             const FilterT& filter = NullFilter(),
-             InterrupterT* interrupter = nullptr);
-
-/// @brief Narrow band sphere stamping with a uniform radius and closest point
-///   attribute transfer.
-/// @details Rasterizes points into a level set using basic sphere stamping with
-///   a uniform radius. The radius parameter is given in world space units and
-///   is applied to every point to generate a fixed surface mask and consequent
-///   distance values. Every voxel's closest point is used to transfer each
-///   attribute in the attributes parameter to a new grid of matching topology.
-///   The destination types of these grids is equal to the ValueConverter result
-///   of the attribute type applied to the PointDataGridT.
-/// @note The AttributeTypes template parameter should be a TypeList of the
-///   required or possible attributes types. i.e. TypeList<int, float, double>.
-///   A runtime error will be thrown if no equivalent type for a given attribute
-////  is found in the AttributeTypes TypeList.
-/// @param points       the point data grid to rasterize
-/// @param radius       the world space radius of every point
-/// @param attributes   list of attributes to transfer
-/// @param halfband     the half band width
-/// @param transform    the target transform for the surface
-/// @param filter       a filter to apply to points
-/// @param interrupter  optional interrupter
+/// @brief  Perform point rasterzation to produce a signed distance field.
+/// @param point     the point data grid to rasterize
+/// @param settings  one of the available transfer setting schemes found below
+///   in this file.
 /// @return A vector of grids. The signed distance field is guaranteed to be
 ///   first and at the type specified by SdfT. Successive grids are the closest
 ///   point attribute grids. These grids are guaranteed to have a topology
 ///   and transform equal to the surface.
+///
+/// @code
+///    points::PointDataGrid g = ...;
+///
+///    // default settings for sphere stamping with a world space radius of 1
+///    SphereSettings<> spheres;
+///    FloatGrid::Ptr sdf = StaticPtrCast<FloatGrid>(points::rasterizeSdf(g, spheres)[0]);
+///
+///    // custom linear transform of target sdf, world space radius of 5
+///    spheres.transform = math::Transform::createLinearTransform(0.3);
+///    spheres.radiusScale = 5;
+///    FloatGrid::Ptr sdf = StaticPtrCast<FloatGrid>(points::rasterizeSdf(g, spheres)[0]);
+///
+///    // smooth sphere rasterization with variable double precision radius
+///    // attribute "pscale" scaled by 2
+///    SmoothSphereSettings<TypeList<>, double> smooth;
+///    smooth.radius = "pscale";
+///    smooth.radiusScale = 2;
+///    smooth.searchRadius = 3;
+///    FloatGrid::Ptr sdf = StaticPtrCast<FloatGrid>(points::rasterizeSdf(g, smooth)[0]);
+///
+///    // anisotropic/ellipsoid rasterization with attribute transferring.
+///    // requires pca attributes to be initialized using points::pca() first
+///    PcaSettings settings;
+///    PcaAttributes attribs;
+///    points::pca(g, settings, attribs);
+///
+///    EllipsoidSettings<TypeList<int32_t, Vec3f>> ellips;
+///    s.pca = attribs;
+///    s.attributes.emplace_back("id");
+///    s.attributes.emplace_back("v");
+///    GridPtrVec grids = points::rasterizeSdf(g, s);
+///    FloatGrid::Ptr sdf = StaticPtrCast<FloatGrid>(grids[0]);
+///    Int32Grid::Ptr id  = StaticPtrCast<Int32Grid>(grids[1]);
+///    Vec3fGrid::Ptr vel = StaticPtrCast<Vec3fGrid>(grids[2]);
+/// @endcode
 template <typename PointDataGridT,
-    typename AttributeTypes,
     typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
-    typename FilterT = NullFilter,
-    typename InterrupterT = util::NullInterrupter>
+    typename SettingsT>
 GridPtrVec
-rasterizeSpheres(const PointDataGridT& points,
-             const Real radius,
-             const std::vector<std::string>& attributes,
-             const Real halfband = LEVEL_SET_HALF_WIDTH,
-             math::Transform::Ptr transform = nullptr,
-             const FilterT& filter = NullFilter(),
-             InterrupterT* interrupter = nullptr);
+rasterizeSdf(const PointDataGridT& points, const SettingsT& settings);
 
-/// @brief Narrow band sphere stamping with a varying radius and closest point
-///   attribute transfer.
-/// @details Rasterizes points into a level set using basic sphere stamping with
-///   a variable radius. The radius string parameter expects a point attribute
-///   of type RadiusT to exist. Every voxel's closest point is used to transfer
-///   each attribute in the attributes parameter to a new grid of matching
-///   topology. The destination types of these grids is equal to the
-///   ValueConverter result of the attribute type applied to the PointDataGridT.
-/// @note The AttributeTypes template parameter should be a TypeList of the
-///   required or possible attributes types. i.e. TypeList<int, float, double>.
-///   A runtime error will be thrown if no equivalent type for a given attribute
-////  is found in the AttributeTypes TypeList.
-/// @param points       the point data grid to rasterize
-/// @param radius       the name of the radius attribute
-/// @param attributes   list of attributes to transfer
-/// @param scale        scale to apply to each per point radius
-/// @param halfband     the half band width
-/// @param transform    the target transform for the surface
-/// @param filter       a filter to apply to points
-/// @param interrupter  optional interrupter
-/// @return A vector of grids. The signed distance field is guaranteed to be
-///   first and at the type specified by SdfT. Successive grids are the closest
-///   point attribute grids. These grids are guaranteed to have a topology
-///   and transform equal to the surface.
-template <typename PointDataGridT,
-    typename AttributeTypes,
-    typename RadiusT = float,
-    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+//
+
+/// @brief  Generic settings for narrow band spherical stamping with a uniform
+///   or varying radius and optionally with closest point attribute transfer of
+///   arbitrary attributes. See the struct member documentation for detailed
+///   behavior.
+/// @note  There exists other more complex kernels that derive from this struct,
+///   but on its own it represents the settings needed to perform basic narrow
+///   band sphere stamping. Parameters are interpreted in the same way across
+///   derived classes.
+template <typename AttributeTs = TypeList<>,
+    typename RadiusAttributeT = float,
     typename FilterT = NullFilter,
     typename InterrupterT = util::NullInterrupter>
-GridPtrVec
-rasterizeSpheres(const PointDataGridT& points,
-             const std::string& radius,
-             const std::vector<std::string>& attributes,
-             const Real scale = 1.0,
-             const Real halfband = LEVEL_SET_HALF_WIDTH,
-             math::Transform::Ptr transform = nullptr,
-             const FilterT& filter = NullFilter(),
-             InterrupterT* interrupter = nullptr);
+struct SphereSettings
+{
+    using AttributeTypes = AttributeTs;
+    using RadiusAttributeType = RadiusAttributeT;
+    using FilterType = FilterT;
+    using InterrupterType = InterrupterT;
 
-/// @brief Smoothed point distribution based sphere stamping with a uniform radius.
-/// @details Rasterizes points into a level set using [Zhu Bridson 05] sphere
-///   stamping with a uniform radius. The radius and search radius parameters
-///   are given in world space units and are applied to every point to generate
-///   a fixed surface mask and consequent distance values. The search radius is
-///   each points points maximum contribution to the target level set. The search
-///   radius should always have a value equal to or larger than the point radius.
-/// @warning The width of the exterior half band *may* be smaller than the
-///   specified half band if the search radius is less than the equivalent
-///   world space halfband distance.
-/// @param points       the point data grid to rasterize
-/// @param radius       the world space radius of every point
-/// @param searchRadius the maximum search distance of every point
-/// @param halfband     the half band width
-/// @param transform    the target transform for the surface
-/// @param filter       a filter to apply to points
-/// @param interrupter  optional interrupter
-/// @return The signed distance field.
-template <typename PointDataGridT,
-    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    /// @param radius  the attribute containing the world space radius
+    /// @details  if the radius parameter is an empty string then the
+    ///   `radiusScale` parameter is used as a uniform world space radius to
+    ///   generate a fixed surface mask. Otherwise, a point attribute
+    ///   representing the world space radius of each point of type
+    ///   `RadiusAttributeT` is expected to exist and radii are scaled by the
+    ///   `radiusScale` parameter.
+    std::string radius = "";
+
+    /// @param radiusScale  the scale applied to every world space radius value
+    /// @note  If no `radius` attribute is provided, this is used as the
+    ///   uniform world space radius for every point. Most surfacing operations
+    ///   will perform faster if they are able to assume a uniform radius (so
+    ///   use this value instead of setting the `radius` parameter if radii are
+    ///   uniform).
+    Real radiusScale = 1.0;
+
+    /// @param halfband  the half band width of the generated surface.
+    Real halfband = LEVEL_SET_HALF_WIDTH;
+
+    /// @param transform  the target transform for the surface. Most surfacing
+    ///   operations impose linear restrictions on the target transform.
+    math::Transform::Ptr transform = nullptr;
+
+    /// @param attributes   list of attributes to transfer
+    /// @details  if the attributes vector is empty, only the surface is built.
+    ///   Otherwise, every voxel's closest point is used to transfer each
+    ///   attribute in the attributes parameter to a new grid of matching
+    ///   topology. The built surface is always the first grid returned from
+    ///   the surfacing operation, followed by attribute grids in the order
+    ///   that they appear in this vector.
+    ///
+    ///   The `AttributeTs` template parameter should be a `TypeList` of the
+    ///   required or possible attributes types. Example:
+    /// @code
+    ///   // compile support for int, double and Vec3f attribute transferring
+    ///   using SupportedTypes = TypeList<int, double, Vec3f>;
+    ///   SphereSettings<SupportedTypes> s;
+    ///
+    ///   // Produce 4 additional grids from the "v", "Cd", "id" and "density"
+    ///   // attributes. Their attribute value types must be available in the
+    ///   // provided TypeList
+    ///   s.attributes = {"v", "Cd", "id", "density"};
+    /// @endcode
+    ///
+    ///   A runtime error will be thrown if no equivalent type for a given
+    ///   attribute is found in the `AttributeTs` TypeList.
+    ///
+    /// @note The destination types of these grids is equal to the
+    ///   `ValueConverter` result of the attribute type applied to the
+    ///   PointDataGridT.
+    std::vector<std::string> attributes;
+
+    /// @param filter  a filter to apply to points. Only points that evaluate
+    ///   to true using this filter are rasterized, regardless of any other
+    ///   filtering derived schemes may use.
+    const FilterT* filter = nullptr;
+
+    /// @param interrupter  optional interrupter
+    InterrupterT* interrupter = nullptr;
+};
+
+/// @brief Smoothed point distribution based sphere stamping with a uniform radius
+///   or varying radius and optionally with closest point attribute transfer of
+///   arbitrary attributes. See the struct member documentation for detailed
+///   behavior.
+/// @note  Protected inheritance prevents accidental struct slicing
+template <typename AttributeTs = TypeList<>,
+    typename RadiusAttributeT = float,
     typename FilterT = NullFilter,
     typename InterrupterT = util::NullInterrupter>
-typename SdfT::Ptr
-rasterizeSmoothSpheres(const PointDataGridT& points,
-             const Real radius,
-             const Real searchRadius,
-             const Real halfband = LEVEL_SET_HALF_WIDTH,
-             math::Transform::Ptr transform = nullptr,
-             const FilterT& filter = NullFilter(),
-             InterrupterT* interrupter = nullptr);
+struct SmoothSphereSettings
+    : protected SphereSettings<AttributeTs, RadiusAttributeT, FilterT, InterrupterT>
+{
+    using BaseT = SphereSettings<AttributeTs, RadiusAttributeT, FilterT, InterrupterT>;
+    using AttributeTypes = typename BaseT::AttributeTypes;
+    using RadiusAttributeType = typename BaseT::RadiusAttributeType;
+    using FilterType = typename BaseT::FilterType;
+    using InterrupterType = typename BaseT::InterrupterType;
 
-/// @brief Smoothed point distribution based sphere stamping with a varying radius.
-/// @details Rasterizes points into a level set using [Zhu Bridson 05] sphere
-///   stamping with a variable radius. The radius string parameter expects a
-///   point attribute of type RadiusT to exist. The radiusScale parameter is
-///   multiplier for radius values held on the radius attribute. The searchRadius
-///   parameter remains a fixed size value which represents each points points
-///   maximum contribution to the target level set. The radius scale and search
-///   radius parameters are given in world space units and are applied to every
-///   point to generate a fixed surface mask and consequent distance values. The
-///   search radius should always have a value equal to or larger than the point
-///   radii.
-/// @warning The width of the exterior half band *may* be smaller than the
-///   specified half band if the search radius is less than the equivalent
-///   world space halfband distance.
-/// @param points       the point data grid to rasterize
-/// @param radius       the attribute containing the world space radius
-/// @param radiusScale  the scale applied to every world space radius value
-/// @param searchRadius the maximum search distance of every point
-/// @param halfband     the half band width
-/// @param transform    the target transform for the surface
-/// @param filter       a filter to apply to points
-/// @param interrupter  optional interrupter
-/// @return The signed distance field.
-template <typename PointDataGridT,
-    typename RadiusT = float,
-    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
+    using BaseT::radius;
+    /// @note  See also the searchRadius parameter for SmoothSpehere
+    ///   rasterization.
+    using BaseT::radiusScale;
+    /// @warning The width of the exterior half band *may* be smaller than the
+    ///   specified half band if the search radius is less than the equivalent
+    ///   world space halfband distance.
+    using BaseT::halfband;
+    using BaseT::transform;
+    using BaseT::attributes;
+    using BaseT::filter;
+    using BaseT::interrupter;
+
+    /// @param searchRadius  the maximum search distance of every point
+    /// @details  The search radius is each points points maximum contribution
+    ///   to the target level set. It should always have a value equal to or
+    ///   larger than the point radius. Both this and the `radiusScale`
+    ///   parameters are given in world space units and are applied to every
+    ///   point to generate a surface mask.
+    Real searchRadius = 1.0;
+};
+
+/// @brief  Anisotropic point rasterization based on the principal component
+///   analysis of point neighbours. See the struct member documentation for
+///   detailed behavior.
+/// @note  Protected inheritance prevents accidental struct slicing
+template <typename AttributeTs = TypeList<>,
+    typename RadiusAttributeT = float,
     typename FilterT = NullFilter,
     typename InterrupterT = util::NullInterrupter>
-typename SdfT::Ptr
-rasterizeSmoothSpheres(const PointDataGridT& points,
-                 const std::string& radius,
-                 const Real radiusScale,
-                 const Real searchRadius,
-                 const Real halfband = LEVEL_SET_HALF_WIDTH,
-                 math::Transform::Ptr transform = nullptr,
-                 const FilterT& filter = NullFilter(),
-                 InterrupterT* interrupter = nullptr);
+struct EllipsoidSettings
+    : protected SphereSettings<AttributeTs, RadiusAttributeT, FilterT, InterrupterT>
+{
+    using BaseT = SphereSettings<AttributeTs, RadiusAttributeT, FilterT, InterrupterT>;
+    using AttributeTypes = typename BaseT::AttributeTypes;
+    using RadiusAttributeType = typename BaseT::RadiusAttributeType;
+    using FilterType = typename BaseT::FilterType;
+    using InterrupterType = typename BaseT::InterrupterType;
 
-/// @brief Smoothed point distribution based sphere stamping with a uniform
-///   radius and closest point attribute transfer.
-/// @details Rasterizes points into a level set using [Zhu Bridson 05] sphere
-///   stamping with a uniform radius. The radius and search radius parameters
-///   are given in world space units and are applied to every point to generate
-///   a fixed surface mask and consequent distance values. The search radius is
-///   each points points maximum contribution to the target level set. The
-///   search radius should always be larger than the point radius. Every voxel's
-///   closest point is used to transfer each attribute in the attributes
-///   parameter to a new grid of matching topology. The destination types of
-///   these grids is equal to the ValueConverter result of the attribute type
-///   applied to the PointDataGridT.
-/// @note The AttributeTypes template parameter should be a TypeList of the
-///   required or possible attributes types. i.e. TypeList<int, float, double>.
-///   A runtime error will be thrown if no equivalent type for a given attribute
-///  is found in the AttributeTypes TypeList.
-/// @warning The width of the exterior half band *may* be smaller than the
-///   specified half band if the search radius is less than the equivalent
-///   world space halfband distance.
-/// @param points       the point data grid to rasterize
-/// @param radius       the world space radius of every point
-/// @param searchRadius the maximum search distance of every point
-/// @param attributes   list of attributes to transfer
-/// @param halfband     the half band width
-/// @param transform    the target transform for the surface
-/// @param filter       a filter to apply to points
-/// @param interrupter  optional interrupter
-/// @return A vector of grids. The signed distance field is guaranteed to be
-///   first and at the type specified by SdfT. Successive grids are the closest
-///   point attribute grids. These grids are guaranteed to have a topology
-///   and transform equal to the surface.
-template <typename PointDataGridT,
-    typename AttributeTypes,
-    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
-    typename FilterT = NullFilter,
-    typename InterrupterT = util::NullInterrupter>
-GridPtrVec
-rasterizeSmoothSpheres(const PointDataGridT& points,
-                 const Real radius,
-                 const Real searchRadius,
-                 const std::vector<std::string>& attributes,
-                 const Real halfband = LEVEL_SET_HALF_WIDTH,
-                 math::Transform::Ptr transform = nullptr,
-                 const FilterT& filter = NullFilter(),
-                 InterrupterT* interrupter = nullptr);
+    using BaseT::radius;
+    using BaseT::radiusScale;
+    using BaseT::halfband;
+    using BaseT::transform;
+    using BaseT::attributes;
+    using BaseT::filter;
+    using BaseT::interrupter;
 
-/// @brief Smoothed point distribution based sphere stamping with a varying
-///   radius and closest point attribute transfer.
-/// @details Rasterizes points into a level set using [Zhu Bridson 05] sphere
-///   stamping with a variable radius. The radius string parameter expects a
-///   point attribute of type RadiusT to exist. The radiusScale parameter is
-///   multiplier for radius values held on the radius attribute. The searchRadius
-///   parameter remains a fixed size value which represents each points points
-///   maximum contribution to the target level set. The radius scale and search
-///   radius parameters are given in world space units and are applied to every
-///   point to generate a fixed surface mask and consequent distance values. The
-///   search radius should always have a value equal to or larger than the point
-///   radii. Every voxel's closest point is used to transfer each attribute in
-///   the attributes parameter to a new grid of matching topology. The
-///   destination types of these grids is equal to the ValueConverter result of
-///   the attribute type applied to the PointDataGridT.
-/// @note The AttributeTypes template parameter should be a TypeList of the
-///   required or possible attributes types. i.e. TypeList<int, float, double>.
-///   A runtime error will be thrown if no equivalent type for a given attribute
-////  is found in the AttributeTypes TypeList.
-/// @warning The width of the exterior half band *may* be smaller than the
-///   specified half band if the search radius is less than the equivalent
-///   world space halfband distance.
-/// @param points       the point data grid to rasterize
-/// @param radius       the attribute containing the world space radius
-/// @param radiusScale  the scale applied to every world space radius value
-/// @param searchRadius the maximum search distance of every point
-/// @param attributes   list of attributes to transfer
-/// @param halfband     the half band width
-/// @param transform    the target transform for the surface
-/// @param filter       a filter to apply to points
-/// @param interrupter  optional interrupter
-/// @return A vector of grids. The signed distance field is guaranteed to be
-///   first and at the type specified by SdfT. Successive grids are the closest
-///   point attribute grids. These grids are guaranteed to have a topology
-///   and transform equal to the surface.
-template <typename PointDataGridT,
-    typename AttributeTypes,
-    typename RadiusT = float,
-    typename SdfT = typename PointDataGridT::template ValueConverter<float>::Type,
-    typename FilterT = NullFilter,
-    typename InterrupterT = util::NullInterrupter>
-GridPtrVec
-rasterizeSmoothSpheres(const PointDataGridT& points,
-                 const std::string& radius,
-                 const Real radiusScale,
-                 const Real searchRadius,
-                 const std::vector<std::string>& attributes,
-                 const Real halfband = LEVEL_SET_HALF_WIDTH,
-                 math::Transform::Ptr transform = nullptr,
-                 const FilterT& filter = NullFilter(),
-                 InterrupterT* interrupter = nullptr);
+    /// @brief  The sphere scale. Points which are not in the inclusion group
+    ///   specified by the pca attributes have their world space radius scaled
+    ///   by this amount. Typically you'd want this value to be <= 1.0 to
+    ///   produce smaller spheres for isolated points.
+    Real sphereScale = 1.0;
+
+    /// @brief  The required principal component analysis attributes which are
+    ///   required to exist on the points being rasterized. These attributes
+    ///   define the rotational and affine transformations which can be used to
+    ///   construct ellipsoids for each point. Typically (for our intended
+    ///   surfacing) these transformations are built by analysing each points
+    ///   neighbourhood distributions and constructing tight ellipsoids that
+    ///   orient themselves to follow these point distributions.
+    PcaAttributes pca;
+};
 
 } // namespace points
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb
 
 #include "impl/PointRasterizeSDFImpl.h"
+#include "impl/PointRasterizeEllipsoidsSDFImpl.h"
 
 #endif //OPENVDB_POINTS_RASTERIZE_SDF_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/points/PointRasterizeSDF.h
+++ b/openvdb/openvdb/points/PointRasterizeSDF.h
@@ -289,12 +289,6 @@ struct EllipsoidSettings
     using BaseT::filter;
     using BaseT::interrupter;
 
-    /// @brief  The sphere scale. Points which are not in the inclusion group
-    ///   specified by the pca attributes have their world space radius scaled
-    ///   by this amount. Typically you'd want this value to be <= 1.0 to
-    ///   produce smaller spheres for isolated points.
-    Real sphereScale = 1.0;
-
     /// @brief  The required principal component analysis attributes which are
     ///   required to exist on the points being rasterized. These attributes
     ///   define the rotational and affine transformations which can be used to

--- a/openvdb/openvdb/points/PrincipalComponentAnalysis.h
+++ b/openvdb/openvdb/points/PrincipalComponentAnalysis.h
@@ -1,0 +1,148 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+/// @author Richard Jones, Nick Avramoussis
+///
+/// @file PrincipalComponentAnalysis.h
+///
+/// @brief  Provides methods to perform principal component analysis (PCA) over
+///   a point set to compute rotational and affine transformations for each
+///   point that represent a their neighborhoods anisotropy. The techniques
+///   and algorithms used here are described in:
+///       [Reconstructing Surfaces of Particle-Based Fluids Using Anisotropic
+///        Kernel - Yu Turk 2010].
+///   The parameters and results of these methods can be combines with the
+///   ellipsoidal surfacing technique found in PointRasterizeSDF.h.
+
+#ifndef OPENVDB_POINTS_POINT_PRINCIPAL_COMPONENT_ANALYSIS_HAS_BEEN_INCLUDED
+#define OPENVDB_POINTS_POINT_PRINCIPAL_COMPONENT_ANALYSIS_HAS_BEEN_INCLUDED
+
+#include <openvdb/openvdb.h>
+#include <openvdb/Grid.h>
+#include <openvdb/Types.h>
+#include <openvdb/math/Coord.h>
+#include <openvdb/thread/Threading.h>
+#include <openvdb/util/NullInterrupter.h>
+#include <openvdb/points/PointAttribute.h>
+#include <openvdb/points/PointGroup.h>
+#include <openvdb/points/PointTransfer.h>
+#include <openvdb/points/PointDataGrid.h>
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <cmath> // std::cbrt
+#include <algorithm> // std::accumulate
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+struct PcaSettings;
+struct PcaAttributes;
+
+/// @brief  Calculate  Calculate ellipsoid transformations from the local point
+///   distributions as described in Yu and Turk's 'Reconstructing Fluid Surfaces
+///   with Anisotropic Kernels'.
+/// @param points   The point data grid to analyses
+/// @param settings The PCA settings for controlling the behavior of the
+///   neighborhood searches and the resulting ellipsoidal values
+/// @param attrs    The PCA attributes to create
+/// @param interrupt An optional interrupter.
+template <typename PointDataGridT,
+    typename FilterT = NullFilter,
+    typename InterrupterT = util::NullInterrupter>
+inline void
+pca(PointDataGridT& points,
+    const PcaSettings& settings,
+    const PcaAttributes& attrs,
+    InterrupterT* interrupt = nullptr);
+
+
+/// @brief  Various settings for the neighborhood analysis of point
+///   distributions.
+struct PcaSettings
+{
+    /// @param searchRadius  the world space search radius of the neighborhood
+    ///   around each point. Increasing this value will result in points
+    ///   including more of their neighbors into their ellipsoidal calculations.
+    ///   This may or may not be desirable depending on the point set's
+    ///   distribution and can be tweaked as necessary. Note however that large
+    ///   values will cause the PCA calculation to become exponentially more
+    ///   expensive. Values equal to or less than 0.0 have undefined results.
+    float searchRadius = 1.0f;
+    /// @param allowedAnisotropyRatio  the maximum allowed ratio between the
+    ///   components in each ellipse' stretch coefficients such that:
+    /// @code
+    ///     const auto s = stretch.sorted();
+    ///     assert(s[0]/s[2] >= allowedAnisotropyRatio);
+    /// @endcode
+    ///   This parameter effectively clamps the allowed anisotropy, with a
+    ///   value of 1.0f resulting in uniform stretch values (representing a
+    ///   sphere). Values tending towards zero will allow for greater
+    ///   anisotropy i.e. much more exaggerated stretches along the computed
+    ///   principal axis and corresponding squashes along the others to
+    ///   compensate.
+    /// @note Very small values may cause very thing ellipses to be produced,
+    ///   so a reasonable minimum should be set. Values equal to or less than
+    ///   0.0, or values greater than 1.0 have undefined results.
+    float allowedAnisotropyRatio = 0.25f;
+    /// @param neighbourThreshold  the number of neighbours a point must have
+    ///   to be classified as having an elliptical distribution. Points with
+    ///   less neighbours than this will end up with uniform stretch values of
+    ///   1.0 and an identity rotation matrix.
+    size_t neighbourThreshold = 20;
+    /// @param averagePositions  the amount (between 0 and 1) to average out
+    ///   positions. All points, whether they end up as ellipses or not,
+    ///   can have their positions smoothed to account for their neighbourhood
+    ///   distribution. This will have no effect for points with no neighbours.
+    /// @warning  This options does NOT modify the P attribute - instead, a
+    ///   world space position attribute "pws" (default) is created and stores
+    ///   the smoothed position.
+    float averagePositions = 1.0f;
+};
+
+/// @brief  The persistent attributes created by the PCA methods.
+/// @note   These can be passed to points::rasterizeSdf with the
+///   EllipsoidSettings to perform ellipsoidal surface construction.
+struct PcaAttributes
+{
+    /// @brief  Settings for the "stretch" attribute, a floating point vector
+    ///   attribute which represents the scaling components of each points
+    ///   ellipse or (1.0,1.0,1.0) for isolated points.
+    using StretchT = math::Vec3<float>;
+    std::string stretch = "stretch";
+
+    /// @brief  Settings for the "rotation" attribute, a floating point matrix
+    ///   attribute which represents the rotation of each points ellipse or
+    ///   the identity matrix for isolated points.
+    using RotationT = math::Mat3<float>;
+    std::string rotation = "rotation";
+
+    /// @brief  Settings for the world space position of every point. This may
+    ///   end up being different to their actual position if the
+    ///   PcaSettings::averagePositions value is not exactly 0. This attribute
+    ///   is used in place of the point's actual position when calling
+    ///   points::rasterizeSdf.
+    /// @note  This should always be at least at double precision
+    using PosWsT = math::Vec3<double>;
+    std::string positionWS = "pws";
+
+    /// @brief A point group to create that represents points which have valid
+    ///   ellipsoidal neighborhood. Points outside of this group will have
+    ///   their stretch and rotation attributes set to describe a canonical
+    ///   sphere. Note however that all points, regardless of this groups
+    ///   membership flag, will still contribute to their neighbours and may
+    ///   have their world space position deformed in relation to their
+    ///   neighboring points.
+    std::string ellipses = "ellipsoids";
+};
+
+}
+}
+}
+
+#include "impl/PrincipalComponentAnalysisImpl.h"
+
+#endif // OPENVDB_POINTS_POINT_PRINCIPAL_COMPONENT_ANALYSIS_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/points/PrincipalComponentAnalysis.h
+++ b/openvdb/openvdb/points/PrincipalComponentAnalysis.h
@@ -32,7 +32,6 @@
 #include <vector>
 #include <memory>
 #include <cmath> // std::cbrt
-#include <algorithm> // std::accumulate
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
@@ -88,6 +87,11 @@ struct PcaSettings
     ///   so a reasonable minimum should be set. Values equal to or less than
     ///   0.0, or values greater than 1.0 have undefined results.
     float allowedAnisotropyRatio = 0.25f;
+    /// @param nonAnisotropicStretch  The stretch coefficient that should be
+    ///   used for points which have no anisotropic neighbourhood (due to
+    ///   being isolated or not having enough neighbours to reach the
+    ///   specified @sa neighbourThreshold).
+    float nonAnisotropicStretch = 1.0;
     /// @param neighbourThreshold  the number of neighbours a point must have
     ///   to be classified as having an elliptical distribution. Points with
     ///   less neighbours than this will end up with uniform stretch values of

--- a/openvdb/openvdb/points/impl/PointRasterizeEllipsoidsSDFImpl.h
+++ b/openvdb/openvdb/points/impl/PointRasterizeEllipsoidsSDFImpl.h
@@ -1,0 +1,626 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+/// @author Richard Jones, Nick Avramoussis
+///
+/// @file PointRasterizeEllipsoidsSDFImpl.h
+///
+
+#ifndef OPENVDB_POINTS_RASTERIZE_ELLIPSOIDS_SDF_IMPL_HAS_BEEN_INCLUDED
+#define OPENVDB_POINTS_RASTERIZE_ELLIPSOIDS_SDF_IMPL_HAS_BEEN_INCLUDED
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+namespace rasterize_sdf_internal
+{
+
+inline math::Vec3d
+calcUnitEllipsoidBoundMaxSq(const math::Mat3s& ellipsoidTransform)
+{
+    math::Vec3d boundMax;
+    for (int i = 0; i < 3; i++) {
+        boundMax[i] =
+            ellipsoidTransform(i,0) * ellipsoidTransform(i,0) +
+            ellipsoidTransform(i,1) * ellipsoidTransform(i,1) +
+            ellipsoidTransform(i,2) * ellipsoidTransform(i,2);
+    }
+    return boundMax;
+}
+
+// compute a tight axis-aligned ellipsoid bounding box
+// based on https://tavianator.com/exact-bounding-boxes-for-spheres-ellipsoids/
+inline math::Vec3d
+calcEllipsoidBoundMax(const math::Mat3s& ellipsoidTransform, const double radius)
+{
+    math::Vec3d boundMax = calcUnitEllipsoidBoundMaxSq(ellipsoidTransform);
+    boundMax[0] = std::sqrt(boundMax[0]) * radius;
+    boundMax[1] = std::sqrt(boundMax[1]) * radius;
+    boundMax[2] = std::sqrt(boundMax[2]) * radius;
+    return boundMax;
+}
+
+struct EllipsIndicies
+{
+    EllipsIndicies(const points::AttributeSet::Descriptor& desc,
+            const PcaAttributes& attribs)
+        : stretch(EllipsIndicies::getAttributeIndex<Vec3f>(desc, attribs.stretch))
+        , rotation(EllipsIndicies::getAttributeIndex<Mat3s>(desc, attribs.rotation))
+        , position(EllipsIndicies::getAttributeIndex<Vec3d>(desc, attribs.positionWS))
+        , ellipsesGroup(desc.groupIndex(attribs.ellipses)) {}
+
+    const size_t stretch, rotation, position;
+    const points::AttributeSet::Descriptor::GroupIndex ellipsesGroup;
+
+private:
+    template<typename ValueT>
+    static inline size_t
+    getAttributeIndex(const points::AttributeSet::Descriptor& desc,
+                      const std::string& name)
+    {
+        const size_t idx = desc.find(name);
+        if (idx == points::AttributeSet::INVALID_POS) {
+            throw std::runtime_error("Missing attribute - " + name);
+        }
+        if (typeNameAsString<ValueT>() != desc.valueType(idx)) {
+            throw std::runtime_error("Wrong attribute type for attribute " + name
+                + ", expected " + typeNameAsString<ValueT>());
+        }
+        return idx;
+    }
+};
+
+template <typename SdfT,
+    typename PositionCodecT,
+    typename RadiusType,
+    bool CPG>
+struct EllipsoidTransfer :
+    public rasterize_sdf_internal::SphericalTransfer<SdfT, PositionCodecT, RadiusType, CPG>
+{
+    using BaseT = rasterize_sdf_internal::SphericalTransfer<SdfT, PositionCodecT, RadiusType, CPG>;
+    using typename BaseT::TreeT;
+    using typename BaseT::ValueT;
+
+    static const Index DIM = TreeT::LeafNodeType::DIM;
+    static const Index LOG2DIM = TreeT::LeafNodeType::LOG2DIM;
+    // The precision of the kernel arithmetic
+    using RealT = double;
+
+    using StretchHandleT = points::AttributeHandle<Vec3f>;
+    using RotationHandleT = points::AttributeHandle<math::Mat3s>;
+    using PwsHandleT = points::AttributeHandle<Vec3d>;
+
+    EllipsoidTransfer(const size_t pidx,
+            const Vec3i width,
+            const RadiusType& rt,
+            const math::Transform& source,
+            SdfT& surface,
+            const Real sphereScale,
+            const EllipsIndicies& indices,
+            Int64Tree* cpg = nullptr,
+            const std::unordered_map<const PointDataTree::LeafNodeType*, Index>* ids = nullptr)
+        : BaseT(pidx, width, rt, source, surface, cpg, ids)
+        , mSphereScale(sphereScale)
+        , mIndices(indices)
+        , mStretchHandle()
+        , mRotationHandle()
+        , mPositionWSHandle()
+        , mEllipsesGroupHandle() {}
+
+    EllipsoidTransfer(const EllipsoidTransfer& other)
+        : BaseT(other)
+        , mSphereScale(other.mSphereScale)
+        , mIndices(other.mIndices)
+        , mStretchHandle()
+        , mRotationHandle()
+        , mPositionWSHandle()
+        , mEllipsesGroupHandle() {}
+
+    inline bool startPointLeaf(const PointDataTree::LeafNodeType& leaf)
+    {
+        const bool ret = this->BaseT::startPointLeaf(leaf);
+        mStretchHandle.reset(new StretchHandleT(leaf.constAttributeArray(mIndices.stretch)));
+        mRotationHandle.reset(new RotationHandleT(leaf.constAttributeArray(mIndices.rotation)));
+        mPositionWSHandle.reset(new PwsHandleT(leaf.constAttributeArray(mIndices.position)));
+        mEllipsesGroupHandle.reset(new points::GroupHandle(leaf.groupHandle(mIndices.ellipsesGroup)));
+        return ret;
+    }
+
+    inline void rasterizePoint(const Coord&,
+                    const Index id,
+                    const CoordBBox& bounds)
+    {
+        // Position may have been smoothed so we need to use the ws handle
+        const Vec3d PWS = this->mPositionWSHandle->get(id);
+        const Vec3d P = this->targetTransform().worldToIndex(PWS);
+        // group membership denotes non-isolated points
+        const bool isolated = !mEllipsesGroupHandle->get(id);
+
+        if (isolated) {
+            this->BaseT::rasterizePoint(P, id, bounds,
+                this->mRadius.eval(id, typename RadiusType::ValueType(mSphereScale)));
+            return;
+        }
+
+        const auto& r = this->mRadius.eval(id);
+        const RealT radius = r.get(); // index space radius
+        const Vec3f stretch = mStretchHandle->get(id);
+        const math::Mat3s rotation = mRotationHandle->get(id);
+        const math::Mat3s ellipsoidTransform = rotation.timesDiagonal(stretch);
+        const Vec3d max = calcEllipsoidBoundMax(ellipsoidTransform, r.max());
+        CoordBBox intersectBox(Coord::round(P - max), Coord::round(P + max));
+        intersectBox.intersect(bounds);
+        if (intersectBox.empty()) return;
+
+        auto* const data = this->template buffer<0>();
+        [[maybe_unused]] auto* const cpg = CPG ? this->template buffer<CPG ? 1 : 0>() : nullptr;
+        auto& mask = *(this->template mask<0>());
+
+        // If min2 == 0.0, then the index space radius is equal to or less than
+        // the desired half band. In this case each sphere interior always needs
+        // to be filled with distance values as we won't ever reach the negative
+        // background value. If, however, a point overlaps a voxel coord exactly,
+        // x2y2z2 will be 0.0. Forcing min2 to be less than zero here avoids
+        // incorrectly setting these voxels to inactive -background values as
+        // x2y2z2 will never be < 0.0. We still want the lteq logic in the
+        // (x2y2z2 <= min2) check as this is valid when min2 > 0.0.
+        const RealT min2 = r.minSq() == 0.0 ? -1.0 : r.minSq();
+        const RealT max2 = r.maxSq();
+
+        // construct modified covariance matrix inverse
+        const Vec3f stretchInverse = (1.0f / stretch);
+        // inverse transformation to create ellipsoid out of sphere
+        const math::Mat3s ellipsoidInverse =
+            rotation.timesDiagonal(stretchInverse) * rotation.transpose();
+
+        // Stamp the ellipsoid by deforming the distance to the iterated voxel
+        // by the inverse ellipsoid transform. We cache the multiples matrix
+        // for each axis component but essentially this resolves to the invMat
+        // multiplied by the x,y,z position difference (i.e. c-p):
+        //   transformedRadialVector = ellipsoidInverse * Vec3d(x,y,z);
+        // Note that the transformation of the ellipse also deforms the narrow
+        // band width - we may want to do something about this.
+        const Coord& a(intersectBox.min());
+        const Coord& b(intersectBox.max());
+        const float* inv = ellipsoidInverse.asPointer(); // @todo do at RealT precision?
+        for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+            const RealT x = static_cast<RealT>(c.x() - P[0]);
+            const Vec3d xradial(x*inv[0], x*inv[3], x*inv[6]);
+            const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
+            for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                const RealT y = static_cast<RealT>(c.y() - P[1]);
+                const Vec3d xyradial = xradial + Vec3d(y*inv[1], y*inv[4], y*inv[7]);
+                const Index ij = i + ((c.y() & (DIM-1u)) << LOG2DIM);
+                for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                    const Index offset = ij + /*k*/(c.z() & (DIM-1u));
+                    if (!mask.isOn(offset)) continue; // inside existing level set or not in range
+
+                    // Transform by inverse of ellipsoidal transform to
+                    // calculate distance to deformed surface.
+                    const RealT z = static_cast<RealT>(c.z() - P[2]);
+                    const Vec3d transformedRadialVector = xyradial + Vec3d(z*inv[2], z*inv[5], z*inv[8]);
+                    const RealT x2y2z2 = transformedRadialVector.lengthSqr();
+
+                    if (x2y2z2 >= max2) continue; //outside narrow band of particle in positive direction
+                    if (x2y2z2 <= min2) { //outside narrow band of the particle in negative direction. can disable this to fill interior
+                        data[offset] = -(this->mBackground);
+                        mask.setOff(offset);
+                        continue;
+                    }
+
+                    const ValueT d = ValueT(this->mDx * (math::Sqrt(x2y2z2) - radius)); // back to world space
+                    ValueT& v = data[offset];
+                    if (d < v) {
+                        v = d;
+                        if constexpr(CPG) cpg[offset] = Int64(this->mPLeafMask | Index64(id));
+                    }
+                }
+            }
+        }
+    }
+
+private:
+    const RealT mSphereScale;
+    const EllipsIndicies& mIndices;
+    std::unique_ptr<StretchHandleT> mStretchHandle;
+    std::unique_ptr<RotationHandleT> mRotationHandle;
+    std::unique_ptr<PwsHandleT> mPositionWSHandle;
+    std::unique_ptr<points::GroupHandle> mEllipsesGroupHandle;
+};
+
+
+template<typename RadiusType, typename MaskTreeT, typename InterrupterT>
+struct EllipsSurfaceMaskOp
+    : public rasterize_sdf_internal::SurfaceMaskOp<MaskTreeT, InterrupterT>
+{
+    using BaseT = rasterize_sdf_internal::SurfaceMaskOp<MaskTreeT, InterrupterT>;
+    using PointDataLeaf = points::PointDataTree::LeafNodeType;
+    using LeafManagerT = tree::LeafManager<const points::PointDataTree>;
+    using RadiusT = typename RadiusType::ValueType;
+    static const Index DIM = points::PointDataTree::LeafNodeType::DIM;
+
+    EllipsSurfaceMaskOp(
+            const math::Transform& src,
+            const math::Transform& trg,
+            const RadiusType& rad,
+            const Real sphereScale,
+            const Real halfband,
+            const EllipsIndicies& indices)
+        : BaseT(src, trg, nullptr)
+        , mRadius(rad)
+        , mSphereScale(sphereScale)
+        , mHalfband(halfband)
+        , mIndices(indices)
+        , mMaxDist(0) {}
+
+    EllipsSurfaceMaskOp(const EllipsSurfaceMaskOp& other, tbb::split)
+        : BaseT(other)
+        , mRadius(other.mRadius)
+        , mSphereScale(other.mSphereScale)
+        , mHalfband(other.mHalfband)
+        , mIndices(other.mIndices)
+        , mMaxDist(0) {}
+
+    Vec3i getMaxDist() const { return mMaxDist; }
+
+    void join(EllipsSurfaceMaskOp& other)
+    {
+        mMaxDist = math::maxComponent(mMaxDist, other.mMaxDist);
+        this->BaseT::join(other);
+    }
+
+    /// @brief  Fill activity by analyzing the stretch values on points in this
+    ///   leaf. Ignored ellipsoid rotations which results in faster but over
+    ///   zealous activation region.
+    void fillFromStretch(const typename LeafManagerT::LeafNodeType& leaf)
+    {
+        // Positions may have been smoothed, so we need to account for that too
+        // @todo  detect this from PcaSettings and avoid checking if no smoothing
+        points::AttributeHandle<Vec3d> pwsHandle(leaf.constAttributeArray(mIndices.position));
+        points::AttributeHandle<Vec3f> stretchHandle(leaf.constAttributeArray(mIndices.stretch));
+        points::GroupHandle ellipses(leaf.groupHandle(mIndices.ellipsesGroup));
+        if (stretchHandle.size() == 0) return;
+
+        RadiusT maxr = 0;
+        // The max stretch coefficient. We can't analyze each xyz component
+        // individually as we don't take into account the ellips rotation, so
+        // have to expand the worst case uniformly
+        float maxs(0);
+        Vec3d maxPos(std::numeric_limits<Real>::lowest()),
+              minPos(std::numeric_limits<Real>::max());
+
+        RadiusType rad(mRadius);
+        rad.reset(leaf);
+        bool hasIsolatedPoints = false;
+
+        for (Index i = 0; i < Index(stretchHandle.size()); ++i)
+        {
+            const Vec3d Pws = pwsHandle.get(i);
+            maxPos = math::maxComponent(maxPos, Pws);
+            minPos = math::minComponent(minPos, Pws);
+
+            if constexpr(!RadiusType::Fixed) {
+                // This is doing an unnecessary multi by the scale for every
+                // point as we could defer the radius scale multi till after
+                // all min/max operations
+                const auto r = rad.eval(i).get(); // index space radius
+                maxr = std::max(maxr, r);
+
+                if (!ellipses.get(i)) {
+                    hasIsolatedPoints = true;
+                }
+                else {
+                    const auto stretch = stretchHandle.get(i);
+                    const float maxcoef = std::max(stretch[0], std::max(stretch[1], stretch[2]));
+                    // scaling by r puts the stretch values in index space
+                    maxs = std::max(maxs, maxcoef * r);
+                }
+            }
+            else {
+                if (!ellipses.get(i)) {
+                    hasIsolatedPoints = true;
+                }
+                else {
+                    const auto stretch = stretchHandle.get(i);
+                    const float maxcoef = std::max(stretch[0], std::max(stretch[1], stretch[2]));
+                    maxs = std::max(maxs, maxcoef);
+                }
+            }
+        }
+
+        if constexpr(RadiusType::Fixed) {
+            maxr = rad.get();
+            // scaling by r puts the stretch values in index space
+            maxs *= float(maxr);
+        }
+
+        // If there are isolated points that we will surface as spheres, use
+        // the max between the stretch values and scaled sphere radii
+        if (hasIsolatedPoints) {
+            // scale radius by sphere scale
+            maxr *= RadiusT(mSphereScale);
+            // choose max component scale - compare the ellips to isolated
+            // points and choose the largest radius of the two
+            maxs = std::max(maxs, float(maxr));
+        }
+
+        // @note  This addition of the halfband here doesn't take into account
+        //   the squash on the halfband itself. The subsequent rasterizer
+        //   squashes the halfband but probably shouldn't, so although this
+        //   expansion is more then necessary, I'm leaving the logic here for
+        //   now.
+        // @note Assumes max stretch coeef <= 1.0f (i.e. always squashes)
+        const Coord dist(static_cast<int>(math::Round(maxs + float(mHalfband))));
+        mMaxDist = math::maxComponent(mMaxDist, dist.asVec3i());
+
+        // Convert point bounds to surface transform, expand and fill
+        CoordBBox surfaceBounds(
+            Coord::round(this->mSurfaceTransform.worldToIndex(minPos)),
+            Coord::round(this->mSurfaceTransform.worldToIndex(maxPos)));
+        surfaceBounds.min() -= dist;
+        surfaceBounds.max() += dist;
+        this->activate(surfaceBounds);
+        /// @todo deactivate min
+    }
+
+    /// @brief  Fill activity by analyzing the axis aligned ellips bounding
+    ///   boxes on points in this leaf. Slightly slower than just looking at
+    ///   ellips stretches but produces a more accurate/tighter activation
+    ///   result
+    void fillFromStretchAndRotation(const typename LeafManagerT::LeafNodeType& leaf)
+    {
+        // positions may have been smoothed, so we need to account for that too :|
+        points::AttributeHandle<Vec3d> pwsHandle(leaf.constAttributeArray(mIndices.position));
+        points::AttributeHandle<Vec3f> stretchHandle(leaf.constAttributeArray(mIndices.stretch));
+        points::AttributeHandle<math::Mat3s> rotHandle(leaf.constAttributeArray(mIndices.rotation));
+        points::GroupHandle ellipses(leaf.groupHandle(mIndices.ellipsesGroup));
+        if (stretchHandle.size() == 0) return;
+
+        RadiusT maxr = 0;
+        Vec3d maxBounds(0),
+            maxPos(std::numeric_limits<Real>::lowest()),
+            minPos(std::numeric_limits<Real>::max());
+
+        RadiusType rad(mRadius);
+        rad.reset(leaf);
+        bool hasIsolatedPoints = false;
+
+        for (Index i = 0; i < stretchHandle.size(); ++i)
+        {
+            const Vec3d Pws = pwsHandle.get(i);
+            maxPos = math::maxComponent(maxPos, Pws);
+            minPos = math::minComponent(minPos, Pws);
+
+            if constexpr(!RadiusType::Fixed) {
+                // This is doing an unnecessary multi by the scale for every
+                // point as we could defer the radius scale multi till after
+                // all min/max operations
+                const auto r = rad.eval(i).get(); // index space radius
+                maxr = std::max(maxr, r);
+
+                if (!ellipses.get(i)) {
+                    hasIsolatedPoints = true;
+                }
+                else {
+                    const Vec3f stretch = stretchHandle.get(i);
+                    const math::Mat3s rotation = rotHandle.get(i);
+                    const math::Mat3s ellipsoidTransform = rotation.timesDiagonal(stretch);
+                    // scaling by r puts the bounds values in index space
+                    const Vec3d bounds = calcEllipsoidBoundMax(ellipsoidTransform, r);
+                    maxBounds = math::maxComponent(maxBounds, bounds);
+                }
+            }
+            else {
+                if (!ellipses.get(i)) {
+                    hasIsolatedPoints = true;
+                }
+                else {
+                    const Vec3f stretch = stretchHandle.get(i);
+                    const math::Mat3s rotation = rotHandle.get(i);
+                    const math::Mat3s ellipsoidTransform = rotation.timesDiagonal(stretch);
+                    // For fixed radii, compared the squared distances - we sqrt at the end
+                    const Vec3d bounds = calcUnitEllipsoidBoundMaxSq(ellipsoidTransform);
+                    maxBounds = math::maxComponent(maxBounds, bounds);
+                }
+            }
+        }
+
+        if constexpr(RadiusType::Fixed) {
+            maxr = rad.get(); // index space radius
+            // scaling by r puts the bounds values in index space
+            maxBounds[0] = std::sqrt(maxBounds[0]) * double(maxr);
+            maxBounds[1] = std::sqrt(maxBounds[1]) * double(maxr);
+            maxBounds[2] = std::sqrt(maxBounds[2]) * double(maxr);
+        }
+
+        if (hasIsolatedPoints) {
+            // scale radius by sphere scale
+            maxr *= RadiusT(mSphereScale);
+            // choose max component scale - compare the ellips to isolated
+            // points and choose the largest radius of the two
+            maxBounds[0] = std::max(double(maxr), maxBounds[0]);
+            maxBounds[1] = std::max(double(maxr), maxBounds[1]);
+            maxBounds[2] = std::max(double(maxr), maxBounds[2]);
+        }
+
+        // @note  This addition of the halfband here doesn't take into account
+        //   the squash on the halfband itself. The subsequent rasterizer
+        //   squashes the halfband but probably shouldn't, so although this
+        //   expansion is more then necessary, I'm leaving the logic here for
+        //   now.
+        // @note Assumes max stretch coeef <= 1.0f (i.e. always squashes)
+        const Coord dist = Coord::round(maxBounds + mHalfband);
+        mMaxDist = math::maxComponent(mMaxDist, dist.asVec3i());
+
+        // Convert point bounds to surface transform, expand and fill
+        CoordBBox surfaceBounds(
+            Coord::round(this->mSurfaceTransform.worldToIndex(minPos)),
+            Coord::round(this->mSurfaceTransform.worldToIndex(maxPos)));
+        surfaceBounds.min() -= dist;
+        surfaceBounds.max() += dist;
+        this->activate(surfaceBounds);
+        /// @todo deactivate min
+    }
+
+    void operator()(const typename LeafManagerT::LeafRange& range)
+    {
+        for (auto leaf = range.begin(); leaf; ++leaf) {
+            this->fillFromStretchAndRotation(*leaf);
+        }
+    }
+
+private:
+    const RadiusType& mRadius;
+    const Real mSphereScale;
+    const Real mHalfband;
+    const EllipsIndicies& mIndices;
+    Vec3i mMaxDist;
+};
+
+template <typename PointDataGridT,
+    typename SdfT,
+    typename SettingsT>
+GridPtrVec
+rasterizeEllipsoids(const PointDataGridT& points,
+                    const SettingsT& settings,
+                    const typename SettingsT::FilterType& filter)
+{
+    static_assert(IsSpecializationOf<PointDataGridT, Grid>::value);
+    static_assert(IsSpecializationOf<SettingsT, EllipsoidSettings>::value);
+
+    using namespace rasterize_sdf_internal;
+
+    using PointDataTreeT = typename PointDataGridT::TreeType;
+    using MaskTreeT = typename SdfT::TreeType::template ValueConverter<ValueMask>::Type;
+
+    using AttributeTypes = typename SettingsT::AttributeTypes;
+    using InterrupterType = typename SettingsT::InterrupterType;
+
+    const std::vector<std::string>& attributes = settings.attributes;
+    const Real halfband = settings.halfband;
+    const Real radiusScale = settings.radiusScale;
+    const Real sphereScale = settings.sphereScale;
+    auto* interrupter = settings.interrupter;
+
+    math::Transform::Ptr transform = settings.transform;
+    if (!transform) transform = points.transform().copy();
+    const Real vs = transform->voxelSize()[0];
+    const typename SdfT::ValueType background =
+        static_cast<typename SdfT::ValueType>(vs * halfband);
+
+    // early exit here if no points
+    const auto leaf = points.constTree().cbeginLeaf();
+    if (!leaf) {
+        typename SdfT::Ptr surface = SdfT::create(background);
+        surface->setTransform(transform);
+        surface->setGridClass(GRID_LEVEL_SET);
+        return GridPtrVec(1, surface);
+    }
+
+    // Get attributes
+    const EllipsIndicies indices(leaf->attributeSet().descriptor(), settings.pca);
+
+    typename SdfT::Ptr surface;
+    GridPtrVec grids;
+
+    if (settings.radius.empty())
+    {
+        // Initial varying Index Space radius. Note that the scale here does NOT
+        // take into account the sphere scale. This is applied per point depending
+        // on the ellipses group during the masking and raster ops.
+        FixedBandRadius<Real> rad(Real(radiusScale / vs), Real(halfband));
+
+        // pre-compute ellipsoidal transform bounds and surface mask. Points that
+        // are not in the ellipse ellipses group are treated as spheres and follow
+        // the same logic as that of the Fixed/VaryingSurfaceMaskOps. Ellipsoids
+        // instead compute the max axis-aligned bounding boxes. The maximum extents
+        // of the spheres/ellipses in a leaf is used for the maximum mask/lookup.
+        // The minimum extent is always the smallest spherical radius.
+        // @todo  Is the min extent correct?
+        Vec3i width;
+        {
+            if (interrupter) interrupter->start("Generating ellipsoidal surface topology");
+
+            tree::LeafManager<const PointDataTreeT> manager(points.tree());
+            // pass radius scale as index space
+
+            EllipsSurfaceMaskOp<FixedBandRadius<Real>, MaskTreeT, InterrupterType>
+                op(points.transform(), *transform, rad, sphereScale, halfband, indices);
+            tbb::parallel_reduce(manager.leafRange(), op);
+
+            surface = rasterize_sdf_internal::initSdfFromMasks<SdfT, MaskTreeT>
+                (transform, background, op.mask(), op.maskoff());
+            // max possible index space radius
+            width = op.getMaxDist();
+
+            if (interrupter) interrupter->end();
+        }
+
+        if (interrupter) interrupter->start("Rasterizing particles to level set using ellipses and fixed spheres");
+
+        grids = doRasterizeSurface<SdfT, EllipsoidTransfer, AttributeTypes, InterrupterType>
+            (points, attributes, filter, *surface, interrupter,
+                width, rad, points.transform(), *surface, sphereScale, indices); // args
+    }
+    else
+    {
+        using RadiusT = typename SettingsT::RadiusAttributeType;
+
+        const size_t ridx = leaf->attributeSet().find(settings.radius);
+        if (ridx == AttributeSet::INVALID_POS) {
+            OPENVDB_THROW(RuntimeError, "Failed to find radius attribute \"" + settings.radius + "\"");
+        }
+
+        // Initial varying Index Space radius. Note that the scale here does NOT
+        // take into account the sphere scale. This is applied per point depending
+        // on the ellipses group during the masking and raster ops.
+        VaryingBandRadius<RadiusT> rad(ridx, RadiusT(halfband), RadiusT(radiusScale / vs));
+
+        // pre-compute ellipsoidal transform bounds and surface mask. Points that
+        // are not in the ellipse ellipses group are treated as spheres and follow
+        // the same logic as that of the Fixed/VaryingSurfaceMaskOps. Ellipsoids
+        // instead compute the max axis-aligned bounding boxes. The maximum extents
+        // of the spheres/ellipses in a leaf is used for the maximum mask/lookup.
+        // The minimum extent is always the smallest spherical radius.
+        // @todo  Is the min extent correct?
+        Vec3i width;
+        {
+            if (interrupter) interrupter->start("Generating variable ellipsoidal surface topology");
+
+            tree::LeafManager<const PointDataTreeT> manager(points.tree());
+
+            // pass radius scale as index space
+            EllipsSurfaceMaskOp<VaryingBandRadius<RadiusT>, MaskTreeT, InterrupterType>
+                op(points.transform(), *transform, rad, sphereScale, halfband, indices);
+            tbb::parallel_reduce(manager.leafRange(), op);
+
+            surface = rasterize_sdf_internal::initSdfFromMasks<SdfT, MaskTreeT>
+                (transform, background, op.mask(), op.maskoff());
+            // max possible index space radius
+            width = op.getMaxDist();
+
+            if (interrupter) interrupter->end();
+        }
+
+        if (interrupter) interrupter->start("Rasterizing particles to level set using variable ellipses");
+
+        grids = doRasterizeSurface<SdfT, EllipsoidTransfer, AttributeTypes, InterrupterType>
+            (points, attributes, filter, *surface, interrupter,
+                    width, rad, points.transform(), *surface, sphereScale, indices); // args
+    }
+
+    if (interrupter) interrupter->end();
+    tools::pruneLevelSet(surface->tree());
+    grids.insert(grids.begin(), surface);
+    return grids;
+}
+
+} // namespace rasterize_sdf_internal
+
+}
+}
+}
+
+#endif // OPENVDB_POINTS_RASTERIZE_ELLIPSOIDS_SDF_IMPL_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/points/impl/PrincipalComponentAnalysisImpl.h
+++ b/openvdb/openvdb/points/impl/PrincipalComponentAnalysisImpl.h
@@ -698,7 +698,16 @@ pca(PointDataGridT& points,
             sigma[2] = std::max(sigma[2], maxs);
 
             // should only happen if all neighbours are coincident
-            if (math::isApproxZero(sigma)) sigma = Vec3f::ones();
+            // @note  The specific tolerance here relates to the normalization
+            //   of the stetch values in step (7) e.g. s*(1.0/cbrt(s.product())).
+            //   math::Tolerance<float>::value is 1e-7f, but we have a bit more
+            //   flexibility here, we can deal with smaller values, common for
+            //   the case where a point only has one neighbour
+            // @todo  have to manually construct the tolerance because
+            //   math::Tolerance<Vec3f> resolves to 0.0. fix this in the math lib
+            if (math::isApproxZero(sigma, Vec3f(1e-11f))) {
+                sigma = Vec3f::ones();
+            }
 
             stretchHandle.set(idx, sigma);
             rotHandle.set(idx, u);

--- a/openvdb/openvdb/points/impl/PrincipalComponentAnalysisImpl.h
+++ b/openvdb/openvdb/points/impl/PrincipalComponentAnalysisImpl.h
@@ -1,0 +1,768 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef OPENVDB_POINTS_POINT_PRINCIPAL_COMPONENT_ANALYSIS_IMPL_HAS_BEEN_INCLUDED
+#define OPENVDB_POINTS_POINT_PRINCIPAL_COMPONENT_ANALYSIS_IMPL_HAS_BEEN_INCLUDED
+
+#ifdef OPENVDB_PROFILE_PCA
+#include <openvdb/util/CpuTimer.h>
+#endif
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+namespace pca_internal {
+
+#ifdef OPENVDB_PROFILE_PCA
+using PcaTimer = util::CpuTimer;
+#else
+struct PcaTimer {
+inline void start(const char*) {}
+inline void stop() {}
+};
+#endif
+
+using WeightSumT = double;
+using WeightedPositionSumT = Vec3d;
+using GroupIndexT = points::AttributeSet::Descriptor::GroupIndex;
+
+struct AttrIndices
+{
+    size_t mPosSumIndex;
+    size_t mWeightSumIndex;
+    size_t mCovMatrixIndex;
+    size_t mPWsIndex;
+    GroupIndexT mEllipsesGroupIndex;
+};
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+template <typename T, typename LeafNodeT>
+inline T* initPcaArrayAttribute(LeafNodeT& leaf, const size_t idx, const bool fill = true)
+{
+    auto& array = leaf.attributeArray(idx);
+    assert(array.valueType() == typeNameAsString<T>());
+    assert(array.codecType() == std::string(NullCodec::name()));
+    // No need to call loadData on these attributes, we know we created them
+    array.expand(fill);
+    const char* data = array.constDataAsByteArray();
+    return reinterpret_cast<T*>(const_cast<char*>(data));
+}
+#else
+template <typename T, typename LeafNodeT>
+inline typename AttributeWriteHandle<T, NullCodec>::Ptr
+initPcaArrayAttribute(LeafNodeT& leaf, const size_t idx)
+{
+    return AttributeWriteHandle<T, NullCodec>::create(leaf.attributeArray(idx), /*expand=*/true);
+}
+#endif
+
+template <typename PointDataTreeT>
+struct PcaTransfer
+    : public VolumeTransfer<PointDataTreeT>
+{
+    using BaseT = VolumeTransfer<PointDataTreeT>;
+    using LeafNodeType = typename PointDataTreeT::LeafNodeType;
+    using PositionHandleT = points::AttributeHandle<Vec3d, NullCodec>;
+
+    PcaTransfer(const AttrIndices& indices,
+                const float searchRadius,
+                const Real vs,
+                tree::LeafManager<PointDataTreeT>& manager)
+        : BaseT(manager.tree())
+        , mIndices(indices)
+        , mSearchRadius(searchRadius)
+        , mDxInv(1.0/vs)
+        , mManager(manager)
+        , mTargetPosition()
+        , mSourcePosition() {}
+
+    PcaTransfer(const PcaTransfer& other)
+        : BaseT(other)
+        , mIndices(other.mIndices)
+        , mSearchRadius(other.mSearchRadius)
+        , mDxInv(other.mDxInv)
+        , mManager(other.mManager)
+        , mTargetPosition()
+        , mSourcePosition() {}
+
+    /*
+    // This is no longer used but kept for reference; each axis iterations of
+    // derived PCA methods uses this technique to skip voxels entirely if a
+    // point's position and search radius does not intersect it
+
+    static bool VoxelIntersectsSphere(const Coord& ijk, const Vec3d& PosIS, const Real r2)
+    {
+        const Vec3d min = ijk.asVec3d() - 0.5;
+        const Vec3d max = ijk.asVec3d() + 0.5;
+        Real dmin = 0;
+        for (int i = 0; i < 3; ++i) {
+            if (PosIS[i] < min[i])      dmin += math::Pow2(PosIS[i] - min[i]);
+            else if (PosIS[i] > max[i]) dmin += math::Pow2(PosIS[i] - max[i]);
+        }
+        return dmin <= r2;
+    }
+    */
+
+    Vec3i range(const Coord&, size_t) const { return this->range(); }
+    Vec3i range() const { return Vec3i(math::Round(mSearchRadius * mDxInv)); }
+
+    inline LeafNodeType* initialize(const Coord& origin, const size_t idx, const CoordBBox& bounds)
+    {
+        BaseT::initialize(origin, idx, bounds);
+        auto& leaf = mManager.leaf(idx);
+        mTargetPosition.reset(new PositionHandleT(leaf.constAttributeArray(mIndices.mPWsIndex)));
+        return &leaf;
+    }
+
+    inline bool startPointLeaf(const typename PointDataTreeT::LeafNodeType& leaf)
+    {
+        mSourcePosition.reset(new PositionHandleT(leaf.constAttributeArray(mIndices.mPWsIndex)));
+        return true;
+    }
+
+    bool endPointLeaf(const typename PointDataTreeT::LeafNodeType&) { return true; }
+
+protected:
+    const AttrIndices& mIndices;
+    const float mSearchRadius;
+    const Real mDxInv;
+    const tree::LeafManager<PointDataTreeT>& mManager;
+    std::unique_ptr<PositionHandleT> mTargetPosition;
+    std::unique_ptr<PositionHandleT> mSourcePosition;
+};
+
+
+template <typename PointDataTreeT>
+struct WeightPosSumsTransfer
+    : public PcaTransfer<PointDataTreeT>
+{
+    using BaseT = PcaTransfer<PointDataTreeT>;
+
+    static const Index DIM = PointDataTreeT::LeafNodeType::DIM;
+    static const Index LOG2DIM = PointDataTreeT::LeafNodeType::LOG2DIM;
+
+    WeightPosSumsTransfer(const AttrIndices& indices,
+                          const float searchRadius,
+                          const int32_t neighbourThreshold,
+                          const Real vs,
+                          tree::LeafManager<PointDataTreeT>& manager)
+        : BaseT(indices, searchRadius, vs, manager)
+        , mNeighbourThreshold(neighbourThreshold)
+        , mWeights()
+        , mWeightedPositions()
+        , mCounts() {}
+
+    WeightPosSumsTransfer(const WeightPosSumsTransfer& other)
+        : BaseT(other)
+        , mNeighbourThreshold(other.mNeighbourThreshold)
+        , mWeights()
+        , mWeightedPositions()
+        , mCounts() {}
+
+    inline void initialize(const Coord& origin, const size_t idx, const CoordBBox& bounds)
+    {
+        auto& leaf = (*BaseT::initialize(origin, idx, bounds));
+        mWeights = initPcaArrayAttribute<WeightSumT>(leaf, this->mIndices.mWeightSumIndex);
+        mWeightedPositions = initPcaArrayAttribute<WeightedPositionSumT>(leaf, this->mIndices.mPosSumIndex);
+        // track neighbours
+        mCounts.assign(this->mTargetPosition->size(), 0);
+    }
+
+    inline void rasterizePoint(const Coord&,
+                    const Index pid,
+                    const CoordBBox& bounds)
+    {
+        const Vec3d Psrc(this->mSourcePosition->get(pid));
+        const Vec3d PsrcIS = Psrc * this->mDxInv;
+
+        const auto* const data = this->template buffer<0>();
+        const auto& mask = *(this->template mask<0>());
+
+        const float searchRadiusInv = 1.0f / this->mSearchRadius;
+        const Real searchRadius2 = math::Pow2(this->mSearchRadius);
+        const Real searchRadiusIS2 = math::Pow2(this->mSearchRadius * this->mDxInv);
+
+        const Coord& a(bounds.min());
+        const Coord& b(bounds.max());
+        for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+            const Real minx = c.x() - 0.5;
+            const Real maxx = c.x() + 0.5;
+            const Real dminx =
+                (PsrcIS[0] < minx ? math::Pow2(PsrcIS[0] - minx) :
+                (PsrcIS[0] > maxx ? math::Pow2(PsrcIS[0] - maxx) : 0));
+            if (dminx > searchRadiusIS2) continue;
+            const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
+            for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                const Real miny = c.y() - 0.5;
+                const Real maxy = c.y() + 0.5;
+                const Real dminxy = dminx +
+                    (PsrcIS[1] < miny ? math::Pow2(PsrcIS[1] - miny) :
+                    (PsrcIS[1] > maxy ? math::Pow2(PsrcIS[1] - maxy) : 0));
+                if (dminxy > searchRadiusIS2) continue;
+                const Index ij = i + ((c.y() & (DIM-1u)) << LOG2DIM);
+                for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                    const Index offset = ij + /*k*/(c.z() & (DIM-1u));
+                    if (!mask.isOn(offset)) continue;
+
+                    const Real minz = c.z() - 0.5;
+                    const Real maxz = c.z() + 0.5;
+                    const Real dminxyz = dminxy +
+                        (PsrcIS[2] < minz ? math::Pow2(PsrcIS[2] - minz) :
+                        (PsrcIS[2] > maxz ? math::Pow2(PsrcIS[2] - maxz) : 0));
+                    // Does this point's radius overlap the voxel c
+                    if (dminxyz > searchRadiusIS2) continue;
+
+                    const Index end = data[offset];
+                    Index id = (offset == 0) ? 0 : Index(data[offset - 1]);
+                    for (; id < end; ++id) {
+                        const Vec3d Ptgt(this->mTargetPosition->get(id));
+                        const Real d2 = (Psrc - Ptgt).lengthSqr();
+                        if (d2 > searchRadius2) continue;
+
+                        const float weight = 1.0f - math::Pow3(float(math::Sqrt(d2)) * searchRadiusInv);
+                        assert(weight >= 0.0f && weight <= 1.0f);
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+                        mWeights[id] += weight;
+                        mWeightedPositions[id] += Psrc * weight; // @note: world space position is weighted
+#else
+                        // @warning  much slower than accessing the buffers directly
+                        mWeights->set(id, mWeights->get(id) + weight);
+                        mWeightedPositions->set(id, mWeightedPositions->get(id) + (Psrc * weight)); // @note: world space position is weighted
+#endif
+                        ++mCounts[id];
+                    } //point idx
+                }
+            }
+        } // outer sdf voxel
+    } // point idx
+
+    bool finalize(const Coord&, size_t idx)
+    {
+        // Add points to group with counts which are more than the neighbouring threshold
+        auto& leaf = this->mManager.leaf(idx);
+
+        {
+            // @todo add API to get the array from the group handle. The handle
+            //   calls loadData but not expand.
+            auto& array = leaf.attributeArray(this->mIndices.mEllipsesGroupIndex.first);
+            array.loadData(); // so we can call setUnsafe/getUnsafe
+            array.expand();
+        }
+
+        points::GroupWriteHandle group(leaf.groupWriteHandle(this->mIndices.mEllipsesGroupIndex));
+
+        for (Index i = 0; i < this->mTargetPosition->size(); ++i)
+        {
+            // every point will have a self contribution (unless this operation
+            // has been interrupted or the search radius was 0) so account for
+            // that here
+            assert(mCounts[i] >= 1);
+            assert(mWeights[i] > 0.0f);
+            mCounts[i] -= 1;
+
+            // turn points OFF if they are ON and don't meet max neighbour requirements
+            if ((mCounts[i] < mNeighbourThreshold) && group.getUnsafe(i)) {
+                group.setUnsafe(i, false);
+            }
+
+            // only self contribution, don't bothering normalizing
+            if (mCounts[i] <= 0) continue;
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+            // Account for self contribution
+            mWeights[i] -= 1.0f;
+            mWeightedPositions[i] -= this->mTargetPosition->get(i);
+            assert(mWeights[i] > 0.0f);
+            // Now normalize
+            mWeights[i] = 1.0 / mWeights[i];
+            mWeightedPositions[i] *= mWeights[i];
+#else
+            // Account for self contribution
+            mWeights->set(i, mWeights->get(i) - 1.0f);
+            mWeightedPositions->set(i, mWeightedPositions->get(i) - this->mTargetPosition->get(i));
+            assert(mWeights->get(i) > 0.0f);
+            // Now normalize
+            mWeights->set(i, 1.0 / mWeights->get(i));
+            mWeightedPositions->set(i, mWeightedPositions->get(i) * mWeights->get(i));
+#endif
+        }
+        return true;
+    }
+
+private:
+    const int32_t mNeighbourThreshold;
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    WeightSumT* mWeights;
+    WeightedPositionSumT* mWeightedPositions;
+#else
+    AttributeWriteHandle<WeightSumT, NullCodec>::Ptr mWeights;
+    AttributeWriteHandle<WeightedPositionSumT, NullCodec>::Ptr mWeightedPositions;
+#endif
+    std::vector<int32_t> mCounts;
+};
+
+template <typename PointDataTreeT>
+struct CovarianceTransfer
+    : public PcaTransfer<PointDataTreeT>
+{
+    using BaseT = PcaTransfer<PointDataTreeT>;
+
+    static const Index DIM = PointDataTreeT::LeafNodeType::DIM;
+    static const Index LOG2DIM = PointDataTreeT::LeafNodeType::LOG2DIM;
+
+    CovarianceTransfer(const AttrIndices& indices,
+                       const float searchRadius,
+                       const Real vs,
+                       tree::LeafManager<PointDataTreeT>& manager)
+        : BaseT(indices, searchRadius, vs, manager)
+        , mIsSameLeaf()
+        , mInclusionGroupHandle()
+        , mWeights()
+        , mWeightedPositions()
+        , mCovMats() {}
+
+    CovarianceTransfer(const CovarianceTransfer& other)
+        : BaseT(other)
+        , mIsSameLeaf()
+        , mInclusionGroupHandle()
+        , mWeights()
+        , mWeightedPositions()
+        , mCovMats() {}
+
+    inline void initialize(const Coord& origin, const size_t idx, const CoordBBox& bounds)
+    {
+        auto& leaf = (*BaseT::initialize(origin, idx, bounds));
+        mInclusionGroupHandle.reset(new points::GroupHandle(leaf.groupHandle(this->mIndices.mEllipsesGroupIndex)));
+        mWeights = initPcaArrayAttribute<WeightSumT>(leaf, this->mIndices.mWeightSumIndex);
+        mWeightedPositions = initPcaArrayAttribute<WeightedPositionSumT>(leaf, this->mIndices.mPosSumIndex);
+        mCovMats = initPcaArrayAttribute<math::Mat3s>(leaf, this->mIndices.mCovMatrixIndex);
+    }
+
+    inline bool startPointLeaf(const typename PointDataTreeT::LeafNodeType& leaf)
+    {
+        BaseT::startPointLeaf(leaf);
+        mIsSameLeaf = this->mTargetPosition->array() == this->mSourcePosition->array();
+        return true;
+    }
+
+    inline void rasterizePoint(const Coord&,
+                    const Index pid,
+                    const CoordBBox& bounds)
+    {
+        const Vec3d Psrc(this->mSourcePosition->get(pid));
+        const Vec3d PsrcIS = Psrc * this->mDxInv;
+
+        const auto* const data = this->template buffer<0>();
+        const auto& mask = *(this->template mask<0>());
+
+        const float searchRadiusInv = 1.0f/this->mSearchRadius;
+        const Real searchRadius2 = math::Pow2(this->mSearchRadius);
+        const Real searchRadiusIS2 = math::Pow2(this->mSearchRadius * this->mDxInv);
+
+        const Coord& a(bounds.min());
+        const Coord& b(bounds.max());
+        for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+            const Real minx = c.x() - 0.5;
+            const Real maxx = c.x() + 0.5;
+            const Real dminx =
+                (PsrcIS[0] < minx ? math::Pow2(PsrcIS[0] - minx) :
+                (PsrcIS[0] > maxx ? math::Pow2(PsrcIS[0] - maxx) : 0));
+            if (dminx > searchRadiusIS2) continue;
+            const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
+            for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                const Real miny = c.y() - 0.5;
+                const Real maxy = c.y() + 0.5;
+                const Real dminxy = dminx +
+                    (PsrcIS[1] < miny ? math::Pow2(PsrcIS[1] - miny) :
+                    (PsrcIS[1] > maxy ? math::Pow2(PsrcIS[1] - maxy) : 0));
+                if (dminxy > searchRadiusIS2) continue;
+                const Index ij = i + ((c.y() & (DIM-1u)) << LOG2DIM);
+                for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                    const Index offset = ij + /*k*/(c.z() & (DIM-1u));
+                    if (!mask.isOn(offset)) continue;
+
+                    const Real minz = c.z() - 0.5;
+                    const Real maxz = c.z() + 0.5;
+                    const Real dminxyz = dminxy +
+                        (PsrcIS[2] < minz ? math::Pow2(PsrcIS[2] - minz) :
+                        (PsrcIS[2] > maxz ? math::Pow2(PsrcIS[2] - maxz) : 0));
+                    // Does this point's radius overlap the voxel c
+                    if (dminxyz > searchRadiusIS2) continue;
+
+                    const Index end = data[offset];
+                    Index id = (offset == 0) ? 0 : Index(data[offset - 1]);
+                    for (; id < end; ++id) {
+                        if (!mInclusionGroupHandle->get(id)) continue;
+                        // @note  Could remove self contribution as in WeightPosSumsTransfer
+                        //   it adds a small % overhead to this entire operator
+                        if (OPENVDB_UNLIKELY(mIsSameLeaf && id == pid)) continue;
+                        const Vec3d Ptgt(this->mTargetPosition->get(id));
+                        const Real d2 = (Psrc - Ptgt).lengthSqr();
+                        if (d2 > searchRadius2) continue;
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+                        // @note  I've observed some performance degradation if
+                        //   we don't take copies of the buffers here (aliasing?)
+                        const WeightSumT totalWeightInv = mWeights[id];
+                        const WeightedPositionSumT currWeightSum = mWeightedPositions[id];
+#else
+                        const WeightSumT totalWeightInv = mWeights->get(id);
+                        const WeightedPositionSumT currWeightSum = mWeightedPositions->get(id);
+#endif
+
+                        const WeightSumT weight = 1.0f - math::Pow3(float(math::Sqrt(d2)) * searchRadiusInv);
+                        const WeightedPositionSumT posMeanDiff = Psrc - currWeightSum;
+                        const WeightedPositionSumT x = (totalWeightInv * weight) * posMeanDiff;
+
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+                        float* const m = mCovMats[id].asPointer();
+#else
+                        // @warning  much slower than accessing the buffers directly
+                        auto cov = mCovMats->get(id);
+                        float* const m = cov.asPointer();
+#endif
+                        /// @note: equal to:
+                        // mat.setCol(0, mat.col(0) + (x * posMeanDiff[0]));
+                        // mat.setCol(1, mat.col(1) + (x * posMeanDiff[1]));
+                        // mat.setCol(2, mat.col(2) + (x * posMeanDiff[2]));
+                        m[0] += float(x[0] * posMeanDiff[0]);
+                        m[1] += float(x[0] * posMeanDiff[1]);
+                        m[2] += float(x[0] * posMeanDiff[2]);
+                        //
+                        m[3] += float(x[1] * posMeanDiff[0]);
+                        m[4] += float(x[1] * posMeanDiff[1]);
+                        m[5] += float(x[1] * posMeanDiff[2]);
+                        //
+                        m[6] += float(x[2] * posMeanDiff[0]);
+                        m[7] += float(x[2] * posMeanDiff[1]);
+                        m[8] += float(x[2] * posMeanDiff[2]);
+
+#if OPENVDB_ABI_VERSION_NUMBER < 9
+                        mCovMats->set(id, cov);
+#endif
+                    } //point idx
+                }
+            }
+        } // outer sdf voxel
+    } // point idx
+
+    bool finalize(const Coord&, size_t) { return true; }
+
+private:
+    bool mIsSameLeaf;
+    points::GroupHandle::UniquePtr mInclusionGroupHandle;
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+    const WeightSumT* mWeights;
+    const WeightedPositionSumT* mWeightedPositions;
+    math::Mat3s* mCovMats;
+#else
+    AttributeHandle<WeightSumT, NullCodec>::Ptr mWeights;
+    AttributeHandle<WeightedPositionSumT, NullCodec>::Ptr mWeightedPositions;
+    AttributeWriteHandle<math::Mat3s, NullCodec>::Ptr mCovMats;
+#endif
+};
+
+/// @brief Sort a vector into descending order and output a vector of the resulting order
+/// @param vector Vector to sort
+template <typename Scalar>
+inline Vec3i
+descendingOrder(math::Vec3<Scalar>& vector)
+{
+    Vec3i order(0,1,2);
+    if (vector[0] < vector[1]) {
+        std::swap(vector[0], vector[1]);
+        std::swap(order[0], order[1]);
+    }
+    if (vector[1] < vector[2]) {
+        std::swap(vector[1], vector[2]);
+        std::swap(order[1], order[2]);
+    }
+    if (vector[0] < vector[1]) {
+        std::swap(vector[0], vector[1]);
+        std::swap(order[0], order[1]);
+    }
+    return order;
+}
+
+/// @brief Decomposes a symmetric matrix into its eigenvalues and a rotation matrix of eigenvectors.
+///        Note that if mat is positive-definite, this will be equivalent to a singular value
+///        decomposition where V = U.
+/// @param mat Matrix to decompose
+/// @param U rotation matrix.  The order of its columns (which will be eigenvectors) will match
+///          the eigenvalues in sigma
+/// @param sigma vector of eigenvalues
+template <typename Scalar>
+inline bool
+decomposeSymmetricMatrix(const math::Mat3<Scalar>& mat,
+                         math::Mat3<Scalar>& U,
+                         math::Vec3<Scalar>& sigma)
+{
+    math::Mat3<Scalar> Q;
+    const bool diagonalized = math::diagonalizeSymmetricMatrix(mat, Q, sigma);
+
+    if (!diagonalized) return false;
+
+    // need to sort eigenvalues and eigenvectors
+    Vec3i order = descendingOrder(sigma);
+
+    // we need to re-order the matrix ("Q") columns to match the new eigenvalue order
+    // to obtain the correct "U" matrix
+    U.setColumns(Q.col(order[0]), Q.col(order[1]), Q.col(order[2]));
+
+    return true;
+}
+
+} // namespace pca_internal
+
+
+template <typename PointDataGridT,
+    typename FilterT,
+    typename InterrupterT>
+inline void
+pca(PointDataGridT& points,
+    const PcaSettings& settings,
+    const PcaAttributes& attrs,
+    InterrupterT* interrupt)
+{
+    static_assert(IsSpecializationOf<PointDataGridT, Grid>::value);
+
+    using namespace pca_internal;
+
+    using PointDataTreeT = typename PointDataGridT::TreeType;
+    using LeafManagerT = tree::LeafManager<PointDataTreeT>;
+    using LeafNodeT = typename PointDataTreeT::LeafNodeType;
+
+    auto& tree = points.tree();
+    const auto leaf = tree.cbeginLeaf();
+    if (!leaf) return;
+
+    // Small lambda to init any one of the necessary ellipsoid attributes
+    // @note  Various algorithms here assume that we are responsible for creating
+    //   these attributes and so can optimize accordingly. If this changes we'll
+    //   need to also change those optimizations (e.g. NullCodec, loadData, etc)
+    const auto initAttribute = [&](const std::string& name, const auto val)
+    {
+        using ValueT = std::decay_t<decltype(val)>;
+        if (leaf->hasAttribute(name)) {
+            OPENVDB_THROW(KeyError, "PCA attribute '"  << name << "' already exists!");
+        }
+
+        points::appendAttribute<ValueT>(tree, name, val);
+        return leaf->attributeSet().find(name);
+    };
+
+    //
+
+    const size_t pvsIdx = leaf->attributeSet().find("P");
+    const auto& xform = points.constTransform();
+    const double vs = xform.voxelSize()[0];
+    LeafManagerT manager(tree);
+
+    // 1) Create persisting attributes
+    const size_t pwsIdx = initAttribute(attrs.positionWS, zeroVal<PcaAttributes::PosWsT>());
+    const size_t rotIdx = initAttribute(attrs.rotation, zeroVal<PcaAttributes::RotationT>());
+    const size_t strIdx = initAttribute(attrs.stretch, PcaAttributes::StretchT(1));
+
+    // 2) Create temporary attributes
+    const auto& descriptor = leaf->attributeSet().descriptor();
+    const std::vector<std::string> temps {
+        descriptor.uniqueName("_weightedpositionsums"),
+        descriptor.uniqueName("_inv_weightssum")
+    };
+
+    const size_t posSumIndex = initAttribute(temps[0], zeroVal<WeightedPositionSumT>());
+    const size_t weightSumIndex = initAttribute(temps[1], zeroVal<WeightSumT>());
+
+    // 3) Create ellipses group
+    if (!leaf->attributeSet().descriptor().hasGroup(attrs.ellipses)) {
+        points::appendGroup(tree, attrs.ellipses);
+        // Include everything by default to start with
+        points::setGroup(tree, attrs.ellipses, true);
+    }
+
+    // Re-acquire the updated descriptor and get the group idx
+    const GroupIndexT ellipsesIdx =
+        leaf->attributeSet().descriptor().groupIndex(attrs.ellipses);
+
+    PcaTimer timer;
+
+    // 3) Store the world space position on the PDG to speed up subsequent
+    //    calculations.
+    timer.start("Compute position world spaces");
+    manager.foreach([&](LeafNodeT& leafnode, size_t)
+    {
+        using PvsT = Vec3f;
+        using PwsT = PcaAttributes::PosWsT;
+
+        points::AttributeHandle<PvsT> Pvs(leafnode.constAttributeArray(pvsIdx));
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+        PwsT* Pws = initPcaArrayAttribute<PwsT>(leafnode, pwsIdx, /*fill=*/false);
+#else
+        points::AttributeWriteHandle<PwsT, NullCodec> Pws(leafnode.attributeArray(pwsIdx));
+#endif
+
+        for (auto voxel = leafnode.cbeginValueOn(); voxel; ++voxel) {
+            const Coord voxelCoord = voxel.getCoord();
+            const Vec3d coordVec = voxelCoord.asVec3d();
+            for (auto iter = leafnode.beginIndexVoxel(voxelCoord); iter; ++iter) {
+#if OPENVDB_ABI_VERSION_NUMBER >= 9
+                Pws[*iter] = xform.indexToWorld(Pvs.get(*iter) + coordVec);
+#else
+                Pws.set(*iter, xform.indexToWorld(Pvs.get(*iter) + coordVec));
+#endif
+            }
+        }
+    });
+
+    timer.stop();
+    if (util::wasInterrupted(interrupt)) return;
+
+    AttrIndices indices;
+    indices.mPosSumIndex = posSumIndex;
+    indices.mWeightSumIndex = weightSumIndex;
+    indices.mCovMatrixIndex = rotIdx;
+    indices.mPWsIndex = pwsIdx;
+    indices.mEllipsesGroupIndex = ellipsesIdx;
+
+    // 4) Init temporary attributes and calculate:
+    //        sum_j w_{i,j} * x_j / (sum_j w_j)
+    //    And neighbour counts for each point.
+    // simultaneously calculates the sum of weighted vector positions (sum w_{i,j} * x_i)
+    // weighted against the inverse sum of weights (1.0 / sum w_{i,j}). Also counts number
+    // of neighours each point has and updates the ellipses group based on minimum
+    // neighbour threshold. Those points which are "included" but which lack sufficient
+    // neighbours will be marked as "not included".
+    timer.start("Compute position weights");
+    {
+        WeightPosSumsTransfer<PointDataTreeT> transfer(indices,
+            settings.searchRadius,
+            int32_t(settings.neighbourThreshold),
+            float(vs),
+            manager);
+
+        points::rasterize<PointDataGridT,
+            decltype(transfer),
+            NullFilter,
+            InterrupterT>(points, transfer, NullFilter(), interrupt);
+    }
+
+    timer.stop();
+    if (util::wasInterrupted(interrupt)) return;
+
+    // 5) Principal axes define the rotation matrix of the ellipsoid.
+    //    Calculates covariance matrices given weighted sums of positions and
+    //    sums of weights per-particle
+    timer.start("Compute covariance matrices");
+    {
+        CovarianceTransfer<PointDataTreeT>
+            transfer(indices, settings.searchRadius, float(vs), manager);
+
+        points::rasterize<PointDataGridT,
+            decltype(transfer),
+            NullFilter,
+            InterrupterT>(points, transfer, NullFilter(), interrupt);
+    }
+
+    timer.stop();
+    if (util::wasInterrupted(interrupt)) return;
+
+    // 6) radii stretches are given by the scaled singular values. Decompose
+    //    the covariance matrix into its principal axes and their lengths
+    timer.start("Decompose covariance matrices");
+    manager.foreach([&](LeafNodeT& leafnode, size_t)
+    {
+        AttributeWriteHandle<Vec3f, NullCodec> stretchHandle(leafnode.attributeArray(strIdx));
+        AttributeWriteHandle<math::Mat3s, NullCodec> rotHandle(leafnode.attributeArray(rotIdx));
+        GroupHandle ellipsesGroupHandle(leafnode.groupHandle(ellipsesIdx));
+
+        // we don't use a group filter here since we need to set the rotation
+        // matrix for excluded points
+
+        for (Index idx = 0; idx < stretchHandle.size(); ++idx) {
+            if (!ellipsesGroupHandle.get(idx)) {
+                rotHandle.set(idx, math::Mat3s::identity());
+                continue;
+            }
+
+            // get singular values of the covariance matrix
+            math::Mat3s u;
+            Vec3s sigma;
+            decomposeSymmetricMatrix(rotHandle.get(idx), u, sigma);
+
+            // fix sigma values, the principal lengths
+            auto maxs = sigma[0] * settings.allowedAnisotropyRatio;
+            sigma[1] = std::max(sigma[1], maxs);
+            sigma[2] = std::max(sigma[2], maxs);
+
+            // should only happen if all neighbours are coincident
+            if (math::isApproxZero(sigma)) sigma = Vec3f::ones();
+
+            stretchHandle.set(idx, sigma);
+            rotHandle.set(idx, u);
+        }
+    });
+    timer.stop();
+
+    // 7) normalise the principal lengths such that the transformation they
+    //    describe 'preserves volume' thus becoming the stretch of the ellipsoids
+
+    // Calculates the average volume change that would occur if applying the
+    // transformations defined by the calculate principal axes and their
+    // lengths using the determinant of the stretch component of the
+    // transformation (given by the sum of the diagonal values) and uses this
+    // value to normalise these lengths such that they are relative to the
+    // identity. This ensures that the transformation preserves volume.
+    timer.start("Normalise the principal lengths");
+    manager.foreach([&](LeafNodeT& leafnode, size_t)
+    {
+        points::GroupFilter filter(ellipsesIdx);
+        filter.reset(leafnode);
+        AttributeWriteHandle<Vec3f, NullCodec> stretchHandle(leafnode.attributeArray(strIdx));
+
+        for (Index i = 0; i < stretchHandle.size(); ++i)
+        {
+            if (!filter.valid(&i)) continue;
+            const Vec3f stretch = stretchHandle.get(i);
+            assert(stretch != Vec3f::zero());
+            const float stretchScale = 1.0f / std::cbrt(stretch.product());
+            stretchHandle.set(i, stretchScale * stretch);
+        }
+    });
+
+    timer.stop();
+    if (util::wasInterrupted(interrupt)) return;
+
+    // 8) do laplacian position smoothing here as we have the weights already
+    ///   calculated (calculates the smoothed kernel origins as described in
+    ///   the paper). averagePositions value biases the smoothed positions
+    ///   towards the weighted mean positions. 1.0  will use the weighted means
+    ///   while 0.0 will use the original world-space positions
+    timer.start("Laplacian smooth positions");
+    if (settings.averagePositions > 0.0f)
+    {
+        manager.foreach([&](LeafNodeT& leafnode, size_t) {
+            AttributeWriteHandle<Vec3d, NullCodec> Pws(leafnode.attributeArray(pwsIdx));
+            AttributeHandle<WeightedPositionSumT, NullCodec> weightedPosSumHandle(leafnode.constAttributeArray(posSumIndex));
+
+            for (Index i = 0; i < Pws.size(); ++i) {
+                const Vec3d smoothedPosition = (1.0f - settings.averagePositions) *
+                    Pws.get(i) + settings.averagePositions * weightedPosSumHandle.get(i);
+                Pws.set(i, smoothedPosition);
+            }
+        });
+    }
+
+    timer.stop();
+
+    // Remove temporary attributes
+    points::dropAttributes(tree, temps);
+}
+
+}
+}
+}
+
+#endif // OPENVDB_POINTS_POINT_PRINCIPAL_COMPONENT_ANALYSIS_IMPL_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/points/impl/PrincipalComponentAnalysisImpl.h
+++ b/openvdb/openvdb/points/impl/PrincipalComponentAnalysisImpl.h
@@ -586,7 +586,7 @@ pca(PointDataGridT& points,
     // 1) Create persisting attributes
     const size_t pwsIdx = initAttribute(attrs.positionWS, zeroVal<PcaAttributes::PosWsT>());
     const size_t rotIdx = initAttribute(attrs.rotation, zeroVal<PcaAttributes::RotationT>());
-    const size_t strIdx = initAttribute(attrs.stretch, PcaAttributes::StretchT(1));
+    const size_t strIdx = initAttribute(attrs.stretch, PcaAttributes::StretchT(settings.nonAnisotropicStretch));
 
     // 2) Create temporary attributes
     const auto& descriptor = leaf->attributeSet().descriptor();

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -128,8 +128,8 @@ else()
     TestMerge.cc
     TestMeshToVolume.cc
     TestMetadata.cc
-    TestMetadataIO.cc
     TestMetaMap.cc
+    TestMetadataIO.cc
     TestMorphology.cc
     TestMultiResGrid.cc
     TestName.cc
@@ -137,6 +137,7 @@ else()
     TestNodeManager.cc
     TestNodeMask.cc
     TestNodeVisitor.cc
+    TestPCA.cc
     TestParticleAtlas.cc
     TestParticlesToLevelSet.cc
     TestPointAdvect.cc

--- a/openvdb/openvdb/unittest/TestPCA.cc
+++ b/openvdb/openvdb/unittest/TestPCA.cc
@@ -1,0 +1,383 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#include <openvdb/openvdb.h>
+#include <openvdb/points/PrincipalComponentAnalysis.h>
+#include <openvdb/points/PointRasterizeSDF.h>
+#include "PointBuilder.h"
+
+#include <gtest/gtest.h>
+
+using namespace openvdb;
+
+class TestPCA: public ::testing::Test
+{
+public:
+    void SetUp() override { openvdb::initialize(); }
+    void TearDown() override { openvdb::uninitialize(); }
+}; // class TestPCA
+
+
+TEST_F(TestPCA, testPCA)
+{
+    const auto CheckPCAAttributes = [](
+        const points::PointDataTree::LeafNodeType& leaf,
+        const points::PcaAttributes& a,
+        const size_t line)
+    {
+        const auto& desc = leaf.attributeSet().descriptor();
+        ASSERT_EQ(NamePair((typeNameAsString<math::Vec3<float>>()), points::NullCodec::name()), desc.type(desc.find(a.stretch))) << "line: "<< line;
+        ASSERT_EQ(NamePair((typeNameAsString<math::Mat3<float>>()), points::NullCodec::name()), desc.type(desc.find(a.rotation))) << "line: "<< line;
+        ASSERT_EQ(NamePair((typeNameAsString<math::Vec3<double>>()), points::NullCodec::name()), desc.type(desc.find(a.positionWS))) << "line: "<< line;
+        ASSERT_TRUE(desc.hasGroup(a.ellipses)) << "line: "<< line;
+    };
+
+    const auto CheckPCAAttributeValues = [&](
+        const std::vector<math::Vec3<float>>& p,
+        const std::vector<math::Vec3<float>>& stretches,
+        const std::vector<math::Mat3<float>>& rotations,
+        const std::vector<math::Vec3<double>>& ws,
+        const std::vector<bool>& memberships,
+        const points::PointDataTree::LeafNodeType& leaf,
+        const points::PcaAttributes& a,
+        const size_t line,
+        const float tolerance = math::Delta<float>::value())
+    {
+        CheckPCAAttributes(leaf, a, line);
+
+        const auto& desc = leaf.attributeSet().descriptor();
+        points::AttributeHandle<math::Vec3<float>> pHandle(leaf.attributeArray(desc.find("P")));
+        points::AttributeHandle<math::Vec3<float>> sHandle(leaf.attributeArray(desc.find(a.stretch)));
+        points::AttributeHandle<math::Mat3<float>> rHandle(leaf.attributeArray(desc.find(a.rotation)));
+        points::AttributeHandle<math::Vec3<double>> pwsHandle(leaf.attributeArray(desc.find(a.positionWS)));
+        points::GroupHandle gHandle(leaf.groupHandle(a.ellipses));
+        EXPECT_EQ(pHandle.size(), p.size());
+
+        for (Index i = 0; i < Index(p.size()); ++i) {
+
+            EXPECT_EQ(pHandle.get(i), p[i]) << "line: "<< line << " index: " << i;
+
+            for (size_t j = 0; j < 3; ++j)
+                EXPECT_NEAR(sHandle.get(i)[j], stretches[i][j], tolerance)
+                    << "line: "<< line << " index: " << i << " component " << j;
+
+            for (size_t j = 0; j < 9; ++j)
+                EXPECT_NEAR(rHandle.get(i).asPointer()[j], rotations[i].asPointer()[j], tolerance)
+                    << "line: "<< line << " index: " << i << " component " << j;
+
+            for (size_t j = 0; j < 3; ++j)
+                EXPECT_NEAR(pwsHandle.get(i)[j], ws[i][j], tolerance)
+                    << "line: "<< line << " index: " << i << " component " << j;
+
+            EXPECT_EQ(gHandle.get(i), memberships[i]) << "line: "<< line << " index: " << i;
+        }
+    };
+
+    // test no points
+    {
+        auto points = PointBuilder({}).voxelsize(0.1).get();
+        points::PcaSettings s;
+        points::PcaAttributes a;
+        points::pca(*points, s, a);
+        EXPECT_TRUE(points->empty());
+    }
+
+    // test single point
+    {
+        // test offset from zero to make sure smoothing does nothing
+        auto points = PointBuilder({Vec3f(1.0f,2.0f,3.0f)}).voxelsize(0.1).get();
+        points::PcaSettings s;
+        points::PcaAttributes a;
+
+        points::pca(*points, s, a);
+        EXPECT_EQ(Index(1), points->tree().leafCount());
+
+        ASSERT_TRUE(points->tree().cbeginLeaf());
+        const auto& leaf = *(points->tree().cbeginLeaf());
+        const auto& desc = leaf.attributeSet().descriptor();
+        EXPECT_EQ(leaf.pointCount(), Index64(1));
+        EXPECT_TRUE(leaf.hasAttribute("P"));
+        EXPECT_EQ(desc.find("P"), size_t(0));
+        EXPECT_EQ(desc.size(), size_t(5));
+
+        CheckPCAAttributeValues(
+                {Vec3f(0.0f)}, // position is at the center of a voxel
+                {Vec3f(1.0f)},
+                {Mat3s::identity()},
+                {Vec3d(1.0,2.0,3.0)},
+                {false},
+            leaf, a, __LINE__);
+    }
+
+    // test attribute names
+    {
+        const auto pos = getBoxPoints();
+        auto points = PointBuilder(pos).voxelsize(0.1).get();
+
+        points::PcaAttributes a;
+        points::PcaSettings s;
+        a.stretch = "test1";
+        a.rotation = "test2";
+        a.positionWS = "test3";
+        a.ellipses = "test4";
+
+        points::pca(*points, s, a);
+        EXPECT_EQ(Index(8), points->tree().leafCount());
+        ASSERT_TRUE(points->tree().cbeginLeaf());
+        Index count = 0 ;
+        for (auto iter = points->tree().cbeginLeaf(); iter; ++iter, ++count)
+        {
+            const auto& leaf = *iter;
+            const auto& desc = leaf.attributeSet().descriptor();
+            EXPECT_EQ(desc.find("P"), size_t(0));
+            EXPECT_TRUE(leaf.hasAttribute(a.stretch));
+            EXPECT_TRUE(leaf.hasAttribute(a.rotation));
+            EXPECT_TRUE(leaf.hasAttribute(a.positionWS));
+            EXPECT_TRUE(leaf.attributeSet().descriptor().hasGroup(a.ellipses));
+            EXPECT_EQ(desc.size(), size_t(5));
+        }
+
+        EXPECT_EQ(Index(8), count);
+
+        // test failure if attributes exist
+        EXPECT_THROW(points::pca(*points, s, a), openvdb::KeyError);
+    }
+
+    // test three coincident points with various settings
+    {
+        auto points = PointBuilder({
+                Vec3f(0.0f, 0.02f, 0.0f),
+                Vec3f(0.0f, 0.01f, 0.0f),
+                Vec3f(0.0f,  0.0f, 0.0f)
+            }).voxelsize(0.1).get();
+
+        ASSERT_TRUE(points->tree().cbeginLeaf());
+        EXPECT_EQ(Index(1), points->tree().leafCount());
+
+        const auto& leaf = *(points->tree().cbeginLeaf());
+        const auto* desc = &(leaf.attributeSet().descriptor());
+        EXPECT_EQ(desc->find("P"), size_t(0));
+
+        points::AttributeHandle<math::Vec3<float>> pHandle(leaf.attributeArray(desc->find("P")));
+        EXPECT_EQ(pHandle.size(), 3);
+
+        std::vector<Vec3f> posistions;
+        for (Index i = 0; i < Index(pHandle.size()); ++i) posistions.emplace_back(pHandle.get(i));
+        const std::vector<Vec3d> posistionsWs {
+            Vec3d(0.0, 0.02, 0.0), Vec3d(0.0, 0.01, 0.0), Vec3d(0.0)
+        };
+
+        points::PcaAttributes a;
+        points::PcaSettings s;
+        s.searchRadius = std::numeric_limits<float>::max();
+        s.averagePositions = 0.0f; // disable position smoothing
+        s.neighbourThreshold = 3; // more than 2, points should end up as spheres
+
+        points::pca(*points, s, a);
+        ASSERT_TRUE(points->tree().cbeginLeaf());
+        ASSERT_EQ(&leaf, &(*points->tree().cbeginLeaf()));
+        desc = &(leaf.attributeSet().descriptor());
+
+        EXPECT_EQ(leaf.pointCount(), Index64(3));
+        EXPECT_TRUE(leaf.hasAttribute("P"));
+        EXPECT_EQ(desc->find("P"), size_t(0));
+        EXPECT_EQ(desc->size(), size_t(5));
+
+        CheckPCAAttributeValues(
+                posistions,
+                {Vec3f(1.0f), Vec3f(1.0f), Vec3f(1.0f)},
+                {Mat3s::identity(), Mat3s::identity(), Mat3s::identity()},
+                posistionsWs,
+                {false, false, false},
+            leaf, a, __LINE__);
+
+        // Test points don't get classified if they are out of range
+
+        points::dropAttributes(points->tree(), {a.stretch, a.rotation, a.positionWS});
+        points::dropGroup(points->tree(), a.ellipses);
+
+        s.searchRadius = 0.001f;
+        s.neighbourThreshold = 1;
+
+        points::pca(*points, s, a);
+        ASSERT_TRUE(points->tree().cbeginLeaf());
+        ASSERT_EQ(&leaf, &(*points->tree().cbeginLeaf()));
+        desc = &(leaf.attributeSet().descriptor());
+
+        EXPECT_EQ(leaf.pointCount(), Index64(3));
+        EXPECT_TRUE(leaf.hasAttribute("P"));
+        EXPECT_EQ(desc->find("P"), size_t(0));
+        EXPECT_EQ(desc->size(), size_t(5));
+
+        CheckPCAAttributeValues(
+                posistions,
+                {Vec3f(1.0f), Vec3f(1.0f), Vec3f(1.0f)},
+                {Mat3s::identity(), Mat3s::identity(), Mat3s::identity()},
+                posistionsWs,
+                {false, false, false},
+            leaf, a, __LINE__);
+
+        // Test only the center point is classified as an ellips
+
+        points::dropAttributes(points->tree(), {a.stretch, a.rotation, a.positionWS});
+        points::dropGroup(points->tree(), a.ellipses);
+
+        // each point is 0.01 distance away from the next, so setting to 0.01
+        // should mean only the middle point gets classified
+        s.searchRadius = std::nextafter(0.01f, 1.0f);
+        s.neighbourThreshold = 2; // only center point
+        s.averagePositions = 0.0f; // disable position smoothing
+
+        points::pca(*points, s, a);
+        ASSERT_TRUE(points->tree().cbeginLeaf());
+        ASSERT_EQ(&leaf, &(*points->tree().cbeginLeaf()));
+        desc = &(leaf.attributeSet().descriptor());
+
+        EXPECT_EQ(leaf.pointCount(), Index64(3));
+        EXPECT_TRUE(leaf.hasAttribute("P"));
+        EXPECT_EQ(desc->find("P"), size_t(0));
+        EXPECT_EQ(desc->size(), size_t(5));
+
+        CheckPCAAttributeValues(
+                posistions,
+                {Vec3f(1.0), Vec3f(2.51984f, 0.62996f, 0.62996f), Vec3f(1.0)},
+                {Mat3s::identity(), Mat3s(0,1,0, 1,0,0, 0,0,1), Mat3s::identity()},
+                posistionsWs,
+                {false, true, false},
+            leaf, a, __LINE__);
+
+        // Now test they get classified as ellipses and re-compute the ellips
+        // transformations to check they are espected. We should end up with
+        // ellips' with no rotation and simply stretched along their principal
+        // axis (in this case Y) and squashed in the others
+
+        points::dropAttributes(points->tree(), {a.stretch, a.rotation, a.positionWS});
+        points::dropGroup(points->tree(), a.ellipses);
+
+        // each point is 0.01 distance away from the next, so make sure
+        // they all find each other i.e. min dist as 0.02
+        s.searchRadius = std::nextafter(0.02f, 1.0f);
+        s.neighbourThreshold = 1; // make sure they get classified
+        s.averagePositions = 0.0f; // disable position smoothing
+        s.allowedAnisotropyRatio = 0.25f;
+
+        points::pca(*points, s, a);
+        ASSERT_TRUE(points->tree().cbeginLeaf());
+        ASSERT_EQ(&leaf, &(*points->tree().cbeginLeaf()));
+        desc = &(leaf.attributeSet().descriptor());
+
+        EXPECT_EQ(leaf.pointCount(), Index64(3));
+        EXPECT_TRUE(leaf.hasAttribute("P"));
+        EXPECT_EQ(desc->find("P"), size_t(0));
+        EXPECT_EQ(desc->size(), size_t(5));
+
+        CheckPCAAttributes(leaf, a, __LINE__);
+
+        pHandle = points::AttributeHandle<math::Vec3<float>>(leaf.attributeArray(desc->find("P")));
+        points::AttributeHandle<math::Vec3<float>> sHandle(leaf.attributeArray(desc->find(a.stretch)));
+        points::AttributeHandle<math::Mat3<float>> rHandle(leaf.attributeArray(desc->find(a.rotation)));
+        points::AttributeHandle<math::Vec3<double>> pwsHandle(leaf.attributeArray(desc->find(a.positionWS)));
+        points::GroupHandle::UniquePtr gHandle(new points::GroupHandle(leaf.groupHandle(a.ellipses)));
+        EXPECT_EQ(pHandle.size(), posistions.size());
+
+        Index i = 0;
+        for (auto iter = leaf.beginIndexOn(); iter; ++iter, ++i)
+        {
+            for (size_t j = 0; j < 3; ++j) EXPECT_NEAR(pHandle.get(i)[j],   posistions[i][j],   1e-6f);
+            for (size_t j = 0; j < 3; ++j) EXPECT_NEAR(pwsHandle.get(i)[j], posistionsWs[i][j], 1e-6f);
+            EXPECT_EQ(gHandle->get(i), true);
+
+            // Now rebuild the expected ellipse transform - should just contain stretches,
+            // predominantly along Y
+            const math::Mat3<float> rot = rHandle.get(i);
+            const math::Vec3<float> stretch = sHandle.get(i);
+            const math::Vec3<float> ordered = stretch.sorted();
+            EXPECT_NEAR(ordered[0], ordered[1], 1e-6f);
+            const float min = ordered[0];
+            const float max = ordered[2];
+
+            // max should be greater than min for each point as each point
+            // has an identifiable PC axis
+            EXPECT_TRUE(max > min);
+
+            // check extents related to allowedAnisotropyRatio value
+            EXPECT_NEAR(min/max, s.allowedAnisotropyRatio, 1e-6f);
+
+            const math::Mat3<float> inv = (rot.timesDiagonal(1.0/stretch) * rot.transpose()).inverse();
+            EXPECT_NEAR(inv(0,0), min, 1e-6f)  << "index: " << i;
+            EXPECT_NEAR(inv(0,1), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(0,2), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(1,0), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(1,1), max, 1e-6f)  << "index: " << i;
+            EXPECT_NEAR(inv(1,2), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(2,0), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(2,1), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(2,2), min, 1e-6f)  << "index: " << i;
+        }
+
+        EXPECT_EQ(i, 3);
+
+        // Test with greater allows anisotropy (i.e. lower ratio). Should get
+        // more stretch and squashes. Compare these to the previous test
+
+        points::dropAttributes(points->tree(), {a.stretch, a.rotation, a.positionWS});
+        points::dropGroup(points->tree(), a.ellipses);
+
+        s.allowedAnisotropyRatio = 0.0625f; // 4x more than 0.25
+
+        points::pca(*points, s, a);
+        ASSERT_TRUE(points->tree().cbeginLeaf());
+        ASSERT_EQ(&leaf, &(*points->tree().cbeginLeaf()));
+        desc = &(leaf.attributeSet().descriptor());
+
+        EXPECT_EQ(leaf.pointCount(), Index64(3));
+        EXPECT_TRUE(leaf.hasAttribute("P"));
+        EXPECT_EQ(desc->find("P"), size_t(0));
+        EXPECT_EQ(desc->size(), size_t(5));
+
+        CheckPCAAttributes(leaf, a, __LINE__);
+
+        pHandle = points::AttributeHandle<math::Vec3<float>>(leaf.attributeArray(desc->find("P")));
+        sHandle = points::AttributeHandle<math::Vec3<float>>(leaf.attributeArray(desc->find(a.stretch)));
+        rHandle = points::AttributeHandle<math::Mat3<float>>(leaf.attributeArray(desc->find(a.rotation)));
+        pwsHandle = points::AttributeHandle<math::Vec3<double>>(leaf.attributeArray(desc->find(a.positionWS)));
+        gHandle = points::GroupHandle::UniquePtr(new points::GroupHandle(leaf.groupHandle(a.ellipses)));
+        EXPECT_EQ(pHandle.size(), posistions.size());
+
+        i = 0;
+        for (auto iter = leaf.beginIndexOn(); iter; ++iter, ++i)
+        {
+            for (size_t j = 0; j < 3; ++j) EXPECT_NEAR(pHandle.get(i)[j],   posistions[i][j],   1e-6f);
+            for (size_t j = 0; j < 3; ++j) EXPECT_NEAR(pwsHandle.get(i)[j], posistionsWs[i][j], 1e-6f);
+            EXPECT_EQ(gHandle->get(i), true);
+
+            // Now rebuild the expected ellipse transform - should just contain stretches,
+            // predominantly along Y
+            const math::Mat3<float> rot = rHandle.get(i);
+            const math::Vec3<float> stretch = sHandle.get(i);
+            const math::Vec3<float> ordered = stretch.sorted();
+            EXPECT_NEAR(ordered[0], ordered[1], 1e-6f);
+            const float min = ordered[0];
+            const float max = ordered[2];
+            // max should be greater than min for each point as each point
+            // has an identifiable PC axis
+            EXPECT_TRUE(max > min);
+
+            // check extents related to allowedAnisotropyRatio value
+            EXPECT_NEAR(min/max, s.allowedAnisotropyRatio, 1e-6f);
+
+            const math::Mat3<float> inv = (rot.timesDiagonal(1.0/stretch) * rot.transpose()).inverse();
+            EXPECT_NEAR(inv(0,0), min, 1e-6f)  << "index: " << i;
+            EXPECT_NEAR(inv(0,1), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(0,2), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(1,0), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(1,1), max, 1e-6f)  << "index: " << i;
+            EXPECT_NEAR(inv(1,2), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(2,0), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(2,1), 0.0f, 1e-6f) << "index: " << i;
+            EXPECT_NEAR(inv(2,2), min, 1e-6f)  << "index: " << i;
+        }
+
+        EXPECT_EQ(i, 3);
+    }
+}

--- a/openvdb/openvdb/unittest/TestPCA.cc
+++ b/openvdb/openvdb/unittest/TestPCA.cc
@@ -268,6 +268,7 @@ TEST_F(TestPCA, testPCA)
         s.searchRadius = std::numeric_limits<float>::max();
         s.averagePositions = 0.0f; // disable position smoothing
         s.neighbourThreshold = 3; // more than 2, points should end up as spheres
+        s.nonAnisotropicStretch = 2.0f;
 
         points::pca(*points, s, a);
         ASSERT_TRUE(points->tree().cbeginLeaf());
@@ -281,7 +282,7 @@ TEST_F(TestPCA, testPCA)
 
         CheckPCAAttributeValues(
                 posistions,
-                {Vec3f(1.0f), Vec3f(1.0f), Vec3f(1.0f)},
+                {Vec3f(s.nonAnisotropicStretch), Vec3f(s.nonAnisotropicStretch), Vec3f(s.nonAnisotropicStretch)},
                 {Mat3s::identity(), Mat3s::identity(), Mat3s::identity()},
                 posistionsWs,
                 {false, false, false},
@@ -294,6 +295,7 @@ TEST_F(TestPCA, testPCA)
 
         s.searchRadius = 0.001f;
         s.neighbourThreshold = 1;
+        s.nonAnisotropicStretch = 1.0f;
 
         points::pca(*points, s, a);
         ASSERT_TRUE(points->tree().cbeginLeaf());
@@ -323,6 +325,7 @@ TEST_F(TestPCA, testPCA)
         s.searchRadius = std::nextafter(0.01f, 1.0f);
         s.neighbourThreshold = 2; // only center point
         s.averagePositions = 0.0f; // disable position smoothing
+        s.nonAnisotropicStretch = 1.3f;
 
         points::pca(*points, s, a);
         ASSERT_TRUE(points->tree().cbeginLeaf());
@@ -336,7 +339,7 @@ TEST_F(TestPCA, testPCA)
 
         CheckPCAAttributeValues(
                 posistions,
-                {Vec3f(1.0), Vec3f(2.51984f, 0.62996f, 0.62996f), Vec3f(1.0)},
+                {Vec3f(s.nonAnisotropicStretch), Vec3f(2.51984f, 0.62996f, 0.62996f), Vec3f(s.nonAnisotropicStretch)},
                 {Mat3s::identity(), Mat3s(0,1,0, 1,0,0, 0,0,1), Mat3s::identity()},
                 posistionsWs,
                 {false, true, false},
@@ -356,6 +359,7 @@ TEST_F(TestPCA, testPCA)
         s.neighbourThreshold = 1; // make sure they get classified
         s.averagePositions = 0.0f; // disable position smoothing
         s.allowedAnisotropyRatio = 0.25f;
+        s.nonAnisotropicStretch = 1.0f;
 
         points::pca(*points, s, a);
         ASSERT_TRUE(points->tree().cbeginLeaf());

--- a/openvdb/openvdb/unittest/TestPointRasterizeSDF.cc
+++ b/openvdb/openvdb/unittest/TestPointRasterizeSDF.cc
@@ -18,9 +18,14 @@ public:
 
 
 template <typename FilterT>
-struct FixedSpheres
+struct FixedSurfacing
 {
-    FixedSpheres(const FilterT& f = FilterT()) : filter(f) {}
+    /// @note  The surface and surfaceSmooth methods use the old API. Once this
+    ///   has been deprecated they can be swicthed over to the new AI (as
+    ///   demonstrated by surfaceEllips).
+    FixedSurfacing(const FilterT& f = FilterT()) : filter(f) {}
+
+    //
 
     FloatGrid::Ptr surface(const Real radius)
     {
@@ -37,6 +42,8 @@ struct FixedSpheres
         grids.front()->setName("fixed");
         return grids;
     }
+
+    //
 
     FloatGrid::Ptr surfaceSmooth(const Real radius, const Real search)
     {
@@ -61,9 +68,9 @@ struct FixedSpheres
 };
 
 template <typename FilterT>
-struct VariableSpheres : public FixedSpheres<FilterT>
+struct VariableSurfacing : public FixedSurfacing<FilterT>
 {
-    VariableSpheres(const FilterT& f = FilterT()) : FixedSpheres<FilterT>(f) {}
+    VariableSurfacing(const FilterT& f = FilterT()) : FixedSurfacing<FilterT>(f) {}
 
     FloatGrid::Ptr surface(const Real scale = 1.0, const std::string& pscale = "pscale")
     {
@@ -106,7 +113,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeSpheres)
     // Test no points
     {
         float radius = 0.2f;
-        FixedSpheres<points::NullFilter> s;
+        FixedSurfacing<points::NullFilter> s;
         s.halfband = 3;
         s.points = PointBuilder({}).voxelsize(0.1).get();
         s.transform = nullptr;
@@ -121,7 +128,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeSpheres)
 
     // Test single point
     {
-        FixedSpheres<points::NullFilter> s;
+        FixedSurfacing<points::NullFilter> s;
 
         // small radius, small voxel size
         float radius = 0.2f;
@@ -221,7 +228,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeSpheres)
 
     // Test multiple points - 8 points at cube corner positions
     {
-        FixedSpheres<points::NullFilter> s;
+        FixedSurfacing<points::NullFilter> s;
         float radius = 0.2f;
         auto positions = getBoxPoints(/*scale*/0.0f);
 
@@ -348,7 +355,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeSpheres)
             .group({1,0,1,0,1,0,1,0}, "test")
             .get();
         points::GroupFilter filter("test", points->tree().cbeginLeaf()->attributeSet());
-        FixedSpheres<points::GroupFilter> s(filter);
+        FixedSurfacing<points::GroupFilter> s(filter);
         s.halfband = 3;
         s.points = points;
         s.transform = nullptr;
@@ -380,13 +387,13 @@ TEST_F(TestPointRasterizeSDF, testRasterizeSpheres)
 }
 
 
-TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
+TEST_F(TestPointRasterizeSDF, testRasterizeVariableSurfacing)
 {
     // First few tests check that the results are fp equivalent to fixed spheres
 
     // Test no points
     {
-        VariableSpheres<points::NullFilter> s;
+        VariableSurfacing<points::NullFilter> s;
         s.halfband = 3;
         s.points = PointBuilder({}).voxelsize(0.1).get();
         s.transform = nullptr;
@@ -401,7 +408,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
 
     // Test single point
     {
-        VariableSpheres<points::NullFilter> s;
+        VariableSurfacing<points::NullFilter> s;
         float radius = 0.2f;
 
         // small radius, small voxel size
@@ -410,7 +417,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
         s.transform = nullptr;
 
         FloatGrid::Ptr sdf = s.surface();
-        FloatGrid::Ptr comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        FloatGrid::Ptr comp = s.FixedSurfacing<points::NullFilter>::surface(radius);
         EXPECT_TRUE(sdf && sdf->getName() == "variable");
         EXPECT_TRUE(comp && comp->getName() == "fixed");
         EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
@@ -426,7 +433,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
         s.transform = nullptr;
 
         sdf = s.surface();
-        comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        comp = s.FixedSurfacing<points::NullFilter>::surface(radius);
         EXPECT_TRUE(sdf && sdf->getName() == "variable");
         EXPECT_TRUE(comp && comp->getName() == "fixed");
         EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
@@ -443,7 +450,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
         s.transform = math::Transform::createLinearTransform(0.3);
 
         sdf = s.surface();
-        comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        comp = s.FixedSurfacing<points::NullFilter>::surface(radius);
         EXPECT_TRUE(sdf && sdf->getName() == "variable");
         EXPECT_TRUE(comp && comp->getName() == "fixed");
         EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
@@ -455,7 +462,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
 
     // Test multiple points - 8 points at cube corner positions
     {
-        VariableSpheres<points::NullFilter> s;
+        VariableSurfacing<points::NullFilter> s;
         float radius = 0.2f;
         auto positions = getBoxPoints(/*scale*/0.0f);
         // test points overlapping all at 0,0,0 - should produce the same grid as first test
@@ -464,7 +471,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
         s.transform = nullptr;
 
         FloatGrid::Ptr sdf = s.surface();
-        FloatGrid::Ptr comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        FloatGrid::Ptr comp = s.FixedSurfacing<points::NullFilter>::surface(radius);
         EXPECT_TRUE(sdf && sdf->getName() == "variable");
         EXPECT_TRUE(comp && comp->getName() == "fixed");
         EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
@@ -481,7 +488,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
         s.transform = nullptr;
 
         sdf = s.surface();
-        comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        comp = s.FixedSurfacing<points::NullFilter>::surface(radius);
         EXPECT_TRUE(sdf && sdf->getName() == "variable");
         EXPECT_TRUE(comp && comp->getName() == "fixed");
         EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
@@ -508,7 +515,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
         s.transform = math::Transform::createLinearTransform(mat);
 
         sdf = s.surface();
-        comp = s.FixedSpheres<points::NullFilter>::surface(radius);
+        comp = s.FixedSurfacing<points::NullFilter>::surface(radius);
         EXPECT_TRUE(sdf && sdf->getName() == "variable");
         EXPECT_TRUE(comp && comp->getName() == "fixed");
         EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
@@ -530,13 +537,13 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
             .attribute(radius, "pscale")
             .get();
         points::GroupFilter filter("test", points->tree().cbeginLeaf()->attributeSet());
-        VariableSpheres<points::GroupFilter> s(filter);
+        VariableSurfacing<points::GroupFilter> s(filter);
         s.halfband = 3;
         s.points = points;
         s.transform = nullptr;
 
         FloatGrid::Ptr sdf = s.surface();
-        FloatGrid::Ptr comp = s.FixedSpheres<points::GroupFilter>::surface(radius);
+        FloatGrid::Ptr comp = s.FixedSurfacing<points::GroupFilter>::surface(radius);
         EXPECT_TRUE(sdf && sdf->getName() == "variable");
         EXPECT_TRUE(comp && comp->getName() == "fixed");
         EXPECT_TRUE(sdf->tree().hasSameTopology(comp->tree()));
@@ -557,7 +564,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSpheres)
             .attribute(rads, "myrad")
             .get();
 
-        VariableSpheres<points::NullFilter> s;
+        VariableSurfacing<points::NullFilter> s;
         s.halfband = 1; // small half band
         s.points = points;
         s.transform = nullptr;
@@ -609,7 +616,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeSmoothSpheres)
     // Test no points
     {
         float radius = 0.2f, search = 0.4f;
-        FixedSpheres<points::NullFilter> s;
+        FixedSurfacing<points::NullFilter> s;
         s.halfband = 3;
         s.points = PointBuilder({}).voxelsize(0.1).get();
         s.transform = nullptr;
@@ -624,7 +631,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeSmoothSpheres)
 
     // Test single point
     {
-        FixedSpheres<points::NullFilter> s;
+        FixedSurfacing<points::NullFilter> s;
         s.halfband = 3;
         s.points = PointBuilder({ Vec3f(0) }).voxelsize(0.1).get();
         s.transform = nullptr;
@@ -676,7 +683,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeSmoothSpheres)
             .group({1,0,0,0,0,0,0,0}, "test") // only first point
             .get();
         points::GroupFilter filter("test", points->tree().cbeginLeaf()->attributeSet());
-        FixedSpheres<points::GroupFilter> s(filter);
+        FixedSurfacing<points::GroupFilter> s(filter);
         s.halfband = 3;
         s.points = points;
         s.transform = nullptr;
@@ -699,7 +706,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeSmoothSpheres)
 
     // Test multiple points - 8 points at cube corner positions
     {
-        FixedSpheres<points::NullFilter> s;
+        FixedSurfacing<points::NullFilter> s;
         // test points overlapping all at 0,0,0 - should produce the same grid as first test
         auto positions = getBoxPoints(/*scale*/0.0f);
         s.halfband = 3;
@@ -756,7 +763,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSmoothSpheres)
     // Test no points
     {
         float radius = 0.2f, search = 0.4f;
-        VariableSpheres<points::NullFilter> s;
+        VariableSurfacing<points::NullFilter> s;
         s.halfband = 3;
         s.points = PointBuilder({}).voxelsize(0.1).get();
         s.transform = nullptr;
@@ -771,7 +778,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSmoothSpheres)
 
     // Test single point
     {
-        VariableSpheres<points::NullFilter> s;
+        VariableSurfacing<points::NullFilter> s;
         s.halfband = 3;
         s.points = PointBuilder({ Vec3f(0) }).voxelsize(0.1).attribute(0.2f, "rad").get();
         s.transform = math::Transform::createLinearTransform(0.1);
@@ -791,7 +798,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSmoothSpheres)
         search = 0.6;
 
         sdf = s.surfaceSmooth(scale, search, "rad");
-        FloatGrid::Ptr comp = s.FixedSpheres<points::NullFilter>::surfaceSmooth(0.2, search);
+        FloatGrid::Ptr comp = s.FixedSurfacing<points::NullFilter>::surfaceSmooth(0.2, search);
         EXPECT_TRUE(sdf && sdf->getName() == "variable_avg");
         EXPECT_TRUE(comp && comp->getName() == "fixed_avg");
         EXPECT_TRUE(sdf->transform() == *s.transform);
@@ -810,7 +817,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSmoothSpheres)
         scale = 0.5; // 0.4*0.5 = 0.2
         search = 5; // search of 5 allows for halfband size to up 10
         sdf = s.surfaceSmooth(scale, search, "rad");
-        comp = s.FixedSpheres<points::NullFilter>::surfaceSmooth(0.2, search);
+        comp = s.FixedSurfacing<points::NullFilter>::surfaceSmooth(0.2, search);
         EXPECT_TRUE(sdf && sdf->getName() == "variable_avg");
         EXPECT_TRUE(comp && comp->getName() == "fixed_avg");
         EXPECT_TRUE(sdf->transform() == *s.transform);
@@ -833,7 +840,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSmoothSpheres)
             .attribute(float(radius), "pscale")
             .get();
         points::GroupFilter filter("test", points->tree().cbeginLeaf()->attributeSet());
-        VariableSpheres<points::GroupFilter> s(filter);
+        VariableSurfacing<points::GroupFilter> s(filter);
         s.halfband = 3;
         s.points = points;
         s.transform = nullptr;
@@ -864,7 +871,7 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSmoothSpheres)
         std::vector<float> rads = {1.1f, 1.3f, 1.5f, 1.7f, 2.1f, 2.3f, 2.5f, 2.7f};
         double scale = 0.6, search = 2.0;
 
-        VariableSpheres<points::NullFilter> s;
+        VariableSurfacing<points::NullFilter> s;
         s.halfband = 4; // large enough to fill interior of the cube
         s.points = PointBuilder(positions).voxelsize(0.2).attribute(rads, "myrad").get();
         s.transform = nullptr;
@@ -888,13 +895,517 @@ TEST_F(TestPointRasterizeSDF, testRasterizeVariableSmoothSpheres)
     }
 }
 
+TEST_F(TestPointRasterizeSDF, testRasterizeEllipsoids)
+{
+    // Test no points
+    {
+        points::EllipsoidSettings<> s;
+        s.radiusScale = 0.2f;
+        s.sphereScale = 1.0f;
+        s.halfband = 3;
+        s.transform = nullptr;
+
+        auto points = PointBuilder({}).voxelsize(0.1).get();
+        auto grids = points::rasterizeSdf(*points, s);
+        FloatGrid::Ptr sdf = StaticPtrCast<FloatGrid>(grids.front());
+
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * points->voxelSize()[0]), sdf->background());
+        EXPECT_TRUE(sdf->empty());
+    }
+
+    // Test single point which is not treated as an ellips. This should give
+    // identicle results to SphereSettings<> (as long as the sphereScale is 1)
+    {
+        points::EllipsoidSettings<> s;
+        s.radiusScale = 0.2f;
+        s.sphereScale = 1.0f;
+        s.halfband = 3;
+        s.transform = nullptr;
+
+        /// 1) test with a single point but that is not in the ellips ellipses group
+        auto points = PointBuilder({Vec3f(0)})
+            .voxelsize(0.1)
+            .group({0}, s.pca.ellipses) // surface as a sphere
+            .attribute(points::PcaAttributes::StretchT(1.0), s.pca.stretch)
+            .attribute(points::PcaAttributes::RotationT::identity(), s.pca.rotation)
+            .attribute(points::PcaAttributes::PosWsT(0.0), s.pca.positionWS)
+            .get();
+
+        auto grids = points::rasterizeSdf(*points, s);
+        FloatGrid::Ptr sdf = StaticPtrCast<FloatGrid>(grids.front());
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(8), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(485), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            float length = float(ws.length()); // dist to center
+            length -= float(s.radiusScale); // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // should only have exterior background
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_EQ(sdf->background(), *iter);
+        }
+
+        /// 2) test with a single point that is marked as an ellips, but has an identity
+        ///    transformation matrix (and so is essentially a sphere)
+        points = PointBuilder({Vec3f(0)})
+            .voxelsize(0.1)
+            .group({1}, s.pca.ellipses) // surface as an ellips
+            .attribute(points::PcaAttributes::StretchT(1.0), s.pca.stretch)
+            .attribute(points::PcaAttributes::RotationT::identity(), s.pca.rotation)
+            .attribute(points::PcaAttributes::PosWsT(0.0), s.pca.positionWS)
+            .get();
+
+        grids = points::rasterizeSdf(*points, s);
+        sdf = StaticPtrCast<FloatGrid>(grids.front());
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(8), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(485), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            float length = float(ws.length()); // dist to center
+            length -= float(s.radiusScale); // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // should only have exterior background
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            EXPECT_EQ(sdf->background(), *iter);
+        }
+
+        /// 3) larger radius, larger voxel size, with sphere scale
+        s.radiusScale = 1.3f;
+        s.sphereScale = 1.6f;
+        points = PointBuilder({Vec3f(0)})
+            .voxelsize(0.5)
+            .group({0}, s.pca.ellipses) // surface as a sphere
+            .attribute(points::PcaAttributes::StretchT(1.0), s.pca.stretch)
+            .attribute(points::PcaAttributes::RotationT::identity(), s.pca.rotation)
+            .attribute(points::PcaAttributes::PosWsT(0.0), s.pca.positionWS)
+            .get();
+
+        grids = points::rasterizeSdf(*points, s);
+        sdf = StaticPtrCast<FloatGrid>(grids.front());
+
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(8), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(1544), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            float length = float(ws.length()); // dist to center
+            length -= float(s.radiusScale * s.sphereScale); // account for radius and sphere scale
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // check off values
+        size_t interiorOff = 0, exteriorOff = 0;
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord());
+            float length = float(ws.length()); // dist to center
+            // if length is <= the (rad - halfbandws), voxel is inside the surface
+            const bool interior = (length <= ((s.radiusScale * s.sphereScale) - (s.halfband * sdf->voxelSize()[0])));
+            if (interior) EXPECT_EQ(-(sdf->background()), *iter);
+            else          EXPECT_EQ(sdf->background(), *iter);
+            interior ? ++interiorOff : ++exteriorOff;
+        }
+
+        EXPECT_EQ(size_t(7), interiorOff);
+        EXPECT_EQ(size_t(297441), exteriorOff);
+
+        /// 4) offset position, different transform, larger half band
+        s.sphereScale = 1.0f;
+        s.radiusScale = 2.0f;
+        s.halfband = 4;
+        s.transform = math::Transform::createLinearTransform(0.3);
+
+        const Vec3f center(-1.2f, 3.4f,-5.6f);
+        points = PointBuilder({Vec3f(center)})
+            .voxelsize(0.1)
+            .group({0}, s.pca.ellipses) // surface as a sphere
+            .attribute(points::PcaAttributes::StretchT(1.0), s.pca.stretch)
+            .attribute(points::PcaAttributes::RotationT::identity(), s.pca.rotation)
+            .attribute(points::PcaAttributes::PosWsT(center), s.pca.positionWS)
+            .get();
+
+        grids = points::rasterizeSdf(*points, s);
+        sdf = StaticPtrCast<FloatGrid>(grids.front());
+
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == *s.transform);
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * s.transform->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(27), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(5005), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord()) - center;
+            float length = float(ws.length()); // dist to center
+            length -= float(s.radiusScale); // account for radius
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // check off values
+        interiorOff = 0;
+        exteriorOff = 0;
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            const Vec3d ws = sdf->transform().indexToWorld(iter.getCoord()) - center;
+            float length = float(ws.length()); // dist to center
+            // if length is <= the (rad - halfbandws), voxel is inside the surface
+            const bool interior = (length <= (s.radiusScale - (s.halfband * s.transform->voxelSize()[0])));
+            if (interior) EXPECT_EQ(-sdf->background(), *iter);
+            else          EXPECT_EQ(sdf->background(), *iter);
+            interior ? ++interiorOff : ++exteriorOff;
+        }
+
+        EXPECT_EQ(size_t(80), interiorOff);
+        EXPECT_EQ(size_t(82438), exteriorOff);
+    }
+
+    // Test single point which is treated as an ellips with scale and rotation
+    // along one principal axis
+    {
+        points::EllipsoidSettings<> s;
+        s.radiusScale = 0.8f;
+        s.sphereScale = 1.0f; // should have no effect
+        s.halfband = 3;
+        s.transform = nullptr;
+
+        // Design an ellips that is squashed in XYZ and then rotated
+        const points::PcaAttributes::StretchT stretch(1.0f, 0.2f, 1.0f);
+        points::PcaAttributes::RotationT rot;
+         // 45 degree rotation about Y (we only squash in Y so this should be a no-op)
+        rot.setToRotation({0,1,0}, 45);
+        // The transform that defines how we go from each voxel back to the source point
+        const math::Mat3s inv = rot.timesDiagonal(1.0 / stretch) * rot.transpose();
+        //
+
+        /// 1) test with a single ellips with Y stretch/rotation
+        auto points = PointBuilder({Vec3f(0)})
+            .voxelsize(0.1)
+            .group({1}, s.pca.ellipses) // surface as an ellips
+            .attribute(stretch, s.pca.stretch)
+            .attribute(rot, s.pca.rotation)
+            .attribute(points::PcaAttributes::PosWsT(0.0), s.pca.positionWS)
+            .get();
+
+        auto grids = points::rasterizeSdf(*points, s);
+        FloatGrid::Ptr sdf = StaticPtrCast<FloatGrid>(grids.front());
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(24), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(1018), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d is = inv * iter.getCoord().asVec3d();
+            float length = float(is.length()); // dist to center in index space
+            length -= float(s.radiusScale / sdf->voxelSize()[0]); // account for radius
+            length *= float(sdf->voxelSize()[0]); // dist to center in world space
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // check off values (because we're also squashing the halfband we
+        // just compre the overal length to 0.0)
+        size_t interiorOff = 0, exteriorOff = 0;
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            const Vec3d is = inv * iter.getCoord().asVec3d();
+            float length = float(is.length()); // dist to center in index space
+            length -= float(s.radiusScale / sdf->voxelSize()[0]); // account for radius
+            length *= float(sdf->voxelSize()[0]); // dist to center in world space
+            const bool interior = (length <= 0.0);
+            if (interior) EXPECT_EQ(-sdf->background(), *iter);
+            else          EXPECT_EQ(sdf->background(), *iter);
+            interior ? ++interiorOff : ++exteriorOff;
+        }
+
+        EXPECT_EQ(size_t(83), interiorOff);
+        EXPECT_EQ(size_t(306067), exteriorOff);
+
+        // Run again with a different Y rotation, should be the same as the above
+        // as we're only squashing in Y. Also test sphereScale has no impact
+        s.sphereScale = 10.0f; // should have no effect
+        rot.setToRotation({0,1,0}, -88);
+        points = PointBuilder({Vec3f(0)})
+            .voxelsize(0.1)
+            .group({1}, s.pca.ellipses) // surface as an ellips
+            .attribute(stretch, s.pca.stretch)
+            .attribute(rot, s.pca.rotation)
+            .attribute(points::PcaAttributes::PosWsT(0.0), s.pca.positionWS)
+            .get();
+
+        grids = points::rasterizeSdf(*points, s);
+        FloatGrid::Ptr sdf2 = StaticPtrCast<FloatGrid>(grids.front());
+        EXPECT_TRUE(sdf2);
+        EXPECT_TRUE(sdf2->transform() == points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf2->getGridClass());
+        EXPECT_EQ(float(s.halfband * points->voxelSize()[0]), sdf2->background());
+        EXPECT_TRUE(sdf->tree().hasSameTopology(sdf2->tree()));
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            EXPECT_NEAR(sdf2->tree().getValue(iter.getCoord()), *iter, 1e-6f);
+        }
+    }
+
+    // Test single point which is treated as an ellips with scale and rotation
+    // along multiple axis
+    {
+        points::EllipsoidSettings<> s;
+        s.sphereScale = 3.0f; // should have no effect
+        s.halfband = 5;
+
+        // Design an ellips that is squashed in XYZ and then rotated
+        const points::PcaAttributes::StretchT stretch(0.3f, 0.6f, 1.8f);
+        points::PcaAttributes::RotationT a,b,c,rot;
+        a.setToRotation({1,0,0}, 20);
+        b.setToRotation({0,1,0}, 45);
+        c.setToRotation({0,0,1}, 66);
+        rot = a * b * c;
+
+        // The transform that defines how we go from each voxel back to the source point
+        const math::Mat3s inv = rot.timesDiagonal(1.0 / stretch) * rot.transpose();
+        //
+
+        /// 1) test with a single ellips with Y stretch/rotation
+        const Vec3f center(-1.2f, 3.4f,-5.6f);
+        auto points = PointBuilder({center})
+            .voxelsize(0.2)
+            .group({1}, s.pca.ellipses) // surface as an ellips
+            .attribute(stretch, s.pca.stretch)
+            .attribute(rot, s.pca.rotation)
+            .attribute(points::PcaAttributes::PosWsT(center), s.pca.positionWS)
+            .get();
+
+        auto grids = points::rasterizeSdf(*points, s);
+        FloatGrid::Ptr sdf = StaticPtrCast<FloatGrid>(grids.front());
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(20), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(1337), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            const Vec3d is = inv * (iter.getCoord().asVec3d() - sdf->transform().worldToIndex(center));
+            float length = float(is.length()); // dist to center in index space
+            length -= float(s.radiusScale / sdf->voxelSize()[0]); // account for radius
+            length *= float(sdf->voxelSize()[0]); // dist to center in world space
+            EXPECT_NEAR(length, *iter, 1e-6f);
+        }
+
+        // check off values (because we're also squashing the halfband we
+        // just compre the overal length to 0.0)
+        size_t interiorOff = 0, exteriorOff = 0;
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            const Vec3d is = inv * (iter.getCoord().asVec3d() - sdf->transform().worldToIndex(center));
+            float length = float(is.length()); // dist to center in index space
+            length -= float(s.radiusScale / sdf->voxelSize()[0]); // account for radius
+            length *= float(sdf->voxelSize()[0]); // dist to center in world space
+            const bool interior = (length <= 0.0);
+            if (interior) EXPECT_EQ(-sdf->background(), *iter);
+            else          EXPECT_EQ(sdf->background(), *iter);
+            interior ? ++interiorOff : ++exteriorOff;
+        }
+
+        EXPECT_EQ(size_t(0), interiorOff);
+        EXPECT_EQ(size_t(82609), exteriorOff);
+    }
+
+    // Test multiple ellips and spheres with different transformations and radii
+    {
+        points::EllipsoidSettings<> s;
+        s.radiusScale = 2.0f;
+        s.sphereScale = 0.8f;
+        s.halfband = 5;
+        s.transform = nullptr;
+
+        const auto positions = getBoxPoints();
+        const std::vector<Vec3d> positionsVec3d(positions.begin(), positions.end());
+        const std::vector<short> ellips {0,1,0,1, 0,1,1,1};
+        const std::vector<points::PcaAttributes::StretchT> stretches {
+            {0.0f, 0.0f, 0.0f}, // sphere (should be ignored)
+            {1.0f, 1.0f, 1.0f}, // ellips
+            {5.0f, 5.0f, 5.0f}, // sphere  (should be ignored)
+            {2.0f, 0.3f, 1.5f}, // ellips
+
+            {1.0f, 1.0f, 1.0f}, // sphere  (should be ignored)
+            {1.1f, 0.8f, 1.0f}, // ellips
+            {0.8f, 4.0f, 1.5f}, // ellips
+            {0.4f, 1.1f, 1.0f}  // ellips
+        };
+        const std::vector<points::PcaAttributes::RotationT> rotations {
+            Mat3s::zero(),                      // sphere (should be ignored)
+            Mat3s::identity(),
+            math::rotation<Mat3s>({0,0,1}, 45), // sphere (should be ignored)
+            Mat3s::identity(),
+
+            math::rotation<Mat3s>({1,0,0}, -20), // sphere (should be ignored)
+            math::rotation<Mat3s>({0,1,0},   5),
+            math::rotation<Mat3s>({0,0,1}, 143),
+            math::rotation<Mat3s>({1,0,0},  49)
+        };
+
+        /// 1) test with uniform radius
+        auto points = PointBuilder(positions)
+            .voxelsize(0.3)
+            .group(ellips, s.pca.ellipses) // surface as an ellips
+            .attribute(stretches, s.pca.stretch)
+            .attribute(rotations, s.pca.rotation)
+            .attribute(positionsVec3d, s.pca.positionWS)
+            .get();
+
+        auto grids = points::rasterizeSdf(*points, s);
+        FloatGrid::Ptr sdf = StaticPtrCast<FloatGrid>(grids.front());
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(147), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(33252), sdf->tree().activeVoxelCount());
+
+        // Small lambda that finds the cloest length to a point that could
+        // either be an ellips of sphere, for a given voxel
+        const auto getClosestLength = [&](const Coord& ijk, const std::vector<float>* radii = nullptr)
+        {
+            double length = std::numeric_limits<double>::max();
+            size_t idx = 0;
+            for (auto& pos : positionsVec3d)
+            {
+                math::Mat3s inv = math::Mat3s::identity();
+                double scale = s.radiusScale / sdf->voxelSize()[0];
+                if (radii) scale *= double((*radii)[idx]);
+
+                if (ellips[idx]) {
+                    inv = rotations[idx].timesDiagonal(1.0 / stretches[idx]) *
+                        rotations[idx].transpose();
+                }
+                else {
+                    scale *= s.sphereScale;
+                }
+
+                const Vec3d is = inv * (ijk.asVec3d() - sdf->transform().worldToIndex(pos));
+                length = std::min(length, (is.length() - scale));
+                ++idx;
+            }
+
+            length *= (sdf->voxelSize()[0]); // dist to center in world space
+            return float(length);
+        };
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            // get closest dist from all points
+            const float length = getClosestLength(iter.getCoord());
+            EXPECT_NEAR(length, *iter, 1e-6f) << iter.getCoord();
+        }
+
+        // check off values (because we're also squashing the halfband we
+        // just compre the overal length to 0.0)
+        size_t interiorOff = 0, exteriorOff = 0;
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            // get closest dist from all points
+            const float length = getClosestLength(iter.getCoord());
+            const bool interior = (length <= 0.0);
+            if (interior) EXPECT_EQ(-sdf->background(), *iter);
+            else          EXPECT_EQ(sdf->background(), *iter);
+            interior ? ++interiorOff : ++exteriorOff;
+        }
+
+        EXPECT_EQ(size_t(147), interiorOff);
+        EXPECT_EQ(size_t(336622), exteriorOff);
+
+        /// 2) test with varying radius
+
+        const std::vector<float> radii {
+            1.0f, 0.0f, 2.0f, 1.1f,
+            0.2f, 0.5f, 0.8f, 3.0f
+        };
+
+        s.radiusScale = 1.2;
+        s.sphereScale = 0.3;
+        s.radius = "pscale";
+        s.halfband = 1;
+
+        points = PointBuilder(positions)
+            .voxelsize(0.3)
+            .group(ellips, s.pca.ellipses) // surface as an ellips
+            .attribute(radii, s.radius)
+            .attribute(stretches, s.pca.stretch)
+            .attribute(rotations, s.pca.rotation)
+            .attribute(positionsVec3d, s.pca.positionWS)
+            .get();
+
+        grids = points::rasterizeSdf(*points, s);
+        sdf = StaticPtrCast<FloatGrid>(grids.front());
+        EXPECT_TRUE(sdf);
+        EXPECT_TRUE(sdf->transform() == points->transform());
+        EXPECT_EQ(GRID_LEVEL_SET, sdf->getGridClass());
+        EXPECT_EQ(float(s.halfband * points->voxelSize()[0]), sdf->background());
+
+        EXPECT_EQ(Index32(39), sdf->tree().leafCount());
+        EXPECT_EQ(Index64(0), sdf->tree().activeTileCount());
+        EXPECT_EQ(Index64(2613), sdf->tree().activeVoxelCount());
+
+        for (auto iter = sdf->cbeginValueOn(); iter; ++iter) {
+            // get closest dist from all points
+            const float length = getClosestLength(iter.getCoord(), &radii);
+            EXPECT_NEAR(length, *iter, 1e-6f) << iter.getCoord();
+        }
+
+        // check off values (because we're also squashing the halfband we
+        // just compre the overal length to 0.0)
+        interiorOff = 0, exteriorOff = 0;
+        for (auto iter = sdf->cbeginValueOff(); iter; ++iter) {
+            // get closest dist from all points
+            const float length = getClosestLength(iter.getCoord(), &radii);
+            const bool interior = (length <= 0.0);
+            if (interior) EXPECT_EQ(-sdf->background(), *iter);
+            else          EXPECT_EQ(sdf->background(), *iter);
+            interior ? ++interiorOff : ++exteriorOff;
+        }
+
+        EXPECT_EQ(size_t(2137), interiorOff);
+        EXPECT_EQ(size_t(310083), exteriorOff);
+    }
+}
+
 
 TEST_F(TestPointRasterizeSDF, testAttrTransfer)
 {
     // Test no points
     {
         float radius = 0.2f, search = 0.4f;
-        FixedSpheres<points::NullFilter> s;
+        FixedSurfacing<points::NullFilter> s;
         s.halfband = 3;
         s.points = PointBuilder({}).voxelsize(0.1).get();
         s.transform = nullptr;
@@ -920,7 +1431,7 @@ TEST_F(TestPointRasterizeSDF, testAttrTransfer)
 
     // Test 8 point attribute transfers for normal spheres and smooth spheres
     {
-        FixedSpheres<points::NullFilter> s;
+        FixedSurfacing<points::NullFilter> s;
 
         std::vector<Vec3f> positions = getBoxPoints(/*scale*/0.5f);
         const std::vector<int64_t> test1data = {9,10,11,12,13,14,15,16};
@@ -1016,7 +1527,7 @@ TEST_F(TestPointRasterizeSDF, testVariableAttrTransfer)
     // Test no points
     {
         float radius = 0.2f, search = 0.4f;
-        VariableSpheres<points::NullFilter> s;
+        VariableSurfacing<points::NullFilter> s;
         s.halfband = 3;
         s.points = PointBuilder({}).voxelsize(0.1).get();
         s.transform = nullptr;
@@ -1043,7 +1554,7 @@ TEST_F(TestPointRasterizeSDF, testVariableAttrTransfer)
     // Test 8 point attribute transfers - overlapping spheres with varying
     // radii and a different target transform
     {
-        VariableSpheres<points::NullFilter> s;
+        VariableSurfacing<points::NullFilter> s;
 
         std::vector<Vec3f> positions = getBoxPoints(/*scale*/0.35f);
         const std::vector<int64_t> test1data = {0,1,2,3,4,5,6,7};

--- a/pendingchanges/surfacing.txt
+++ b/pendingchanges/surfacing.txt
@@ -1,0 +1,25 @@
+
+OpenVDB:
+    New:
+        - Introduced anisotropic surfacing tools in points/PointRasterizeSDF.h
+        and principle component analysis (PCA) methods in points/PrincipleComponentAnalysis.h.
+        The latter tool analyses point neighborhoods and computes affine
+        transformations representing elliptical distributions. The prior tool
+        takes rotational and stretch point attributes (optionally computed from
+        the prior PCA methods) and generates anisotropic surfaces.
+
+    API Changes:
+        - Re-worked the API in PointRasterizeSDF.h with the addition of anisotropic
+        surfacing kernels. The new API exposes more concise free functions which
+        take structs of parameters. The old API remains supported but is
+        deprecated.
+
+    Improvements:
+        - Improved the performance of PointRasterizeSDF.h tools with larger radii
+        with better bound computation approximations.
+
+    Fixes:
+        - Fixed a bug in points::rasterizeSpheres and points::rasterizeSmoothSpheres
+        which could cause sections of the generated surface to incorrectly be marked
+        as negative interior values.
+        - Fixed some precision issues in various Matrix methods

--- a/pendingchanges/surfacing.txt
+++ b/pendingchanges/surfacing.txt
@@ -22,4 +22,6 @@ OpenVDB:
         - Fixed a bug in points::rasterizeSpheres and points::rasterizeSmoothSpheres
         which could cause sections of the generated surface to incorrectly be marked
         as negative interior values.
+        - Fixed a bug in points::rasterizeSmoothSpheres which could result in
+        incomplete surface reconstruction with significantly larger search distances.
         - Fixed some precision issues in various Matrix methods


### PR DESCRIPTION
    New:
        - Introduced anisotropic surfacing tools in points/PointRasterizeSDF.h
        and principal component analysis (PCA) methods in points/PrincipalComponentAnalysis.h.
        The latter tool analyses point neighborhoods and computes affine
        transformations representing elliptical distributions. The prior tool
        takes rotational and stretch point attributes (optionally computed from
        the prior PCA methods) and generates anisotropic surfaces.

    API Changes:
        - Re-worked the API in PointRasterizeSDF.h with the addition of anisotropic
        surfacing kernels. The new API exposes more concise free functions which
        take structs of parameters. The old API remains supported but is
        deprecated.

    Improvements:
        - Improved the performance of PointRasterizeSDF.h tools with larger radii
        with better bound computation approximations.

    Fixes:
        - Fixed a bug in points::rasterizeSpheres and points::rasterizeSmoothSpheres
        which could cause sections of the generated surface to incorrectly be marked
        as negative interior values.
        - Fixed a bug in points::rasterizeSmoothSpheres which could result in
        incomplete surface reconstruction with significantly larger search distances.
        - Fixed some precision issues in various Matrix methods
