### PR TITLE
Overhauled OpenVDB Clip SOP camera frustum padding + misc QOL changes

### DIFF
--- a/openvdb_houdini/openvdb_houdini/GeometryUtil.cc
+++ b/openvdb_houdini/openvdb_houdini/GeometryUtil.cc
@@ -33,7 +33,7 @@ void
 drawFrustum(
     GU_Detail& geo, const openvdb::math::Transform& transform,
     const UT_Vector3* boxColor, const UT_Vector3* tickColor,
-    bool shaded, bool drawTicks)
+    bool shaded, bool drawTicks, const openvdb::Vec4d& padding)
 {
     if (transform.mapType() != openvdb::math::NonlinearFrustumMap::mapType()) {
         return;
@@ -41,7 +41,12 @@ drawFrustum(
 
     const openvdb::math::NonlinearFrustumMap& frustum =
         *transform.map<openvdb::math::NonlinearFrustumMap>();
-    const openvdb::BBoxd bbox = frustum.getBBox();
+    openvdb::BBoxd bbox = frustum.getBBox();
+    if (!padding.isZero()) {
+        const openvdb::Vec2d extentsXY(bbox.extents().asPointer());
+        bbox.min() -= openvdb::Vec3d(padding[0]*extentsXY.x(), padding[1]*extentsXY.y(), 0.0);
+        bbox.max() += openvdb::Vec3d(padding[2]*extentsXY.x(), padding[3]*extentsXY.y(), 0.0);
+    }
 
     UT_Vector3 corners[8];
 

--- a/openvdb_houdini/openvdb_houdini/GeometryUtil.h
+++ b/openvdb_houdini/openvdb_houdini/GeometryUtil.h
@@ -46,8 +46,8 @@ class Interrupter;
 OPENVDB_HOUDINI_API
 void
 drawFrustum(GU_Detail&, const openvdb::math::Transform&,
-    const UT_Vector3* boxColor, const UT_Vector3* tickColor,
-    bool shaded, bool drawTicks = true);
+    const UT_Vector3* boxColor, const UT_Vector3* tickColor, bool shaded,
+    bool drawTicks = true, const openvdb::Vec4d& padding = openvdb::Vec4d::zero());
 
 
 /// Construct a frustum transform from a Houdini camera.


### PR DESCRIPTION
The Clip SOPs handling of frustum clipping was odd in several ways, and this caused confusion among users. Padding in particular was opaque and unintuitive.

This change implements more consistent and explainable padding for the camera clipping mode. Padding is specified and applied in normalized device coordinates. Rather than reading the same float3 padding parm used by the other modes, this new implementation adds float2 parms 'padwinx' and 'padwiny', specifying the amount of padding to add on the left/right and top/bottom sides of the camera frustum. These are enabled only in camera mode. Padding is applied symmetrically by default, similar to the old method, but can be made asymmetric by unlinking the parameters. There is no Z-axis padding value, as the near/far plane override parameters make this functionality redundant.

A `legacycamclip` toggle was added to optionally revert back to the original implementation for compatibility reasons.

To implement this change, it was necessary to make minor modifications to the clipping implementation in the OpenVDB library. A padding arg was added for the camera frustum signature of `clip`. A similar change was made to the `hvdb::drawFrustum()` function. All other changes were made just to the SOP itself.

**Additional Changes:**
+ Tooltips and documentation for the node's parameters have been updated and expanded.
+ Some parameters that were previously non-animatable can now be animated. There was no documented reason given for them being fixed, and I've observed no issues with their being animated. It is the padding (old and new) and near/far clipping plane parameters which have been changed.
+ The `xVoxelCount` argument of `hvdb::frustumTransformFromCamera()` is now set to the cameras x-resolution, avoiding the rounding error that previously made the resulting frustum slightly inaccurate.
+ Mask clipping mode now disables the y and z components of the 'padding' parm, to indicate that only uniform padding is supported in that mode.
+ When clipping in mask mode, the warning regarding nonuniform not being supported previously triggered whenever the three 'padding' values were not equal. This caused it to be raised for valid non-zero values as well. I've fixed it to trigger only when the y or z components are non-zero.