### PR TITLE
fVDB: Fix typo in 01_api_basics.ipynb

### DIFF
--- a/fvdb/notebooks/01_api_basics.ipynb
+++ b/fvdb/notebooks/01_api_basics.ipynb
@@ -257,7 +257,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Here we create a list of Tensors, one for each grid in the batch with its number of active voxels and 8 random features per-voxel\n",
+    "# Here we create a list of Tensors, one for each grid in the batch with its number of active voxels and 5 random features per-voxel\n",
     "list_of_features = [torch.randn(int(grid_batch.num_voxels[i]), 5, device=grid_batch.device) for i in range(grid_batch.grid_count)]\n",
     "# Now we make a JaggedTensor out of this list of heterogeneous Tensors\n",
     "features  = fvdb.JaggedTensor(list_of_features)"


### PR DESCRIPTION
Fixed a minor typo causing minor confusion in one of the tutorial notebooks.