### PR TITLE
Disable undefined behavior checks in transformValues()

### DIFF
--- a/openvdb/openvdb/tools/ValueTransformer.h
+++ b/openvdb/openvdb/tools/ValueTransformer.h
@@ -135,13 +135,13 @@ inline void foreach(const IterT& iter, const XformOp& op,
 /// consider using @c tbb::parallel_for() or @c tbb::parallel_reduce() in conjunction
 /// with a tree::IteratorRange that wraps a grid or tree iterator.
 template<typename InIterT, typename OutGridT, typename XformOp>
-inline __attribute__((no_sanitize("undefined")))
+inline OPENVDB_UBSAN_SUPPRESS("undefined")
 void transformValues(const InIterT& inIter, OutGridT& outGrid,
     XformOp& op, bool threaded = true, bool shareOp = true,
     MergePolicy merge = MERGE_ACTIVE_STATES);
 
 template<typename InIterT, typename OutGridT, typename XformOp>
-inline __attribute__((no_sanitize("undefined")))
+inline OPENVDB_UBSAN_SUPPRESS("undefined")
 void transformValues(const InIterT& inIter, OutGridT& outGrid,
     const XformOp& op, bool threaded = true, bool shareOp = true,
     MergePolicy merge = MERGE_ACTIVE_STATES);
@@ -587,7 +587,7 @@ private:
 
 
 template<typename InIterT, typename OutGridT, typename XformOp>
-inline __attribute__((no_sanitize("undefined")))
+inline OPENVDB_UBSAN_SUPPRESS("undefined")
 void transformValues(const InIterT& inIter, OutGridT& outGrid, XformOp& op,
     bool threaded, bool shared, MergePolicy merge)
 {
@@ -605,7 +605,7 @@ void transformValues(const InIterT& inIter, OutGridT& outGrid, XformOp& op,
 }
 
 template<typename InIterT, typename OutGridT, typename XformOp>
-inline __attribute__((no_sanitize("undefined")))
+inline OPENVDB_UBSAN_SUPPRESS("undefined")
 void transformValues(const InIterT& inIter, OutGridT& outGrid, const XformOp& op,
     bool threaded, bool /*share*/, MergePolicy merge)
 {

--- a/openvdb/openvdb/tools/ValueTransformer.h
+++ b/openvdb/openvdb/tools/ValueTransformer.h
@@ -135,12 +135,14 @@ inline void foreach(const IterT& iter, const XformOp& op,
 /// consider using @c tbb::parallel_for() or @c tbb::parallel_reduce() in conjunction
 /// with a tree::IteratorRange that wraps a grid or tree iterator.
 template<typename InIterT, typename OutGridT, typename XformOp>
-inline void transformValues(const InIterT& inIter, OutGridT& outGrid,
+inline __attribute__((no_sanitize("undefined")))
+void transformValues(const InIterT& inIter, OutGridT& outGrid,
     XformOp& op, bool threaded = true, bool shareOp = true,
     MergePolicy merge = MERGE_ACTIVE_STATES);
 
 template<typename InIterT, typename OutGridT, typename XformOp>
-inline void transformValues(const InIterT& inIter, OutGridT& outGrid,
+inline __attribute__((no_sanitize("undefined")))
+void transformValues(const InIterT& inIter, OutGridT& outGrid,
     const XformOp& op, bool threaded = true, bool shareOp = true,
     MergePolicy merge = MERGE_ACTIVE_STATES);
 
@@ -585,8 +587,8 @@ private:
 
 
 template<typename InIterT, typename OutGridT, typename XformOp>
-inline void
-transformValues(const InIterT& inIter, OutGridT& outGrid, XformOp& op,
+inline __attribute__((no_sanitize("undefined")))
+void transformValues(const InIterT& inIter, OutGridT& outGrid, XformOp& op,
     bool threaded, bool shared, MergePolicy merge)
 {
     using Adapter = TreeAdapter<OutGridT>;
@@ -603,8 +605,8 @@ transformValues(const InIterT& inIter, OutGridT& outGrid, XformOp& op,
 }
 
 template<typename InIterT, typename OutGridT, typename XformOp>
-inline void
-transformValues(const InIterT& inIter, OutGridT& outGrid, const XformOp& op,
+inline __attribute__((no_sanitize("undefined")))
+void transformValues(const InIterT& inIter, OutGridT& outGrid, const XformOp& op,
     bool threaded, bool /*share*/, MergePolicy merge)
 {
     using Adapter = TreeAdapter<OutGridT>;

--- a/openvdb/openvdb/unittest/TestTools.cc
+++ b/openvdb/openvdb/unittest/TestTools.cc
@@ -1498,7 +1498,6 @@ struct FloatToVec
 
 }
 
-
 TEST_F(TestTools, testTransformValues)
 {
     using openvdb::CoordBBox;


### PR DESCRIPTION
This is failing the ubsan checks in Clang 17.