### PR TITLE
Slowdown fix - Avoid unnecessary getLastWriteTime calls for memory mapped files on windows

### DIFF
--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -554,6 +554,7 @@ MappedFile::filename() const
 SharedPtr<std::streambuf>
 MappedFile::createBuffer() const
 {
+#ifndef _WIN32
     if (!mImpl->mAutoDelete && mImpl->mLastWriteTime > 0) {
         // Warn if the file has been modified since it was opened
         // (but don't bother checking if it is a private, temporary file).
@@ -563,6 +564,7 @@ MappedFile::createBuffer() const
             mImpl->mLastWriteTime = 0; // suppress further warnings
         }
     }
+#endif
 
     return SharedPtr<std::streambuf>{
         new boost::iostreams::stream_buffer<boost::iostreams::array_source>{


### PR DESCRIPTION
We are reading very large openvdb volumes (8gb and larger) and discovered that, on our Windows systems, using `delayLoad=true` for volumes causes 10x slower file reads compared to `delayLoad=false`.

Profiling pointed us to this behavior in `Archive::getLastWriteTime()`, which makes three system calls (open file, get file time, close file): https://github.com/AcademySoftwareFoundation/openvdb/blob/5ff0edc2cc333a70923c0122d6a6deec3bc80cc4/openvdb/openvdb/io/Archive.cc#L506-L512

The above is called once per node when reading the node from the file due to this check in `MappedFile::createBuffer()`: https://github.com/AcademySoftwareFoundation/openvdb/blob/5ff0edc2cc333a70923c0122d6a6deec3bc80cc4/openvdb/openvdb/io/Archive.cc#L557-L565

This check and warning is unnecessary on Windows as memory mapped files are automatically write-locked and cannot be modified while the memory mapping is open. The only time it *might* be necessary is reading a volume over a network.

This PR guards the last write time check in `MappedFile::createBuffer()` with `#ifndef _WIN32`.