### PR TITLE
Fix CHAR_BIT undefined. climits header is missing in some build envir…

### DIFF
--- a/openvdb/openvdb/points/AttributeSet.h
+++ b/openvdb/openvdb/points/AttributeSet.h
@@ -15,6 +15,7 @@
 #include <openvdb/MetaMap.h>
 
 #include <limits>
+#include <climits>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
I had one environment where CHAR_BIT was undefined and failed my build