### PR TITLE
Fix CUDA 13 deprecation warning

### DIFF
--- a/nanovdb/nanovdb/cuda/DeviceStreamMap.h
+++ b/nanovdb/nanovdb/cuda/DeviceStreamMap.h
@@ -77,7 +77,11 @@ DeviceStreamMap::DeviceStreamMap(DeviceType t, std::vector<int> exclude, int ver
     cudaCheck(cudaSetDevice(current));// reset to the previous device
 
     void* entryPoint = nullptr;
-#if CUDART_VERSION >= 12000// queryResult argument was added in CUDA 12
+#if CUDART_VERSION >= 13000
+    cudaDriverEntryPointQueryResult queryResult;
+    cudaCheck(cudaGetDriverEntryPointByVersion("cuMemGetAllocationGranularity", &entryPoint, 13000, cudaEnableDefault, &queryResult));
+    NANOVDB_ASSERT(queryResult == cudaDriverEntryPointSuccess);
+#elif CUDART_VERSION >= 12000// queryResult argument was added in CUDA 12
     cudaDriverEntryPointQueryResult queryResult;
     cudaCheck(cudaGetDriverEntryPoint("cuMemGetAllocationGranularity", &entryPoint, cudaEnableDefault, &queryResult));
     NANOVDB_ASSERT(queryResult == cudaDriverEntryPointSuccess);


### PR DESCRIPTION
`cudaDriverGetEntryPoint` has been deprecated in CUDA 13 and is replaced by `cudaGetDriverEntryPointByVersion`. Although `cudaGetDriverEntryPointByVersion` is available in CUDA 12, earlier versions of the driver that support CUDA 12 don't have the requisite symbols so we limit this to CUDA 13 to avoid that.