### PR TITLE
Bug fixes to v11.0.0

### DIFF
--- a/cmake/FindOpenVDB.cmake
+++ b/cmake/FindOpenVDB.cmake
@@ -491,11 +491,37 @@ endif()
 # Add standard dependencies
 
 find_package(TBB REQUIRED COMPONENTS tbb)
+find_package(Boost REQUIRED COMPONENTS iostreams)
 
 # Add deps for pyopenvdb
+# @todo track for numpy
 
 if(pyopenvdb IN_LIST OpenVDB_FIND_COMPONENTS)
   find_package(Python REQUIRED)
+
+  # Boost python handling - try and find both python and pythonXx (version suffixed).
+  # Prioritize the version suffixed library, failing if neither exist.
+
+  find_package(Boost ${MINIMUM_BOOST_VERSION}
+    QUIET COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}
+  )
+
+  if(TARGET Boost::python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+    set(BOOST_PYTHON_LIB "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+    message(STATUS "Found boost_python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+  else()
+    find_package(Boost ${MINIMUM_BOOST_VERSION} QUIET COMPONENTS python)
+    if(TARGET Boost::python)
+      set(BOOST_PYTHON_LIB "python")
+      message(STATUS "Found non-suffixed boost_python, assuming to be python version "
+        "\"${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}\" compatible"
+      )
+    else()
+      message(FATAL_ERROR "Unable to find boost_python or "
+        "boost_python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}."
+      )
+    endif()
+  endif()
 endif()
 
 # Add deps for openvdb_ax
@@ -630,10 +656,6 @@ if(OpenVDB_USES_IMATH_HALF)
   find_package(Imath REQUIRED CONFIG)
 endif()
 
-if(OpenVDB_USES_DELAYED_LOADING)
-  find_package(Boost REQUIRED COMPONENTS iostreams)
-endif()
-
 if(UNIX)
   find_package(Threads REQUIRED)
 endif()
@@ -744,7 +766,7 @@ if(OpenVDB_pyopenvdb_LIBRARY)
     set_target_properties(OpenVDB::pyopenvdb PROPERTIES
       IMPORTED_LOCATION "${OpenVDB_pyopenvdb_LIBRARY}"
       INTERFACE_INCLUDE_DIRECTORIES "${OpenVDB_pyopenvdb_INCLUDE_DIR};${PYTHON_INCLUDE_DIR}"
-      INTERFACE_LINK_LIBRARIES "OpenVDB::openvdb;${PYTHON_LIBRARIES}"
+      INTERFACE_LINK_LIBRARIES "OpenVDB::openvdb;Boost::${BOOST_PYTHON_LIB};${PYTHON_LIBRARIES}"
       INTERFACE_COMPILE_FEATURES cxx_std_17
    )
   endif()

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -267,7 +267,7 @@ PyBind11       | C++/python bindings                                            
 NumPy          | Scientific computing with Python                                | Optional (Python)  |
 LLVM           | Target-independent code generation                              | OpenVDB AX         |
 
-At a minimum a matching C++17 compiler and CMake will be required. See
+At a minimum, boost, a matching C++17 compiler and CMake will be required. See
 the full [dependency list](@ref dependencies) for help with downloading and
 installing the above software. Note that as Blosc and ZLib are provided as part
 of the Houdini installation `USE_BLOSC` and `USE_ZLIB` should be left `ON`.

--- a/doc/dependencies.txt
+++ b/doc/dependencies.txt
@@ -36,7 +36,7 @@ Reference Platform, but for those that do, their specified versions are
 
 Component               | Requirements                                    | Optional
 ----------------------- | ----------------------------------------------- | --------
-OpenVDB Core Library    | CMake, C++17 compiler, TBB::tbb                 | Blosc, ZLib, Log4cplus, Imath::Imath, Boost::iostream
+OpenVDB Core Library    | CMake, C++17 compiler, TBB::tbb, Boost::headers | Blosc, ZLib, Log4cplus, Imath::Imath, Boost::iostream
 OpenVDB Print           | Core Library dependencies                       | -
 OpenVDB LOD             | Core Library dependencies                       | -
 OpenVDB Render          | Core Library dependencies                       | OpenEXR, Imath::Imath, libpng
@@ -65,7 +65,7 @@ Imath          | 3.1     | Latest      | Half precision floating points         
 OpenEXR        | 3.1     | Latest      | EXR serialization support                                         | Y       | Y        | http://www.openexr.com
 TBB            | 2020.2  | 2020.3      | Threading Building Blocks - template library for task parallelism | Y       | Y        | https://www.threadingbuildingblocks.org
 ZLIB           | 1.2.7   | Latest      | Compression library for disk serialization compression            | Y       | Y        | https://www.zlib.net
-Boost          | 1.73    | 1.80        | Components: iostreams                                             | Y       | Y        | https://www.boost.org
+Boost          | 1.73    | 1.80        | Components: headers, iostreams                                    | Y       | Y        | https://www.boost.org
 LLVM           | 10.0.0  | 13.0.0*     | Target-independent code generation                                | Y       | Y        | https://llvm.org/
 Bison          | 3.0.0   | 3.7.0       | General-purpose parser generator                                  | Y       | Y        | https://www.gnu.org/software/gcc
 Flex           | 2.6.0   | 2.6.4       | Fast lexical analyzer generator                                   | Y       | Y        | https://github.com/westes/flex

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -110,14 +110,16 @@ endif()
 
 if(OPENVDB_USE_DELAYED_LOADING)
   find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS iostreams)
+else()
+  find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS headers)
+endif()
 
-  if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_BOOST_VERSION)
-    # The X.Y.Z boost version value isn't available until CMake 3.14
-    set(FULL_BOOST_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-    if(${FULL_BOOST_VERSION} VERSION_LESS FUTURE_MINIMUM_BOOST_VERSION)
-      message(DEPRECATION "Support for Boost versions < ${FUTURE_MINIMUM_BOOST_VERSION} "
-        "is deprecated and will be removed.")
-    endif()
+if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_BOOST_VERSION)
+  # The X.Y.Z boost version value isn't available until CMake 3.14
+  set(FULL_BOOST_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+  if(${FULL_BOOST_VERSION} VERSION_LESS FUTURE_MINIMUM_BOOST_VERSION)
+    message(DEPRECATION "Support for Boost versions < ${FUTURE_MINIMUM_BOOST_VERSION} "
+      "is deprecated and will be removed.")
   endif()
 endif()
 
@@ -244,17 +246,20 @@ endif()
 
 if(OPENVDB_USE_DELAYED_LOADING)
   list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Boost::iostreams)
-  if(WIN32)
-    # Boost headers contain #pragma commands on Windows which causes Boost
-    # libraries to be linked in automatically. Custom boost installations
-    # may find that these naming conventions don't always match and can
-    # cause linker errors. This option disables this feature of Boost. Note
-    # -DBOOST_ALL_NO_LIB can also be provided manually.
-    if(OPENVDB_DISABLE_BOOST_IMPLICIT_LINKING)
-        list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
-          Boost::disable_autolinking  # add -DBOOST_ALL_NO_LIB
-        )
-    endif()
+else()
+  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Boost::headers)
+endif()
+
+if(WIN32)
+  # Boost headers contain #pragma commands on Windows which causes Boost
+  # libraries to be linked in automatically. Custom boost installations
+  # may find that these naming conventions don't always match and can
+  # cause linker errors. This option disables this feature of Boost. Note
+  # -DBOOST_ALL_NO_LIB can also be provided manually.
+  if(OPENVDB_DISABLE_BOOST_IMPLICIT_LINKING)
+      list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
+        Boost::disable_autolinking  # add -DBOOST_ALL_NO_LIB
+      )
   endif()
 endif()
 

--- a/openvdb/openvdb/math/Math.h
+++ b/openvdb/openvdb/math/Math.h
@@ -10,6 +10,7 @@
 
 #include <openvdb/Platform.h>
 #include <openvdb/version.h>
+#include <boost/numeric/conversion/conversion_traits.hpp>
 #include <algorithm> // for std::max()
 #include <cassert>
 #include <cmath>     // for std::ceil(), std::fabs(), std::pow(), std::sqrt(), etc.
@@ -915,9 +916,10 @@ enum RotationOrder {
     ZXZ_ROTATION
 };
 
-template <typename S, typename T, typename = std::enable_if_t<std::is_arithmetic_v<S>&& std::is_arithmetic_v<T>>>
+
+template <typename S, typename T>
 struct promote {
-    using type = typename std::common_type_t<S,T>;
+    using type = typename boost::numeric::conversion_traits<S, T>::supertype;
 };
 
 /// @brief Return the index [0,1,2] of the smallest value in a 3D vector.

--- a/pendingchanges/iofix.txt
+++ b/pendingchanges/iofix.txt
@@ -1,0 +1,3 @@
+Bug Fixes:
+    - Fix potential crash reading corrupt .vdb files with invalid
+      blosc or zip chunks.  [Fix thanks to Matthias Ueberheide]


### PR DESCRIPTION
* Fix for potential crash when reading invalid .vdb files.
* Revert "Replace boost conversion_traits with std::common_type"
* Revert "Remove boost from the build system when OPENVDB_USE_DELAYED_LOADING is OFF" 