### PR TITLE
Fix for potential crash when reading invalid .vdb files.

### DIFF
--- a/pendingchanges/iofix.txt
+++ b/pendingchanges/iofix.txt
@@ -1,0 +1,3 @@
+Bug Fixes:
+    - Fix potential crash reading corrupt .vdb files with invalid
+      blosc or zip chunks.  [Fix thanks to Matthias Ueberheide]


### PR DESCRIPTION
Original fix thanks to Matthias Ueberheide.