### PR TITLE
Compute sin(acos(qdot)) as sqrt(1 - qdot*qdot), which is faster.

### DIFF
--- a/openvdb/openvdb/math/Quat.h
+++ b/openvdb/openvdb/math/Quat.h
@@ -36,7 +36,7 @@ Quat<T> slerp(const Quat<T> &q1, const Quat<T> &q2, T t, T tolerance=0.00001)
         sineAngle = 0;
     } else {
         angle     = acos(qdot);
-        sineAngle = sin(angle);
+        sineAngle = sqrt(1.0 - qdot*qdot);
     }
 
     //


### PR DESCRIPTION
Notice that despite the subtraction "1-qdot*qdot" there is no significant loss of accuracy here, even for small angles where "qdot" is near 1. This is because our knowledge of the angle from "qdot" (i.e. cos(theta) for some theta) is already limited by the floating point representation error near 1, which is 2^-23 (~1.1e-7) for single and 2^-52 (~2.2e-16) for double precision.

The following program tabulates the relative error of the two formulas, evaluated in single precision, compared to evaluating the original formula in double precision:

https://godbolt.org/z/qrzWcd43c