### PR TITLE
Fix Houdini CI Caching

### DIFF
--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -96,7 +96,7 @@ jobs:
         key: linux-vfx-hou${{ matrix.config.hou }}-${{ matrix.config.image }}-${{ matrix.config.cxx }}-${{ steps.timestamp.outputs.timestamp }}
         restore-keys: linux-vfx-hou${{ matrix.config.hou }}-${{ matrix.config.image }}-${{ matrix.config.cxx }}-
     - name: fetch_houdini
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: hou
         key: dummy-houdini${{ matrix.config.hou }}-${{ steps.timestamp.outputs.timestamp }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -74,6 +74,16 @@ jobs:
       image: aswf/ci-base:2023
     steps:
     - uses: actions/checkout@v3
+    # We bumped from the 2021 CI image to 2023 here to fix some OpenSSL issues
+    # with the Houdini download script. In so doing we broke some of the caching
+    # between this job and the jobs in houdini.yml which _don't_ use the 2023
+    # image yet. The issue is that the cache action will use zstd if it's
+    # available to zip the cache and this causes it to be inserted with a unique
+    # hash which images without zstd (i.e. the 2021/2022 images don't have
+    # access to). For now, uninstall zstd here instead of installing it
+    # everywhere and ask the LF to add zstd to the older base images.
+    - name: remove zstd
+      run: yum -y remove zstd
     - name: timestamp
       id: timestamp
       run: echo "timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
@@ -85,7 +95,7 @@ jobs:
         cp hou/hou.tar.gz $HOME/houdini_install/hou.tar.gz
         cd $HOME/houdini_install && tar -xzf hou.tar.gz && cd -
     - name: write_houdini_cache
-      uses: actions/cache@v3
+      uses: actions/cache/save@v3
       with:
         path: hou
         key: vdb-v5-houdini${{ matrix.config.houdini_version_str }}-${{ steps.timestamp.outputs.timestamp }}

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cmake --build . --parallel 4 --config Release --target install
 #### Building OpenVDB AX and NanoVDB
 
 OpenVDB AX depends on the core OpenVDB library. NanoVDB can be built with and
-without OpenVDB support. Note that NanoVDB has its own build instructuins, see
+without OpenVDB support. Note that NanoVDB has its own build instructions, see
 the [NanoVDB build documentation](https://www.openvdb.org/documentation/doxygen/NanoVDB_HowToBuild.html)
 for details.
 


### PR DESCRIPTION
    # We bumped from the 2021 CI image to 2023 to fix some OpenSSL issues
    # with the Houdini download script. In so doing we broke some of the caching
    # between this job and the jobs in houdini.yml which _don't_ use the 2023
    # image yet. The issue is that the cache action will use zstd if it's
    # available to zip the cache and this causes it to be inserted with a unique
    # hash which images without zstd (i.e. the 2021/2022 images don't have
    # access to). For now, uninstall zstd here instead of installing it
    # everywhere and ask the LF to add zstd to the older base images.