### PR TITLE
Fix NanoVDB Build

### DIFF
--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 #include <algorithm>// for std::sort
+#include <iomanip> // for std::setw, std::setfill
 
 namespace nanovdb {// this namespace is required by gtest
 


### PR DESCRIPTION
This fixes an issue building the NanoVDB unit tests on Windows due to these errors:
```
unittest\TestNanoVDB.cu(2555): error : namespace "std" has no member "setw" 
unittest\TestNanoVDB.cu(2555): error : namespace "std" has no member "setfill" 
```

(@kmuseth @apradhana)