### PR TITLE
Add DWA to Apache 2.0 RE-LICENSE_NOTE.txt

### DIFF
--- a/RE-LICENSE_NOTE.txt
+++ b/RE-LICENSE_NOTE.txt
@@ -4,3 +4,4 @@ Version 2.0, are hereby relicensed to the Apache License, Version 2.0,
 and are submitted pursuant to the Developer Certificate of Origin, version 1.1:
 
 Ken Museth
+DreamWorks Animation


### PR DESCRIPTION
DreamWorks Animation and NBCU legal teams have reviewed and approved the request to relicense DWA contributions to OpenVDB from MPL-2.0 to Apache-2.0.

Per guidance from the OpenVDB TSC, we are adding DreamWorks Animation to `RE-LCENSE_NOTE.txt` to mark our approval.