### PR TITLE
Fix nullptr dereferences found by gcc 11.4

### DIFF
--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Convert.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Convert.cc
@@ -1206,7 +1206,7 @@ SOP_OpenVDB_Convert::Cache::referenceMeshing(
         typename GridType::ConstPtr grid = openvdb::gridConstPtrCast<GridType>(*it);
 
         if (!grid) {
-            badTypeList.push_back(grid->getName());
+            badTypeList.push_back((*it)->getName());
             continue;
         }
 

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Extrapolate.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Extrapolate.cc
@@ -583,7 +583,8 @@ SOP_OpenVDB_Extrapolate::Cache::process(
     if (parms.mNeedExt) {
         typename ExtGridT::ConstPtr extGrid = openvdb::gridConstPtrCast<ExtGridT>(exPrim->getConstGridPtr());
         if (!extGrid) {
-            std::string msg = "Extension grid (" + extGrid->getName() + ") cannot be converted " +
+            auto grid = exPrim->getConstGridPtr();
+            std::string msg = "Extension grid (" + grid->getName() + ") cannot be converted " +
                               "to the explicit type specified.";
             throw std::runtime_error(msg);
         }

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Fracture.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_Fracture.cc
@@ -531,7 +531,7 @@ SOP_OpenVDB_Fracture::Cache::process(
                 residuals.push_back(residual);
 
             } else {
-                badTypeList.push_back(residual->getName());
+                badTypeList.push_back((*it)->getName());
                 continue;
             }
 

--- a/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_To_Polygons.cc
+++ b/openvdb_houdini/openvdb_houdini/SOP_OpenVDB_To_Polygons.cc
@@ -896,7 +896,7 @@ SOP_OpenVDB_To_Polygons::Cache::referenceMeshing(
         typename GridType::ConstPtr grid = openvdb::gridConstPtrCast<GridType>(*it);
 
         if (!grid) {
-            badTypeList.push_back(grid->getName());
+            badTypeList.push_back((*it)->getName());
             continue;
         }
 


### PR DESCRIPTION
I'm not sure if we can actually hit these code paths in practice but this at least shuts up the warnings.