### PR TITLE
Fixing build issue caused by adding cwiseAdd in `math/Vec3.h`

### DIFF
--- a/openvdb/openvdb/Types.h
+++ b/openvdb/openvdb/Types.h
@@ -688,6 +688,23 @@ class Steal {};
 /// @brief Tag dispatch class that distinguishes constructors during file input
 class PartialCreate {};
 
+// For half compilation
+namespace math {
+template<>
+inline auto cwiseAdd(const math::Vec3<math::half>& v, const float s)
+{
+    math::Vec3<math::half> out;
+    const math::half* ip = v.asPointer();
+    math::half* op = out.asPointer();
+    for (unsigned i = 0; i < 3; ++i, ++op, ++ip) {
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
+        *op = *ip + s;
+        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
+    }
+    return out;
+}
+} // namespace math
+
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb
 

--- a/openvdb/openvdb/math/Vec3.h
+++ b/openvdb/openvdb/math/Vec3.h
@@ -594,20 +594,6 @@ Abs(const Vec3<T>& v)
     return Vec3<T>(Abs(v[0]), Abs(v[1]), Abs(v[2]));
 }
 
-template<>
-inline auto cwiseAdd(const Vec3<math::internal::half>& v, const float s)
-{
-    Vec3<math::internal::half> out;
-    const math::internal::half* ip = v.asPointer();
-    math::internal::half* op = out.asPointer();
-    for (unsigned i = 0; i < 3; ++i, ++op, ++ip) {
-        OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
-        *op = *ip + s;
-        OPENVDB_NO_TYPE_CONVERSION_WARNING_END
-    }
-    return out;
-}
-
 /// Orthonormalize vectors v1, v2 and v3 and store back the resulting
 /// basis e.g.   Vec3d::orthonormalize(v1,v2,v3);
 template <typename T>


### PR DESCRIPTION
Template specialization of `cwiseAdd` for `Vec3` half-type should be in be in `Types.h` instead of in `math/Vec3.h`.