### PR TITLE
More pybind11 bugfixes and cleanup

### DIFF
--- a/openvdb/openvdb/python/pyOpenVDBModule.cc
+++ b/openvdb/openvdb/python/pyOpenVDBModule.cc
@@ -371,10 +371,6 @@ PYBIND11_MODULE(PY_OPENVDB_MODULE_NAME, m)
 
 #undef PYOPENVDB_TRANSLATE_EXCEPTION
 
-    py::class_<openvdb::PointDataIndex32>(m, "PointDataIndex32")
-        .def(py::init<openvdb::Index32>(), py::arg("i") = openvdb::Index32(0));
-
-
     // Export the python bindings.
     exportTransform(m);
     exportMetadata(m);


### PR DESCRIPTION
1. Fixed `__setitem__` for iterators being bound to `getItem` instead of `setItem`
2. Removed obsolete class binding for PointDataIndex32 -- this is handled by the `PointDataIndex32` typecaster
3. Made the `TreeCombineOp` more concise and formally typed via the `std::functional` support in pybind11.