### PR TITLE
Chain vdb_view to vdb_render

### DIFF
--- a/openvdb_cmd/vdb_view/Camera.cc
+++ b/openvdb_cmd/vdb_view/Camera.cc
@@ -44,6 +44,15 @@ Camera::Camera()
 }
 
 
+openvdb::Mat4s
+Camera::getTransformationMatrix()
+{
+    float matrix[16];
+    glGetFloatv(GL_MODELVIEW_MATRIX, matrix);
+    return openvdb::Mat4s(matrix);
+}
+
+
 void
 Camera::lookAt(const openvdb::Vec3d& p, double dist)
 {

--- a/openvdb_cmd/vdb_view/Camera.h
+++ b/openvdb_cmd/vdb_view/Camera.h
@@ -23,6 +23,8 @@ public:
 
     void aim();
 
+    openvdb::Mat4s getTransformationMatrix();
+
     void lookAt(const openvdb::Vec3d& p, double dist = 1.0);
     void lookAtTarget();
 

--- a/openvdb_cmd/vdb_view/Viewer.cc
+++ b/openvdb_cmd/vdb_view/Viewer.cc
@@ -58,6 +58,7 @@ public:
     void showNextGrid();
 
     bool needsDisplay();
+    void printCameraTransformationMatrix();
     void setNeedsDisplay();
 
     void toggleRenderModule(size_t n);
@@ -992,6 +993,9 @@ ViewerImpl::keyCallback(int key, int action)
         case 'i': case 'I':
             toggleInfoText();
             break;
+        case 'p': case 'P':
+            printCameraTransformationMatrix();
+            break;
         case GLFW_KEY_LEFT:
             showPrevGrid();
             break;
@@ -1081,6 +1085,13 @@ ViewerImpl::needsDisplay()
         return true;
     }
     return false;
+}
+
+
+void
+ViewerImpl::printCameraTransformationMatrix()
+{
+    std::cout << mCamera->getTransformationMatrix() << std::endl;
 }
 
 

--- a/openvdb_cmd/vdb_view/main.cc
+++ b/openvdb_cmd/vdb_view/main.cc
@@ -36,6 +36,7 @@ usage [[noreturn]] (const char* progName, int status)
 "    G                  (\"geometry\") look at center of geometry\n" <<
 "    H                  (\"home\") look at origin\n" <<
 "    I                  toggle on-screen grid info on/off\n" <<
+"    P                  print camera transformation matrix\n" <<
 "    left mouse         tumble\n" <<
 "    right mouse        pan\n" <<
 "    mouse wheel        zoom\n" <<


### PR DESCRIPTION
I was interested when using `vdb_view` to render a color image using `vdb_render`. The changes in this PR cause `vdb_view` to print the camera transformation matrix when the user hits the 'p' key. This allows the user the option of connecting the two programs together.

Previous discussion on this subject:
https://github.com/AcademySoftwareFoundation/openvdb/discussions/1715