### PR TITLE
More CI Fixes

### DIFF
--- a/.github/workflows/ax.yml
+++ b/.github/workflows/ax.yml
@@ -74,6 +74,9 @@ jobs:
           - { image: '2021-clang10', cxx: 'g++',     build: 'Release', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
       fail-fast: false
     steps:
+      - name: Enable Node 16
+        run: |
+          echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: pybind11
         #if: contains(matrix.config.image, '2023') == false

--- a/.github/workflows/ax.yml
+++ b/.github/workflows/ax.yml
@@ -75,6 +75,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Enable Node 16
+        if: contains(matrix.config.image, '2021') || contains(matrix.config.image, '2022')
         run: |
           echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,9 @@ jobs:
           - { cxx: g++,     image: '2022-clang11',   abi: '9',  build: 'Release', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
       fail-fast: false
     steps:
+    - name: Enable Node 16
+      run: |
+        echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
     - uses: actions/checkout@v3
     - name: pybind11
       #if: contains(matrix.config.image, '2023') == false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,8 @@ jobs:
       fail-fast: false
     steps:
     - name: Enable Node 16
+      # Solution taken from https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default
+      if: contains(matrix.config.image, '2022')
       run: |
         echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
     - uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,8 @@ jobs:
     #   run: pip install epydoc
     - name: install_latex
       run: |
+        # Fix error: Cannot prepare internal mirrorlist: No URLs in mirrorlist. CentOS 8 reached EOL means need to replace the official mirror to vault.centos.org
+        # Comment out mirrorlist and replace #baseurl=...mirror.centos.org with baseurl=...vault.centos.org in files starting with CentOS- in /etc/yum.repos.d folder
         sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
         sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
         yum -y install texlive-latex-bin texlive-dvips texlive-collection-fontsrecommended texlive-collection-latexrecommended

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,9 @@ jobs:
       # need to re-write the python docs to use sphinx
       image: aswf/ci-openvdb:2022
     steps:
+    - name: Enable Node 16
+      run: |
+        echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
     - uses: actions/checkout@v3
     - name: install_doxygen
       run: ./ci/install_doxygen.sh 1_8_11
@@ -51,7 +54,10 @@ jobs:
     # - name: install_epydoc
     #   run: pip install epydoc
     - name: install_latex
-      run: yum -y install texlive-latex-bin texlive-dvips texlive-collection-fontsrecommended texlive-collection-latexrecommended
+      run: |
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        yum -y install texlive-latex-bin texlive-dvips texlive-collection-fontsrecommended texlive-collection-latexrecommended
     - name: build
       run: >
         ./ci/build.sh -v

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -83,6 +83,9 @@ jobs:
     steps:
       # See note on this step in the Houdini weekly.yml job
       # We can remove this when we no longer use < 2023 images
+    - name: Enable Node 16
+      run: |
+        echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
     - name: remove zstd
       run: yum -y remove zstd
     - uses: actions/checkout@v3

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -65,9 +65,14 @@ jobs:
           - { cxx: clang++, image: '2022-clang11', build: 'Debug' }
       fail-fast: false
     steps:
+      - name: Enable Node 16
+        run: |
+          echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: install_cuda_11
         run: |
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
           yum -y install yum-utils
           yum-config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
           echo "Installing cuda toolkit"
@@ -98,7 +103,7 @@ jobs:
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.config.vc }}
       visual_studio: "Visual Studio 17 2022"
-      cuda: "11.6.2"
+      cuda: "12.4.0"
     strategy:
       matrix:
         config:
@@ -153,8 +158,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - { runner: 'macos-11', cxx: 'clang++', build: 'Release' }
-          - { runner: 'macos-11', cxx: 'clang++', build: 'Debug'   }
+          - { runner: 'macos-12', cxx: 'clang++', build: 'Release' }
+          - { runner: 'macos-12', cxx: 'clang++', build: 'Debug'   }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -162,12 +167,12 @@ jobs:
         run: ./ci/install_macos.sh
       - name: build
         run: >
-          ./ci/build.sh -v
+          sudo ./ci/build.sh -v
           --build-type=${{ matrix.config.build }}
           --components=core,nano,nanotest,nanoexam,nanobench,nanotool
           --cargs=\'-DUSE_EXPLICIT_INSTANTIATION=OFF -DNANOVDB_USE_CUDA=OFF -DNANOVDB_USE_OPENVDB=ON\'
       - name: test
-        run: cd build && ctest -V -E ".*cuda.*"
+        run: cd build && sudo ctest -V -E ".*cuda.*"
 
   nanovdb-lite:
     if: |
@@ -186,6 +191,6 @@ jobs:
           cd nanovdb/nanovdb
           sudo mkdir .build
           cd .build
-          sudo cmake -DUSE_EXPLICIT_INSTANTIATION=OFF -DNANOVDB_BUILD_UNITTESTS=ON ../
+          sudo cmake -DUSE_EXPLICIT_INSTANTIATION=OFF -DNANOVDB_BUILD_UNITTESTS=ON -DNANOVDB_USE_OPENVDB=OFF -DNANOVDB_USE_CUDA=OFF ../
           sudo make -j8 install
           sudo ctest -V

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -66,11 +66,14 @@ jobs:
       fail-fast: false
     steps:
       - name: Enable Node 16
+        if: contains(matrix.config.image, '2022')
         run: |
           echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: install_cuda_11
         run: |
+          # Fix error: Cannot prepare internal mirrorlist: No URLs in mirrorlist. CentOS 8 reached EOL means need to replace the official mirror to vault.centos.org
+          # Comment out mirrorlist and replace #baseurl=...mirror.centos.org with baseurl=...vault.centos.org in files starting with CentOS- in /etc/yum.repos.d folder
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
           yum -y install yum-utils
@@ -167,12 +170,12 @@ jobs:
         run: ./ci/install_macos.sh
       - name: build
         run: >
-          sudo ./ci/build.sh -v
+          ./ci/build.sh -v
           --build-type=${{ matrix.config.build }}
           --components=core,nano,nanotest,nanoexam,nanobench,nanotool
           --cargs=\'-DUSE_EXPLICIT_INSTANTIATION=OFF -DNANOVDB_USE_CUDA=OFF -DNANOVDB_USE_OPENVDB=ON\'
       - name: test
-        run: cd build && sudo ctest -V -E ".*cuda.*"
+        run: cd build && ctest -V -E ".*cuda.*"
 
   nanovdb-lite:
     if: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -77,6 +77,9 @@ jobs:
     container:
       image: aswf/ci-base:2023
     steps:
+    - name: Enable Node 16
+      run: |
+        echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
     - uses: actions/checkout@v3
     # We bumped from the 2021 CI image to 2023 here to fix some OpenSSL issues
     # with the Houdini download script. In so doing we broke some of the caching
@@ -171,6 +174,9 @@ jobs:
           - { name: 'conf',  build: 'Release', components: 'core,python,bin,view,render,test,axcore,axtest', cmake: '-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON' }
       fail-fast: false
     steps:
+    - name: Enable Node 16
+      run: |
+        echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
     - uses: actions/checkout@v3
     - name: pybind11
       #if: contains(container.image, '2023') == false
@@ -253,6 +259,9 @@ jobs:
           - { image: '2022-clang11', cxx: 'g++',     build: 'Release', components: 'core', cmake: '' }
       fail-fast: false
     steps:
+      - name: Enable Node 16
+        run: |
+          echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: pybind11
         #f: contains(matrix.config.image, '2023') == false
@@ -397,6 +406,9 @@ jobs:
         blosc: ['1.18.0','1.19.0','1.20.0','1.21.0']
       fail-fast: false
     steps:
+    - name: Enable Node 16
+      run: |
+        echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
     - uses: actions/checkout@v3
     - name: install_blosc
       run: sudo ./ci/install_blosc.sh ${{ matrix.blosc }}
@@ -423,6 +435,9 @@ jobs:
       # may not have this build type. See OpenVDBCXX.cmake
       CXXFLAGS: "-gdwarf-4 -g3 -ggdb -Og"
     steps:
+    - name: Enable Node 16
+      run: |
+        echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -260,6 +260,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Enable Node 16
+        if: contains(matrix.config.image, '2021') || contains(matrix.config.image, '2022')
         run: |
           echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
       - uses: actions/checkout@v3

--- a/ci/install_windows_cuda.ps1
+++ b/ci/install_windows_cuda.ps1
@@ -26,12 +26,13 @@ $CUDA_KNOWN_URLS = @{
     "11.2.1" = "https://developer.download.nvidia.com/compute/cuda/11.2.1/network_installers/cuda_11.2.1_win10_network.exe";
     "11.2.2" = "https://developer.download.nvidia.com/compute/cuda/11.2.2/network_installers/cuda_11.2.2_win10_network.exe";
     "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe";
-    "11.6.2" = "https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe"
+    "11.6.2" = "https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe";
+    "12.4.0" = "https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
 $VISUAL_STUDIO_MIN_CUDA = @{
-    "2022" = "11.6";
+    "2022" = "12.4";
     "2019" = "10.1";
     "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on  version
     "2015" = "8.0"; # might support older, unsure.


### PR DESCRIPTION
Fix NanoVDB CI: `NanoVDB` lite and on Windows: upgrade to CUDA 12.4 for Visual Studio 2022, allow use of unsecure node version, use node 16 in ax, build, docs, houdini, and weekly workflow.