### PR TITLE
Fix Windows CI

### DIFF
--- a/ci/install_windows.ps1
+++ b/ci/install_windows.ps1
@@ -7,7 +7,6 @@ $vcpkgPackages = @(
     "zlib",
     "libpng",
     "openexr",
-    "pdal",
     "tbb",
     "gtest",
     "cppunit",


### PR DESCRIPTION
The Windows static builds are failing when using vcpkg and attempting to install pdal. Removing pdal, which is unused as far as I can tell in the CI currently.

(@swahtz)