### PR TITLE
Fix Clang Template errors

### DIFF
--- a/nanovdb/nanovdb/tools/GridBuilder.h
+++ b/nanovdb/nanovdb/tools/GridBuilder.h
@@ -1158,7 +1158,7 @@ struct LeafNode
         ValueIterator& operator=(const ValueIterator&) = default;
         ValueType operator*() const { NANOVDB_ASSERT(*this); return mParent->mValues[mPos];}
         Coord getCoord() const { NANOVDB_ASSERT(*this); return mParent->offsetToGlobalCoord(mPos);}
-        bool isActive() const { NANOVDB_ASSERT(*this); return mParent->isActive(mPos);}
+        bool isActive() const { NANOVDB_ASSERT(*this); return mParent->mValueMask.isOn(mPos);}
         operator bool() const {return mPos < SIZE;}
         ValueIterator& operator++() {++mPos; return *this;}
         ValueIterator operator++(int) {

--- a/openvdb/openvdb/tree/NodeManager.h
+++ b/openvdb/openvdb/tree/NodeManager.h
@@ -328,7 +328,7 @@ private:
         void operator()(const NodeRange& range) const
         {
             for (typename NodeRange::Iterator it = range.begin(); it; ++it) {
-                OpT::template eval(mNodeOp, it);
+                OpT::eval(mNodeOp, it);
             }
         }
         const NodeOp mNodeOp;
@@ -348,7 +348,7 @@ private:
         void operator()(const NodeRange& range) const
         {
             for (typename NodeRange::Iterator it = range.begin(); it; ++it) {
-                OpT::template eval(mNodeOp, it);
+                OpT::eval(mNodeOp, it);
             }
         }
         const NodeOp& mNodeOp;
@@ -373,7 +373,7 @@ private:
         void operator()(const NodeRange& range)
         {
             for (typename NodeRange::Iterator it = range.begin(); it; ++it) {
-                OpT::template eval(*mNodeOp, it);
+                OpT::eval(*mNodeOp, it);
             }
         }
         void join(const NodeReducer& other)


### PR DESCRIPTION
Upcoming versions of Clang/LLVM change some behaviour around templating that causes OpenVDB to fail to compile.

This commit addresses two issues and allows VDB to compile again.

1. There were three instances of an unnecessary template keyword in NodeManager.h that were not followed by a template call, and therefore are illegal to the compiler.

2. GridBuilder.h had a template call to a non-existent method. This was not previously validated, but is now validated.  Switching the call from `isActive` to `isOn` works (as suggested by Ken).

See the [changelog](https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics:~:text=Clang%20now%20looks%20up%20members%20of%20the%20current%20instantiation%20in%20the%20template%20definition%20context%20if%20the%20current%20instantiation%20has%20no%20dependent%20base%20classes.) for Clang and the associated [PR for the second point above](https://github.com/llvm/llvm-project/pull/84050)


This fixes https://github.com/AcademySoftwareFoundation/openvdb/issues/1976

Built on macOS with the following build args

```
-DBOOST_ROOT=/usr/local/apps/boost/1.82.0-a0
-DTBB_ROOT=/usr/local/apps/tbb/2020_U3-a1/platform-osx
-DBlosc_ROOT=/usr/local/apps/blosc/1.21.5-a0/apple_universal-2
-DOPENVDB_BUILD_NANOVDB=ON
-DNANOVDB_USE_OPENVDB=ON
```