### PR TITLE
Update RE-LICENSE_NOTE.txt

### DIFF
--- a/RE-LICENSE_NOTE.txt
+++ b/RE-LICENSE_NOTE.txt
@@ -23,3 +23,4 @@ David Aguilar
 Brian Sharpe
 Kartik Shrivastava
 Michael Lackner
+The Linux Foundation


### PR DESCRIPTION
Adding confirmation from the Linux Foundation for relicensing any of its contributions to OpenVDB.