### PR TITLE
Fix OpenVDB Python module with NumPy compilation on Windows MSVC

### DIFF
--- a/openvdb/openvdb/python/pyGrid.h
+++ b/openvdb/openvdb/python/pyGrid.h
@@ -38,6 +38,11 @@
 #include <vector>
 #include <variant>
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 namespace py = pybind11;
 
 #ifdef __clang__


### PR DESCRIPTION
I couldn't compile the OpenVDB python module with NumPy due to ssize_t missing on MSVC. This hopefully fixes it.