### PR TITLE
Initial Adaptive Grid prototype

### DIFF
--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -402,6 +402,10 @@ set(OPENVDB_LIBRARY_IO_INCLUDE_FILES
   io/TempFile.h
 )
 
+set(OPENVDB_LIBRARY_ADAPTIVE_INCLUDE_FILES
+  adaptive/AdaptiveGrid.h
+)
+
 set(OPENVDB_LIBRARY_MATH_INCLUDE_FILES
   math/BBox.h
   math/ConjGradient.h

--- a/openvdb/openvdb/Types.h
+++ b/openvdb/openvdb/Types.h
@@ -237,6 +237,17 @@ using make_index_sequence =
 ////////////////////////////////////////
 
 
+template<typename TreeT>
+struct TreeTraits
+{
+    static const bool IsSparse = false;
+    static const bool IsAdaptive = false;
+};
+
+
+////////////////////////////////////////
+
+
 template<typename T, bool = IsSpecializationOf<T, math::Vec2>::value ||
                             IsSpecializationOf<T, math::Vec3>::value ||
                             IsSpecializationOf<T, math::Vec4>::value>

--- a/openvdb/openvdb/adaptive/AdaptiveGrid.h
+++ b/openvdb/openvdb/adaptive/AdaptiveGrid.h
@@ -1,0 +1,236 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef OPENVDB_ADAPTIVE_ADAPTIVE_GRID_HAS_BEEN_INCLUDED
+#define OPENVDB_ADAPTIVE_ADAPTIVE_GRID_HAS_BEEN_INCLUDED
+
+#include <openvdb/version.h>
+#include <openvdb/Grid.h>
+#include <openvdb/tree/Tree.h>
+
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+
+
+////////////////////////////////////////
+
+
+namespace adaptive {
+
+
+template<typename _ValueType>
+class AdaptiveTree: public TreeBase
+{
+public:
+    using Ptr = SharedPtr<AdaptiveTree>;
+    using ConstPtr = SharedPtr<const AdaptiveTree>;
+
+    using ValueType = _ValueType;
+    using BuildType = _ValueType;
+
+    static const Index DEPTH = 1;
+
+    AdaptiveTree() = default;
+
+    AdaptiveTree& operator=(const AdaptiveTree&) = delete; // disallow assignment
+
+    /// Deep copy constructor
+    AdaptiveTree(const AdaptiveTree& other): TreeBase(other), mBackground(other.mBackground) { }
+
+    /// Empty tree constructor
+    AdaptiveTree(const ValueType& background): mBackground(background) { }
+
+    ~AdaptiveTree() final = default;
+
+    /// Return the name of this type of tree.
+    static const Name& treeType();
+
+    /// Return the name of this tree's type.
+    const Name& type() const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// Return the name of the type of a voxel's value (e.g., "float" or "vec3d").
+    Name valueType() const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// Return @c true if this tree is of the same type as the template parameter.
+    template<typename TreeType>
+    bool isType() const { return (this->type() == TreeType::treeType()); }
+
+    /// Return a pointer to a deep copy of this tree
+    TreeBase::Ptr copy() const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// @brief Return this tree's background value.
+    const ValueType& background() const { return mBackground; }
+
+    /// @brief Return @c true if this tree contains no nodes.
+    bool empty() const { return true; }
+
+    /// Remove all nodes.
+    void clear() { }
+
+    /// @brief Not implemented.
+    void prune(const ValueType& tolerance = zeroVal<ValueType>()) { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// @brief Not implemented.
+    void clip(const CoordBBox&) { OPENVDB_THROW(NotImplementedError, ""); }
+
+    //
+    // Tree methods
+    //
+
+    /// @brief Return in @a bbox the axis-aligned bounding box of all
+    /// active tiles and leaf nodes with active values.
+    /// @details This is faster than calling evalActiveVoxelBoundingBox,
+    /// which visits the individual active voxels, and hence
+    /// evalLeafBoundingBox produces a less tight, i.e. approximate, bbox.
+    /// @return @c false if the bounding box is empty (in which case
+    /// the bbox is set to its default value).
+    bool evalLeafBoundingBox(CoordBBox& bbox) const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// @brief Return in @a dim the dimensions of the axis-aligned bounding box
+    /// of all leaf nodes.
+    /// @return @c false if the bounding box is empty.
+    bool evalLeafDim(Coord& dim) const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// @brief Return in @a bbox the axis-aligned bounding box of all
+    /// active voxels and tiles.
+    /// @details This method produces a more accurate, i.e. tighter,
+    /// bounding box than evalLeafBoundingBox which is approximate but
+    /// faster.
+    /// @return @c false if the bounding box is empty (in which case
+    /// the bbox is set to its default value).
+    bool evalActiveVoxelBoundingBox(CoordBBox& bbox) const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// @brief Return in @a dim the dimensions of the axis-aligned bounding box of all
+    /// active voxels.  This is a tighter bounding box than the leaf node bounding box.
+    /// @return @c false if the bounding box is empty.
+    bool evalActiveVoxelDim(Coord& dim) const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    void getIndexRange(CoordBBox& bbox) const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// @brief Replace with background tiles any nodes whose voxel buffers
+    /// have not yet been allocated.
+    /// @details Typically, unallocated nodes are leaf nodes whose voxel buffers
+    /// are not yet resident in memory because delayed loading is in effect.
+    /// @sa readNonresidentBuffers, io::File::open
+    void clipUnallocatedNodes() final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Return the total number of unallocated leaf nodes residing in this tree.
+    Index32 unallocatedLeafCount() const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+
+    //
+    // Statistics
+    //
+    /// @brief Return the depth of this tree.
+    ///
+    /// A tree with only a root node and leaf nodes has depth 2, for example.
+    Index treeDepth() const final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Return the number of leaf nodes.
+    Index32 leafCount() const final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Return a vector with node counts. The number of nodes of type NodeType
+    /// is given as element NodeType::LEVEL in the return vector. Thus, the size
+    /// of this vector corresponds to the height (or depth) of this tree.
+    std::vector<Index32> nodeCount() const final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Return the number of non-leaf nodes.
+    Index32 nonLeafCount() const final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Return the number of active voxels stored in leaf nodes.
+    Index64 activeLeafVoxelCount() const final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Return the number of inactive voxels stored in leaf nodes.
+    Index64 inactiveLeafVoxelCount() const final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Return the total number of active voxels.
+    Index64 activeVoxelCount() const final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Return the number of inactive voxels within the bounding box of all active voxels.
+    Index64 inactiveVoxelCount() const final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Return the total number of active tiles.
+    Index64 activeTileCount() const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+
+    //
+    // I/O methods
+    //
+    /// Read all data buffers for this tree.
+    void readBuffers(std::istream&, bool saveFloatAsHalf = false) final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Read all of this tree's data buffers that intersect the given bounding box.
+    void readBuffers(std::istream&, const CoordBBox&, bool saveFloatAsHalf = false) final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// @brief Read all of this tree's data buffers that are not yet resident in memory
+    /// (because delayed loading is in effect).
+    /// @details If this tree was read from a memory-mapped file, this operation
+    /// disconnects the tree from the file.
+    /// @sa clipUnallocatedNodes, io::File::open, io::MappedFile
+    void readNonresidentBuffers() const final { OPENVDB_THROW(NotImplementedError, ""); }
+    /// Write out all the data buffers for this tree.
+    void writeBuffers(std::ostream&, bool saveFloatAsHalf = false) const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// @brief Print statistics, memory usage and other information about this tree.
+    /// @param os            a stream to which to write textual information
+    /// @param verboseLevel  1: print tree configuration only;
+    ///                      2: include node and voxel statistics;
+    ///                      3: include memory usage;
+    ///                      4: include minimum and maximum voxel values
+    /// @warning @a verboseLevel 4 forces loading of any unallocated nodes.
+    void print(std::ostream& os = std::cout, int verboseLevel = 1) const final { OPENVDB_THROW(NotImplementedError, ""); }
+
+    /// @brief Dummy declarations to keep Grid class happy
+    using LeafNodeType = void;
+    using ValueAllIter = void;
+    using ValueAllCIter = void;
+    using ValueOnIter = void;
+    using ValueOnCIter = void;
+    using ValueOffIter = void;
+    using ValueOffCIter = void;
+
+private:
+    ValueType mBackground = zeroVal<ValueType>();
+}; // class AdaptiveTree
+
+
+
+////////////////////////////////////////
+
+
+template<typename ValueType>
+inline const Name&
+AdaptiveTree<ValueType>::treeType()
+{
+    static std::string sTreeTypeName = []()
+    {
+        std::ostringstream ostr;
+        ostr << "Adaptive_Tree_" << typeNameAsString<BuildType>();
+        return ostr.str();
+    }();
+    return sTreeTypeName;
+}
+
+
+
+
+/// @brief Adaptive grid.
+template <typename T>
+using AdaptiveGrid      = Grid<AdaptiveTree<T>>;
+
+using FloatAdaptiveGrid = AdaptiveGrid<float>;
+
+using AdaptiveGridTypes = TypeList<FloatAdaptiveGrid>;
+
+} // namespace adaptive
+
+
+////////////////////////////////////////
+
+
+template<typename ValueT>
+struct TreeTraits<adaptive::AdaptiveTree<ValueT>>
+{
+    static const bool IsSparse = false;
+    static const bool IsAdaptive = true;
+};
+
+
+////////////////////////////////////////
+
+
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif // OPENVDB_ADAPTIVE_ADAPTIVE_GRID_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/openvdb.h
+++ b/openvdb/openvdb/openvdb.h
@@ -13,6 +13,7 @@
 #include "Grid.h"
 #include "tree/Tree.h"
 #include "points/PointDataGrid.h"
+#include "adaptive/AdaptiveGrid.h"
 #include "io/File.h"
 
 
@@ -98,8 +99,8 @@ using NumericGridTypes  = RealGridTypes::Append<IntegerGridTypes>;
 /// The Vec3 Grid types which OpenVDB will register by default.
 using Vec3GridTypes     = TypeList<Vec3IGrid, Vec3SGrid, Vec3DGrid>;
 
-/// The Grid types which OpenVDB will register by default.
-using GridTypes =
+/// The sparse Grid types.
+using SparseGridTypes =
     NumericGridTypes::
         Append<Vec3GridTypes>::
         Append<tools::PointIndexGrid>::
@@ -108,6 +109,12 @@ using GridTypes =
         Append<points::PointDataGrid>::
 #endif
         Append<BoolGrid, MaskGrid>;
+/// @}
+
+/// The Grid types which OpenVDB will register by default.
+using GridTypes =
+    SparseGridTypes::
+        Append<adaptive::AdaptiveGridTypes>;
 /// @}
 
 

--- a/openvdb/openvdb/tools/Count.h
+++ b/openvdb/openvdb/tools/Count.h
@@ -492,24 +492,34 @@ Index64 countActiveTiles(const TreeT& tree, bool threaded)
 template <typename TreeT>
 Index64 memUsage(const TreeT& tree, bool threaded)
 {
-    count_internal::MemUsageOp<TreeT> op(true);
-    tree::DynamicNodeManager<const TreeT> nodeManager(tree);
-    nodeManager.reduceTopDown(op, threaded);
-    return op.mCount + sizeof(tree);
+    if constexpr (TreeTraits<TreeT>::IsSparse) {
+        count_internal::MemUsageOp<TreeT> op(true);
+        tree::DynamicNodeManager<const TreeT> nodeManager(tree);
+        nodeManager.reduceTopDown(op, threaded);
+        return op.mCount + sizeof(tree);
+    } else if constexpr (TreeTraits<TreeT>::IsAdaptive) {
+        return 0;
+    }
+    OPENVDB_THROW(NotImplementedError, "");
 }
 
 template <typename TreeT>
 Index64 memUsageIfLoaded(const TreeT& tree, bool threaded)
 {
-    /// @note  For numeric (non-point) grids this really doesn't need to
-    ///   traverse the tree and could instead be computed from the node counts.
-    ///   We do so anyway as it ties this method into the tree data structure
-    ///   which makes sure that changes to the tree/nodes are reflected/kept in
-    ///   sync here.
-    count_internal::MemUsageOp<TreeT> op(false);
-    tree::DynamicNodeManager<const TreeT> nodeManager(tree);
-    nodeManager.reduceTopDown(op, threaded);
-    return op.mCount + sizeof(tree);
+    if constexpr (TreeTraits<TreeT>::IsSparse) {
+        /// @note  For numeric (non-point) grids this really doesn't need to
+        ///   traverse the tree and could instead be computed from the node counts.
+        ///   We do so anyway as it ties this method into the tree data structure
+        ///   which makes sure that changes to the tree/nodes are reflected/kept in
+        ///   sync here.
+        count_internal::MemUsageOp<TreeT> op(false);
+        tree::DynamicNodeManager<const TreeT> nodeManager(tree);
+        nodeManager.reduceTopDown(op, threaded);
+        return op.mCount + sizeof(tree);
+    } else if constexpr (TreeTraits<TreeT>::IsAdaptive) {
+        return 0;
+    }
+    OPENVDB_THROW(NotImplementedError, "");
 }
 
 template <typename TreeT>

--- a/openvdb/openvdb/tree/Tree.h
+++ b/openvdb/openvdb/tree/Tree.h
@@ -2059,6 +2059,22 @@ Tree<RootNodeType>::print(std::ostream& os, int verboseLevel) const
 }
 
 } // namespace tree
+
+
+////////////////////////////////////////
+
+
+template<typename NodeT>
+struct TreeTraits<tree::Tree<NodeT>>
+{
+    static const bool IsSparse = true;
+    static const bool IsAdaptive = false;
+};
+
+
+////////////////////////////////////////
+
+
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb
 

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -76,6 +76,7 @@ if(OPENVDB_TESTS)
 else()
   list(APPEND UNITTEST_SOURCE_FILES
     TestActivate.cc
+    TestAdaptive.cc
     TestAttributeArray.cc
     TestAttributeArrayString.cc
     TestAttributeGroup.cc

--- a/openvdb/openvdb/unittest/TestAdaptive.cc
+++ b/openvdb/openvdb/unittest/TestAdaptive.cc
@@ -1,0 +1,25 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#include <openvdb/openvdb.h>
+#include <openvdb/adaptive/AdaptiveGrid.h>
+
+#include <gtest/gtest.h>
+
+class TestAdaptive: public ::testing::Test
+{
+public:
+    void SetUp() override { openvdb::initialize(); }
+    void TearDown() override { openvdb::initialize(); }
+};
+
+
+////////////////////////////////////////
+
+
+TEST_F(TestAdaptive, test)
+{
+    openvdb::adaptive::AdaptiveGrid<float> adaptiveGrid(5.0f);
+
+    EXPECT_EQ(adaptiveGrid.background(), 5.0f);
+}


### PR DESCRIPTION
Sharing an initial Adaptive Grid prototype (@kmuseth). In this case, it's not even a dense grid, it just contains a single background value and I've done the minimal work to make this compile with most of the required methods set to throw a not implemented error currently. No IO implemented yet. Some brief notes:

I'm using an `adaptive::` namespace, this sits within an `openvdb/adaptive` sub-directory and I'm calling this `AdaptiveTree`. It derives from `TreeBase` as we discussed and this is nested within a `Grid` as well and aliased to `AdaptiveGrid`.

I've changed the existing `GridTypes` alias to `SparseGridTypes` and re-introduced `GridTypes` to be `SparseGridTypes` + `AdaptiveGridTypes`. You can now do `grid.apply<SparseGridTypes>()` to get back the original behavior. There's a question as to whether we should leave `GridTypes` alone to maintain backwards-compatibility and to introduce something new like `AllGridTypes`, but not sure if this will make sense if we add more.

I introduced a new `TreeTraits` class to determine whether grids are adaptive or sparse and added a specialization to the relevant template classes. The main goal here was to not need to add new virtual methods or static member variables to the Tree class (or any other derived classes there might be in the wild). I've changed the `memUsage()` method which conveniently is used in `vdb_print` to see how this might affect the logic, it now does this:

```
Index64 memUsage(const TreeT& tree, bool threaded)
{
    if constexpr (TreeTraits<TreeT>::IsSparse) {
        // sparse implementation
    } else if constexpr (TreeTraits<TreeT>::IsAdaptive) {
        // adaptive implementation
    }
    OPENVDB_THROW(NotImplementedError, "");
}
```

This should be sufficient to get some conversation going as to how this kind of thing could work. It might make sense to consider using an `impl` sub-directory as we have done elsewhere, but where should the implementation for sparse trees and adaptive trees live? Should we just include both implementations in the body of this function as I've done here? Should we add a new sparse sub-directory and put the original implementation of this method there and then put the adaptive one in the adaptive sub-directory? How would this work for some of the much larger, more complicated methods? What about if we added more logic for handling dense trees? How is this going to work with explicit template instantiation?