### PR TITLE
Rename Committer to Maintainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,18 +57,20 @@ code and has the right to release it under the
 [Mozilla Public License, version 2.0](LICENSE.md)
 license. See the [TAC documentation on contribution sign off](https://github.com/AcademySoftwareFoundation/tac/blob/master/process/contributing.md#contribution-sign-off) for more information on this requirement.
 
-## Committer
+## Maintainer
 
-The committer role enables the participant to commit code directly to the repository, but also comes with the obligation to be a responsible leader in the community.
+The maintainer role is the equivalent of the "Committer" role in the charter.
 
-### Process for becoming a committer
+This role enables the participant to commit code directly to the repository, but also comes with the obligation to be a responsible leader in the community.
+
+### Process for becoming a maintainer
 
 * Show your experience with the codebase through contributions and engagement on the community channels.
-* Request to become a committer.
-* Have the majority of committers approve you becoming a committer.
+* Request to become a maintainer.
+* Have the majority of maintainers approve you becoming a maintainer.
 * Your name and email is added to the MAINTAINERS.md file for the project.
 
-### Committer responsibilities
+### Maintainer responsibilities
 
 * Monitor email aliases.
 * Monitor Slack (delayed response is perfectly acceptable).
@@ -76,17 +78,17 @@ The committer role enables the participant to commit code directly to the reposi
 * Make sure that ongoing PRs are moving forward at the right pace or close them.
 * Remain an active contributor to the project in general and the code base in particular.
 
-### When does a committer lose committer status?
+### When does a maintainer lose maintainer status?
 
-If a committer is no longer interested or cannot perform the committer duties listed above, they
+If a maintainer is no longer interested or cannot perform the maintainer duties listed above, they
 should volunteer to be moved to emeritus status. In extreme cases this can also occur by a vote of
-the committers per the voting process below.
+the maintainers per the voting process below.
 
 ## Technical Steering Committee (TSC) member
 
 The Technical Steering Committee (TSC) oversees the overall technical direction of OpenVDB, as defined in the [charter](charter.md).
 
-TSC voting members consist of committers that have been nominated by the committers, with a supermajority of voting members required to have a committer elected to be a TSC voting member. TSC voting members term and succession is defined in the [charter](charter.md).
+TSC voting members consist of maintainers that have been nominated by the TSC, with a supermajority of voting members required to have a maintainer elected to be a TSC voting member. TSC voting members term and succession is defined in the [charter](charter.md).
 
 All meetings of the TSC are open to participation by any member of the OpenVDB community. Meeting times are listed in the [ASWF technical community calendar](https://lists.aswf.io/g/tac/calendar).
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,5 +14,5 @@ The current OpenVDB maintainers are:
 | Ken Museth       | ken.museth@gmail.com
 | Andre Pradhana   | andre.pradhana@gmail.com
 | Richard Jones    | richardj@ilm.com
-| Gergory Hurst    | tbd
+| Gregory Hurst    | tbd
 | Jonathan Swartz  | tbd

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,3 +14,5 @@ The current OpenVDB maintainers are:
 | Ken Museth       | ken.museth@gmail.com
 | Andre Pradhana   | andre.pradhana@gmail.com
 | Richard Jones    | richardj@ilm.com
+| Gergory Hurst    | tbd
+| Jonathan Swartz  | tbd

--- a/tsc/process/codereview.md
+++ b/tsc/process/codereview.md
@@ -1,24 +1,24 @@
 **Code Reviewing and Merging OpenVDB Pull Requests**
 
-The Technical Steering Committee have write-access to the OpenVDB repository and are responsible for triaging, reviewing and ultimately merging or rejecting GitHub pull requests. This document lists the policy and best practices to guide the TSC in this process.
+The Maintainers have write-access to the OpenVDB repository and are responsible for triaging, reviewing and ultimately merging or rejecting GitHub pull requests. This document lists the policy and best practices to guide the Maintainers in this process.
 
 ***Policy***
 
 * No direct commits to the master (or any other protected) branch, every code change should be a pull request
 * Any member of the community can provide feedback on any pull request (and is encouraged to do so)
 * A CODEOWNERS file introduced to the root of the repo to configure ownership (global, per-directory and/or per-file) - this will automatically request pull request reviews from the relevant maintainers (https://help.github.com/articles/about-codeowners/)
-* Minimum of one non-author TSC member approval on every pull request before merging
+* Minimum of one non-author Maintainer member approval on every pull request before merging
 * Non fast-forward merges must be used (ie the merge must not be rebased onto master)
 * Travis CI and DCO status checks must strictly pass before merging, ASWF Jenkins CI should loosely pass (https://help.github.com/articles/types-of-required-status-checks)
 
 ***Best Practices***
 
 * Prefer all requested reviewers to approve before merging
-* Merging a pull request should be the responsibility of the author if they are a TSC member
-* Any TSC member can merge a pull request authored by a non-TSC member, but with a preferred minimum of two approvals from TSC members (including themself)
+* Merging a pull request should be the responsibility of the author if they are a Maintainer member
+* Any Maintainer member can merge a pull request authored by a non-Maintainer member, but with a preferred minimum of two approvals from Maintainer members (including themself)
 * Re-writing the branch history by rebasing a pull request branch just before a merge is discouraged, unless it significantly improves the overall history (such as any broken commits on the review branch that might make reverting or bisecting more difficult)
 * Prefer pull requests to be open for a minimum of 72 hours before merging in order to gather any feedback
-* Aim for all pull requests to be responded to by one of the TSC members within a minimum of two weeks with either explanation of non-acceptance, request for changes or merge
+* Aim for all pull requests to be responded to by one of the Maintainer members within a minimum of two weeks with either explanation of non-acceptance, request for changes or merge
 * TSC meetings should regularly review and discuss any outstanding pull requests
 * Pull requests should link to the associated Jira ticket (if applicable) in the description or title, this provides a route back to the Jira ticket through the Git history (git blame -> PR merge -> Jira ticket)
 * All pull request comments should aim to be answered and resolved before committing


### PR DESCRIPTION
Ensure all TSC are Maintainers
Add Jonathan Swartz as a Maintainer.
Adjust voting procedure for new TSC members to require TSC approval, not maintainer approval.