### PR TITLE
Fix a couple of small windows CI / vcpkg bugs

### DIFF
--- a/ci/install_windows.sh
+++ b/ci/install_windows.sh
@@ -3,6 +3,11 @@
 set -x
 set -e
 
+# Temporary workaround pending: https://github.com/microsoft/vcpkg-tool/pull/1501
+export SystemDrive="$SYSTEMDRIVE"
+export SystemRoot="$SYSTEMROOT"
+export windir="$WINDIR"
+
 # Required dependencies
 VCPKG_INSTALL_CMD="vcpkg install
     zlib
@@ -31,12 +36,12 @@ $VCPKG_INSTALL_CMD
 STATUS=$?
 
 # Subsequent commands cannot fail
-set -x
+set -e
 
 if [ $STATUS -ne 0 ]; then
   # Try once more with latest ports
   echo "vcpkg install failed, retrying with latest ports..."
-  cd $VCPKG_INSTALLATION_ROOT && git pull && cd-
+  cd $VCPKG_INSTALLATION_ROOT && git pull && cd -
   vcpkg update
   $VCPKG_INSTALL_CMD
 fi


### PR DESCRIPTION
All our Windows CI checks are failing right now due to an issue with vcpkg + bash + github actions. This suggested work-around resolve this. In making this change, I also noticed a couple of small bugs with the fallback vcpkg workflow that wasn't correctly aborting when the installation failed.