### PR TITLE
Add missing log4cplus/version.h include

### DIFF
--- a/openvdb/openvdb/util/logging.h
+++ b/openvdb/openvdb/util/logging.h
@@ -14,6 +14,7 @@
 #include <log4cplus/layout.h>
 #include <log4cplus/logger.h>
 #include <log4cplus/spi/loggingevent.h>
+#include <log4cplus/version.h>
 #include <algorithm> // for std::remove()
 #include <cstring> // for ::strrchr()
 #include <memory>


### PR DESCRIPTION
Currently, the logging.h header checks the LOG4CPLUS_VERSION macro to determine whether to use std::auto_ptr or std::unique_ptr. However, the LOG4CPLUS_VERSION macro is defined in log4cplus/version.h, which is not explicitlyincluded from logging.h. Explicitly include log4cplus/version.h to ensure that the LOG4CPLUS_VERSION macro is defined.