### PR TITLE
Drop ABI=9 support

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -184,7 +184,6 @@ set -x
 # - always enabled the python tests with OPENVDB_BUILD_PYTHON_UNITTESTS if the python module is in use,
 #   regardless of the 'test' component being enabled or not (see the OPENVDB_BUILD_PYTHON_UNITTESTS option).
 cmake \
-    -DOPENVDB_USE_DEPRECATED_ABI_9=ON \
     -DOPENVDB_USE_DEPRECATED_ABI_10=ON \
     -DOPENVDB_BUILD_VDB_PRINT=ON \
     -DOPENVDB_BUILD_VDB_LOD=ON \

--- a/openvdb/openvdb/openvdb.cc
+++ b/openvdb/openvdb/openvdb.cc
@@ -14,18 +14,13 @@
 #include <blosc.h>
 #endif
 
-#if OPENVDB_ABI_VERSION_NUMBER <= 8
-    #error ABI <= 8 is no longer supported
+#if OPENVDB_ABI_VERSION_NUMBER <= 9
+    #error ABI <= 9 is no longer supported
 #endif
 
 // If using an OPENVDB_ABI_VERSION_NUMBER that has been deprecated, issue an
 // error directive. This can be optionally suppressed by defining:
 //   OPENVDB_USE_DEPRECATED_ABI_<VERSION>=ON.
-#ifndef OPENVDB_USE_DEPRECATED_ABI_9
-    #if OPENVDB_ABI_VERSION_NUMBER == 9
-        #error ABI = 9 is deprecated, CMake option OPENVDB_USE_DEPRECATED_ABI_9 suppresses this error
-    #endif
-#endif
 #ifndef OPENVDB_USE_DEPRECATED_ABI_10
     #if OPENVDB_ABI_VERSION_NUMBER == 10
         #error ABI = 10 is deprecated, CMake option OPENVDB_USE_DEPRECATED_ABI_10 suppresses this error

--- a/openvdb/openvdb/points/AttributeArray.h
+++ b/openvdb/openvdb/points/AttributeArray.h
@@ -145,14 +145,6 @@ public:
     /// Return a copy of this attribute.
     virtual AttributeArray::Ptr copy() const = 0;
 
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-    /// Return a copy of this attribute.
-#ifndef _MSC_VER
-    OPENVDB_DEPRECATED_MESSAGE("In-memory compression no longer supported, use AttributeArray::copy() instead")
-#endif
-    virtual AttributeArray::Ptr copyUncompressed() const = 0;
-#endif
-
     /// Return the number of elements in this array.
     /// @note This does not count each data element in a strided array
     virtual Index size() const = 0;
@@ -197,13 +189,11 @@ public:
     /// Return the number of bytes of memory used by this attribute.
     virtual size_t memUsage() const = 0;
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     /// Return the number of bytes of memory used by this attribute array once it
     /// has been deserialized (this may be different to memUsage() if delay-loading
     /// is in use). Note that this method does NOT consider the fact that a
     /// uniform attribute could be expanded and only deals with delay-loading.
     virtual size_t memUsageIfLoaded() const = 0;
-#endif
 
     /// Create a new attribute array of the given (registered) type, length and stride.
     /// @details If @a lock is non-null, the AttributeArray registry mutex
@@ -227,15 +217,6 @@ public:
     /// Return @c true if this attribute has a value type the same as the template parameter
     template<typename ValueType>
     bool hasValueType() const { return this->type().first == typeNameAsString<ValueType>(); }
-
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-    /// @brief Set value at given index @a n from @a sourceIndex of another @a sourceArray.
-    // Windows does not allow base classes to be easily deprecated.
-#ifndef _MSC_VER
-    OPENVDB_DEPRECATED_MESSAGE("Use copyValues() with source-target index pairs")
-#endif
-    virtual void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) = 0;
-#endif
 
     /// @brief Copy values into this array from a source array to a target array
     /// as referenced by an iterator.
@@ -277,19 +258,6 @@ public:
     virtual void collapse() = 0;
     /// Compact the existing array to become uniform if all values are identical
     virtual bool compact() = 0;
-
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-    // Windows does not allow base classes to be deprecated
-#ifndef _MSC_VER
-    OPENVDB_DEPRECATED_MESSAGE("Previously this compressed the attribute array, now it does nothing")
-#endif
-    virtual bool compress() = 0;
-    // Windows does not allow base classes to be deprecated
-#ifndef _MSC_VER
-    OPENVDB_DEPRECATED_MESSAGE("Previously this uncompressed the attribute array, now it does nothing")
-#endif
-    virtual bool decompress() = 0;
-#endif
 
     /// @brief   Specify whether this attribute should be hidden (e.g., from UI or iterators).
     /// @details This is useful if the attribute is used for blind data or as scratch space
@@ -359,10 +327,8 @@ public:
     bool operator==(const AttributeArray& other) const;
     bool operator!=(const AttributeArray& other) const { return !this->operator==(other); }
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 9
     /// Indirect virtual function to retrieve the data buffer cast to a char byte array
     const char* constDataAsByteArray() const { return this->dataAsByteArray(); }
-#endif
 
 private:
     friend class ::TestAttributeArray;
@@ -565,11 +531,6 @@ public:
     /// while being copied using this copy-constructor in another thread.
     /// It is not thread-safe for write.
     TypedAttributeArray(const TypedAttributeArray&);
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-    /// Deep copy constructor.
-    OPENVDB_DEPRECATED_MESSAGE("Use copy-constructor without unused bool parameter")
-    TypedAttributeArray(const TypedAttributeArray&, bool /*unused*/);
-#endif
 
     /// Deep copy assignment operator.
     /// @note this operator is thread-safe.
@@ -584,13 +545,6 @@ public:
     /// Return a copy of this attribute.
     /// @note This method is thread-safe.
     AttributeArray::Ptr copy() const override;
-
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-    /// Return a copy of this attribute.
-    /// @note This method is thread-safe.
-    OPENVDB_DEPRECATED_MESSAGE("In-memory compression no longer supported, use AttributeArray::copy() instead")
-    AttributeArray::Ptr copyUncompressed() const override;
-#endif
 
     /// Return a new attribute array of the given length @a n and @a stride with uniform value zero.
     static Ptr create(Index n, Index strideOrTotalSize = 1, bool constantStride = true,
@@ -657,13 +611,11 @@ public:
     /// Return the number of bytes of memory used by this attribute.
     size_t memUsage() const override;
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     /// Return the number of bytes of memory used by this attribute array once it
     /// has been deserialized (this may be different to memUsage() if delay-loading
     /// is in use). Note that this method does NOT consider the fact that a
     /// uniform attribute could be expanded and only deals with delay-loading.
     size_t memUsageIfLoaded() const override;
-#endif
 
     /// Return the value at index @a n (assumes in-core)
     ValueType getUnsafe(Index n) const;
@@ -691,12 +643,6 @@ public:
     /// (assumes in-core)
     static void setUnsafe(AttributeArray* array, const Index n, const ValueType& value);
 
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-    /// Set value at given index @a n from @a sourceIndex of another @a sourceArray
-    OPENVDB_DEPRECATED_MESSAGE("Use copyValues() with source-target index pairs")
-    void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) override;
-#endif
-
     /// Return @c true if this array is stored as a single uniform value.
     bool isUniform() const override { return mIsUniform; }
     /// @brief  Replace the single value storage with an array of length size().
@@ -718,15 +664,6 @@ public:
     static void collapse(AttributeArray* array, const ValueType& value);
     /// Non-member equivalent to fill() that static_casts array to this TypedAttributeArray
     static void fill(AttributeArray* array, const ValueType& value);
-
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-    /// Compress the attribute array.
-    OPENVDB_DEPRECATED_MESSAGE("Previously this compressed the attribute array, now it does nothing")
-    bool compress() override;
-    /// Uncompress the attribute array.
-    OPENVDB_DEPRECATED_MESSAGE("Previously this uncompressed the attribute array, now it does nothing")
-    bool decompress() override;
-#endif
 
     /// Read attribute data from a stream.
     void read(std::istream&) override;
@@ -789,14 +726,7 @@ private:
     /// Load data from memory-mapped file.
     inline void doLoad() const;
     /// Load data from memory-mapped file (unsafe as this function is not protected by a mutex).
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     inline void doLoadUnsafe() const;
-#else
-    /// @param compression parameter no longer used
-    inline void doLoadUnsafe(const bool compression = true) const;
-    /// Compress in-core data assuming mutex is locked
-    inline bool compressUnsafe();
-#endif
 
     /// Toggle out-of-core state
     inline void setOutOfCore(const bool);
@@ -1275,15 +1205,6 @@ TypedAttributeArray<ValueType_, Codec_>::copy() const
 }
 
 
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-template<typename ValueType_, typename Codec_>
-AttributeArray::Ptr
-TypedAttributeArray<ValueType_, Codec_>::copyUncompressed() const
-{
-    return this->copy();
-}
-#endif
-
 template<typename ValueType_, typename Codec_>
 size_t
 TypedAttributeArray<ValueType_, Codec_>::arrayMemUsage() const
@@ -1385,14 +1306,13 @@ TypedAttributeArray<ValueType_, Codec_>::memUsage() const
     return sizeof(*this) + (bool(mData) ? this->arrayMemUsage() : 0);
 }
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
+
 template<typename ValueType_, typename Codec_>
 size_t
 TypedAttributeArray<ValueType_, Codec_>::memUsageIfLoaded() const
 {
     return sizeof(*this) + (mIsUniform ? 1 : this->dataSize()) * sizeof(StorageType);
 }
-#endif
 
 
 template<typename ValueType_, typename Codec_>
@@ -1497,21 +1417,6 @@ TypedAttributeArray<ValueType_, Codec_>::setUnsafe(AttributeArray* array, const 
 }
 
 
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-template<typename ValueType_, typename Codec_>
-void
-TypedAttributeArray<ValueType_, Codec_>::set(Index n, const AttributeArray& sourceArray, const Index sourceIndex)
-{
-    const TypedAttributeArray& sourceTypedArray = static_cast<const TypedAttributeArray&>(sourceArray);
-
-    ValueType sourceValue;
-    sourceTypedArray.get(sourceIndex, sourceValue);
-
-    this->set(n, sourceValue);
-}
-#endif
-
-
 template<typename ValueType_, typename Codec_>
 void
 TypedAttributeArray<ValueType_, Codec_>::expand(bool fill)
@@ -1603,32 +1508,6 @@ TypedAttributeArray<ValueType_, Codec_>::fill(AttributeArray* array, const Value
 {
     static_cast<TypedAttributeArray<ValueType, Codec>*>(array)->fill(value);
 }
-
-
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-template<typename ValueType_, typename Codec_>
-inline bool
-TypedAttributeArray<ValueType_, Codec_>::compress()
-{
-    return false;
-}
-
-
-template<typename ValueType_, typename Codec_>
-inline bool
-TypedAttributeArray<ValueType_, Codec_>::compressUnsafe()
-{
-    return false;
-}
-
-
-template<typename ValueType_, typename Codec_>
-inline bool
-TypedAttributeArray<ValueType_, Codec_>::decompress()
-{
-    return false;
-}
-#endif
 
 
 template<typename ValueType_, typename Codec_>
@@ -1976,11 +1855,7 @@ TypedAttributeArray<ValueType_, Codec_>::writePagedBuffers(compression::PagedOut
 
 template<typename ValueType_, typename Codec_>
 void
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
 TypedAttributeArray<ValueType_, Codec_>::doLoadUnsafe() const
-#else
-TypedAttributeArray<ValueType_, Codec_>::doLoadUnsafe(const bool /*compression*/) const
-#endif
 {
     if (!(this->isOutOfCore())) return;
 

--- a/openvdb/openvdb/points/AttributeSet.cc
+++ b/openvdb/openvdb/points/AttributeSet.cc
@@ -140,7 +140,6 @@ AttributeSet::memUsage() const
 }
 
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
 size_t
 AttributeSet::memUsageIfLoaded() const
 {
@@ -150,7 +149,6 @@ AttributeSet::memUsageIfLoaded() const
     }
     return bytes;
 }
-#endif
 
 
 size_t

--- a/openvdb/openvdb/points/AttributeSet.h
+++ b/openvdb/openvdb/points/AttributeSet.h
@@ -114,12 +114,10 @@ public:
     /// Return the number of bytes of memory used by this attribute set.
     size_t memUsage() const;
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     /// Return the number of bytes of memory used by this attribute set once it
     /// has been deserialized (this may be different to memUsage() if delay-loading
     /// is in use).
     size_t memUsageIfLoaded() const;
-#endif
 
     /// @brief  Return the position of the attribute array whose name is @a name,
     ///         or @c INVALID_POS if no match is found.

--- a/openvdb/openvdb/points/PointDataGrid.h
+++ b/openvdb/openvdb/points/PointDataGrid.h
@@ -504,9 +504,7 @@ public:
 
 
     Index64 memUsage() const;
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     Index64 memUsageIfLoaded() const;
-#endif
 
     void evalActiveBoundingBox(CoordBBox& bbox, bool visitVoxels = true) const;
 
@@ -1524,14 +1522,12 @@ PointDataLeafNode<T, Log2Dim>::memUsage() const
     return BaseLeaf::memUsage() + mAttributeSet->memUsage();
 }
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
 template<typename T, Index Log2Dim>
 inline Index64
 PointDataLeafNode<T, Log2Dim>::memUsageIfLoaded() const
 {
     return BaseLeaf::memUsageIfLoaded() + mAttributeSet->memUsageIfLoaded();
 }
-#endif
 
 template<typename T, Index Log2Dim>
 inline void

--- a/openvdb/openvdb/tree/RootNode.h
+++ b/openvdb/openvdb/tree/RootNode.h
@@ -881,7 +881,6 @@ public:
     void combine2(const RootNode& other0, const OtherRootNode& other1,
                   CombineOp& op, bool prune = false);
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     /// Return the grid index coordinates of this node's local origin.
     const Coord& origin() const { return mOrigin; }
     /// @brief change the origin on this root node
@@ -890,7 +889,6 @@ public:
     /// @warning This method will throw if the origin is non-zero, since
     ///          other tools do not yet support variable offsets.
     void setOrigin(const Coord &origin);
-#endif
 
 private:
     /// During topology-only construction, access is needed
@@ -913,13 +911,8 @@ private:
     Index getActiveTileCount() const;
     Index getInactiveTileCount() const;
 
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-    /// Static method that returns a MapType key for the given coordinates.
-    static Coord coordToKey(const Coord& xyz) {return xyz & ~(ChildType::DIM - 1); }
-#else
     /// Return a MapType key for the given coordinates, offset by the mOrigin.
     Coord coordToKey(const Coord& xyz) const { return (xyz - mOrigin) & ~(ChildType::DIM - 1); }
-#endif
 
     /// Insert this node's mTable keys into the given set.
     void insertKeys(CoordSet&) const;
@@ -963,9 +956,7 @@ private:
 
     MapType mTable;
     ValueType mBackground;
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     Coord mOrigin;
-#endif
     /// Transient Data (not serialized)
     Index32 mTransientData = 0;
 }; // end of RootNode class
@@ -1032,9 +1023,7 @@ template<typename ChildT>
 inline
 RootNode<ChildT>::RootNode()
     : mBackground(zeroVal<ValueType>())
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     , mOrigin(0, 0, 0)
-#endif
 {
     this->initTable();
 }
@@ -1044,9 +1033,7 @@ template<typename ChildT>
 inline
 RootNode<ChildT>::RootNode(const ValueType& background)
     : mBackground(background)
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     , mOrigin(0, 0, 0)
-#endif
 {
     this->initTable();
 }
@@ -1058,18 +1045,14 @@ inline
 RootNode<ChildT>::RootNode(const RootNode<OtherChildType>& other,
     const ValueType& backgd, const ValueType& foregd, TopologyCopy)
     : mBackground(backgd)
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     , mOrigin(other.mOrigin)
-#endif
     , mTransientData(other.mTransientData)
 {
     using OtherRootT = RootNode<OtherChildType>;
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     if (mOrigin != Coord(0,0,0)) {
         OPENVDB_THROW(ValueError, "RootNode::RootNode: non-zero offsets are currently not supported");
     }
-#endif
 
     enforceSameConfiguration(other);
 
@@ -1090,18 +1073,14 @@ inline
 RootNode<ChildT>::RootNode(const RootNode<OtherChildType>& other,
     const ValueType& backgd, TopologyCopy)
     : mBackground(backgd)
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     , mOrigin(other.mOrigin)
-#endif
     , mTransientData(other.mTransientData)
 {
     using OtherRootT = RootNode<OtherChildType>;
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
     if (mOrigin != Coord(0,0,0)) {
         OPENVDB_THROW(ValueError, "RootNode::RootNode: non-zero offsets are currently not supported");
     }
-#endif
 
     enforceSameConfiguration(other);
 
@@ -1158,12 +1137,10 @@ struct RootNodeCopyHelper<RootT, OtherRootT, /*Compatible=*/true>
         };
 
         self.mBackground = Local::convertValue(other.mBackground);
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
         if (other.mOrigin != Coord(0,0,0)) {
             OPENVDB_THROW(ValueError, "RootNodeCopyHelper::copyWithValueConversion: non-zero offsets are currently not supported");
         }
         self.mOrigin = other.mOrigin;
-#endif
         self.mTransientData = other.mTransientData;
 
         self.clear();
@@ -1191,12 +1168,10 @@ RootNode<ChildT>::operator=(const RootNode& other)
 {
     if (&other != this) {
         mBackground = other.mBackground;
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
         mOrigin = other.mOrigin;
         if (mOrigin != Coord(0,0,0)) {
             OPENVDB_THROW(ValueError, "RootNode::operator=: non-zero offsets are currently not supported");
         }
-#endif
         mTransientData = other.mTransientData;
 
         this->clear();
@@ -2652,7 +2627,6 @@ RootNode<ChildT>::addChild(ChildT* child)
     return true;
 }
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
 template<typename ChildT>
 inline void
 RootNode<ChildT>::setOrigin(const Coord &origin)
@@ -2662,7 +2636,6 @@ RootNode<ChildT>::setOrigin(const Coord &origin)
         OPENVDB_THROW(ValueError, "RootNode::setOrigin: non-zero offsets are currently not supported");
     }
 }
-#endif
 
 template<typename ChildT>
 inline void

--- a/openvdb/openvdb/unittest/TestValueAccessor.cc
+++ b/openvdb/openvdb/unittest/TestValueAccessor.cc
@@ -665,8 +665,6 @@ TEST_F(TestValueAccessor, testGetNode)
     }
 }
 
-#if OPENVDB_ABI_VERSION_NUMBER >= 10
-
 template <typename TreeT> struct AssertBypass
 {
     inline void operator()() {
@@ -703,5 +701,3 @@ TEST_F(TestValueAccessor, testBypassLeafAPI)
     static_assert(!ValueAccessor2<FloatTree, true, 1, 2>::BypassLeafAPI);
     static_assert(!ValueAccessor3<MaskTree, true, 0, 1, 2>::BypassLeafAPI);
 }
-
-#endif

--- a/openvdb/openvdb/version.h.in
+++ b/openvdb/openvdb/version.h.in
@@ -189,12 +189,6 @@
 // directive. This can be suppressed by defining OPENVDB_USE_DEPRECATED_ABI_<VERSION>.
 // Note that, whilst the VDB CMake does not allow this option to be hit,
 // it exists to propagate this message to downstream targets
-#ifndef OPENVDB_USE_DEPRECATED_ABI_9
-    #if OPENVDB_ABI_VERSION_NUMBER == 9
-        PRAGMA(message("NOTE: ABI = 9 is deprecated, define OPENVDB_USE_DEPRECATED_ABI_9 "
-            "to suppress this message"))
-    #endif
-#endif
 #ifndef OPENVDB_USE_DEPRECATED_ABI_10
     #if OPENVDB_ABI_VERSION_NUMBER == 10
         PRAGMA(message("NOTE: ABI = 10 is deprecated, define OPENVDB_USE_DEPRECATED_ABI_10 "

--- a/openvdb_cmd/vdb_print/main.cc
+++ b/openvdb_cmd/vdb_print/main.cc
@@ -210,31 +210,15 @@ printShortListing(const StringVec& filenames, bool metadata)
             // Print the grid's size, in bytes
 
             // no support for memUsageIfLoaded until ABI >= 10 for points::PointDataGrid types
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-            using ListT = openvdb::GridTypes::Remove<openvdb::points::PointDataGrid>;
-#else
             using ListT = openvdb::GridTypes;
-#endif
-            const bool success =
-                grid->apply<ListT>([&](const auto& typed){
-                    // @todo combine these methods to avoid iterating across the tree twice
-                    const openvdb::Index64 incore = openvdb::tools::memUsage(typed.tree());
-                    const openvdb::Index64 total = openvdb::tools::memUsageIfLoaded(typed.tree());
+            grid->apply<ListT>([&](const auto& typed){
+                // @todo combine these methods to avoid iterating across the tree twice
+                const openvdb::Index64 incore = openvdb::tools::memUsage(typed.tree());
+                const openvdb::Index64 total = openvdb::tools::memUsageIfLoaded(typed.tree());
 
-                    std::cout << " " << std::right << std::setw(6) << bytesAsString(incore) << " (In Core)";
-                    std::cout << " " << std::right << std::setw(6) << bytesAsString(total) << " (Total)";
-                });
-
-            (void)success;
-#if OPENVDB_ABI_VERSION_NUMBER < 10
-            if (!success) {
-                // could be a points grid, print in-core memory only
-                grid->apply<openvdb::GridTypes>([&](const auto& typed){
-                    const openvdb::Index64 incore = openvdb::tools::memUsage(typed.tree());
-                    std::cout << " " << std::right << std::setw(6) << bytesAsString(incore) << " (In Core)";
-                });
-            }
-#endif
+                std::cout << " " << std::right << std::setw(6) << bytesAsString(incore) << " (In Core)";
+                std::cout << " " << std::right << std::setw(6) << bytesAsString(total) << " (Total)";
+            });
 
             std::cout << std::endl;
 

--- a/tsc/process/deprecation.md
+++ b/tsc/process/deprecation.md
@@ -5,7 +5,7 @@ OpenVDB is committed to supporting three years of
 Houdini and Maya based on those versions of the platform. The latest supported
 year is that in which the VDB version listed matches the major version.
 
-For example, version 6.1.0 of OpenVDB supports VFX Reference Platform years
+For example, all 6.x versions of OpenVDB support VFX Reference Platform years
 2019, 2018 and 2017.
 
 This infers the following support:
@@ -14,9 +14,5 @@ This infers the following support:
 * C++11 and C++14
 * Houdini 16.5, 17.0 and 17.5
 
-When version 7.0.0 is released, OpenVDB will support VFX Reference Platform
-years 2020, 2019 and 2018. Support for Houdini 16.5 and C++11 will be dropped.
-
-Support for obsolete ABIs will not be dropped until the first minor release
-after the introduction of a new ABI. For example, the latest version to retain
-support for ABI=4 will be the release prior to 7.1.0.
+All 7.x versions of OpenVDB support VFX Reference Platform years 2020, 2019 and
+2018. Support for Houdini 16.5, C++11 and ABI=4 is removed.


### PR DESCRIPTION
This drops ABI=9 support in preparation for VDB 12.0, but keeps the version as 11.x for the time being.

This also edits the deprecation document to accurately reflect the change in policy around when to remove support for obsolete ABIs.