### PR TITLE
Add TSC meeting notes from April 30, 2024.

### DIFF
--- a/tsc/meetings/2024-04-30.md
+++ b/tsc/meetings/2024-04-30.md
@@ -1,0 +1,67 @@
+Minutes from OpenVDB TSC meeting, April 30th, 2024
+
+Attendees: *Ken* M., *Dan* B., *Greg* H., *Rich* J., *Andre* P
+
+Additional Attendees:
+Matthew Cong (NVIDIA), Alexandre Sirois-Vigneux (SideFX),
+Efty Sifakis (Univ. Wisconsin), Francis Williams (NVIDIA),
+Jonathan Schwartz (NVIDIA), Michiel Hagedoorn
+Dhruv Govil (Apple), Tom (Sidefx), Rayhaan Tanweer,
+Rabih, Youmna, Shahan N
+
+Regrets: *Jeff* L., *Nick* A.
+
+Agenda:
+
+1) Confirm quorum
+2) Secretary
+3) Migration from PyBind11 to NanoBind
+4) Greg's ASWF membership
+5) FVDB
+6) Next meeting
+
+------------
+
+1) Confirm quorum
+
+Quorum is present.
+
+2) Secretary
+
+Secretary is Andre Pradhana.
+
+3) Migration from PyBind11 to NanoBind
+
+Matthew Cong presented a solution to handle NanoBind dependency
+by using pip. He has done work on the NanoBind-side to allow this workflow.
+The solution with Git-subtree/submodule is brittle because it
+can run into firewall issues.
+
+It was re-iterated that NanoBind is preferred because of zero-interop
+on the GPU side.
+
+Dhruv Govil pointed out that PyBind is used by other projects
+for its support for multiple inheritance (which NanoBind doesn’t
+support).
+
+4) Greg's ASWF membership
+
+Greg will follow up with John Mertic to be added to ASWF organization.
+
+5) FVDB
+
+NVIDIA team presented a presentation on fVDB, a project that is for
+consideration to be adopted by OpenVDB project. It is a framework to
+do spatial reasoning on 3D volumetric dataset, which includes deep-
+learning.
+
+The main dependencies is pytorch. The project will live in its own
+directory, parallel to the `openvdb` directory.
+
+Ken will bring up the need for GPU-support in the CI in the TAC meeting.
+TSC members will be added to the private fVDB repository for further
+investigation. Jonathan Schwartz provided us with documentation.
+
+6) Next meeting
+
+Next meeting is on May 7th, 2024. 2pm-3pm EDT (GMT-4)


### PR DESCRIPTION
Add TSC meeting notes from April 30, 2024. Topics:

- You can use `pip` install for NanoBind, making it easier to support NanoBind dependency.,
- fVDB presentation. fVDB is a framework for doing spatial reasoning with sparse volumetric 3D data structure. It includes deep learning framework, such as sparse convolution operators.