### PR TITLE
Add 2024 CI Images and Drop 2021 CI Images

### DIFF
--- a/.github/workflows/ax.yml
+++ b/.github/workflows/ax.yml
@@ -72,12 +72,10 @@ jobs:
           - { image: '2023-clang15', cxx: 'clang++', build: 'Debug',   cmake: '' }
           - { image: '2022-clang11', cxx: 'clang++', build: 'Release', cmake: '' }
           - { image: '2022-clang11', cxx: 'g++',     build: 'Release', cmake: '' }
-          - { image: '2021-clang10', cxx: 'clang++', build: 'Release', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
-          - { image: '2021-clang10', cxx: 'g++',     build: 'Release', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
       fail-fast: false
     steps:
       - name: Enable Node 16
-        if: contains(matrix.config.image, '2021') || contains(matrix.config.image, '2022')
+        if: contains(matrix.config.image, '2022')
         run: |
           echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,13 +79,13 @@ jobs:
           # @note  we specifically use clang15.0 (not clang15) here as the newest
           #  versions of the clang15.X containers have some issues with the GLFW
           #  installation
-          - { cxx: clang++, image: '2023-clang15.0', abi: '11', build: 'Release', cmake: '' }
-          - { cxx: g++,     image: '2023-clang15.0', abi: '11', build: 'Release', cmake: '' }
-          - { cxx: clang++, image: '2022-clang11',   abi: '11', build: 'Debug',   cmake: '' }
-          - { cxx: clang++, image: '2022-clang11',   abi: '10', build: 'Release', cmake: '' }
-          - { cxx: g++,     image: '2022-clang11',   abi: '10', build: 'Release', cmake: '' }
-          - { cxx: clang++, image: '2022-clang11',   abi: '9',  build: 'Release', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
-          - { cxx: g++,     image: '2022-clang11',   abi: '9',  build: 'Release', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
+          - { cxx: clang++, image: '2024', abi: '11', build: 'Release', cmake: '' }
+          - { cxx: g++,     image: '2024', abi: '11', build: 'Release', cmake: '' }
+          - { cxx: clang++, image: '2024', abi: '11', build: 'Debug',   cmake: '' }
+          - { cxx: clang++, image: '2023', abi: '11', build: 'Release', cmake: '' }
+          - { cxx: g++,     image: '2023', abi: '11', build: 'Release', cmake: '' }
+          - { cxx: clang++, image: '2022', abi: '10', build: 'Release', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
+          - { cxx: g++,     image: '2022', abi: '10', build: 'Release', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
       fail-fast: false
     steps:
     - name: Enable Node 16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,9 @@ jobs:
     - name: pybind11
       #if: contains(matrix.config.image, '2023') == false
       run: ./ci/install_pybind11.sh 2.10.0
+    - name: glfw
+      if: contains(matrix.config.image, '2023') == true
+      run: ./ci/install_glfw.sh 3.3.10
     - name: timestamp
       id: timestamp
       run: echo "timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,6 @@ jobs:
     strategy:
       matrix:
         config:
-          # @note  we specifically use clang15.0 (not clang15) here as the newest
-          #  versions of the clang15.X containers have some issues with the GLFW
-          #  installation
           - { cxx: clang++, image: '2024', abi: '11', build: 'Release', cmake: '' }
           - { cxx: g++,     image: '2024', abi: '11', build: 'Release', cmake: '' }
           - { cxx: clang++, image: '2024', abi: '11', build: 'Debug',   cmake: '' }

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -98,6 +98,9 @@ jobs:
     - name: glfw
       if: contains(matrix.config.image, '2023') == true
       run: ./ci/install_glfw.sh 3.3.10
+    - name: cppunit
+      if: contains(matrix.config.image, '2022') == false
+      run: ./ci/install_cppunit.sh 1.15.1
     - name: timestamp
       id: timestamp
       run: echo "timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -75,11 +75,12 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cxx: clang++, image: '2023.0', hou_hash: '20_0-newabi', build: 'Release', components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
+          - { cxx: clang++, image: '2024', hou_hash: '20_5', build: 'Release', components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
+          - { cxx: clang++, image: '2023', hou_hash: '20_5', build: 'Debug',   components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
+          - { cxx: g++,     image: '2023', hou_hash: '20_5', build: 'Release', components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
+          - { cxx: clang++, image: '2023', hou_hash: '20_0-newabi', build: 'Release', components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
+          - { cxx: g++,     image: '2023', hou_hash: '20_0-newabi', build: 'Release', components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
           - { cxx: clang++, image: '2022',   hou_hash: '20_0-oldabi', build: 'Release', components: 'core,hou' }
-          - { cxx: clang++, image: '2021',   hou_hash: '19_5',        build: 'Release', components: 'core,hou' }
-          - { cxx: clang++, image: '2023.0', hou_hash: '20_0-newabi', build: 'Debug',   components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
-          - { cxx: g++,     image: '2023.0', hou_hash: '20_0-newabi', build: 'Release', components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
           - { cxx: g++,     image: '2022',   hou_hash: '20_0-oldabi', build: 'Release', components: 'core,hou' }
       fail-fast: false
     steps:

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -95,6 +95,9 @@ jobs:
     - name: pybind11
       #if: contains(matrix.config.image, '2023') == false
       run: ./ci/install_pybind11.sh 2.10.0
+    - name: glfw
+      if: contains(matrix.config.image, '2023') == true
+      run: ./ci/install_glfw.sh 3.3.10
     - name: timestamp
       id: timestamp
       run: echo "timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT

--- a/.github/workflows/houdini.yml
+++ b/.github/workflows/houdini.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cxx: clang++, image: '2024', hou_hash: '20_5', build: 'Release', components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
+          - { cxx: clang++, image: '2024', hou_hash: '20_5', build: 'Release', components: 'core,hou,bin,view,render,python,test' }
           - { cxx: clang++, image: '2023', hou_hash: '20_5', build: 'Debug',   components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
           - { cxx: g++,     image: '2023', hou_hash: '20_5', build: 'Release', components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }
           - { cxx: clang++, image: '2023', hou_hash: '20_0-newabi', build: 'Release', components: 'core,hou,bin,view,render,python,test,axcore,axbin,axtest' }

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -61,10 +61,10 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cxx: g++,     image: '2022-clang11', build: 'Release' }
-          - { cxx: g++,     image: '2022-clang11', build: 'Debug' }
-          - { cxx: clang++, image: '2022-clang11', build: 'Release' }
-          - { cxx: clang++, image: '2022-clang11', build: 'Debug' }
+          - { cxx: g++,     image: '2024', build: 'Release' }
+          - { cxx: g++,     image: '2024', build: 'Debug' }
+          - { cxx: clang++, image: '2024', build: 'Release' }
+          - { cxx: clang++, image: '2024', build: 'Debug' }
       fail-fast: false
     steps:
       - name: Enable Node 16

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -61,10 +61,10 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cxx: g++,     image: '2024', build: 'Release' }
-          - { cxx: g++,     image: '2024', build: 'Debug' }
-          - { cxx: clang++, image: '2024', build: 'Release' }
-          - { cxx: clang++, image: '2024', build: 'Debug' }
+          - { cxx: g++,     image: '2022-clang11', build: 'Release' }
+          - { cxx: g++,     image: '2022-clang11', build: 'Debug' }
+          - { cxx: clang++, image: '2022-clang11', build: 'Release' }
+          - { cxx: clang++, image: '2022-clang11', build: 'Debug' }
       fail-fast: false
     steps:
       - name: Enable Node 16

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -73,9 +73,10 @@ jobs:
           - { houdini_version: '19.5', platform: 'linux_x86_64_gcc9.3',  hou_hash: '19_5' }
           - { houdini_version: '20.0', platform: 'linux_x86_64_gcc9.3',  hou_hash: '20_0-oldabi' }
           - { houdini_version: '20.0', platform: 'linux_x86_64_gcc11.2', hou_hash: '20_0-newabi' }
+          - { houdini_version: '20.5', platform: 'linux_x86_64_gcc11.2', hou_hash: '20_5' }
       fail-fast: false
     container:
-      image: aswf/ci-base:2023
+      image: aswf/ci-base:2024
     steps:
     - name: Enable Node 16
       run: |
@@ -156,7 +157,7 @@ jobs:
       # @note  we specifically use clang15.0 (not clang15) here as the newest
       #  versions of the clang15.X containers have some issues with the GLFW
       #  installation
-      image: aswf/ci-openvdb:2023-clang15.0
+      image: aswf/ci-openvdb:2024
     env:
       CXX: clang++
     strategy:
@@ -303,19 +304,18 @@ jobs:
       matrix:
         config:
           # Unified
-          - { image: '2022-clang14', cxx: 'clang++', build: 'Release', components: 'core,bin,axcore,axbin,axtest', cmake: '' }
-          - { image: '2022-clang14', cxx: 'g++',     build: 'Release', components: 'core,bin,axcore,axbin,axtest', cmake: '' }
+          - { image: '2023-clang14', cxx: 'clang++', build: 'Release', components: 'core,bin,axcore,axbin,axtest', cmake: '' }
+          - { image: '2023-clang14', cxx: 'g++',     build: 'Release', components: 'core,bin,axcore,axbin,axtest', cmake: '' }
           - { image: '2022-clang13', cxx: 'clang++', build: 'Release', components: 'core,bin,axcore,axbin,axtest', cmake: '' }
           - { image: '2022-clang13', cxx: 'g++',     build: 'Release', components: 'core,bin,axcore,axbin,axtest', cmake: '' }
           # Standalone
-          - { image: '2021-clang10', cxx: 'clang++', build: 'Release', components: 'core', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
           - { image: '2022-clang11', cxx: 'clang++', build: 'Debug',   components: 'core', cmake: '' }
           - { image: '2022-clang11', cxx: 'clang++', build: 'Release', components: 'core', cmake: '' }
           - { image: '2022-clang11', cxx: 'g++',     build: 'Release', components: 'core', cmake: '' }
       fail-fast: false
     steps:
       - name: Enable Node 16
-        if: contains(matrix.config.image, '2021') || contains(matrix.config.image, '2022')
+        if: contains(matrix.config.image, '2022')
         run: |
           echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
       - uses: actions/checkout@v3

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -154,9 +154,6 @@ jobs:
     runs-on: ${{ (github.repository_owner == 'AcademySoftwareFoundation' && 'ubuntu-20.04-8c-32g-300h') || 'ubuntu-latest' }}
     name: linux-extra:${{ matrix.config.name }}
     container:
-      # @note  we specifically use clang15.0 (not clang15) here as the newest
-      #  versions of the clang15.X containers have some issues with the GLFW
-      #  installation
       image: aswf/ci-openvdb:2024
     env:
       CXX: clang++

--- a/ci/install_cppunit.sh
+++ b/ci/install_cppunit.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ex
+CURL_VERSION="$1"
+
+wget -O cppunit.tar.gz https://dev-www.libreoffice.org/src/cppunit-${CURL_VERSION}.tar.gz
+
+tar -xzf cppunit.tar.gz
+
+cd cppunit-${CURL_VERSION}
+
+./configure 
+
+make -j8
+make install

--- a/ci/install_cppunit.sh
+++ b/ci/install_cppunit.sh
@@ -9,7 +9,7 @@ tar -xzf cppunit.tar.gz
 
 cd cppunit-${CURL_VERSION}
 
-./configure 
+./configure
 
 make -j8
 make install

--- a/ci/install_glfw.sh
+++ b/ci/install_glfw.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+GLFW_VERSION="$1"
+
+git clone https://github.com/glfw/glfw.git
+cd glfw
+
+if [ "$GLFW_VERSION" != "latest" ]; then
+    git checkout tags/${GLFW_VERSION} -b ${GLFW_VERSION}
+fi
+
+mkdir build
+cd build
+
+cmake ..
+
+make -j8
+make install


### PR DESCRIPTION
This drops CI jobs for the VFX Reference Platform 2021 images which we are about to drop support for and introduces 2024 images which we haven't used until now. I've also removed the clang-specific images in favor of the base image (where possible, AX does not yet work on LLVM>15). There was an outstanding issue where the version of glfw was incorrectly installed in the 2023 image so this is now installed from source to resolve this.