### PR TITLE
Improve const-correctness in io::writeCompressedValues

### DIFF
--- a/openvdb/openvdb/io/Compression.h
+++ b/openvdb/openvdb/io/Compression.h
@@ -643,7 +643,7 @@ writeCompressedValuesSize(ValueT* srcBuf, Index srcCount,
 /// @param toHalf     if true, convert floating-point values to 16-bit half floats
 template<typename ValueT, typename MaskT>
 inline void
-writeCompressedValues(std::ostream& os, ValueT* srcBuf, Index srcCount,
+writeCompressedValues(std::ostream& os, const ValueT* srcBuf, Index srcCount,
     const MaskT& valueMask, const MaskT& childMask, bool toHalf)
 {
     // Get the stream's compression settings.
@@ -651,7 +651,7 @@ writeCompressedValues(std::ostream& os, ValueT* srcBuf, Index srcCount,
     const bool maskCompress = compress & COMPRESS_ACTIVE_MASK;
 
     Index tempCount = srcCount;
-    ValueT* tempBuf = srcBuf;
+    ValueT* tempBuf = nullptr;
     std::unique_ptr<ValueT[]> scopedTempBuf;
 
     int8_t metadata = NO_MASK_AND_ALL_VALS;
@@ -743,9 +743,10 @@ writeCompressedValues(std::ostream& os, ValueT* srcBuf, Index srcCount,
 
     // Write out the buffer.
     if (toHalf) {
-        HalfWriter<RealToHalf<ValueT>::isReal, ValueT>::write(os, tempBuf, tempCount, compress);
+        HalfWriter<RealToHalf<ValueT>::isReal, ValueT>::write(os,
+            bool(tempBuf) ? tempBuf : srcBuf, tempCount, compress);
     } else {
-        writeData(os, tempBuf, tempCount, compress);
+        writeData(os, bool(tempBuf) ? tempBuf : srcBuf, tempCount, compress);
     }
 }
 

--- a/openvdb/openvdb/points/PointDataGrid.h
+++ b/openvdb/openvdb/points/PointDataGrid.h
@@ -104,7 +104,7 @@ readCompressedValues(   std::istream& is, PointDataIndex32* destBuf, Index destC
 /// ignore the value mask, use a larger block size and use 16-bit size instead of 64-bit
 template<>
 inline void
-writeCompressedValues(  std::ostream& os, PointDataIndex32* srcBuf, Index srcCount,
+writeCompressedValues(  std::ostream& os, const PointDataIndex32* srcBuf, Index srcCount,
                         const util::NodeMask<3>& /*valueMask*/,
                         const util::NodeMask<3>& /*childMask*/, bool /*toHalf*/)
 {

--- a/pendingchanges/write_compressed_const.txt
+++ b/pendingchanges/write_compressed_const.txt
@@ -1,0 +1,3 @@
+API Changes:
+  - io::writeCompressedValues() now takes a const ValueT* source buffer for
+    improved const-correctness.


### PR DESCRIPTION
It is not currently possible to pass in a `const ValueT*` to `io::writeCompressedValues()` because it requires the array to be non-const (even though it is not actually modified).

A small refactoring here allows us to improve const-correctness.