### PR TITLE
RootNode and InternalNode Probe Methods

### DIFF
--- a/openvdb/openvdb/tree/RootNode.h
+++ b/openvdb/openvdb/tree/RootNode.h
@@ -735,7 +735,7 @@ public:
     /// return @c nullptr.
     bool probe(const Coord& xyz, ChildNodeType*& child, ValueType& value, bool& active);
     bool probeConst(const Coord& xyz, const ChildNodeType*& child, ValueType& value, bool& active) const;
-    bool probe(const Coord& xyz, const ChildNodeType*& child, ValueType& value, bool& active) const;
+    bool probe(const Coord& xyz, const ChildNodeType*& child, ValueType& value, bool& active) const { return this->probeConst(xyz, child, value, active); }
     //}
 
     //@{
@@ -752,7 +752,7 @@ public:
     /// If no such node exists, return @c nullptr.
     ChildNodeType* probeChild(const Coord& xyz);
     const ChildNodeType* probeConstChild(const Coord& xyz) const;
-    const ChildNodeType* probeChild(const Coord& xyz) const;
+    const ChildNodeType* probeChild(const Coord& xyz) const { return this->probeConstChild(xyz); }
     //@}
 
     //@{
@@ -760,7 +760,7 @@ public:
     /// If no such node exists, return @c nullptr.
     LeafNodeType* probeLeaf(const Coord& xyz);
     const LeafNodeType* probeConstLeaf(const Coord& xyz) const;
-    const LeafNodeType* probeLeaf(const Coord& xyz) const;
+    const LeafNodeType* probeLeaf(const Coord& xyz) const { return this->probeConstLeaf(xyz); }
     //@}
 
     //@{
@@ -2873,26 +2873,10 @@ RootNode<ChildT>::probeConst(const Coord& xyz, const ChildNodeType*& child, Valu
 
 
 template<typename ChildT>
-inline bool
-RootNode<ChildT>::probe(const Coord& xyz, const ChildNodeType*& child, ValueType& value, bool& active) const
-{
-    return this->probeConst(xyz, child, value, active);
-}
-
-
-template<typename ChildT>
 inline ChildT*
 RootNode<ChildT>::probeChild(const Coord& xyz)
 {
     return this->template probeNode<ChildT>(xyz);
-}
-
-
-template<typename ChildT>
-inline const ChildT*
-RootNode<ChildT>::probeChild(const Coord& xyz) const
-{
-    return this->template probeConstNode<ChildT>(xyz);
 }
 
 

--- a/openvdb/openvdb/tree/RootNode.h
+++ b/openvdb/openvdb/tree/RootNode.h
@@ -724,8 +724,19 @@ public:
     template <typename NodeT>
     NodeT* probeNode(const Coord& xyz);
     template <typename NodeT>
+    const NodeT* probeNode(const Coord& xyz) const;
+    template <typename NodeT>
     const NodeT* probeConstNode(const Coord& xyz) const;
     //@}
+
+    //@{
+    /// @brief Return a pointer to the root child node that contains voxel (x, y, z).
+    /// If no such node exists, query and set the tile value and active status and
+    /// return @c nullptr.
+    bool probe(const Coord& xyz, ChildNodeType*& child, ValueType& value, bool& active);
+    bool probeConst(const Coord& xyz, const ChildNodeType*& child, ValueType& value, bool& active) const;
+    bool probe(const Coord& xyz, const ChildNodeType*& child, ValueType& value, bool& active) const;
+    //}
 
     //@{
     /// @brief Same as probeNode() but, if necessary, update the given accessor with pointers
@@ -734,6 +745,14 @@ public:
     NodeT* probeNodeAndCache(const Coord& xyz, AccessorT& acc);
     template<typename NodeT, typename AccessorT>
     const NodeT* probeConstNodeAndCache(const Coord& xyz, AccessorT& acc) const;
+    //@}
+
+    //@{
+    /// @brief Return a pointer to the root child node that contains voxel (x, y, z).
+    /// If no such node exists, return @c nullptr.
+    ChildNodeType* probeChild(const Coord& xyz);
+    const ChildNodeType* probeConstChild(const Coord& xyz) const;
+    const ChildNodeType* probeChild(const Coord& xyz) const;
     //@}
 
     //@{
@@ -2789,6 +2808,15 @@ RootNode<ChildT>::probeNode(const Coord& xyz)
 template<typename ChildT>
 template<typename NodeT>
 inline const NodeT*
+RootNode<ChildT>::probeNode(const Coord& xyz) const
+{
+    return this->template probeConstNode<NodeT>(xyz);
+}
+
+
+template<typename ChildT>
+template<typename NodeT>
+inline const NodeT*
 RootNode<ChildT>::probeConstNode(const Coord& xyz) const
 {
     if ((NodeT::LEVEL == ChildT::LEVEL && !(std::is_same<NodeT, ChildT>::value)) ||
@@ -2801,6 +2829,78 @@ RootNode<ChildT>::probeConstNode(const Coord& xyz) const
         ? reinterpret_cast<const NodeT*>(child)
         : child->template probeConstNode<NodeT>(xyz);
     OPENVDB_NO_UNREACHABLE_CODE_WARNING_END
+}
+
+
+template<typename ChildT>
+inline bool
+RootNode<ChildT>::probe(const Coord& xyz, ChildNodeType*& child, ValueType& value, bool& active)
+{
+    MapIter iter = this->findCoord(xyz);
+    if (iter == mTable.end()) {
+        child = nullptr;
+        return false;
+    } else if (isChild(iter)) {
+        child = &getChild(iter);
+        return true;
+    }
+    const Tile& tile = getTile(iter);
+    child = nullptr;
+    value = tile.value;
+    active = tile.active;
+    return true;
+}
+
+
+template<typename ChildT>
+inline bool
+RootNode<ChildT>::probeConst(const Coord& xyz, const ChildNodeType*& child, ValueType& value, bool& active) const
+{
+    MapCIter iter = this->findCoord(xyz);
+    if (iter == mTable.end()) {
+        child = nullptr;
+        return false;
+    } else if (isChild(iter)) {
+        child = &getChild(iter);
+        return true;
+    }
+    const Tile& tile = getTile(iter);
+    child = nullptr;
+    value = tile.value;
+    active = tile.active;
+    return true;
+}
+
+
+template<typename ChildT>
+inline bool
+RootNode<ChildT>::probe(const Coord& xyz, const ChildNodeType*& child, ValueType& value, bool& active) const
+{
+    return this->probeConst(xyz, child, value, active);
+}
+
+
+template<typename ChildT>
+inline ChildT*
+RootNode<ChildT>::probeChild(const Coord& xyz)
+{
+    return this->template probeNode<ChildT>(xyz);
+}
+
+
+template<typename ChildT>
+inline const ChildT*
+RootNode<ChildT>::probeChild(const Coord& xyz) const
+{
+    return this->template probeConstNode<ChildT>(xyz);
+}
+
+
+template<typename ChildT>
+inline const ChildT*
+RootNode<ChildT>::probeConstChild(const Coord& xyz) const
+{
+    return this->template probeConstNode<ChildT>(xyz);
 }
 
 

--- a/openvdb/openvdb/unittest/TestInternalNode.cc
+++ b/openvdb/openvdb/unittest/TestInternalNode.cc
@@ -151,7 +151,7 @@ TEST_F(TestInternalNode, testProbe)
         EXPECT_FALSE(bool(node6));
     }
 
-    { // probeChild, probeConstChild - coord access
+    { // probeChild, probeConstChild
         auto* node1 = internalNode.probeChild(Coord(0, 256, 4096));
         EXPECT_TRUE(bool(node1));
         auto* node2 = internalNode.probeChild(Coord(0, 128, 4096));
@@ -167,32 +167,26 @@ TEST_F(TestInternalNode, testProbe)
         EXPECT_FALSE(bool(node6));
     }
 
-    { // probeChild, probeConstChild - index access
-        auto* node1 = internalNode.probeChild(64);
+    { // probeChildUnsafe, probeConstChildUnsafe
+        auto* node1 = internalNode.probeChildUnsafe(64);
         EXPECT_TRUE(bool(node1));
-        auto* node2 = internalNode.probeChild(33);
+        auto* node2 = internalNode.probeChildUnsafe(33);
         EXPECT_FALSE(bool(node2));
         const InternalNode& constInternalNode = internalNode;
-        auto* node3 = constInternalNode.probeChild(64);
+        auto* node3 = constInternalNode.probeChildUnsafe(64);
         EXPECT_TRUE(bool(node3));
-        auto* node4 = constInternalNode.probeChild(33);
+        auto* node4 = constInternalNode.probeChildUnsafe(33);
         EXPECT_FALSE(bool(node4));
-        auto* node5 = internalNode.probeConstChild(64);
+        auto* node5 = internalNode.probeConstChildUnsafe(64);
         EXPECT_TRUE(bool(node5));
-        auto* node6 = internalNode.probeConstChild(33);
+        auto* node6 = internalNode.probeConstChildUnsafe(33);
         EXPECT_FALSE(bool(node6));
-
-        // wrap-around modulo indexing
-        auto* node7 = internalNode.probeConstChild(64 + 32*32*32);
-        EXPECT_TRUE(bool(node7));
-        auto* node8 = internalNode.probeConstChild(33 + 32*32*32);
-        EXPECT_FALSE(bool(node8));
     }
 
     float value = -1.0f;
     bool active = false;
 
-    { // probeChild, probeConstChild - coord access with value and active status
+    { // probeChild, probeConstChild with value and active status
         auto* node1 = internalNode.probeChild(Coord(0, 256, 4096), value, active);
         EXPECT_TRUE(bool(node1));
         EXPECT_EQ(value, -1.0f);
@@ -220,40 +214,30 @@ TEST_F(TestInternalNode, testProbe)
         EXPECT_TRUE(active); active = false;
     }
 
-    { // probeChild, probeConstChild - index access with value and active status
-        auto* node1 = internalNode.probeChild(64, value, active);
+    { // probeChildUnsafe, probeConstChildUnsafe with value and active status
+        auto* node1 = internalNode.probeChildUnsafe(64, value, active);
         EXPECT_TRUE(bool(node1));
         EXPECT_EQ(value, -1.0f);
         EXPECT_FALSE(active);
-        auto* node2 = internalNode.probeChild(33, value, active);
+        auto* node2 = internalNode.probeChildUnsafe(33, value, active);
         EXPECT_FALSE(bool(node2));
         EXPECT_EQ(value, 4.0f); value = -1.0f;
         EXPECT_TRUE(active); active = false;
         const InternalNode& constInternalNode = internalNode;
-        auto* node3 = constInternalNode.probeChild(64, value, active);
+        auto* node3 = constInternalNode.probeChildUnsafe(64, value, active);
         EXPECT_TRUE(bool(node3));
         EXPECT_EQ(value, -1.0f);
         EXPECT_FALSE(active);
-        auto* node4 = constInternalNode.probeChild(33, value, active);
+        auto* node4 = constInternalNode.probeChildUnsafe(33, value, active);
         EXPECT_FALSE(bool(node4));
         EXPECT_EQ(value, 4.0f); value = -1.0f;
         EXPECT_TRUE(active); active = false;
-        auto* node5 = internalNode.probeConstChild(64, value, active);
+        auto* node5 = internalNode.probeConstChildUnsafe(64, value, active);
         EXPECT_TRUE(bool(node5));
         EXPECT_EQ(value, -1.0f);
         EXPECT_FALSE(active);
-        auto* node6 = internalNode.probeConstChild(33, value, active);
+        auto* node6 = internalNode.probeConstChildUnsafe(33, value, active);
         EXPECT_FALSE(bool(node6));
-        EXPECT_EQ(value, 4.0f); value = -1.0f;
-        EXPECT_TRUE(active); active = false;
-
-        // wrap-around modulo indexing
-        auto* node7 = internalNode.probeConstChild(64 + 32*32*32, value, active);
-        EXPECT_TRUE(bool(node7));
-        EXPECT_EQ(value, -1.0f);
-        EXPECT_FALSE(active);
-        auto* node8 = internalNode.probeConstChild(33 + 32*32*32, value, active);
-        EXPECT_FALSE(bool(node8));
         EXPECT_EQ(value, 4.0f); value = -1.0f;
         EXPECT_TRUE(active); active = false;
     }

--- a/openvdb/openvdb/unittest/TestInternalNode.cc
+++ b/openvdb/openvdb/unittest/TestInternalNode.cc
@@ -120,3 +120,141 @@ TEST_F(TestInternalNode, test)
         EXPECT_EQ(Index32(5), internalNode3.transientData());
     }
 }
+
+TEST_F(TestInternalNode, testProbe)
+{
+    using RootNode = FloatTree::RootNodeType;
+    using InternalNode = RootNode::ChildNodeType;
+
+    const Coord ijk(0, 0, 4096);
+    InternalNode internalNode(ijk, 1.0f);
+
+    internalNode.addTile(32, 3.0f, true); // (0, 128, 4096)
+    internalNode.addTile(33, 4.0f, true); // (0, 128, 4224)
+
+    auto* child = new InternalNode::ChildNodeType(Coord(0, 256, 4096), 5.0f, true);
+    EXPECT_TRUE(internalNode.addChild(child)); // always returns true
+
+    { // probeNode, probeConstNode
+        auto* node1 = internalNode.probeNode<InternalNode::ChildNodeType>(Coord(0, 256, 4096));
+        EXPECT_TRUE(bool(node1));
+        auto* node2 = internalNode.probeNode<InternalNode::ChildNodeType>(Coord(0, 128, 4096));
+        EXPECT_FALSE(bool(node2));
+        const InternalNode& constInternalNode = internalNode;
+        auto* node3 = constInternalNode.probeNode<InternalNode::ChildNodeType>(Coord(0, 256, 4096));
+        EXPECT_TRUE(bool(node3));
+        auto* node4 = constInternalNode.probeNode<InternalNode::ChildNodeType>(Coord(0, 128, 4096));
+        EXPECT_FALSE(bool(node4));
+        auto* node5 = internalNode.probeConstNode<InternalNode::ChildNodeType>(Coord(0, 256, 4096));
+        EXPECT_TRUE(bool(node5));
+        auto* node6 = internalNode.probeConstNode<InternalNode::ChildNodeType>(Coord(0, 128, 4096));
+        EXPECT_FALSE(bool(node6));
+    }
+
+    { // probeChild, probeConstChild - coord access
+        auto* node1 = internalNode.probeChild(Coord(0, 256, 4096));
+        EXPECT_TRUE(bool(node1));
+        auto* node2 = internalNode.probeChild(Coord(0, 128, 4096));
+        EXPECT_FALSE(bool(node2));
+        const InternalNode& constInternalNode = internalNode;
+        auto* node3 = constInternalNode.probeChild(Coord(0, 256, 4096));
+        EXPECT_TRUE(bool(node3));
+        auto* node4 = constInternalNode.probeChild(Coord(0, 128, 4096));
+        EXPECT_FALSE(bool(node4));
+        auto* node5 = internalNode.probeConstChild(Coord(0, 256, 4096));
+        EXPECT_TRUE(bool(node5));
+        auto* node6 = internalNode.probeConstChild(Coord(0, 128, 4096));
+        EXPECT_FALSE(bool(node6));
+    }
+
+    { // probeChild, probeConstChild - index access
+        auto* node1 = internalNode.probeChild(64);
+        EXPECT_TRUE(bool(node1));
+        auto* node2 = internalNode.probeChild(33);
+        EXPECT_FALSE(bool(node2));
+        const InternalNode& constInternalNode = internalNode;
+        auto* node3 = constInternalNode.probeChild(64);
+        EXPECT_TRUE(bool(node3));
+        auto* node4 = constInternalNode.probeChild(33);
+        EXPECT_FALSE(bool(node4));
+        auto* node5 = internalNode.probeConstChild(64);
+        EXPECT_TRUE(bool(node5));
+        auto* node6 = internalNode.probeConstChild(33);
+        EXPECT_FALSE(bool(node6));
+
+        // wrap-around modulo indexing
+        auto* node7 = internalNode.probeConstChild(64 + 32*32*32);
+        EXPECT_TRUE(bool(node7));
+        auto* node8 = internalNode.probeConstChild(33 + 32*32*32);
+        EXPECT_FALSE(bool(node8));
+    }
+
+    float value = -1.0f;
+    bool active = false;
+
+    { // probeChild, probeConstChild - coord access with value and active status
+        auto* node1 = internalNode.probeChild(Coord(0, 256, 4096), value, active);
+        EXPECT_TRUE(bool(node1));
+        EXPECT_EQ(value, -1.0f);
+        EXPECT_FALSE(active);
+        auto* node2 = internalNode.probeChild(Coord(0, 128, 4096), value, active);
+        EXPECT_FALSE(bool(node2));
+        EXPECT_EQ(value, 3.0f); value = -1.0f;
+        EXPECT_TRUE(active); active = false;
+        const InternalNode& constInternalNode = internalNode;
+        auto* node3 = constInternalNode.probeChild(Coord(0, 256, 4096), value, active);
+        EXPECT_TRUE(bool(node3));
+        EXPECT_EQ(value, -1.0f);
+        EXPECT_FALSE(active);
+        auto* node4 = constInternalNode.probeChild(Coord(0, 128, 4096), value, active);
+        EXPECT_FALSE(bool(node4));
+        EXPECT_EQ(value, 3.0f); value = -1.0f;
+        EXPECT_TRUE(active); active = false;
+        auto* node5 = internalNode.probeConstChild(Coord(0, 256, 4096), value, active);
+        EXPECT_TRUE(bool(node5));
+        EXPECT_EQ(value, -1.0f);
+        EXPECT_FALSE(active);
+        auto* node6 = internalNode.probeConstChild(Coord(0, 128, 4096), value, active);
+        EXPECT_FALSE(bool(node6));
+        EXPECT_EQ(value, 3.0f); value = -1.0f;
+        EXPECT_TRUE(active); active = false;
+    }
+
+    { // probeChild, probeConstChild - index access with value and active status
+        auto* node1 = internalNode.probeChild(64, value, active);
+        EXPECT_TRUE(bool(node1));
+        EXPECT_EQ(value, -1.0f);
+        EXPECT_FALSE(active);
+        auto* node2 = internalNode.probeChild(33, value, active);
+        EXPECT_FALSE(bool(node2));
+        EXPECT_EQ(value, 4.0f); value = -1.0f;
+        EXPECT_TRUE(active); active = false;
+        const InternalNode& constInternalNode = internalNode;
+        auto* node3 = constInternalNode.probeChild(64, value, active);
+        EXPECT_TRUE(bool(node3));
+        EXPECT_EQ(value, -1.0f);
+        EXPECT_FALSE(active);
+        auto* node4 = constInternalNode.probeChild(33, value, active);
+        EXPECT_FALSE(bool(node4));
+        EXPECT_EQ(value, 4.0f); value = -1.0f;
+        EXPECT_TRUE(active); active = false;
+        auto* node5 = internalNode.probeConstChild(64, value, active);
+        EXPECT_TRUE(bool(node5));
+        EXPECT_EQ(value, -1.0f);
+        EXPECT_FALSE(active);
+        auto* node6 = internalNode.probeConstChild(33, value, active);
+        EXPECT_FALSE(bool(node6));
+        EXPECT_EQ(value, 4.0f); value = -1.0f;
+        EXPECT_TRUE(active); active = false;
+
+        // wrap-around modulo indexing
+        auto* node7 = internalNode.probeConstChild(64 + 32*32*32, value, active);
+        EXPECT_TRUE(bool(node7));
+        EXPECT_EQ(value, -1.0f);
+        EXPECT_FALSE(active);
+        auto* node8 = internalNode.probeConstChild(33 + 32*32*32, value, active);
+        EXPECT_FALSE(bool(node8));
+        EXPECT_EQ(value, 4.0f); value = -1.0f;
+        EXPECT_TRUE(active); active = false;
+    }
+}

--- a/openvdb/openvdb/unittest/TestRootNode.cc
+++ b/openvdb/openvdb/unittest/TestRootNode.cc
@@ -202,17 +202,17 @@ TEST_F(TestRoot, testProbe)
         EXPECT_FALSE(bool(childPtr));
 
         const RootNode& constRoot = root;
-        EXPECT_TRUE(root.probe(Coord(0, 0, 0), childPtr, value, active));
-        EXPECT_FALSE(bool(childPtr));
+        EXPECT_TRUE(constRoot.probe(Coord(0, 0, 0), constChildPtr, value, active));
+        EXPECT_FALSE(bool(constChildPtr));
         EXPECT_EQ(value, 2.0f);
         EXPECT_EQ(active, true);
         value = -1.0f;
-        EXPECT_TRUE(root.probe(Coord(4096, 0, 0), childPtr, value, active));
-        EXPECT_FALSE(bool(childPtr));
+        EXPECT_TRUE(root.probe(Coord(4096, 0, 0), constChildPtr, value, active));
+        EXPECT_FALSE(bool(constChildPtr));
         EXPECT_EQ(value, 3.0f);
         EXPECT_EQ(active, false);
-        EXPECT_FALSE(root.probe(Coord(4096, 4096, 4096), childPtr, value, active));
-        EXPECT_FALSE(bool(childPtr));
+        EXPECT_FALSE(root.probe(Coord(4096, 4096, 4096), constChildPtr, value, active));
+        EXPECT_FALSE(bool(constChildPtr));
 
         EXPECT_TRUE(root.probeConst(Coord(0, 0, 0), constChildPtr, value, active));
         EXPECT_FALSE(bool(constChildPtr));

--- a/openvdb/openvdb/unittest/TestRootNode.cc
+++ b/openvdb/openvdb/unittest/TestRootNode.cc
@@ -110,3 +110,120 @@ TEST_F(TestRoot, test)
         EXPECT_EQ(Index32(5), rootNode3.transientData());
     }
 }
+
+TEST_F(TestRoot, testProbe)
+{
+    using RootNode = FloatTree::RootNodeType;
+
+    RootNode root(1.0f);
+
+    root.addTile(Coord(1, 2, 3), 2.0f, true);
+    root.addTile(Coord(4096, 2, 3), 3.0f, false);
+
+    auto* child = new RootNode::ChildNodeType(Coord(0, 0, 4096), 5.0f, true);
+    EXPECT_TRUE(root.addChild(child)); // always returns true
+
+    { // probeNode, probeConstNode
+        auto* node1 = root.probeNode<RootNode::ChildNodeType>(Coord(0, 0, 4096));
+        EXPECT_TRUE(bool(node1));
+        auto* node2 = root.probeNode<RootNode::ChildNodeType>(Coord(4096, 0, 0));
+        EXPECT_FALSE(bool(node2));
+        const RootNode& constRoot = root;
+        auto* node3 = constRoot.probeNode<RootNode::ChildNodeType>(Coord(0, 0, 4096));
+        EXPECT_TRUE(bool(node3));
+        auto* node4 = constRoot.probeNode<RootNode::ChildNodeType>(Coord(4096, 0, 0));
+        EXPECT_FALSE(bool(node4));
+        auto* node5 = root.probeConstNode<RootNode::ChildNodeType>(Coord(0, 0, 4096));
+        EXPECT_TRUE(bool(node5));
+        auto* node6 = root.probeConstNode<RootNode::ChildNodeType>(Coord(4096, 0, 0));
+        EXPECT_FALSE(bool(node6));
+    }
+
+    { // probeChild, probeConstChild
+        auto* node1 = root.probeChild(Coord(0, 0, 4096));
+        EXPECT_TRUE(bool(node1));
+        auto* node2 = root.probeChild(Coord(4096, 0, 0));
+        EXPECT_FALSE(bool(node2));
+        const RootNode& constRoot = root;
+        auto* node3 = constRoot.probeChild(Coord(0, 0, 4096));
+        EXPECT_TRUE(bool(node3));
+        auto* node4 = constRoot.probeChild(Coord(4096, 0, 0));
+        EXPECT_FALSE(bool(node4));
+        auto* node5 = root.probeConstChild(Coord(0, 0, 4096));
+        EXPECT_TRUE(bool(node5));
+        auto* node6 = root.probeConstChild(Coord(4096, 0, 0));
+        EXPECT_FALSE(bool(node6));
+    }
+
+    RootNode::ChildNodeType* childPtr = nullptr;
+    const RootNode::ChildNodeType* constChildPtr = nullptr;
+    float value = -1.0f;
+    bool active = false;
+
+    { // probe, probeConst - child
+        bool keyExists = root.probe(Coord(0, 0, 4096), childPtr, value, active);
+        EXPECT_TRUE(keyExists);
+        EXPECT_TRUE(bool(childPtr));
+        childPtr = nullptr;
+        keyExists = root.probe(Coord(0, 10, 4096), childPtr, value, active);
+        EXPECT_TRUE(keyExists);
+        EXPECT_TRUE(bool(childPtr));
+        childPtr = nullptr;
+        EXPECT_FALSE(root.probe(Coord(4096, 4096, 4096), childPtr, value, active));
+        EXPECT_FALSE(bool(childPtr));
+
+        const RootNode& constRoot = root;
+        keyExists = constRoot.probe(Coord(0, 0, 4096), constChildPtr, value, active);
+        EXPECT_TRUE(keyExists);
+        EXPECT_TRUE(bool(constChildPtr));
+        constChildPtr = nullptr;
+        EXPECT_FALSE(root.probe(Coord(4096, 4096, 4096), constChildPtr, value, active));
+        EXPECT_FALSE(bool(childPtr));
+
+        keyExists = root.probeConst(Coord(0, 0, 4096), constChildPtr, value, active);
+        EXPECT_TRUE(keyExists);
+        EXPECT_TRUE(bool(constChildPtr));
+        constChildPtr = nullptr;
+        EXPECT_FALSE(root.probeConst(Coord(4096, 4096, 4096), constChildPtr, value, active));
+        EXPECT_FALSE(bool(constChildPtr));
+    }
+
+    { // probe, probeConst - tile
+        EXPECT_TRUE(root.probe(Coord(0, 0, 0), childPtr, value, active));
+        EXPECT_FALSE(bool(childPtr));
+        EXPECT_EQ(value, 2.0f);
+        EXPECT_EQ(active, true);
+        value = -1.0f;
+        EXPECT_TRUE(root.probe(Coord(4096, 0, 0), childPtr, value, active));
+        EXPECT_FALSE(bool(childPtr));
+        EXPECT_EQ(value, 3.0f);
+        EXPECT_EQ(active, false);
+        EXPECT_FALSE(root.probe(Coord(4096, 4096, 4096), childPtr, value, active));
+        EXPECT_FALSE(bool(childPtr));
+
+        const RootNode& constRoot = root;
+        EXPECT_TRUE(root.probe(Coord(0, 0, 0), childPtr, value, active));
+        EXPECT_FALSE(bool(childPtr));
+        EXPECT_EQ(value, 2.0f);
+        EXPECT_EQ(active, true);
+        value = -1.0f;
+        EXPECT_TRUE(root.probe(Coord(4096, 0, 0), childPtr, value, active));
+        EXPECT_FALSE(bool(childPtr));
+        EXPECT_EQ(value, 3.0f);
+        EXPECT_EQ(active, false);
+        EXPECT_FALSE(root.probe(Coord(4096, 4096, 4096), childPtr, value, active));
+        EXPECT_FALSE(bool(childPtr));
+
+        EXPECT_TRUE(root.probeConst(Coord(0, 0, 0), constChildPtr, value, active));
+        EXPECT_FALSE(bool(constChildPtr));
+        EXPECT_EQ(value, 2.0f);
+        EXPECT_EQ(active, true);
+        value = -1.0f;
+        EXPECT_TRUE(root.probeConst(Coord(4096, 0, 0), constChildPtr, value, active));
+        EXPECT_FALSE(bool(constChildPtr));
+        EXPECT_EQ(value, 3.0f);
+        EXPECT_EQ(active, false);
+        EXPECT_FALSE(root.probeConst(Coord(4096, 4096, 4096), constChildPtr, value, active));
+        EXPECT_FALSE(bool(constChildPtr));
+    }
+}

--- a/pendingchanges/probe.txt
+++ b/pendingchanges/probe.txt
@@ -1,0 +1,10 @@
+Improvements:
+    - Added RootNode::probeChild() const.
+    - Added RootNode::probeChild() and RootNode::probeConstChild().
+    - Added RootNode::probe() and RootNode::probeConst() to query key presence,
+      child node, value and active state.
+    - Added InternalNode::probeChild() const.
+    - Added InternalNode::probeChild() and probeChildConst() with coord access
+      and optionally value and active state.
+    - Added InternalNode::probeChild() and probeChildConst() with index access
+      and optionally value and active state.


### PR DESCRIPTION
This PR adds a bunch of new "probe" methods to fill in some gaps in the API in being able to query child nodes as well as adds some additional convenience methods. 

**RootNode**

The root node adds convenience methods to query the child nodes (as opposed to needing to supply a template parameter `probeNode<ChildT>(const Coord&)`). In addition, there are new `probe()` methods that query whether a key exists (and returns false if not) and returns either a child node or a value and active state otherwise. Finally, a templated `probeNode()` method that can be called on a const RootNode has been added.

Here are all the new RootNode methods:

```
ChildNodeType*       RootNode::probeChild(const Coord&);
const ChildNodeType* RootNode::probeConstChild(const Coord&) const;
const ChildNodeType* RootNode::probeChild(const Coord&) const;
bool                 RootNode::probe(const Coord&, ChildNodeType*&, ValueType&, bool&);
bool                 RootNode::probeConst(const Coord&, const ChildNodeType*&, ValueType&, bool&) const;
bool                 RootNode::probe(const Coord&, const ChildNodeType*&, ValueType&, bool&) const;
template <typename NodeT> 
const NodeT*         RootNode::probeNode(const Coord&) const;
```

**InternalNode**

The internal node adds convenience methods to query the child nodes (as opposed to needing to supply a template parameter `probeNode<ChildT>(const Coord&)`). In addition, there are also methods that allow querying from an offset (and ensures the offset is not out-of-bounds) as well as being able to pass in value and active state reference variables that are populated if a child node is not present. Finally, a templated `probeNode()` method that can be called on a const InternalNode has been added.

Here are all the new InternalNode methods:
```
ChildNodeType*       InternalNode::probeChild(const Coord&);
const ChildNodeType* InternalNode::probeConstChild(const Coord&) const;
const ChildNodeType* InternalNode::probeChild(const Coord&) const;
ChildNodeType*       InternalNode::probeChild(const Coord&, ValueType&, bool&);
const ChildNodeType* InternalNode::probeConstChild(const Coord&, ValueType&, bool&) const;
const ChildNodeType* InternalNode::probeChild(const Coord&, ValueType&, bool&) const;
ChildNodeType*       InternalNode::probeChild(Index);
const ChildNodeType* InternalNode::probeConstChild(Index) const;
const ChildNodeType* InternalNode::probeChild(Index) const;
ChildNodeType*       InternalNode::probeChild(Index, ValueType&, bool&);
const ChildNodeType* InternalNode::probeConstChild(Index, ValueType&, bool&) const;
const ChildNodeType* InternalNode::probeChild(Index, ValueType&, bool&) const;
template<typename NodeType>
const NodeType*      InternalNode::probeNode(const Coord&) const;
```