### PR TITLE
Add NANOVDB_USE_SYNC_CUDA_MALLOC define to force sync CUDA malloc

### DIFF
--- a/nanovdb/nanovdb/util/cuda/CudaAddBlindData.cuh
+++ b/nanovdb/nanovdb/util/cuda/CudaAddBlindData.cuh
@@ -62,7 +62,7 @@ cudaAddBlindData(const NanoGrid<BuildT> *d_grid,
     // extract byte sizes of the grid, blind meta data and blind data
     enum {GRID=0, META=1, DATA=2, CHECKSUM=3};
     uint64_t tmp[4], *d_tmp;
-    cudaCheck(cudaMallocAsync((void**)&d_tmp, 4*sizeof(uint64_t), stream));
+    cudaCheck(CUDA_MALLOC((void**)&d_tmp, 4*sizeof(uint64_t), stream));
     cudaLambdaKernel<<<1, 1, 0, stream>>>(1, [=] __device__(size_t) {
         if (auto count = d_grid->blindDataCount()) {
             d_tmp[GRID] = PtrDiff(&d_grid->blindMetaData(0), d_grid);
@@ -114,7 +114,7 @@ cudaAddBlindData(const NanoGrid<BuildT> *d_grid,
         for (uint32_t i=0, n=grid.mBlindMetadataCount-1; i<n; ++i, ++meta) meta->mDataOffset += sizeof(GridBlindMetaData);
         grid.mGridSize += sizeof(GridBlindMetaData) + meta->blindDataSize();// expansion with 32 byte alignment
     }); cudaCheckError();
-    cudaCheck(cudaFreeAsync(d_tmp, stream));
+    cudaCheck(CUDA_FREE(d_tmp, stream));
 
     GridChecksum cs(tmp[CHECKSUM]);
     cudaGridChecksum(reinterpret_cast<GridData*>(d_data), cs.mode());

--- a/nanovdb/nanovdb/util/cuda/CudaDeviceBuffer.h
+++ b/nanovdb/nanovdb/util/cuda/CudaDeviceBuffer.h
@@ -153,7 +153,7 @@ inline void CudaDeviceBuffer::init(uint64_t size, bool host, void* stream)
         cudaCheck(cudaMallocHost((void**)&mCpuData, size)); // un-managed pinned memory on the host (can be slow to access!). Always 32B aligned
         checkPtr(mCpuData, "CudaDeviceBuffer::init: failed to allocate host buffer");
     } else {
-        cudaCheck(cudaMallocAsync((void**)&mGpuData, size, reinterpret_cast<cudaStream_t>(stream))); // un-managed memory on the device, always 32B aligned!
+        cudaCheck(CUDA_MALLOC((void**)&mGpuData, size, reinterpret_cast<cudaStream_t>(stream))); // un-managed memory on the device, always 32B aligned!
         checkPtr(mGpuData, "CudaDeviceBuffer::init: failed to allocate device buffer");
     }
     mSize = size;
@@ -163,7 +163,7 @@ inline void CudaDeviceBuffer::deviceUpload(void* stream, bool sync) const
 {
     checkPtr(mCpuData, "uninitialized cpu data");
     if (mGpuData == nullptr) {
-        cudaCheck(cudaMallocAsync((void**)&mGpuData, mSize, reinterpret_cast<cudaStream_t>(stream))); // un-managed memory on the device, always 32B aligned!
+        cudaCheck(CUDA_MALLOC((void**)&mGpuData, mSize, reinterpret_cast<cudaStream_t>(stream))); // un-managed memory on the device, always 32B aligned!
     }
     checkPtr(mGpuData, "uninitialized gpu data");
     cudaCheck(cudaMemcpyAsync(mGpuData, mCpuData, mSize, cudaMemcpyHostToDevice, reinterpret_cast<cudaStream_t>(stream)));
@@ -183,7 +183,7 @@ inline void CudaDeviceBuffer::deviceDownload(void* stream, bool sync) const
 
 inline void CudaDeviceBuffer::clear(void *stream)
 {
-    if (mGpuData) cudaCheck(cudaFreeAsync(mGpuData, reinterpret_cast<cudaStream_t>(stream)));
+    if (mGpuData) cudaCheck(CUDA_FREE(mGpuData, reinterpret_cast<cudaStream_t>(stream)));
     if (mCpuData) cudaCheck(cudaFreeHost(mCpuData));
     mCpuData = mGpuData = nullptr;
     mSize = 0;

--- a/nanovdb/nanovdb/util/cuda/CudaGridHandle.cuh
+++ b/nanovdb/nanovdb/util/cuda/CudaGridHandle.cuh
@@ -71,7 +71,7 @@ cudaSplitGridHandles(const GridHandle<BufferT> &handle, const BufferT* other = n
     if (ptr == nullptr) return VectorT<GridHandle<BufferT>>();
     VectorT<GridHandle<BufferT>> handles(handle.gridCount());
     bool dirty, *d_dirty;// use this to check if the checksum needs to be recomputed
-    cudaCheck(cudaMallocAsync((void**)&d_dirty, sizeof(bool), stream));
+    cudaCheck(CUDA_MALLOC((void**)&d_dirty, sizeof(bool), stream));
     for (uint32_t n=0; n<handle.gridCount(); ++n) {
         auto buffer = BufferT::create(handle.gridSize(n), other, false, stream);
         GridData *dst = reinterpret_cast<GridData*>(buffer.deviceData());
@@ -84,7 +84,7 @@ cudaSplitGridHandles(const GridHandle<BufferT> &handle, const BufferT* other = n
         handles[n] = GridHandle<BufferT>(std::move(buffer));
         ptr += handle.gridSize(n);
     }
-    cudaCheck(cudaFreeAsync(d_dirty, stream));
+    cudaCheck(CUDA_FREE(d_dirty, stream));
     return std::move(handles);
 }// cudaSplitGridHandles
 
@@ -106,7 +106,7 @@ cudaMergeGridHandles(const VectorT<GridHandle<BufferT>> &handles, const BufferT*
     auto buffer = BufferT::create(size, other, false, stream);
     uint8_t *dst = buffer.deviceData();
     bool dirty, *d_dirty;// use this to check if the checksum needs to be recomputed
-    cudaCheck(cudaMallocAsync((void**)&d_dirty, sizeof(bool), stream));
+    cudaCheck(CUDA_MALLOC((void**)&d_dirty, sizeof(bool), stream));
     for (auto &h : handles) {
         const uint8_t *src = h.deviceData();
         for (uint32_t n=0; n<h.gridCount(); ++n) {
@@ -120,7 +120,7 @@ cudaMergeGridHandles(const VectorT<GridHandle<BufferT>> &handles, const BufferT*
             src += h.gridSize(n);
         }
     }
-    cudaCheck(cudaFreeAsync(d_dirty, stream));
+    cudaCheck(CUDA_FREE(d_dirty, stream));
     return GridHandle<BufferT>(std::move(buffer));
 }// cudaMergeGridHandles
 

--- a/nanovdb/nanovdb/util/cuda/CudaGridStats.cuh
+++ b/nanovdb/nanovdb/util/cuda/CudaGridStats.cuh
@@ -210,7 +210,7 @@ void CudaGridStats<BuildT, StatsT>::operator()(NanoGrid<BuildT> *d_grid, cudaStr
 
     StatsT *d_stats = nullptr;
 
-    if constexpr(StatsT::hasAverage()) cudaCheck(cudaMallocAsync((void**)&d_stats, nodeCount[0]*sizeof(StatsT), stream));
+    if constexpr(StatsT::hasAverage()) cudaCheck(CUDA_MALLOC((void**)&d_stats, nodeCount[0]*sizeof(StatsT), stream));
 
     processLeaf<BuildT><<<blocksPerGrid(nodeCount[0]), threadsPerBlock, 0, stream>>>(d_nodeMgr, d_stats);
 
@@ -220,7 +220,7 @@ void CudaGridStats<BuildT, StatsT>::operator()(NanoGrid<BuildT> *d_grid, cudaStr
 
     processRootAndGrid<BuildT><<<1, 1, 0, stream>>>(d_nodeMgr, d_stats);
 
-    if constexpr(StatsT::hasAverage()) cudaCheck(cudaFreeAsync(d_stats, stream));
+    if constexpr(StatsT::hasAverage()) cudaCheck(CUDA_FREE(d_stats, stream));
 
 } // CudaGridStats::operator()( Grid )
 

--- a/nanovdb/nanovdb/util/cuda/CudaNodeManager.cuh
+++ b/nanovdb/nanovdb/util/cuda/CudaNodeManager.cuh
@@ -38,7 +38,7 @@ cudaCreateNodeManager(const NanoGrid<BuildT> *d_grid,
     auto buffer = BufferT::create(sizeof(NodeManagerData), &pool, false, stream);
     auto *d_data = (NodeManagerData*)buffer.deviceData();
     size_t size = 0u, *d_size;
-    cudaCheck(cudaMallocAsync((void**)&d_size, sizeof(size_t), stream));
+    cudaCheck(CUDA_MALLOC((void**)&d_size, sizeof(size_t), stream));
     cudaLambdaKernel<<<1, 1, 0, stream>>>(1, [=] __device__(size_t) {
 #ifdef NANOVDB_USE_NEW_MAGIC_NUMBERS
         *d_data = NodeManagerData{NANOVDB_MAGIC_NODE,   0u, (void*)d_grid, {0u,0u,0u}};
@@ -58,7 +58,7 @@ cudaCreateNodeManager(const NanoGrid<BuildT> *d_grid,
     });
     cudaCheckError();
     cudaCheck(cudaMemcpyAsync(&size, d_size, sizeof(size_t), cudaMemcpyDeviceToHost, stream));
-    cudaCheck(cudaFreeAsync(d_size, stream));
+    cudaCheck(CUDA_FREE(d_size, stream));
     if (size > sizeof(NodeManagerData)) {
         auto tmp = BufferT::create(size, &pool, false, stream);// only allocate buffer on the device
         cudaCheck(cudaMemcpyAsync(tmp.deviceData(), buffer.deviceData(), sizeof(NodeManagerData), cudaMemcpyDeviceToDevice, stream));

--- a/nanovdb/nanovdb/util/cuda/CudaPointsToGrid.cuh
+++ b/nanovdb/nanovdb/util/cuda/CudaPointsToGrid.cuh
@@ -265,7 +265,7 @@ public:
     {
         mData.map = map;
         mData.flags.initMask({GridFlags::HasBBox, GridFlags::IsBreadthFirst});
-        cudaCheck(cudaMallocAsync((void**)&mDeviceData, sizeof(Data), mStream));
+        cudaCheck(CUDA_MALLOC((void**)&mDeviceData, sizeof(Data), mStream));
     }
 
     /// @brief Default constructor
@@ -276,7 +276,7 @@ public:
         : CudaPointsToGrid(Map(scale, trans), stream) {}
 
     /// @brief Destructor
-    ~CudaPointsToGrid() {cudaCheck(cudaFreeAsync(mDeviceData, mStream));}
+    ~CudaPointsToGrid() {cudaCheck(CUDA_FREE(mDeviceData, mStream));}
 
     /// @brief Toggle on and off verbose mode
     /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking

--- a/nanovdb/nanovdb/util/cuda/CudaSignedFloodFill.cuh
+++ b/nanovdb/nanovdb/util/cuda/CudaSignedFloodFill.cuh
@@ -153,11 +153,11 @@ void CudaSignedFloodFill<BuildT>::operator()(NanoGrid<BuildT> *d_grid)
     static_assert(BuildTraits<BuildT>::is_float, "CudaSignedFloodFill only works on float grids");
     NANOVDB_ASSERT(d_grid);
     uint64_t count[4], *d_count = nullptr;
-    cudaCheck(cudaMallocAsync((void**)&d_count, 4*sizeof(uint64_t), mStream));
+    cudaCheck(CUDA_MALLOC((void**)&d_count, 4*sizeof(uint64_t), mStream));
     cudaCpyNodeCount<BuildT><<<1, 1, 0, mStream>>>(d_grid, d_count);
     cudaCheckError();
     cudaCheck(cudaMemcpyAsync(&count, d_count, 4*sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
-    cudaCheck(cudaFreeAsync(d_count, mStream));
+    cudaCheck(CUDA_FREE(d_count, mStream));
 
     static const int threadsPerBlock = 128;
     auto blocksPerGrid = [&](size_t count)->uint32_t{return (count + (threadsPerBlock - 1)) / threadsPerBlock;};

--- a/nanovdb/nanovdb/util/cuda/CudaUtils.h
+++ b/nanovdb/nanovdb/util/cuda/CudaUtils.h
@@ -55,7 +55,7 @@
 
 // cudaMallocAsync and cudaFreeAsync were introduced in CUDA 11.2, for older CUDA 
 // versions fall back to cudaMalloc and cudaFree. The fallback can also be forced 
-// using the USE_SYNC_CUDA_MALLOC flag. This may be useful when deploying nanoVDB
+// using the NANOVDB_USE_SYNC_CUDA_MALLOC flag. This may be useful when deploying nanoVDB
 // code in virtualized environments that share the GPU between instances by slicing
 // it up into vGPU's. In such environments GPU unified memory is usually disabled
 // out of security considerations, which means cudaMallocAsync can not be used.


### PR DESCRIPTION
In virtualized environments that slice up the GPU and share it between instances as vGPU's, GPU unified memory is usually disabled out of security considerations. Asynchronous CUDA malloc/free depends on GPU unified memory, so before, it was not possible to deploy and run NanoVDB code in such environments.

This commit adds macros CUDA_MALLOC and CUDA_FREE and replaces all CUDA alloc/free calls with these macros. CUDA_MALLOC and CUDA_FREE expand to asynchronous CUDA malloc & free if the following two conditions are met:

  - CUDA version needs to be >= 11.2 as this is the first version that supports cudaMallocAsync/cudaMallocFree
  - NANOVDB_USE_SYNC_CUDA_MALLOC needs to undefined

In all other cases, CUDA_MALLOC and CUDA_FREE expand to synchronous cudaMalloc/cudaFree.

Since NanoVDB is distributed as header-only, setting the NANOVDB_USE_SYNC_CUDA_MALLOC flag should be handled by the project's build system itself.