### PR TITLE
Replace ssize_t with Py_ssize_t

### DIFF
--- a/openvdb/openvdb/python/pyGrid.h
+++ b/openvdb/openvdb/python/pyGrid.h
@@ -322,7 +322,7 @@ copyToArray(GridType&, const py::object&, py::object)
 
 #else // if defined(PY_OPENVDB_USE_NUMPY)
 
-using ArrayDimVec = std::vector<ssize_t>;
+using ArrayDimVec = std::vector<Py_ssize_t>;
 
 // ID numbers for supported value types
 enum class DtId { NONE, FLOAT, DOUBLE, BOOL, INT16, INT32, INT64, UINT32, UINT64/*, HALF*/ };
@@ -768,12 +768,12 @@ template<typename GridType>
 inline typename GridType::Ptr
 meshToLevelSet(py::array_t<float> pointsObj, py::array_t<Index32> trianglesObj, py::array_t<Index32> quadsObj, math::Transform::Ptr xform, float halfWidth)
 {
-    auto validate2DArray = [](py::array array, ssize_t N) {
+    auto validate2DArray = [](py::array array, Py_ssize_t N) {
         if (array.ndim() != 2 || array.shape(1) != N) {
             std::ostringstream os;
             os << "Expected a 2-dimensional numpy.ndarray with shape(1) = "<< N;
             os << ", found " << array.ndim() << "-dimensional array with shape = (";
-            for (ssize_t i = 0; i < array.ndim(); ++i) {
+            for (Py_ssize_t i = 0; i < array.ndim(); ++i) {
                 os << array.shape(i);
                 if (i != array.ndim() - 1)
                     os << ", ";
@@ -826,12 +826,12 @@ volumeToQuadMesh(const GridType& grid, double isovalue)
     std::vector<Vec4I> quads;
     tools::volumeToMesh(grid, points, quads, isovalue);
 
-    std::vector<ssize_t> shape = { static_cast<ssize_t>(points.size()), 3 };
-    std::vector<ssize_t> strides = { 3 * static_cast<ssize_t>(sizeof(float)), static_cast<ssize_t>(sizeof(float))};
+    std::vector<Py_ssize_t> shape = { static_cast<Py_ssize_t>(points.size()), 3 };
+    std::vector<Py_ssize_t> strides = { 3 * static_cast<Py_ssize_t>(sizeof(float)), static_cast<Py_ssize_t>(sizeof(float))};
     py::array_t<float> pointArrayObj(py::buffer_info(points.data(), sizeof(float), py::format_descriptor<float>::format(), 2, shape, strides));
 
-    shape = { static_cast<ssize_t>(quads.size()), 4 };
-    strides = { 4 * static_cast<ssize_t>(sizeof(Index32)), static_cast<ssize_t>(sizeof(Index32))};
+    shape = { static_cast<Py_ssize_t>(quads.size()), 4 };
+    strides = { 4 * static_cast<Py_ssize_t>(sizeof(Index32)), static_cast<Py_ssize_t>(sizeof(Index32))};
     py::array_t<Index32> quadArrayObj(py::buffer_info(quads.data(), sizeof(Index32), py::format_descriptor<Index32>::format(), 2, shape, strides));
 
     return std::make_tuple(pointArrayObj, quadArrayObj);
@@ -857,18 +857,18 @@ volumeToMesh(const GridType& grid, double isovalue, double adaptivity)
     // Create a deep copy of the array (because the point vector will be destroyed
     // when this function returns).
 
-    std::vector<ssize_t> shape = { static_cast<ssize_t>(points.size()), 3 };
-    std::vector<ssize_t> strides = { 3 * static_cast<ssize_t>(sizeof(float)), static_cast<ssize_t>(sizeof(float))};
+    std::vector<Py_ssize_t> shape = { static_cast<Py_ssize_t>(points.size()), 3 };
+    std::vector<Py_ssize_t> strides = { 3 * static_cast<Py_ssize_t>(sizeof(float)), static_cast<Py_ssize_t>(sizeof(float))};
     py::buffer_info pointInfo(points.data(), sizeof(float), py::format_descriptor<float>::format(), 2, shape, strides);
     py::array_t<float> pointArray(pointInfo);
 
-    shape = { static_cast<ssize_t>(triangles.size()), 3 };
-    strides = { 3 * static_cast<ssize_t>(sizeof(Index32)), static_cast<ssize_t>(sizeof(Index32))};
+    shape = { static_cast<Py_ssize_t>(triangles.size()), 3 };
+    strides = { 3 * static_cast<Py_ssize_t>(sizeof(Index32)), static_cast<Py_ssize_t>(sizeof(Index32))};
     py::buffer_info triangleInfo(triangles.data(), sizeof(Index32), py::format_descriptor<Index32>::format(), 2, shape, strides);
     py::array_t<Index32> triangleArray(triangleInfo);
 
-    shape = { static_cast<ssize_t>(quads.size()), 4 };
-    strides = { 4 * static_cast<ssize_t>(sizeof(Index32)), static_cast<ssize_t>(sizeof(Index32))};
+    shape = { static_cast<Py_ssize_t>(quads.size()), 4 };
+    strides = { 4 * static_cast<Py_ssize_t>(sizeof(Index32)), static_cast<Py_ssize_t>(sizeof(Index32))};
     py::buffer_info quadInfo(quads.data(), sizeof(Index32), py::format_descriptor<Index32>::format(), 2, shape, strides);
     py::array_t<Index32> quadArray(quadInfo);
 
@@ -1590,8 +1590,8 @@ exportGrid(py::module_ m)
             &pyGrid::meshToLevelSet<GridType>,
             py::arg("points"),
 #ifdef PY_OPENVDB_USE_NUMPY
-            py::arg("triangles")=py::array_t<Index32>({ 0, 3 }, { 3 * static_cast<ssize_t>(sizeof(Index32)), static_cast<ssize_t>(sizeof(Index32))} ),
-            py::arg("quads")=py::array_t<Index32>({ 0, 4 }, { 4 * static_cast<ssize_t>(sizeof(Index32)), static_cast<ssize_t>(sizeof(Index32))} ),
+            py::arg("triangles")=py::array_t<Index32>({ 0, 3 }, { 3 * static_cast<Py_ssize_t>(sizeof(Index32)), static_cast<Py_ssize_t>(sizeof(Index32))} ),
+            py::arg("quads")=py::array_t<Index32>({ 0, 4 }, { 4 * static_cast<Py_ssize_t>(sizeof(Index32)), static_cast<Py_ssize_t>(sizeof(Index32))} ),
 #else
             py::arg("triangles")=std::vector<Index32>(),
             py::arg("quads")=std::vector<Index32>(),


### PR DESCRIPTION
I ran into the same issue brought up in #1658 while [updating the conda-forge feedstock for openvdb](https://github.com/conda-forge/openvdb-feedstock/pull/14).

On Windows and Python > 3.9 `ssize_t` is undeclared.

```
%SRC_DIR%\openvdb\openvdb\python\pyGrid.h(325,33): error C2065: 'ssize_t': undeclared identifier (compiling source file %SRC_DIR%\openvdb\openvdb\python\pyFloatGrid.cc) [%SRC_DIR%\build\openvdb\openvdb\python\pyopenvdb.vcxproj]
```

I opted to replace every ssize_t with Py_ssize_t but this could of course also have been done with a typedef or using. I'm open to other solutions.

I'm attaching two logs from the PR mentioned from conda-forge's CI.

Passes: win_64_numpy1.22python3.9.____cpython [Azure CI](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=816104&view=logs&j=00f5923e-fdef-5026-5091-0d5a0b3d5a2c&t=f42c1d49-d161-5453-1c0e-990f827a8536) [attached log file](https://github.com/AcademySoftwareFoundation/openvdb/files/13241116/win_64_numpy1.22python3.9.____cpython.log)

Fails: win_64_numpy1.22python3.10.____cpython [Azure CI](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=816104&view=logs&j=171a126d-c574-5c8c-1269-ff3b989e923d&t=623c2ba8-c4f1-582d-6c78-1c7699e2e0a2) [attached log file](https://github.com/AcademySoftwareFoundation/openvdb/files/13241126/win_64_numpy1.22python3.10.____cpython.log)

The logs will be removed from Azure CI after 1 month.