### PR TITLE
Add early-exit optimization for LeafNode::resetBackground()

### DIFF
--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -1610,6 +1610,7 @@ LeafNode<T, Log2Dim>::resetBackground(const ValueType& oldBackground,
                                       const ValueType& newBackground)
 {
     if (!this->allocate()) return;
+    if (oldBackground == newBackground || math::negative(oldBackground) == newBackground) return;
 
     typename NodeMaskType::OffIterator iter;
     // For all inactive values...

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -1610,7 +1610,7 @@ LeafNode<T, Log2Dim>::resetBackground(const ValueType& oldBackground,
                                       const ValueType& newBackground)
 {
     if (!this->allocate()) return;
-    if (oldBackground == newBackground || math::negative(oldBackground) == newBackground) return;
+    if (math::isExactlyEqual(oldBackground, newBackground)) return;
 
     typename NodeMaskType::OffIterator iter;
     // For all inactive values...


### PR DESCRIPTION
Hi Academy Software Foundation! This merge request adds a small early-exit check to `LeafNode::resetBackground()`. This results in a significant speedup when an app merges grids on a node-by-node level using `Grid::merge(..., openvdb::MergePolicy::MERGE_NODES)`.

For a grid where voxels are either equal to the background value, or more than the default tolerance (1e-7) away from the (positive or negative) background value, `LeafNode::resetBackground()` is a no-op if `oldBackground == newBackground` or `oldBackground == -newBackground`:

```cpp
template<typename T, Index Log2Dim>
inline void
LeafNode<T, Log2Dim>::resetBackground(const ValueType& oldBackground,
                                      const ValueType& newBackground)
{
    if (!this->allocate()) return;

    typename NodeMaskType::OffIterator iter;
    // For all inactive values...
    for (iter = this->mValueMask.beginOff(); iter; ++iter) {
        ValueType &inactiveValue = mBuffer[iter.pos()];
        if (math::isApproxEqual(inactiveValue, oldBackground)) {
            // The condition in the text implies that inactiveValue == oldBackground. So this line is a no-op:
            inactiveValue = newBackground;
        } else if (math::isApproxEqual(inactiveValue, math::negative(oldBackground))) {
            // The condition in the text implies that inactiveValue == math::negative(oldBackground). So this line is a no-op:
            inactiveValue = math::negative(newBackground);
        }
    }
}
```

This means that we can add this check to skip the `for` loop entirely:

```cpp
    if (oldBackground == newBackground || math::negative(oldBackground) == newBackground) return;
```

On my test application (which computes multiple grids in parallel in such a way that they can use `openvdb::MergePolicy::MERGE_NODES`), this improves performance of merging together several grids with the same background by about 20x, from ~0.1 seconds to ~0.005 seconds on a ~100 MB volume.

There's one thing to consider here, though: If a grid has values that are ApproxEqual but not exactly equal to the background, then `resetBackground(x, +-x)`'s current implementation "canonicalizes" these values to be exactly equal to the background. This is undocumented -- the documentation for `resetBackground()` only talks about values that are exactly equal to the background -- but maybe there's an app out there that relies upon this.

Thank you! Please let me know if there are any changes I can make to this.