### PR TITLE
guarding UINT64_C in nanovdb

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -170,7 +170,9 @@ typedef unsigned long long uint64_t;
 
 #define NANOVDB_ASSERT(x)
 
+#ifndef UINT64_C
 #define UINT64_C(x)  (x ## ULL)
+#endif
 
 #else // !__CUDACC_RTC__
 


### PR DESCRIPTION
guarding UINT64_C in nanovdb (for NVRTC users who have it defined already)