### PR TITLE
Remove unnecessary null pointer checks (ASWF issue #257)

### DIFF
--- a/nanovdb/nanovdb/tools/GridBuilder.h
+++ b/nanovdb/nanovdb/tools/GridBuilder.h
@@ -1968,7 +1968,7 @@ void Grid<BuildT>::operator()(const Func& func, const CoordBBox& bbox, ValueType
                 NANOVDB_ASSERT(leaf == nullptr);
             }
         }// loop over sub-part of leafBBox
-        if (leaf) delete leaf;
+        delete leaf;
     });
 
     // Prune leaf and tile nodes

--- a/openvdb_houdini/openvdb_houdini/reference/GEO_PrimVDB.cc
+++ b/openvdb_houdini/openvdb_houdini/reference/GEO_PrimVDB.cc
@@ -2985,7 +2985,6 @@ vdbJSON()
         GA_PrimitiveJSON* json = new geo_PrimVDBJSON;
         if (nullptr != theJSON.compare_swap(nullptr, json)) {
             delete json;
-            json = nullptr;
         }
     }
     return theJSON;


### PR DESCRIPTION
Fix remove unnecessary set local variable to null before it immediately goes out of scope. N

Fix remove unnecessary null pointer checks, issue #257.

There only appeared to be one obvious case left.

Code search process:

    grep -C 3 delete .

... then look for if statements, in C-like code, conditioned on the same variable, and no other obvious purpose that required the if statement.

See:

https://github.com/AcademySoftwareFoundation/openvdb/issues/257

Note: one of the two commits doesn't technically match the paradigm raised in the issue, but setting a pointer variable to nullptr immediately before it goes out of scope is unnecessary.