### PR TITLE
[REQUEST]  Add int8 grid to python bindings

### DIFF
--- a/openvdb/openvdb/openvdb.h
+++ b/openvdb/openvdb/openvdb.h
@@ -53,6 +53,7 @@ namespace io { class DelayedLoadMetadata; }
 using BoolTree     = tree::Tree4<bool,        5, 4, 3>::Type;
 using DoubleTree   = tree::Tree4<double,      5, 4, 3>::Type;
 using FloatTree    = tree::Tree4<float,       5, 4, 3>::Type;
+using Int8Tree    = tree::Tree4<int8_t,     5, 4, 3>::Type;
 using Int32Tree    = tree::Tree4<int32_t,     5, 4, 3>::Type;
 using Int64Tree    = tree::Tree4<int64_t,     5, 4, 3>::Type;
 using MaskTree     = tree::Tree4<ValueMask,   5, 4, 3>::Type;
@@ -73,6 +74,7 @@ using VectorTree   = Vec3fTree;
 using BoolGrid     = Grid<BoolTree>;
 using DoubleGrid   = Grid<DoubleTree>;
 using FloatGrid    = Grid<FloatTree>;
+using Int8Grid    = Grid<Int8Tree>;
 using Int32Grid    = Grid<Int32Tree>;
 using Int64Grid    = Grid<Int64Tree>;
 using MaskGrid     = Grid<MaskTree>;
@@ -90,7 +92,7 @@ using VectorGrid   = Vec3fGrid;
 /// The floating point Grid types which OpenVDB will register by default.
 using RealGridTypes   = TypeList<FloatGrid, DoubleGrid>;
 /// The integer Grid types which OpenVDB will register by default.
-using IntegerGridTypes = TypeList<Int32Grid, Int64Grid>;
+using IntegerGridTypes = TypeList<Int8Grid, Int32Grid, Int64Grid>;
 /// The scalar Grid types which OpenVDB will register by default. This is a
 /// combination of native floating point and integer grid types. Note that
 /// this list does not include Bool or Mask Grids.

--- a/openvdb/openvdb/python/pyIntGrid.cc
+++ b/openvdb/openvdb/python/pyIntGrid.cc
@@ -11,6 +11,7 @@ exportIntGrid(nb::module_ m)
 {
     pyGrid::exportScalarGrid<BoolGrid>(m);
 #ifdef PY_OPENVDB_WRAP_ALL_GRID_TYPES
+    pyGrid::exportScalarGrid<Int8Grid>(m);
     pyGrid::exportScalarGrid<Int32Grid>(m);
     pyGrid::exportScalarGrid<Int64Grid>(m);
 #endif

--- a/openvdb/openvdb/python/pyutil.h
+++ b/openvdb/openvdb/python/pyutil.h
@@ -59,6 +59,7 @@ GRID_TRAITS(openvdb::Vec3SGrid, "Vec3SGrid");
 GRID_TRAITS(openvdb::BoolGrid, "BoolGrid");
 #ifdef PY_OPENVDB_WRAP_ALL_GRID_TYPES
 GRID_TRAITS(openvdb::DoubleGrid, "DoubleGrid");
+GRID_TRAITS(openvdb::Int8Grid, "Int8Grid");
 GRID_TRAITS(openvdb::Int32Grid, "Int32Grid");
 GRID_TRAITS(openvdb::Int64Grid, "Int64Grid");
 GRID_TRAITS(openvdb::Vec3IGrid, "Vec3IGrid");


### PR DESCRIPTION
Int8 is a very common GRID when doing occupancy grids and log-odds occupancy mapping as they are very efficient. The robotics community's interest in openvdb is growing and it would be nice to have them bound to python by default when setting OPENVDB_PYTHON_WRAP_ALL_GRID_TYPES to true. Possibly more types such as int16 are also useful.

For now I had to add it myself and recompile openvdb.


