### PR TITLE
Fixed C++20 compatibility of OpenVDB and TBB

### DIFF
--- a/openvdb/openvdb/points/AttributeSet.cc
+++ b/openvdb/openvdb/points/AttributeSet.cc
@@ -280,7 +280,8 @@ AttributeSet::isShared(size_t pos) const
 {
     assert(pos != INVALID_POS);
     assert(pos < mAttrs.size());
-    return !mAttrs[pos].unique();
+    // Warning: In multithreaded environment, the value returned by use_count is approximate.
+    return mAttrs[pos].use_count() != 1;
 }
 
 
@@ -289,7 +290,8 @@ AttributeSet::makeUnique(size_t pos)
 {
     assert(pos != INVALID_POS);
     assert(pos < mAttrs.size());
-    if (!mAttrs[pos].unique()) {
+    // Warning: In multithreaded environment, the value returned by use_count is approximate.
+    if (mAttrs[pos].use_count() != 1) {
         mAttrs[pos] = mAttrs[pos]->copy();
     }
 }

--- a/openvdb/openvdb/tools/Diagnostics.h
+++ b/openvdb/openvdb/tools/Diagnostics.h
@@ -1209,7 +1209,7 @@ public:
     void getInactiveValues(SetType&) const;
 
     inline InactiveTileValues(const InactiveTileValues<TreeType>&, tbb::split);
-    inline void operator()(IterRange&);
+    inline void operator()(const IterRange&);
     inline void join(const InactiveTileValues<TreeType>&);
 
 private:
@@ -1252,10 +1252,10 @@ InactiveTileValues<TreeType>::runSerial(IterRange& range)
 
 template<typename TreeType>
 inline void
-InactiveTileValues<TreeType>::operator()(IterRange& range)
+InactiveTileValues<TreeType>::operator()(const IterRange& range)
 {
-    for (; range && !thread::isGroupExecutionCancelled(); ++range) {
-        typename TreeType::ValueOffCIter iter = range.iterator();
+    for (IterRange it(range); it.test() && !thread::isGroupExecutionCancelled(); ++it) {
+        typename TreeType::ValueOffCIter iter = it.iterator();
         for (; iter; ++iter) {
             mInactiveValues.insert(iter.getValue());
         }

--- a/openvdb/openvdb/tools/GridTransformer.h
+++ b/openvdb/openvdb/tools/GridTransformer.h
@@ -799,11 +799,11 @@ public:
     void setInterrupt(const InterruptFunc& f) { mInterrupt = f; }
 
     /// Transform each leaf node in the given range.
-    void operator()(LeafRange& r)
+    void operator()(const LeafRange& r)
     {
-        for ( ; r; ++r) {
+        for (LeafRange it(r); it.test(); ++it) {
             if (interrupt()) break;
-            LeafIterT i = r.iterator();
+            LeafIterT i = it.iterator();
             CoordBBox bbox(i->origin(), i->origin() + Coord(i->dim()));
             if (!mBBox.empty()) {
                 // Intersect the leaf node's bounding box with mBBox.
@@ -818,12 +818,12 @@ public:
     }
 
     /// Transform each non-background tile in the given range.
-    void operator()(TileRange& r)
+    void operator()(const TileRange& r)
     {
-        for ( ; r; ++r) {
+        for (TileRange it(r); it.test(); ++it) {
             if (interrupt()) break;
 
-            TileIterT i = r.iterator();
+            TileIterT i = it.iterator();
             // Skip voxels and background tiles.
             if (!i.isTileValue()) continue;
             if (!i.isValueOn() && math::isApproxEqual(*i, mOutTree->background())) continue;

--- a/openvdb/openvdb/tools/LevelSetSphere.h
+++ b/openvdb/openvdb/tools/LevelSetSphere.h
@@ -189,7 +189,7 @@ private:
                 Op(TreeT &tree) : mDelete(false), mTree(&tree) {}
                 Op(const Op& other, tbb::split) : mDelete(true), mTree(new TreeT(other.mTree->background())) {}
                 ~Op() { if (mDelete) delete mTree; }
-                void operator()(RangeT &r) { for (auto i=r.begin(); i!=r.end(); ++i) this->merge(*i);}
+                void operator()(const RangeT &r) { for (auto i=r.begin(); i!=r.end(); ++i) this->merge(*i);}
                 void join(Op &other) { this->merge(*(other.mTree)); }
                 void merge(TreeT &tree) { mTree->merge(tree, openvdb::MERGE_ACTIVE_STATES); }
             } op( mGrid->tree() );

--- a/openvdb/openvdb/tools/ValueTransformer.h
+++ b/openvdb/openvdb/tools/ValueTransformer.h
@@ -657,7 +657,7 @@ public:
         }
     }
 
-    void operator()(IterRange& r) { for ( ; r; ++r) (*mOp)(r.iterator()); }
+    void operator()(const IterRange& r) { for (IterRange it(r); it.test(); ++it) (*mOp)(it.iterator()); }
 
     void join(OpAccumulator& other) { mOp->join(*other.mOp); }
 


### PR DESCRIPTION
## Change List:
- Fixed compatibility of OpenVDB and TBB by fixing invocations of `tbb::parallel_reduce`, which from C++20 have `__TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)`. In that requires expression `parallel_reduce_body<Body, Range>` was failing because Body didn't have an `operator()` that takes a constant reference to `Range`:
```cpp
template <typename Body, typename Range>
concept parallel_reduce_body = splittable<Body> &&
                               requires( Body& body, const Range& range, Body& rhs ) {
                                   body(range);
                                   body.join(rhs);
                               };
```
- Replaced usage of `std::shared_ptr<T>::unique` (which was removed in C++20) by `std::shared_ptr<T>::use_count` (similiar to what @jdumas did in #1628 )

Fixes issue: #1590 