### PR TITLE
Remove Half LUT

### DIFF
--- a/openvdb/openvdb/math/Half.h
+++ b/openvdb/openvdb/math/Half.h
@@ -203,7 +203,7 @@ namespace internal {
 // Use of lookup table is explicitly suppressed and the generation of
 // a lookup table is suppressed.  This is required because we namespace
 // our type, but the lookup table is extern "C" and lacks a namespace.
-// Thus any attempt to link two versions of OpenVDB with different 
+// Thus any attempt to link two versions of OpenVDB with different
 // namespaces will clash due to redefinition with a new type.
 // The default was not to use a lookup table.
 #undef  IMATH_HALF_USE_LOOKUP_TABLE

--- a/openvdb/openvdb/math/Half.h
+++ b/openvdb/openvdb/math/Half.h
@@ -200,6 +200,15 @@ namespace OPENVDB_VERSION_NAME {
 namespace math {
 namespace internal {
 
+// Use of lookup table is explicitly suppressed and the generation of
+// a lookup table is suppressed.  This is required because we namespace
+// our type, but the lookup table is extern "C" and lacks a namespace.
+// Thus any attempt to link two versions of OpenVDB with different 
+// namespaces will clash due to redefinition with a new type.
+// The default was not to use a lookup table.
+#undef  IMATH_HALF_USE_LOOKUP_TABLE
+#define IMATH_HALF_NO_LOOKUP_TABLE
+
 //-------------------------------------------------------------------------
 // Limits
 //

--- a/pendingchanges/remove_half_lut.txt
+++ b/pendingchanges/remove_half_lut.txt
@@ -1,0 +1,5 @@
+Fixes:
+    - The Half.h is no longer built with an internal lookup table, but
+      explicilty selects the non-lut version and disables creation of
+      a lut.  This is required to avoid symbol conflicts with
+      different namespaced OpenVDB builds.


### PR DESCRIPTION
OpenEXR 3 added an extern "C" LUT for Half.  The default configuration wasn't using it, but exporting it means that because the _type_ of the lookup table is namespaced, we can end up with conflicts if two namespaced versions of OpenVDB are compiled together, or OpenVDB with any OpenEXR external library.

This explicitly disables the creation of the Half LUT to avoid this.