### PR TITLE
Support for instantiating Half-Typed-grid from stored float or double grids

### DIFF
--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -212,6 +212,8 @@ struct StreamMetadata::Impl
     bool mDelayedLoadMeta = DelayedLoadMetadata::isRegisteredType();
     uint64_t mLeaf = 0;
     uint32_t mTest = 0; // for testing only
+    std::string mDesiredScalarType = "";
+    SharedPtr<ConvertingReaderBase> mConvertingReader;
 }; // struct StreamMetadata
 
 
@@ -278,6 +280,12 @@ uint64_t        StreamMetadata::leaf() const            { return mImpl->mLeaf; }
 MetaMap&        StreamMetadata::gridMetadata()          { return mImpl->mGridMetadata; }
 const MetaMap&  StreamMetadata::gridMetadata() const    { return mImpl->mGridMetadata; }
 uint32_t        StreamMetadata::__test() const          { return mImpl->mTest; }
+
+const std::string&    StreamMetadata::desiredScalarType() const { return mImpl->mDesiredScalarType; }
+void StreamMetadata::setDesiredScalarType(std::string t) { mImpl->mDesiredScalarType = t; }
+
+const ConvertingReaderBase* StreamMetadata::convertingReader() const {return mImpl->mConvertingReader.get();}
+void StreamMetadata::setConvertingReader(SharedPtr<ConvertingReaderBase> t) {mImpl->mConvertingReader = t;}
 
 StreamMetadata::AuxDataMap& StreamMetadata::auxData() { return mImpl->mAuxData; }
 const StreamMetadata::AuxDataMap& StreamMetadata::auxData() const { return mImpl->mAuxData; }
@@ -1186,6 +1194,17 @@ Archive::isDelayedLoadingEnabled()
 }
 
 
+Name Archive::conversionToString(Archive::ScalarConversion conv)
+{
+    switch (conv)
+    {
+        case Archive::ScalarConversion::None:
+            return "";
+        case Archive::ScalarConversion::Half:
+            return typeNameAsString<math::half>();
+    }
+}
+
 namespace {
 
 struct NoBBox {};
@@ -1223,6 +1242,7 @@ doReadGrid(GridBase::Ptr grid, const GridDescriptor& gd, std::istream& is, const
         streamMetadata.reset(new StreamMetadata);
     }
     streamMetadata->setHalfFloat(grid->saveFloatAsHalf());
+    streamMetadata->setConvertingReader(gd.convertingReader());
     io::setStreamMetadataPtr(is, streamMetadata, /*transfer=*/false);
 
     io::setGridClass(is, GRID_UNKNOWN);

--- a/openvdb/openvdb/io/Archive.h
+++ b/openvdb/openvdb/io/Archive.h
@@ -34,6 +34,8 @@ public:
     using Ptr = SharedPtr<Archive>;
     using ConstPtr = SharedPtr<const Archive>;
 
+    enum class ScalarConversion { None, Half };
+
     static const uint32_t DEFAULT_COMPRESSION_FLAGS;
 
     Archive();
@@ -97,6 +99,8 @@ public:
     /// @note Define the environment variable @c OPENVDB_DISABLE_DELAYED_LOAD
     /// to disable delayed loading unconditionally.
     static bool isDelayedLoadingEnabled();
+
+    static Name conversionToString(ScalarConversion conv);
 
 protected:
     /// @brief Return @c true if the input stream contains grid offsets

--- a/openvdb/openvdb/io/Compression.h
+++ b/openvdb/openvdb/io/Compression.h
@@ -320,6 +320,197 @@ struct HalfReader</*IsReal=*/true, T> {
 };
 
 
+struct ConvertingReaderBase
+{
+    using Ptr = SharedPtr<ConvertingReaderBase>;
+
+    virtual ~ConvertingReaderBase() = default;
+};
+
+template<typename ValueT>
+struct ConvertingReader: ConvertingReaderBase
+{
+    virtual void read(
+        std::istream& is, ValueT* data, Index count, uint32_t compression,
+        DelayedLoadMetadata* metadata = nullptr, size_t metadataOffset = size_t(0),
+        bool fromHalf = false) const = 0;
+
+    virtual void read(std::istream& is, ValueT& data) const = 0;
+
+    virtual void seekElement(std::istream& is, int offset, std::ios_base::seekdir dir) const = 0;
+
+    static const ConvertingReader& get(std::istream& is);
+};
+
+template<typename ValueT, typename TValueFrom>
+struct TypedConvertingReader: ConvertingReader<ValueT>
+{
+    using HalfT = typename RealToHalf<TValueFrom>::HalfT;
+
+    static constexpr bool do_conversion                 = !std::is_same<ValueT, TValueFrom>::value;
+    static constexpr bool from_half_flag_is_relevant    = RealToHalf<TValueFrom>::isReal;
+    
+    template<typename TRead>
+    static void readHelper(
+        std::istream& is, ValueT* data, Index count, uint32_t compression,
+        DelayedLoadMetadata* metadata, size_t metadataOffset)
+    {
+        if constexpr (std::is_same<ValueT, TRead>::value)
+        {
+            // either reads or skips through compressed data (count == 0) or it
+            // is seeking (data == nullptr)
+            io::readData(is, data, count, compression, metadata, metadataOffset);
+        }
+        else
+        {
+            // reading
+            if (data && count > 0)
+            {
+                std::vector<TRead> buffer(count);
+                io::readData(is, buffer.data(), count, compression, metadata, metadataOffset);
+                std::copy(buffer.begin(), buffer.end(), data);
+            }
+            // either skips through compressed data (count == 0) or it is
+            // seeking (data == nullptr)
+            else
+            {
+                // reinterpret_cast<TRead*>(data) might produce not-aligned
+                // pointer, but io::readData will not write to it, so it should
+                // be safe. We must not skip this statement, nor we can pass
+                // nullptr instead of data, it causes failures in the testsuite.
+                // Now it behaves exactly as before.
+                io::readData(is, reinterpret_cast<TRead*>(data), count,
+                    compression, metadata, metadataOffset);
+            }
+        }
+    }
+
+    virtual void read(
+        std::istream& is, ValueT* data, Index count, uint32_t compression,
+        DelayedLoadMetadata* metadata = nullptr, size_t metadataOffset = size_t(0),
+        bool fromHalf = false) const override
+    {
+        // this if-statement is here to maintain the original logic when
+        // HalfReader<T> is being used. It can't be removed as it breaks bunch
+        // of tests in the testsuite.
+        if (fromHalf && from_half_flag_is_relevant && count < 1)
+            return;
+
+        // due to std::vector<bool> being weird and not fitting the overall
+        // templating idea here (it doesn't have data() method), the following
+        // will fail to do non-identity conversion for bool-typed data. But for
+        // bool-typed data there is just identity at the moment.
+        if constexpr (from_half_flag_is_relevant)
+        {
+            if (fromHalf)
+            {
+                readHelper<HalfT>(is, data, count, compression, metadata, metadataOffset);
+            }
+            else
+            {
+                readHelper<TValueFrom>(is, data, count, compression, metadata, metadataOffset);
+            }
+        }
+        else
+        {
+            readHelper<TValueFrom>(is, data, count, compression, metadata, metadataOffset);
+        }
+    }
+
+    virtual void read(std::istream& is, ValueT& data) const override
+    {
+        if constexpr (do_conversion)
+        {
+            TValueFrom buffer;
+            is.read(reinterpret_cast<char*>(&buffer), /*bytes=*/sizeof(TValueFrom));
+            data = buffer;
+        }
+        else
+        {
+            is.read(reinterpret_cast<char*>(&data), /*bytes=*/sizeof(ValueT));
+        }
+    }
+
+    virtual void seekElement(std::istream& is, int offset, std::ios_base::seekdir dir) const override
+    {
+        if constexpr (do_conversion)
+        {
+            is.seekg(/*bytes=*/sizeof(TValueFrom) * offset, dir);
+        }
+        else
+        {
+            is.seekg(/*bytes=*/sizeof(ValueT) * offset, dir);
+        }
+    }
+};
+
+template<typename ValueT>
+inline const ConvertingReader<ValueT>& ConvertingReader<ValueT>::get(std::istream& is)
+{
+    SharedPtr<io::StreamMetadata> meta = io::getStreamMetadataPtr(is);
+
+    auto ptr = static_cast<const ConvertingReader*>(meta->convertingReader());
+    if(ptr)
+    {
+        return *ptr;
+    }
+    auto ptr2 = new TypedConvertingReader<ValueT, ValueT>();
+    meta->setConvertingReader(Ptr(ptr2));
+    return *ptr2;
+}
+
+struct ConvertingReaderFactory
+{
+    using ReaderPtr = ConvertingReaderBase::Ptr;
+
+    struct FactoryEntry
+    {
+        ReaderPtr   reader;
+        Name        new_grid_value_type;
+    };
+
+private:
+    template<typename T1, typename T2>
+    static Name getTypeName()
+    {
+        return Name(typeNameAsString<T1>()) + Name(typeNameAsString<T2>());
+    }
+
+    template<typename T1, typename T2, typename T3>
+    static auto getMapEntry()
+    {
+        return std::pair
+        { 
+            getTypeName<T1, T2>(),
+            FactoryEntry { ReaderPtr(new TypedConvertingReader<T3, T1>()), typeNameAsString<T3>()}
+        };
+    }
+
+public:
+    static FactoryEntry create(const Name& grid_value_type, const Name& desired_scalar_type)
+    {
+        static std::unordered_map<Name, FactoryEntry> type_map =
+        {
+            getMapEntry<float, Half, Half>(),
+            getMapEntry<double, Half, Half>(),
+            getMapEntry<Vec2f, Half, Vec2H>(),
+            getMapEntry<Vec2d, Half, Vec2H>(),
+            getMapEntry<Vec3f, Half, Vec3H>(),
+            getMapEntry<Vec3d, Half, Vec3H>(),
+        };
+
+        if (auto it = type_map.find(grid_value_type + desired_scalar_type); it != type_map.end())
+        {
+            return it->second;
+        }
+        else
+        {
+            return {nullptr, ""};
+        }
+    }
+};
+
+
 template<typename T>
 inline size_t
 writeDataSize(const T *data, Index count, uint32_t compression)
@@ -474,6 +665,9 @@ readCompressedValues(std::istream& is, ValueT* destBuf, Index destCount,
     const bool seek = (destBuf == nullptr);
     OPENVDB_ASSERT(!seek || (!meta || meta->seekable()));
 
+    // converting reader for reading grid values
+    auto& convertingReader = io::ConvertingReader<ValueT>::get(is);
+
     // Get delayed load metadata if it exists
 
     DelayedLoadMetadata::Ptr delayLoadMeta;
@@ -512,16 +706,16 @@ readCompressedValues(std::istream& is, ValueT* destBuf, Index destCount,
     {
         // Read one of at most two distinct inactive values.
         if (seek) {
-            is.seekg(/*bytes=*/sizeof(ValueT), std::ios_base::cur);
+            convertingReader.seekElement(is, 1, std::ios_base::cur);
         } else {
-            is.read(reinterpret_cast<char*>(&inactiveVal0), /*bytes=*/sizeof(ValueT));
+            convertingReader.read(is, inactiveVal0);
         }
         if (metadata == MASK_AND_TWO_INACTIVE_VALS) {
             // Read the second of two distinct inactive values.
             if (seek) {
-                is.seekg(/*bytes=*/sizeof(ValueT), std::ios_base::cur);
+                convertingReader.seekElement(is, 1, std::ios_base::cur);
             } else {
-                is.read(reinterpret_cast<char*>(&inactiveVal1), /*bytes=*/sizeof(ValueT));
+                convertingReader.read(is, inactiveVal1);
             }
         }
     }
@@ -558,13 +752,8 @@ readCompressedValues(std::istream& is, ValueT* destBuf, Index destCount,
     }
 
     // Read in the buffer.
-    if (fromHalf) {
-        HalfReader<RealToHalf<ValueT>::isReal, ValueT>::read(
-            is, (seek ? nullptr : tempBuf), tempCount, compression, delayLoadMeta.get(), leafIndex);
-    } else {
-        readData<ValueT>(
-            is, (seek ? nullptr : tempBuf), tempCount, compression, delayLoadMeta.get(), leafIndex);
-    }
+    convertingReader.read(
+        is, (seek ? nullptr : tempBuf), tempCount, compression, delayLoadMeta.get(), leafIndex, fromHalf);
 
     // If mask compression is enabled and the number of active values read into
     // the temp buffer is smaller than the size of the destination buffer,

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -280,9 +280,9 @@ File::isOpen() const
 
 bool
 #ifdef OPENVDB_USE_DELAYED_LOADING
-File::open(bool delayLoad, const MappedFile::Notifier& notifier)
+File::open(bool delayLoad, const MappedFile::Notifier& notifier, ScalarConversion conversion)
 #else
-File::open(bool /*delayLoad = true*/)
+File::open(bool /*delayLoad = true*/, ScalarConversion conversion)
 #endif // OPENVDB_USE_DELAYED_LOADING
 {
     if (isOpen()) {
@@ -367,6 +367,7 @@ File::open(bool /*delayLoad = true*/)
     // and other metadata.
     mImpl->mStreamMetadata.reset(new StreamMetadata);
     mImpl->mStreamMetadata->setSeekable(true);
+    mImpl->mStreamMetadata->setDesiredScalarType(conversionToString(conversion));
     io::setStreamMetadataPtr(inputStream(), mImpl->mStreamMetadata, /*transfer=*/false);
     Archive::setFormatVersion(inputStream());
     Archive::setLibraryVersion(inputStream());

--- a/openvdb/openvdb/io/File.h
+++ b/openvdb/openvdb/io/File.h
@@ -64,9 +64,10 @@ public:
     /// @throw IoError if the file is not a valid VDB file.
     /// @return @c true if the file's UUID has changed since it was last read.
     /// @see setCopyMaxBytes
-    bool open(bool delayLoad = true, const MappedFile::Notifier& = MappedFile::Notifier());
+    bool open(bool delayLoad = true, const MappedFile::Notifier& = MappedFile::Notifier(),
+        ScalarConversion conversion = ScalarConversion::None);
 #else
-    bool open(bool /*delayLoad*/ = false);
+    bool open(bool /*delayLoad*/ = false, ScalarConversion conversion = ScalarConversion::None);
 #endif
 
     /// Return @c true if the file has been opened for reading.

--- a/openvdb/openvdb/io/GridDescriptor.h
+++ b/openvdb/openvdb/io/GridDescriptor.h
@@ -13,6 +13,8 @@ OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
 namespace io {
 
+struct ConvertingReaderBase;
+
 /// This structure stores useful information that describes a grid on disk.
 /// It can be used to retrieve I/O information about the grid such as
 /// offsets into the file where the grid is located, its type, etc.
@@ -34,6 +36,7 @@ public:
     bool isInstance() const { return !mInstanceParentName.empty(); }
 
     bool saveFloatAsHalf() const { return mSaveFloatAsHalf; }
+    SharedPtr<ConvertingReaderBase> convertingReader() const { return mConvertingReader; }
 
     void setGridPos(int64_t pos) { mGridPos = pos; }
     int64_t getGridPos() const { return mGridPos; }
@@ -90,6 +93,8 @@ private:
     Name mGridType;
     /// Are floats quantized to 16 bits on disk?
     bool mSaveFloatAsHalf;
+    ///
+    SharedPtr<ConvertingReaderBase> mConvertingReader;
     /// Location in the stream where the grid data is stored
     int64_t mGridPos;
     /// Location in the stream where the grid blocks are stored

--- a/openvdb/openvdb/io/Stream.cc
+++ b/openvdb/openvdb/io/Stream.cc
@@ -71,7 +71,7 @@ removeTempFile(const std::string expectedFilename, const std::string& filename)
 #endif // OPENVDB_USE_DELAYED_LOADING
 
 
-Stream::Stream(std::istream& is, bool delayLoad): mImpl(new Impl)
+Stream::Stream(std::istream& is, bool delayLoad, ScalarConversion conversion): mImpl(new Impl)
 {
     if (!is) return;
 
@@ -97,7 +97,8 @@ Stream::Stream(std::istream& is, bool delayLoad): mImpl(new Impl)
             mImpl->mFile->setCopyMaxBytes(0); // don't make a copy of the temporary file
             /// @todo Need to pass auto-deletion flag to MappedFile.
             mImpl->mFile->open(delayLoad,
-                std::bind(&removeTempFile, filename, std::placeholders::_1));
+                std::bind(&removeTempFile, filename, std::placeholders::_1),
+                conversion);
         }
     }
 #endif // OPENVDB_USE_DELAYED_LOADING
@@ -111,6 +112,7 @@ Stream::Stream(std::istream& is, bool delayLoad): mImpl(new Impl)
         io::setStreamMetadataPtr(is, streamMetadata, /*transfer=*/false);
         io::setVersion(is, libraryVersion(), fileVersion());
         io::setDataCompression(is, compression());
+        streamMetadata->setDesiredScalarType(conversionToString(conversion));
 
         // Read in the VDB metadata.
         mImpl->mMeta.reset(new MetaMap);

--- a/openvdb/openvdb/io/Stream.h
+++ b/openvdb/openvdb/io/Stream.h
@@ -26,7 +26,8 @@ public:
     /// into memory and enable delayed loading of grids.
     /// @note Define the environment variable @c OPENVDB_DISABLE_DELAYED_LOAD
     /// to disable delayed loading unconditionally.
-    explicit Stream(std::istream&, bool delayLoad = true);
+    explicit Stream(std::istream&, bool delayLoad = true,
+        ScalarConversion conversion = ScalarConversion::None);
 
     /// Construct an archive for stream output.
     Stream();

--- a/openvdb/openvdb/io/io.h
+++ b/openvdb/openvdb/io/io.h
@@ -24,6 +24,8 @@ class MetaMap;
 
 namespace io {
 
+struct ConvertingReaderBase;
+
 /// @brief Container for metadata describing how to unserialize grids from and/or
 /// serialize grids to a stream (which file format, compression scheme, etc. to use)
 /// @details This class is mainly for internal use.
@@ -100,6 +102,12 @@ public:
     uint32_t __test() const;
     /// @private
     void __setTest(uint32_t);
+
+    const std::string& desiredScalarType() const;
+    void setDesiredScalarType(std::string t);
+
+    const ConvertingReaderBase* convertingReader() const;
+    void setConvertingReader(SharedPtr<ConvertingReaderBase> t);
 
     /// Return a string describing this stream metadata.
     std::string str() const;

--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -2199,6 +2199,9 @@ InternalNode<ChildT, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
     const ValueType background = (!io::getGridBackgroundValuePtr(is) ? zeroVal<ValueType>()
         : *static_cast<const ValueType*>(io::getGridBackgroundValuePtr(is)));
 
+    // converting reader for reading grid values
+    auto& convertingReader = io::ConvertingReader<ValueType>::get(is);
+
     mChildMask.load(is);
     mValueMask.load(is);
 
@@ -2211,7 +2214,7 @@ InternalNode<ChildT, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
                 child->readTopology(is);
             } else {
                 ValueType value;
-                is.read(reinterpret_cast<char*>(&value), sizeof(ValueType));
+                convertingReader.read(is, value);
                 mNodes[i].setValue(value);
             }
         }

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -1380,16 +1380,13 @@ LeafNode<T,Log2Dim>::readBuffers(std::istream& is, const CoordBBox& clipBBox, bo
     }
 
     if (numBuffers > 1) {
+        auto& convertingReader = io::ConvertingReader<T>::get(is);
         // Read in and discard auxiliary buffers that were created with earlier
         // versions of the library.  (Auxiliary buffers are not mask compressed.)
         const bool zipped = io::getDataCompression(is) & io::COMPRESS_ZIP;
         Buffer temp;
         for (int i = 1; i < numBuffers; ++i) {
-            if (fromHalf) {
-                io::HalfReader<io::RealToHalf<T>::isReal, T>::read(is, temp.mData, SIZE, zipped);
-            } else {
-                io::readData<T>(is, temp.mData, SIZE, zipped);
-            }
+            convertingReader.read(is, temp.mData, SIZE, zipped, nullptr, 0, fromHalf);
         }
     }
 


### PR DESCRIPTION
This is still WIP and it depends on #1730 .

The main motivation for this patch is to be able to load half-typed grids directly from files containing non-half-typed grids in order to keep the process peak memory low. When having large grids or large number of grids this can be important.

The PR does (atm) the conversion according to the following rules:
| stored grid value type | desired conversion | returned grid |
---------------|----------------------|-------------
float | half | half |
double | half | half |
vec2f | half | vec2h |
vec3f | half | vec3h |
vec2d | half | vec2h |
vec3d | half | vec3h |

The above rules can be extended if desirable, and in the future there could be also 'store' counterpart to do conversion into other grid types while storing. That could potentially replace the need for "saveFloatAsHalf" flag.

The core implementation has been already tested with various vdb files, some of them using saveFloatAsHalf, and the approach seems to be working without issues.

The implementation is straightforward and follows these steps:
- User specifies desired conversion when calling `File::open` or when instantiating `Stream`
- Desired conversion information then propagates into `StreamMetadata`
- `GridDescriptor` picks up the conversion from the metadata and from `io::ConvertingReaderFactory` it gets a reader and the resulting grid valuetype. It then instantiates a grid with this new valuetype instead of using the original value type. If there is no suitable reader for the desired conversion, descriptor instantiates a grid with the original valuetype.
- The reader returned from `io::ConvertingReaderFactory` is also stored in `StreamMetadata` and used during topology/buffers loading.