### PR TITLE
Python CI Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,11 @@ if(OPENVDB_BUILD_PYTHON_MODULE OR (OPENVDB_BUILD_NANOVDB AND NANOVDB_BUILD_PYTHO
   endif()
 
   if(NOT DEFINED VDB_PYTHON_INSTALL_DIRECTORY)
-    get_filename_component(Python_PACKAGES_DIR ${Python_SITELIB} NAME)
+    if(DEFINED Python_SITELIB)
+      get_filename_component(Python_PACKAGES_DIR ${Python_SITELIB} NAME)
+    else()
+      set(Python_PACKAGES_DIR "site-packages")
+    endif()
     set(VDB_PYTHON_INSTALL_DIRECTORY
       ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/${Python_PACKAGES_DIR}
       CACHE STRING "The directory to install the openvdb and nanovdb Python modules."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,62 +453,17 @@ endif()
 
 # Locate Python and nanobind if necessary
 if(OPENVDB_BUILD_PYTHON_MODULE OR (OPENVDB_BUILD_NANOVDB AND NANOVDB_BUILD_PYTHON_MODULE))
-  # Small function which mimics basic output (bar components) of
-  # FindPackageHandleStandardArgs. This is required as we want to ensure
-  # the minimum python version is MINIMUM_PYTHON_VERSION - however this cannot
-  # be provided to find_package(Python) with differing major versions. e.g.
-  # calls to find_package(Python 2.7) fails if python3 is found on the system.
-  function(OPENVDB_CHECK_PYTHON_VERSION)
-    set(PY_TARGET ${ARGV0})
-    set(PY_TARGET_VERSION ${ARGV1})
-    set(PY_TARGET_INCLUDES ${ARGV2})
-    set(MIN_VERSION ${ARGV3})
-    set(FUTURE_MIN_VERSION ${ARGV4})
 
-    if(NOT TARGET ${PY_TARGET})
-      message(FATAL_ERROR "Could NOT find ${PY_TARGET} (Required is at least version "
-        "\"${MIN_VERSION}\")"
-      )
-    endif()
-
-    if(PY_TARGET_VERSION AND MIN_VERSION)
-      if(PY_TARGET_VERSION VERSION_LESS MIN_VERSION)
-        message(FATAL_ERROR "Could NOT find ${PY_TARGET}: Found unsuitable version "
-          "\"${PY_TARGET_VERSION}\" but required is at least \"${MIN_VERSION}\" (found ${PY_TARGET_INCLUDES})"
-        )
-      endif()
-    endif()
-
-    message(STATUS "Found ${PY_TARGET}: ${PY_TARGET_INCLUDES}) (found suitable "
-      "version \"${PY_TARGET_VERSION}\", minimum required is \"${MIN_VERSION}\")"
-    )
-
-    if(OPENVDB_FUTURE_DEPRECATION AND PY_TARGET_VERSION AND FUTURE_MIN_VERSION)
-      if(PY_TARGET_VERSION VERSION_LESS FUTURE_MIN_VERSION)
-        message(DEPRECATION "Support for ${PY_TARGET} versions < ${FUTURE_MIN_VERSION} "
-          "is deprecated and will be removed.")
-      endif()
-    endif()
-  endfunction()
-
-  # Configure Python and Numpy.
-  # To ensure consistent versions between components Interpreter, Compiler,
-  # Development and NumPy, specify all components at the same time when using
-  # FindPython.
-
-  # @note  explicitly only search for Development.Module from 3.18 as searching
-  #   Development.Embed can cause issues on linux systems where it doesn't exist
-  set(OPENVDB_PYTHON_REQUIRED_COMPONENTS Development Interpreter)
-
-  # Make sure find_package(Python) is only ever invoked once with all required components
-  find_package(Python 3.8 REQUIRED COMPONENTS ${OPENVDB_PYTHON_REQUIRED_COMPONENTS})
+  # Call find_package(Python ...)
+  find_package(Python 3.8 REQUIRED COMPONENTS Development Interpreter)
   find_package(nanobind REQUIRED)
 
-  openvdb_check_python_version(Python::Module
-    "${Python_VERSION}"
-    "${Python_INCLUDE_DIRS}"
-    "${MINIMUM_PYTHON_VERSION}"
-    "${FUTURE_MINIMUM_PYTHON_VERSION}")
+  if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_PYTHON_VERSION)
+    if(Python_VERSION VERSION_LESS ${FUTURE_MINIMUM_PYTHON_VERSION})
+      message(DEPRECATION "Support for Python versions < ${FUTURE_MINIMUM_GLFW_VERSION} "
+        "is deprecated and will be removed.")
+    endif()
+  endif()
 
   if(NOT DEFINED VDB_PYTHON_INSTALL_DIRECTORY)
     get_filename_component(Python_PACKAGES_DIR ${Python_SITELIB} NAME)

--- a/ci/install_nanobind.sh
+++ b/ci/install_nanobind.sh
@@ -25,4 +25,4 @@ cmake \
     ..
 
 make -j8
-make install
+sudo make install

--- a/cmake/FindOpenVDB.cmake
+++ b/cmake/FindOpenVDB.cmake
@@ -334,10 +334,8 @@ set(_OPENVDB_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
 set(OPENVDB_PYTHON_PATH_SUFFIXES
   lib64/python
-  lib64/python2.7
   lib64/python3
   lib/python
-  lib/python2.7
   lib/python3
 )
 


### PR DESCRIPTION
Fixing a few python-related issues that was failing the weekly CI. Remove some Python2 functionality from CMake build (no longer required now that OpenVDB is Python 3+) and adding a "site-packages" fallback if `Python_SITELIB` is not defined. Finally, fixes an issue where nanobind needs to be installed using sudo on ubuntu.

@matthewdcong 