### PR TITLE
Bump internal copy of half to fix issues on older x86_64 CPUs on Windows

### DIFF
--- a/openvdb/openvdb/math/Half.h
+++ b/openvdb/openvdb/math/Half.h
@@ -342,8 +342,14 @@ imath_half_to_float (imath_half_bits_t h)
         // other compilers may provide count-leading-zeros primitives,
         // but we need the community to inform us of the variants
         uint32_t lc;
-#    if defined(_MSC_VER) && (_M_IX86 || _M_X64)
-        lc = __lzcnt (hexpmant);
+#    if defined(_MSC_VER)
+        // The direct intrinsic for this is __lznct, but that is not supported
+        // on older x86_64 hardware or ARM. Instead uses the bsr instruction
+        // and one additional subtraction. This assumes hexpmant != 0, for 0
+        // bsr and lznct would behave differently.
+        unsigned long bsr;
+        _BitScanReverse (&bsr, hexpmant);
+        lc = (31 - bsr);
 #    elif defined(__GNUC__) || defined(__clang__)
         lc = (uint32_t) __builtin_clz (hexpmant);
 #    else


### PR DESCRIPTION
On some older CPUs without support for the lzcnt instruction, the conversion from half to float was wrong.

See AcademySoftwareFoundation/Imath#358 for more details.

Thanks to Ray Molenkamp for tracking down this bug.