### PR TITLE
Transpose on NanoToOpenVDB allowing round tripping

### DIFF
--- a/nanovdb/nanovdb/tools/NanoToOpenVDB.h
+++ b/nanovdb/nanovdb/tools/NanoToOpenVDB.h
@@ -160,7 +160,7 @@ NanoToOpenVDB<NanoBuildT>::operator()(const NanoGrid<NanoBuildT>& grid, int /*ve
     const nanovdb::Map& nanoMap = reinterpret_cast<const GridData*>(srcGrid)->mMap;
     auto                mat = openvdb::math::Mat4<double>::identity();
     mat.setMat3(openvdb::math::Mat3<double>(nanoMap.mMatD));
-    mat.transpose(); // the 3x3 in nanovdb is transposed relative to openvdb's 3x3
+    mat = mat.transpose(); // the 3x3 in nanovdb is transposed relative to openvdb's 3x3
     mat.setTranslation(openvdb::math::Vec3<double>(nanoMap.mVecD));
     dstGrid->setTransform(openvdb::math::Transform::createLinearTransform(mat)); // calls simplify!
 

--- a/pendingchanges/nanovdb_transpose.txt
+++ b/pendingchanges/nanovdb_transpose.txt
@@ -1,0 +1,3 @@
+NanoVDB:
+  Bug fix:
+    Map is now properly transposed when converting NanoVDB to OpenVDB.


### PR DESCRIPTION
The openvdb::Mat3::transpose() method returns a transpose of itself, it doesn't do an in-place transpose.

Thus the line

    mat.transpose(); // the 3x3 in nanovdb is transposed relative to openvdb's 3x3

is a no-op, and not actually transposing the matrix.  Since we DO transpose when we do an OpenToNano; it is important we transpose here or we can't round-trip.

Unfortunately, it has been this way since the initial commit, so it is quite likely tooling has already worked around this....