### PR TITLE
Don't update timestamp when regenerating instantation files.

### DIFF
--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -582,13 +582,19 @@ if(USE_EXPLICIT_INSTANTIATION)
 
     # Define the source file location - "<binary_dir>/instantiations/Activate.cc"
     set(INSTANTIATE_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/instantiations/${NAME}.cc")
+    set(INSTANTIATE_INPUT "${CMAKE_CURRENT_BINARY_DIR}/instantiations.in/${NAME}.cc")
 
     # The auto-generated file holds the instantiate define and the header
     # which contains all the functions to be explicitly instantiated.
-    file(WRITE ${INSTANTIATE_SOURCE}
+    file(WRITE ${INSTANTIATE_INPUT}
       "#define OPENVDB_INSTANTIATE_${UPPER_NAME}\n"
       "#include <openvdb/${HEADER}>\n"
     )
+
+    # Update the actual source file only if the content has been modified.
+    # Without this step, rerunning CMake would update the timestamp of the
+    # auto-generated file systematically, retriggering compilation.
+    configure_file(${INSTANTIATE_INPUT} ${INSTANTIATE_SOURCE} COPYONLY)
 
     # Add to the list of library source files
     # (prepend as instantiations tend to be slow to compile).


### PR DESCRIPTION
Currently, when `USE_EXPLICIT_INSTANTIATION=ON`, re-running CMake will trigger recompilation of OpenVDB instantiation files. The culprit is the following line:

https://github.com/AcademySoftwareFoundation/openvdb/blob/3f8b6f30cf7c7d0d7f8fa7714965fb15d5db555b/openvdb/openvdb/CMakeLists.txt#L601

As the documentation for [file(WRITE)](https://cmake.org/cmake/help/latest/command/file.html#writing) mentions, one should use [configure_file()](https://cmake.org/cmake/help/latest/command/configure_file.html#command:configure_file) to copy generated files used as build sources, only if the content changes. Given that `USE_EXPLICIT_INSTANTIATION` was created to save time when recompiling dependent files, this is quite an unfortunate mistake. This PR fixes that.