### PR TITLE
Various Fixes

### DIFF
--- a/ci/download_houdini.py
+++ b/ci/download_houdini.py
@@ -94,7 +94,7 @@ def get_access_token_and_expiry_time(
             ),
         })
     if response.status_code != 200:
-        raise AuthorizationError(response.status_code, reponse.text)
+        raise AuthorizationError(response.status_code, response.text)
 
     response_json = response.json()
     access_token_expiry_time = time.time() - 2 + response_json["expires_in"]

--- a/cmake/OpenVDBHoudiniSetup.cmake
+++ b/cmake/OpenVDBHoudiniSetup.cmake
@@ -288,7 +288,11 @@ endif()
 
 # Jemalloc
 
-if(NOT JEMALLOC_LIBRARYDIR)
+# * On Mac OSX, linking against Jemalloc < 4.3.0 seg-faults with this error:
+#     malloc: *** malloc_zone_unregister() failed for 0xaddress
+#   As of Houdini 20, it still ships with Jemalloc 3.6.0, so don't expose it
+#   on Mac OSX (https://github.com/jemalloc/jemalloc/issues/420).
+if(NOT APPLE AND NOT JEMALLOC_LIBRARYDIR)
   set(JEMALLOC_LIBRARYDIR ${HOUDINI_LIB_DIR})
 endif()
 

--- a/openvdb/openvdb/math/Mat4.h
+++ b/openvdb/openvdb/math/Mat4.h
@@ -149,7 +149,7 @@ public:
     /// Get ith row, e.g.    Vec4f v = m.row(1);
     Vec4<T> row(int i) const
     {
-        OPENVDB_ASSERT(i>=0 && i<3);
+        OPENVDB_ASSERT(i>=0 && i<4);
         return Vec4<T>((*this)(i,0), (*this)(i,1), (*this)(i,2), (*this)(i,3));
     }
 


### PR DESCRIPTION
 - Fixed an incorrect assert in Mat4.h. This should fix the debug CI.
 - Fixed an issues caused by 6ce7033a2ba1a641c8ba1a32d22cc25afcd4473a (basically we want to prefer jemalloc, but don't use the one shipped by Houdini on MacOS). This should fix the Houdini CI stalling.