### PR TITLE
Half Grid Support PR

### DIFF
--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -413,6 +413,7 @@ set(OPENVDB_LIBRARY_MATH_INCLUDE_FILES
   math/DDA.h
   math/FiniteDifference.h
   math/Half.h
+  math/HalfDecl.h
   math/LegacyFrustum.h
   math/Maps.h
   math/Mat.h

--- a/openvdb/openvdb/Grid.h
+++ b/openvdb/openvdb/Grid.h
@@ -1784,7 +1784,7 @@ createLevelSet(Real voxelSize, Real halfWidth)
     using ValueType = typename GridType::ValueType;
 
     // GridType::ValueType is required to be a floating-point scalar.
-    static_assert(std::is_floating_point<ValueType>::value,
+    static_assert(openvdb::is_floating_point<ValueType>::value,
         "level-set grids must be floating-point-valued");
 
     typename GridType::Ptr grid = GridType::create(

--- a/openvdb/openvdb/Metadata.h
+++ b/openvdb/openvdb/Metadata.h
@@ -359,6 +359,7 @@ operator<<(std::ostream& ostr, const Metadata& metadata)
 using BoolMetadata   = TypedMetadata<bool>;
 using DoubleMetadata = TypedMetadata<double>;
 using FloatMetadata  = TypedMetadata<float>;
+using HalfMetadata   = TypedMetadata<math::half>;
 using Int32Metadata  = TypedMetadata<int32_t>;
 using Int64Metadata  = TypedMetadata<int64_t>;
 using StringMetadata = TypedMetadata<std::string>;

--- a/openvdb/openvdb/Types.h
+++ b/openvdb/openvdb/Types.h
@@ -8,27 +8,7 @@
 #include "Platform.h"
 #include "TypeList.h" // backwards compat
 
-#ifdef OPENVDB_USE_IMATH_HALF
-#ifdef OPENVDB_IMATH_VERSION
-#include <Imath/half.h>
-#else
-#include <OpenEXR/half.h>
-#endif
-namespace openvdb {
-OPENVDB_USE_VERSION_NAMESPACE
-namespace OPENVDB_VERSION_NAME {
-namespace math {
-using half = half;
-}}}
-#else
-#include <openvdb/math/Half.h>
-namespace openvdb {
-OPENVDB_USE_VERSION_NAMESPACE
-namespace OPENVDB_VERSION_NAME {
-namespace math {
-using half = internal::half;
-}}}
-#endif
+#include <openvdb/math/HalfDecl.h>
 
 #include <openvdb/math/Math.h>
 #include <openvdb/math/BBox.h>
@@ -58,12 +38,13 @@ using Int64   = int64_t;
 using Int     = Int32;
 using Byte    = unsigned char;
 using Real    = double;
+using Half    = math::half;
 
 // Two-dimensional vector types
 using Vec2R = math::Vec2<Real>;
 using Vec2I = math::Vec2<Index32>;
 using Vec2f = math::Vec2<float>;
-using Vec2H = math::Vec2<math::half>;
+using Vec2H = math::Vec2<Half>;
 using math::Vec2i;
 using math::Vec2s;
 using math::Vec2d;
@@ -72,7 +53,7 @@ using math::Vec2d;
 using Vec3R = math::Vec3<Real>;
 using Vec3I = math::Vec3<Index32>;
 using Vec3f = math::Vec3<float>;
-using Vec3H = math::Vec3<math::half>;
+using Vec3H = math::Vec3<Half>;
 using Vec3U8 = math::Vec3<uint8_t>;
 using Vec3U16 = math::Vec3<uint16_t>;
 using math::Vec3i;
@@ -87,7 +68,7 @@ using BBoxd = math::BBox<Vec3d>;
 using Vec4R = math::Vec4<Real>;
 using Vec4I = math::Vec4<Index32>;
 using Vec4f = math::Vec4<float>;
-using Vec4H = math::Vec4<math::half>;
+using Vec4H = math::Vec4<Half>;
 using math::Vec4i;
 using math::Vec4s;
 using math::Vec4d;
@@ -499,6 +480,54 @@ struct CanConvertType<ValueMask, T> { enum {value = CanConvertType<bool, T>::val
 ////////////////////////////////////////
 
 
+/// @brief Maps low precision floating point types to a floating-point type suitable for computation.
+///
+/// Selectively promotes low-precision types (e.g., `math::half`) to a higher-precision
+/// type (e.g., `float`) to balance numerical accuracy and performance in
+/// compute-intensive code.
+///
+/// Types already suitable for computation, float precision and higher, are left unchanged.
+///
+/// This trait is useful when intermediate compute precision must differ from storage
+/// precision to prevent precision loss or instability.
+///
+/// @tparam T The input type to be mapped to a compute-appropriate floating-point type.
+template <typename T>
+struct ComputeTypeFor
+{
+    using type = T;
+};
+
+// Specialization for half -> float
+template <>
+struct ComputeTypeFor<Half>
+{
+    using type = float;
+};
+
+// Specialization for Vec<half> -> Vec<float>
+template <>
+struct ComputeTypeFor<Vec2H>
+{
+    using type = Vec2s;
+};
+
+template <>
+struct ComputeTypeFor<Vec3H>
+{
+    using type = Vec3s;
+};
+
+template <>
+struct ComputeTypeFor<Vec4H>
+{
+    using type = Vec4s;
+};
+
+
+////////////////////////////////////////
+
+
 /// @brief CopyConstness<T1, T2>::Type is either <tt>const T2</tt>
 /// or @c T2 with no @c const qualifier, depending on whether @c T1 is @c const.
 /// @details For example,
@@ -515,6 +544,21 @@ template<typename FromType, typename ToType> struct CopyConstness<const FromType
     using Type = const ToType;
 };
 /// @endcond
+
+
+////////////////////////////////////////
+template<class T>
+struct is_floating_point : std::is_floating_point<T> { };
+
+template<>
+struct is_floating_point<Half> : std::is_floating_point<float> { };
+
+
+template<class T>
+struct is_signed : std::is_signed<T> { };
+
+template<>
+struct is_signed<Half> : std::is_signed<float> { };
 
 
 ////////////////////////////////////////
@@ -762,11 +806,11 @@ class PartialCreate {};
 // For half compilation
 namespace math {
 template<>
-inline auto cwiseAdd(const math::Vec3<math::half>& v, const float s)
+inline auto cwiseAdd(const Vec3H& v, const float s)
 {
-    math::Vec3<math::half> out;
-    const math::half* ip = v.asPointer();
-    math::half* op = out.asPointer();
+    Vec3H out;
+    const Half* ip = v.asPointer();
+    Half* op = out.asPointer();
     for (unsigned i = 0; i < 3; ++i, ++op, ++ip) {
         OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         *op = *ip + s;

--- a/openvdb/openvdb/math/FiniteDifference.h
+++ b/openvdb/openvdb/math/FiniteDifference.h
@@ -299,10 +299,14 @@ temporalIntegrationSchemeToMenuName(TemporalIntegrationScheme tis)
 /// ( f(x+dx/2) - f(x-dx/2) ) / dx  = df/dx (x) + error,
 /// where the error is fifth-order in smooth regions: O(dx) <= error <=O(dx^5)
 template<typename ValueType>
-inline ValueType
+inline typename ComputeTypeFor<ValueType>::type
 WENO5(const ValueType& v1, const ValueType& v2, const ValueType& v3,
     const ValueType& v4, const ValueType& v5, float scale2 = 0.01f)
 {
+    using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+    const ComputeType f1 = v1, f2 = v2, f3 = v3, f4 = v4, f5 = v5;
+
     const double C = 13.0 / 12.0;
     // WENO is formulated for non-dimensional equations, here the optional scale2
     // is a reference value (squared) for the function being interpolated.  For
@@ -310,44 +314,51 @@ WENO5(const ValueType& v1, const ValueType& v2, const ValueType& v3,
     // leave scale2 = 1.
     const double eps = 1.0e-6 * static_cast<double>(scale2);
     // {\tilde \omega_k} = \gamma_k / ( \beta_k + \epsilon)^2 in Shu's ICASE report)
-    const double A1=0.1/math::Pow2(C*math::Pow2(v1-2*v2+v3)+0.25*math::Pow2(v1-4*v2+3.0*v3)+eps),
-                 A2=0.6/math::Pow2(C*math::Pow2(v2-2*v3+v4)+0.25*math::Pow2(v2-v4)+eps),
-                 A3=0.3/math::Pow2(C*math::Pow2(v3-2*v4+v5)+0.25*math::Pow2(3.0*v3-4*v4+v5)+eps);
+    const double A1=0.1/math::Pow2(C*math::Pow2(f1-2*f2+f3)+0.25*math::Pow2(f1-4*f2+3.0*f3)+eps),
+                 A2=0.6/math::Pow2(C*math::Pow2(f2-2*f3+f4)+0.25*math::Pow2(f2-f4)+eps),
+                 A3=0.3/math::Pow2(C*math::Pow2(f3-2*f4+f5)+0.25*math::Pow2(3.0*f3-4*f4+f5)+eps);
 
-    return static_cast<ValueType>(static_cast<ValueType>(
-        A1*(2.0*v1 - 7.0*v2 + 11.0*v3) +
-        A2*(5.0*v3 -     v2 +  2.0*v4) +
-        A3*(2.0*v3 + 5.0*v4 -      v5))/(6.0*(A1+A2+A3)));
+    return static_cast<ComputeType>(static_cast<ComputeType>(
+        A1*(2.0*f1 - 7.0*f2 + 11.0*f3) +
+        A2*(5.0*f3 -     f2 +  2.0*f4) +
+        A3*(2.0*f3 + 5.0*f4 -      f5))/(6.0*(A1+A2+A3)));
 }
 
 
 template <typename Real>
-inline Real GodunovsNormSqrd(bool isOutside,
-                             Real dP_xm, Real dP_xp,
-                             Real dP_ym, Real dP_yp,
-                             Real dP_zm, Real dP_zp)
+inline typename ComputeTypeFor<Real>::type
+GodunovsNormSqrd(bool isOutside,
+                 Real dP_xm, Real dP_xp,
+                 Real dP_ym, Real dP_yp,
+                 Real dP_zm, Real dP_zp)
 {
     using math::Max;
     using math::Min;
     using math::Pow2;
 
-    const Real zero(0);
-    Real dPLen2;
+    using ComputeType = typename ComputeTypeFor<Real>::type;
+
+    const ComputeType dpXm = dP_xm, dpYm = dP_ym, dpZm = dP_zm,
+                      dpXp = dP_xp, dpYp = dP_yp, dpZp = dP_zp;
+
+    const ComputeType zero(0);
+    ComputeType dPLen2;
     if (isOutside) { // outside
-        dPLen2  = Max(Pow2(Max(dP_xm, zero)), Pow2(Min(dP_xp,zero))); // (dP/dx)2
-        dPLen2 += Max(Pow2(Max(dP_ym, zero)), Pow2(Min(dP_yp,zero))); // (dP/dy)2
-        dPLen2 += Max(Pow2(Max(dP_zm, zero)), Pow2(Min(dP_zp,zero))); // (dP/dz)2
+        dPLen2  = Max(Pow2(Max(dpXm, zero)), Pow2(Min(dpXp, zero))); // (dP/dx)2
+        dPLen2 += Max(Pow2(Max(dpYm, zero)), Pow2(Min(dpYp, zero))); // (dP/dy)2
+        dPLen2 += Max(Pow2(Max(dpZm, zero)), Pow2(Min(dpZp, zero))); // (dP/dz)2
     } else { // inside
-        dPLen2  = Max(Pow2(Min(dP_xm, zero)), Pow2(Max(dP_xp,zero))); // (dP/dx)2
-        dPLen2 += Max(Pow2(Min(dP_ym, zero)), Pow2(Max(dP_yp,zero))); // (dP/dy)2
-        dPLen2 += Max(Pow2(Min(dP_zm, zero)), Pow2(Max(dP_zp,zero))); // (dP/dz)2
+        dPLen2  = Max(Pow2(Min(dpXm, zero)), Pow2(Max(dpXp, zero))); // (dP/dx)2
+        dPLen2 += Max(Pow2(Min(dpYm, zero)), Pow2(Max(dpYp, zero))); // (dP/dy)2
+        dPLen2 += Max(Pow2(Min(dpZm, zero)), Pow2(Max(dpZp, zero))); // (dP/dz)2
     }
+
     return dPLen2; // |\nabla\phi|^2
 }
 
 
 template<typename Real>
-inline Real
+inline typename ComputeTypeFor<Real>::type
 GodunovsNormSqrd(bool isOutside, const Vec3<Real>& gradient_m, const Vec3<Real>& gradient_p)
 {
     return GodunovsNormSqrd<Real>(isOutside,
@@ -416,37 +427,48 @@ struct D1
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk);
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk);
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk);
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S);
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S);
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S);
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S);
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S);
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S);
 };
 
 template<>
 struct D1<CD_2NDT>
 {
-    // the difference opperator
+    // the difference operator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xp1, const ValueType& xm1) {
-        return xp1 - xm1;
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp1, const ValueType& xm1)
+    {
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        return ComputeType(xp1) - ComputeType(xm1);
     }
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(1, 0, 0)),
@@ -454,7 +476,8 @@ struct D1<CD_2NDT>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(0, 1, 0)),
@@ -462,7 +485,8 @@ struct D1<CD_2NDT>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(0, 0, 1)),
@@ -471,21 +495,24 @@ struct D1<CD_2NDT>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
-        return difference( S.template getValue< 1, 0, 0>(),  S.template getValue<-1, 0, 0>());
+        return difference( S.template getValue< 1, 0, 0>(), S.template getValue<-1, 0, 0>());
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
-        return difference( S.template getValue< 0, 1, 0>(),  S.template getValue< 0,-1, 0>());
+        return difference( S.template getValue< 0, 1, 0>(), S.template getValue< 0,-1, 0>());
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
-        return difference( S.template getValue< 0, 0, 1>(),  S.template getValue< 0, 0,-1>());
+        return difference( S.template getValue< 0, 0, 1>(), S.template getValue< 0, 0,-1>());
     }
 };
 
@@ -493,10 +520,14 @@ template<>
 struct D1<CD_2ND>
 {
 
-    // the difference opperator
+    // the difference operator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xp1, const ValueType& xm1) {
-        return (xp1 - xm1)*ValueType(0.5);
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp1, const ValueType& xm1)
+    {
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        return (ComputeType(xp1) - ComputeType(xm1))*ComputeType(0.5);
     }
     static bool difference(const bool& xp1, const bool& /*xm1*/) {
         return xp1;
@@ -505,7 +536,8 @@ struct D1<CD_2ND>
 
     // random access
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(1, 0, 0)),
@@ -513,7 +545,8 @@ struct D1<CD_2ND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(0, 1, 0)),
@@ -521,7 +554,8 @@ struct D1<CD_2ND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(0, 0, 1)),
@@ -531,18 +565,21 @@ struct D1<CD_2ND>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference(S.template getValue< 1, 0, 0>(), S.template getValue<-1, 0, 0>());
     }
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference(S.template getValue< 0, 1, 0>(), S.template getValue< 0,-1, 0>());
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference(S.template getValue< 0, 0, 1>(), S.template getValue< 0, 0,-1>());
     }
@@ -555,15 +592,22 @@ struct D1<CD_4TH>
 
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference( const ValueType& xp2, const ValueType& xp1,
-                                 const ValueType& xm1, const ValueType& xm2 ) {
-        return ValueType(2./3.)*(xp1 - xm1) + ValueType(1./12.)*(xm2 - xp2) ;
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp2, const ValueType& xp1,
+               const ValueType& xm1, const ValueType& xm2 )
+    {
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        const ComputeType xcp1 = xp1, xcp2 = xp2, xcm1 = xm1, xcm2 = xm2;
+
+        return ComputeType(2./3.)*(xcp1 - xcm1) + ComputeType(1./12.)*(xcm2 - xcp2);
     }
 
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy( 2,0,0)), grid.getValue(ijk.offsetBy( 1,0,0)),
@@ -571,18 +615,18 @@ struct D1<CD_4TH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
-
         return difference(
             grid.getValue(ijk.offsetBy( 0, 2, 0)), grid.getValue(ijk.offsetBy( 0, 1, 0)),
             grid.getValue(ijk.offsetBy( 0,-1, 0)), grid.getValue(ijk.offsetBy( 0,-2, 0)) );
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
-
         return difference(
             grid.getValue(ijk.offsetBy( 0, 0, 2)), grid.getValue(ijk.offsetBy( 0, 0, 1)),
             grid.getValue(ijk.offsetBy( 0, 0,-1)), grid.getValue(ijk.offsetBy( 0, 0,-2)) );
@@ -591,7 +635,8 @@ struct D1<CD_4TH>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference( S.template getValue< 2, 0, 0>(),
                            S.template getValue< 1, 0, 0>(),
@@ -600,7 +645,8 @@ struct D1<CD_4TH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference( S.template getValue< 0, 2, 0>(),
                            S.template getValue< 0, 1, 0>(),
@@ -609,7 +655,8 @@ struct D1<CD_4TH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference( S.template getValue< 0, 0, 2>(),
                            S.template getValue< 0, 0, 1>(),
@@ -622,19 +669,25 @@ template<>
 struct D1<CD_6TH>
 {
 
-    // the difference opperator
+    // the difference operator
     template <typename ValueType>
-    static ValueType difference( const ValueType& xp3, const ValueType& xp2, const ValueType& xp1,
-                                 const ValueType& xm1, const ValueType& xm2, const ValueType& xm3 )
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp3, const ValueType& xp2, const ValueType& xp1,
+               const ValueType& xm1, const ValueType& xm2, const ValueType& xm3 )
     {
-        return ValueType(3./4.)*(xp1 - xm1) - ValueType(0.15)*(xp2 - xm2)
-            + ValueType(1./60.)*(xp3-xm3);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        const ComputeType xcp1 = xp1, xcp2 = xp2, xcp3 = xp3, xcm1 = xm1, xcm2 = xm2, xcm3 = xm3;
+
+        return ComputeType(3./4.)*(xcp1 - xcm1) - ComputeType(0.15)*(xcp2 - xcm2)
+            + ComputeType(1./60.)*(xcp3 - xcm3);
     }
 
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy( 3,0,0)), grid.getValue(ijk.offsetBy( 2,0,0)),
@@ -643,7 +696,8 @@ struct D1<CD_6TH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy( 0, 3, 0)), grid.getValue(ijk.offsetBy( 0, 2, 0)),
@@ -652,7 +706,8 @@ struct D1<CD_6TH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy( 0, 0, 3)), grid.getValue(ijk.offsetBy( 0, 0, 2)),
@@ -662,7 +717,8 @@ struct D1<CD_6TH>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return  difference(S.template getValue< 3, 0, 0>(),
                            S.template getValue< 2, 0, 0>(),
@@ -673,7 +729,8 @@ struct D1<CD_6TH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
 
         return  difference( S.template getValue< 0, 3, 0>(),
@@ -685,7 +742,8 @@ struct D1<CD_6TH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
 
         return  difference( S.template getValue< 0, 0, 3>(),
@@ -704,45 +762,55 @@ struct D1<FD_1ST>
 
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xp1, const ValueType& xp0) {
-        return xp1 - xp0;
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp1, const ValueType& xp0)
+    {
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        return ComputeType(xp1) - ComputeType(xp0);
     }
 
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference(grid.getValue(ijk.offsetBy(1, 0, 0)), grid.getValue(ijk));
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference(grid.getValue(ijk.offsetBy(0, 1, 0)), grid.getValue(ijk));
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference(grid.getValue(ijk.offsetBy(0, 0, 1)), grid.getValue(ijk));
     }
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference(S.template getValue< 1, 0, 0>(), S.template getValue< 0, 0, 0>());
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference(S.template getValue< 0, 1, 0>(), S.template getValue< 0, 0, 0>());
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference(S.template getValue< 0, 0, 1>(), S.template getValue< 0, 0, 0>());
     }
@@ -754,15 +822,21 @@ struct D1<FD_2ND>
 {
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xp2, const ValueType& xp1, const ValueType& xp0)
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp2, const ValueType& xp1, const ValueType& xp0)
     {
-        return ValueType(2)*xp1 -(ValueType(0.5)*xp2 + ValueType(3./2.)*xp0);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        const ComputeType xcp0 = xp0, xcp1 = xp1, xcp2 = xp2;
+
+        return ComputeType(2)*xcp1 - (ComputeType(0.5)*xcp2 + ComputeType(3./2.)*xcp0);
     }
 
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(2,0,0)),
@@ -771,7 +845,8 @@ struct D1<FD_2ND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(0,2,0)),
@@ -780,7 +855,8 @@ struct D1<FD_2ND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(0,0,2)),
@@ -791,7 +867,8 @@ struct D1<FD_2ND>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference( S.template getValue< 2, 0, 0>(),
                            S.template getValue< 1, 0, 0>(),
@@ -799,7 +876,8 @@ struct D1<FD_2ND>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference( S.template getValue< 0, 2, 0>(),
                            S.template getValue< 0, 1, 0>(),
@@ -807,7 +885,8 @@ struct D1<FD_2ND>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference( S.template getValue< 0, 0, 2>(),
                            S.template getValue< 0, 0, 1>(),
@@ -823,16 +902,23 @@ struct D1<FD_3RD>
 
     // the difference opperator
     template<typename ValueType>
-    static ValueType difference(const ValueType& xp3, const ValueType& xp2,
-        const ValueType& xp1, const ValueType& xp0)
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp3, const ValueType& xp2,
+               const ValueType& xp1, const ValueType& xp0)
     {
-        return static_cast<ValueType>(xp3/3.0 - 1.5*xp2 + 3.0*xp1 - 11.0*xp0/6.0);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        const ComputeType xcp0 = xp0, xcp1 = xp1, xcp2 = xp2, xcp3 = xp3;
+
+        return ComputeType(1.0/3.0)*xcp3 - ComputeType(1.5)*xcp2
+            + ComputeType(3)*xcp1 - ComputeType(11.0/6.0)*xcp0;
     }
 
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy(3,0,0)),
                            grid.getValue(ijk.offsetBy(2,0,0)),
@@ -841,7 +927,8 @@ struct D1<FD_3RD>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy(0,3,0)),
                            grid.getValue(ijk.offsetBy(0,2,0)),
@@ -850,7 +937,8 @@ struct D1<FD_3RD>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy(0,0,3)),
                            grid.getValue(ijk.offsetBy(0,0,2)),
@@ -861,7 +949,8 @@ struct D1<FD_3RD>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference(S.template getValue< 3, 0, 0>(),
                           S.template getValue< 2, 0, 0>(),
@@ -870,7 +959,8 @@ struct D1<FD_3RD>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference(S.template getValue< 0, 3, 0>(),
                           S.template getValue< 0, 2, 0>(),
@@ -879,7 +969,8 @@ struct D1<FD_3RD>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference( S.template getValue< 0, 0, 3>(),
                            S.template getValue< 0, 0, 2>(),
@@ -895,26 +986,31 @@ struct D1<BD_1ST>
 
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xm1, const ValueType& xm0) {
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xm1, const ValueType& xm0)
+    {
         return -D1<FD_1ST>::difference(xm1, xm0);
     }
 
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference(grid.getValue(ijk.offsetBy(-1,0,0)), grid.getValue(ijk));
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference(grid.getValue(ijk.offsetBy(0,-1,0)), grid.getValue(ijk));
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference(grid.getValue(ijk.offsetBy(0, 0,-1)), grid.getValue(ijk));
     }
@@ -922,19 +1018,22 @@ struct D1<BD_1ST>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference(S.template getValue<-1, 0, 0>(), S.template getValue< 0, 0, 0>());
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference(S.template getValue< 0,-1, 0>(), S.template getValue< 0, 0, 0>());
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference(S.template getValue< 0, 0,-1>(), S.template getValue< 0, 0, 0>());
     }
@@ -947,7 +1046,8 @@ struct D1<BD_2ND>
 
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xm2, const ValueType& xm1, const ValueType& xm0)
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xm2, const ValueType& xm1, const ValueType& xm0)
     {
         return -D1<FD_2ND>::difference(xm2, xm1, xm0);
     }
@@ -955,7 +1055,8 @@ struct D1<BD_2ND>
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy(-2,0,0)),
                            grid.getValue(ijk.offsetBy(-1,0,0)),
@@ -963,7 +1064,8 @@ struct D1<BD_2ND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy(0,-2,0)),
                            grid.getValue(ijk.offsetBy(0,-1,0)),
@@ -971,7 +1073,8 @@ struct D1<BD_2ND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy(0,0,-2)),
                            grid.getValue(ijk.offsetBy(0,0,-1)),
@@ -980,7 +1083,8 @@ struct D1<BD_2ND>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference( S.template getValue<-2, 0, 0>(),
                            S.template getValue<-1, 0, 0>(),
@@ -988,7 +1092,8 @@ struct D1<BD_2ND>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference( S.template getValue< 0,-2, 0>(),
                            S.template getValue< 0,-1, 0>(),
@@ -996,7 +1101,8 @@ struct D1<BD_2ND>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference( S.template getValue< 0, 0,-2>(),
                            S.template getValue< 0, 0,-1>(),
@@ -1011,15 +1117,17 @@ struct D1<BD_3RD>
 
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xm3, const ValueType& xm2,
-        const ValueType& xm1, const ValueType& xm0)
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xm3, const ValueType& xm2,
+               const ValueType& xm1, const ValueType& xm0)
     {
         return -D1<FD_3RD>::difference(xm3, xm2, xm1, xm0);
     }
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy(-3,0,0)),
                            grid.getValue(ijk.offsetBy(-2,0,0)),
@@ -1028,7 +1136,8 @@ struct D1<BD_3RD>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy( 0,-3,0)),
                            grid.getValue(ijk.offsetBy( 0,-2,0)),
@@ -1037,7 +1146,8 @@ struct D1<BD_3RD>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy( 0, 0,-3)),
                            grid.getValue(ijk.offsetBy( 0, 0,-2)),
@@ -1047,7 +1157,8 @@ struct D1<BD_3RD>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference( S.template getValue<-3, 0, 0>(),
                            S.template getValue<-2, 0, 0>(),
@@ -1056,7 +1167,8 @@ struct D1<BD_3RD>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference( S.template getValue< 0,-3, 0>(),
                            S.template getValue< 0,-2, 0>(),
@@ -1065,7 +1177,8 @@ struct D1<BD_3RD>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference( S.template getValue< 0, 0,-3>(),
                            S.template getValue< 0, 0,-2>(),
@@ -1080,17 +1193,19 @@ struct D1<FD_WENO5>
 {
     // the difference operator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xp3, const ValueType& xp2,
-                                const ValueType& xp1, const ValueType& xp0,
-                                const ValueType& xm1, const ValueType& xm2) {
-        return WENO5<ValueType>(xp3, xp2, xp1, xp0, xm1)
-              - WENO5<ValueType>(xp2, xp1, xp0, xm1, xm2);
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp3, const ValueType& xp2,
+               const ValueType& xp1, const ValueType& xp0,
+               const ValueType& xm1, const ValueType& xm2)
+    {
+        return WENO5(xp3, xp2, xp1, xp0, xm1) - WENO5(xp2, xp1, xp0, xm1, xm2);
     }
 
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1105,7 +1220,8 @@ struct D1<FD_WENO5>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1120,7 +1236,8 @@ struct D1<FD_WENO5>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1136,7 +1253,8 @@ struct D1<FD_WENO5>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
 
         return static_cast<typename Stencil::ValueType>(difference(
@@ -1150,7 +1268,8 @@ struct D1<FD_WENO5>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return static_cast<typename Stencil::ValueType>(difference(
             S.template getValue< 0, 3, 0>(),
@@ -1162,7 +1281,8 @@ struct D1<FD_WENO5>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return static_cast<typename Stencil::ValueType>(difference(
             S.template getValue< 0, 0, 3>(),
@@ -1180,15 +1300,22 @@ struct D1<FD_HJWENO5>
 
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xp3, const ValueType& xp2,
-                                const ValueType& xp1, const ValueType& xp0,
-                                const ValueType& xm1, const ValueType& xm2) {
-        return WENO5<ValueType>(xp3 - xp2, xp2 - xp1, xp1 - xp0, xp0-xm1, xm1-xm2);
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp3, const ValueType& xp2,
+               const ValueType& xp1, const ValueType& xp0,
+               const ValueType& xm1, const ValueType& xm2)
+    {
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        const ComputeType xcp0 = xp0, xcp1 = xp1, xcp2 = xp2, xcp3 = xp3, xcm1 = xm1, xcm2 = xm2;
+
+        return WENO5<ComputeType>(xcp3 - xcp2, xcp2 - xcp1, xcp1 - xcp0, xcp0-xcm1, xcm1-xcm2);
     }
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1204,7 +1331,8 @@ struct D1<FD_HJWENO5>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1219,7 +1347,8 @@ struct D1<FD_HJWENO5>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1235,7 +1364,8 @@ struct D1<FD_HJWENO5>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
 
         return difference( S.template getValue< 3, 0, 0>(),
@@ -1248,7 +1378,8 @@ struct D1<FD_HJWENO5>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference( S.template getValue< 0, 3, 0>(),
                            S.template getValue< 0, 2, 0>(),
@@ -1259,7 +1390,8 @@ struct D1<FD_HJWENO5>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
 
         return difference( S.template getValue< 0, 0, 3>(),
@@ -1277,8 +1409,9 @@ struct D1<BD_WENO5>
 {
 
     template<typename ValueType>
-    static ValueType difference(const ValueType& xm3, const ValueType& xm2, const ValueType& xm1,
-                                const ValueType& xm0, const ValueType& xp1, const ValueType& xp2)
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xm3, const ValueType& xm2, const ValueType& xm1,
+               const ValueType& xm0, const ValueType& xp1, const ValueType& xp2)
     {
         return -D1<FD_WENO5>::difference(xm3, xm2, xm1, xm0, xp1, xp2);
     }
@@ -1286,7 +1419,8 @@ struct D1<BD_WENO5>
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1301,7 +1435,8 @@ struct D1<BD_WENO5>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1316,7 +1451,8 @@ struct D1<BD_WENO5>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1332,7 +1468,8 @@ struct D1<BD_WENO5>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         using ValueType = typename Stencil::ValueType;
         ValueType V[6];
@@ -1347,7 +1484,8 @@ struct D1<BD_WENO5>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         using ValueType = typename Stencil::ValueType;
         ValueType V[6];
@@ -1362,7 +1500,8 @@ struct D1<BD_WENO5>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         using ValueType = typename Stencil::ValueType;
         ValueType V[6];
@@ -1382,15 +1521,17 @@ template<>
 struct D1<BD_HJWENO5>
 {
     template<typename ValueType>
-    static ValueType difference(const ValueType& xm3, const ValueType& xm2, const ValueType& xm1,
-                                const ValueType& xm0, const ValueType& xp1, const ValueType& xp2)
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xm3, const ValueType& xm2, const ValueType& xm1,
+               const ValueType& xm0, const ValueType& xp1, const ValueType& xp2)
     {
         return -D1<FD_HJWENO5>::difference(xm3, xm2, xm1, xm0, xp1, xp2);
     }
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1405,7 +1546,8 @@ struct D1<BD_HJWENO5>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1420,7 +1562,8 @@ struct D1<BD_HJWENO5>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
         ValueType V[6];
@@ -1436,7 +1579,8 @@ struct D1<BD_HJWENO5>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         using ValueType = typename Stencil::ValueType;
         ValueType V[6];
@@ -1451,7 +1595,8 @@ struct D1<BD_HJWENO5>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         using ValueType = typename Stencil::ValueType;
         ValueType V[6];
@@ -1466,7 +1611,8 @@ struct D1<BD_HJWENO5>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         using ValueType = typename Stencil::ValueType;
         ValueType V[6];
@@ -1487,20 +1633,20 @@ struct D1Vec
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inX(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<DiffScheme>::inX(grid, ijk)[n];
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inY(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<DiffScheme>::inY(grid, ijk)[n];
     }
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inZ(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<DiffScheme>::inZ(grid, ijk)[n];
@@ -1509,19 +1655,22 @@ struct D1Vec
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inX(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inX(const Stencil& S, int n)
     {
         return D1<DiffScheme>::inX(S)[n];
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inY(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inY(const Stencil& S, int n)
     {
         return D1<DiffScheme>::inY(S)[n];
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inZ(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inZ(const Stencil& S, int n)
     {
         return D1<DiffScheme>::inZ(S)[n];
     }
@@ -1534,7 +1683,7 @@ struct D1Vec<CD_2NDT>
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inX(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_2NDT>::difference( grid.getValue(ijk.offsetBy( 1, 0, 0))[n],
@@ -1542,7 +1691,7 @@ struct D1Vec<CD_2NDT>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inY(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_2NDT>::difference( grid.getValue(ijk.offsetBy(0, 1, 0))[n],
@@ -1550,7 +1699,7 @@ struct D1Vec<CD_2NDT>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inZ(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_2NDT>::difference( grid.getValue(ijk.offsetBy(0, 0, 1))[n],
@@ -1559,21 +1708,24 @@ struct D1Vec<CD_2NDT>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inX(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inX(const Stencil& S, int n)
     {
         return D1<CD_2NDT>::difference( S.template getValue< 1, 0, 0>()[n],
                                         S.template getValue<-1, 0, 0>()[n] );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inY(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inY(const Stencil& S, int n)
     {
         return D1<CD_2NDT>::difference( S.template getValue< 0, 1, 0>()[n],
                                         S.template getValue< 0,-1, 0>()[n] );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inZ(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inZ(const Stencil& S, int n)
     {
         return D1<CD_2NDT>::difference( S.template getValue< 0, 0, 1>()[n],
                                         S.template getValue< 0, 0,-1>()[n] );
@@ -1586,7 +1738,7 @@ struct D1Vec<CD_2ND>
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inX(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_2ND>::difference( grid.getValue(ijk.offsetBy( 1, 0, 0))[n] ,
@@ -1594,7 +1746,7 @@ struct D1Vec<CD_2ND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inY(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_2ND>::difference( grid.getValue(ijk.offsetBy(0, 1, 0))[n] ,
@@ -1602,7 +1754,7 @@ struct D1Vec<CD_2ND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inZ(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_2ND>::difference( grid.getValue(ijk.offsetBy(0, 0, 1))[n] ,
@@ -1612,21 +1764,24 @@ struct D1Vec<CD_2ND>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inX(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inX(const Stencil& S, int n)
     {
         return D1<CD_2ND>::difference( S.template getValue< 1, 0, 0>()[n],
                                        S.template getValue<-1, 0, 0>()[n] );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inY(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inY(const Stencil& S, int n)
     {
         return D1<CD_2ND>::difference( S.template getValue< 0, 1, 0>()[n],
                                        S.template getValue< 0,-1, 0>()[n] );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inZ(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inZ(const Stencil& S, int n)
     {
         return D1<CD_2ND>::difference( S.template getValue< 0, 0, 1>()[n],
                                        S.template getValue< 0, 0,-1>()[n] );
@@ -1641,7 +1796,7 @@ struct D1Vec<CD_4TH> {
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inX(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_4TH>::difference(
@@ -1650,7 +1805,7 @@ struct D1Vec<CD_4TH> {
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inY(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_4TH>::difference(
@@ -1659,7 +1814,7 @@ struct D1Vec<CD_4TH> {
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inZ(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_4TH>::difference(
@@ -1669,7 +1824,8 @@ struct D1Vec<CD_4TH> {
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inX(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inX(const Stencil& S, int n)
     {
         return D1<CD_4TH>::difference(
             S.template getValue< 2, 0, 0>()[n],  S.template getValue< 1, 0, 0>()[n],
@@ -1677,7 +1833,8 @@ struct D1Vec<CD_4TH> {
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inY(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inY(const Stencil& S, int n)
     {
         return D1<CD_4TH>::difference(
             S.template getValue< 0, 2, 0>()[n],  S.template getValue< 0, 1, 0>()[n],
@@ -1685,7 +1842,8 @@ struct D1Vec<CD_4TH> {
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inZ(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inZ(const Stencil& S, int n)
     {
         return D1<CD_4TH>::difference(
             S.template getValue< 0, 0, 2>()[n],  S.template getValue< 0, 0, 1>()[n],
@@ -1701,7 +1859,7 @@ struct D1Vec<CD_6TH>
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inX(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_6TH>::difference(
@@ -1711,7 +1869,7 @@ struct D1Vec<CD_6TH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inY(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_6TH>::difference(
@@ -1721,7 +1879,7 @@ struct D1Vec<CD_6TH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType::value_type
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     inZ(const Accessor& grid, const Coord& ijk, int n)
     {
         return D1<CD_6TH>::difference(
@@ -1733,7 +1891,8 @@ struct D1Vec<CD_6TH>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inX(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inX(const Stencil& S, int n)
     {
         return D1<CD_6TH>::difference(
             S.template getValue< 3, 0, 0>()[n], S.template getValue< 2, 0, 0>()[n],
@@ -1742,7 +1901,8 @@ struct D1Vec<CD_6TH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inY(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inY(const Stencil& S, int n)
     {
         return D1<CD_6TH>::difference(
             S.template getValue< 0, 3, 0>()[n], S.template getValue< 0, 2, 0>()[n],
@@ -1751,7 +1911,8 @@ struct D1Vec<CD_6TH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType::value_type inZ(const Stencil& S, int n)
+    static typename ComputeTypeFor<typename Stencil::ValueType::value_type>::type
+    inZ(const Stencil& S, int n)
     {
         return D1<CD_6TH>::difference(
             S.template getValue< 0, 0, 3>()[n], S.template getValue< 0, 0, 2>()[n],
@@ -1765,40 +1926,56 @@ struct D2
 {
 
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk);
+
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk);
+
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk);
 
     // cross derivatives
     template<typename Accessor>
-    static typename Accessor::ValueType inXandY(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inXandY(const Accessor& grid, const Coord& ijk);
 
     template<typename Accessor>
-    static typename Accessor::ValueType inXandZ(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inXandZ(const Accessor& grid, const Coord& ijk);
 
     template<typename Accessor>
-    static typename Accessor::ValueType inYandZ(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inYandZ(const Accessor& grid, const Coord& ijk);
 
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S);
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S);
+
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S);
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S);
+
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S);
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S);
 
     // cross derivatives
     template<typename Stencil>
-    static typename Stencil::ValueType inXandY(const Stencil& S);
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inXandY(const Stencil& S);
 
     template<typename Stencil>
-    static typename Stencil::ValueType inXandZ(const Stencil& S);
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inXandZ(const Stencil& S);
 
     template<typename Stencil>
-    static typename Stencil::ValueType inYandZ(const Stencil& S);
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inYandZ(const Stencil& S);
 };
 
 template<>
@@ -1807,28 +1984,40 @@ struct D2<CD_SECOND>
 
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xp1, const ValueType& xp0, const ValueType& xm1)
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp1, const ValueType& xp0, const ValueType& xm1)
     {
-        return xp1 + xm1 - ValueType(2)*xp0;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        const ComputeType xcp0 = xp0, xcp1 = xp1, xcm1 = xm1;
+
+        return xcp1 + xcm1 - ComputeType(2)*xcp0;
     }
 
     template <typename ValueType>
-    static ValueType crossdifference(const ValueType& xpyp, const ValueType& xpym,
-                                     const ValueType& xmyp, const ValueType& xmym)
+    static typename ComputeTypeFor<ValueType>::type
+    crossdifference(const ValueType& xpyp, const ValueType& xpym,
+                    const ValueType& xmyp, const ValueType& xmym)
     {
-        return ValueType(0.25)*(xpyp + xmym - xpym - xmyp);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        const ComputeType xcpyp = xpyp, xcpym = xpym, xcmyp = xmyp, xcmym = xmym;
+
+        return ComputeType(0.25)*(xcpyp + xcmym - xcpym - xcmyp);
     }
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy( 1,0,0)), grid.getValue(ijk),
                            grid.getValue(ijk.offsetBy(-1,0,0)) );
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
 
         return difference( grid.getValue(ijk.offsetBy(0, 1,0)), grid.getValue(ijk),
@@ -1836,7 +2025,8 @@ struct D2<CD_SECOND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
         return difference( grid.getValue(ijk.offsetBy( 0,0, 1)), grid.getValue(ijk),
                            grid.getValue(ijk.offsetBy( 0,0,-1)) );
@@ -1844,7 +2034,8 @@ struct D2<CD_SECOND>
 
     // cross derivatives
     template<typename Accessor>
-    static typename Accessor::ValueType inXandY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inXandY(const Accessor& grid, const Coord& ijk)
     {
         return crossdifference(
             grid.getValue(ijk.offsetBy(1, 1,0)), grid.getValue(ijk.offsetBy( 1,-1,0)),
@@ -1853,7 +2044,8 @@ struct D2<CD_SECOND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inXandZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inXandZ(const Accessor& grid, const Coord& ijk)
     {
         return crossdifference(
             grid.getValue(ijk.offsetBy(1,0, 1)), grid.getValue(ijk.offsetBy(1, 0,-1)),
@@ -1861,7 +2053,8 @@ struct D2<CD_SECOND>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inYandZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inYandZ(const Accessor& grid, const Coord& ijk)
     {
         return crossdifference(
             grid.getValue(ijk.offsetBy(0, 1,1)), grid.getValue(ijk.offsetBy(0, 1,-1)),
@@ -1871,21 +2064,24 @@ struct D2<CD_SECOND>
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference( S.template getValue< 1, 0, 0>(), S.template getValue< 0, 0, 0>(),
                            S.template getValue<-1, 0, 0>() );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference( S.template getValue< 0, 1, 0>(), S.template getValue< 0, 0, 0>(),
                            S.template getValue< 0,-1, 0>() );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference( S.template getValue< 0, 0, 1>(), S.template getValue< 0, 0, 0>(),
                            S.template getValue< 0, 0,-1>() );
@@ -1893,21 +2089,24 @@ struct D2<CD_SECOND>
 
     // cross derivatives
     template<typename Stencil>
-    static typename Stencil::ValueType inXandY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inXandY(const Stencil& S)
     {
         return crossdifference(S.template getValue< 1, 1, 0>(),  S.template getValue< 1,-1, 0>(),
                                S.template getValue<-1, 1, 0>(),  S.template getValue<-1,-1, 0>() );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inXandZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inXandZ(const Stencil& S)
     {
         return crossdifference(S.template getValue< 1, 0, 1>(),  S.template getValue< 1, 0,-1>(),
                                S.template getValue<-1, 0, 1>(),  S.template getValue<-1, 0,-1>() );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inYandZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inYandZ(const Stencil& S)
     {
         return crossdifference(S.template getValue< 0, 1, 1>(),  S.template getValue< 0, 1,-1>(),
                                S.template getValue< 0,-1, 1>(),  S.template getValue< 0,-1,-1>() );
@@ -1921,35 +2120,53 @@ struct D2<CD_FOURTH>
 
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xp2, const ValueType& xp1, const ValueType& xp0,
-                                const ValueType& xm1, const ValueType& xm2) {
-        return ValueType(-1./12.)*(xp2 + xm2) + ValueType(4./3.)*(xp1 + xm1) -ValueType(2.5)*xp0;
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp2, const ValueType& xp1, const ValueType& xp0,
+               const ValueType& xm1, const ValueType& xm2)
+    {
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        const ComputeType xcp0 = xp0, xcp1 = xp1, xcp2 = xp2, xcm1 = xm1, xcm2 = xm2;
+
+        return ComputeType(-1./12.)*(xcp2 + xcm2)
+            + ComputeType(4./3.)*(xcp1 + xcm1) - ComputeType(2.5)*xcp0;
     }
 
     template <typename ValueType>
-    static ValueType crossdifference(const ValueType& xp2yp2, const ValueType& xp2yp1,
-                                     const ValueType& xp2ym1, const ValueType& xp2ym2,
-                                     const ValueType& xp1yp2, const ValueType& xp1yp1,
-                                     const ValueType& xp1ym1, const ValueType& xp1ym2,
-                                     const ValueType& xm2yp2, const ValueType& xm2yp1,
-                                     const ValueType& xm2ym1, const ValueType& xm2ym2,
-                                     const ValueType& xm1yp2, const ValueType& xm1yp1,
-                                     const ValueType& xm1ym1, const ValueType& xm1ym2 ) {
-        ValueType tmp1 =
-            ValueType(2./3.0)*(xp1yp1 - xm1yp1 - xp1ym1 + xm1ym1)-
-            ValueType(1./12.)*(xp2yp1 - xm2yp1 - xp2ym1 + xm2ym1);
-        ValueType tmp2 =
-            ValueType(2./3.0)*(xp1yp2 - xm1yp2 - xp1ym2 + xm1ym2)-
-            ValueType(1./12.)*(xp2yp2 - xm2yp2 - xp2ym2 + xm2ym2);
+    static typename ComputeTypeFor<ValueType>::type
+    crossdifference(const ValueType& xp2yp2, const ValueType& xp2yp1,
+                    const ValueType& xp2ym1, const ValueType& xp2ym2,
+                    const ValueType& xp1yp2, const ValueType& xp1yp1,
+                    const ValueType& xp1ym1, const ValueType& xp1ym2,
+                    const ValueType& xm2yp2, const ValueType& xm2yp1,
+                    const ValueType& xm2ym1, const ValueType& xm2ym2,
+                    const ValueType& xm1yp2, const ValueType& xm1yp1,
+                    const ValueType& xm1ym1, const ValueType& xm1ym2 )
+    {
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        return ValueType(2./3.)*tmp1 - ValueType(1./12.)*tmp2;
+        const ComputeType xcp2yp2 = xp2yp2, xcp2yp1 = xp2yp1, xcp2ym1 = xp2ym1, xcp2ym2 = xp2ym2,
+                          xcp1yp2 = xp1yp2, xcp1yp1 = xp1yp1, xcp1ym1 = xp1ym1, xcp1ym2 = xp1ym2,
+                          xcm2yp2 = xm2yp2, xcm2yp1 = xm2yp1, xcm2ym1 = xm2ym1, xcm2ym2 = xm2ym2,
+                          xcm1yp2 = xm1yp2, xcm1yp1 = xm1yp1, xcm1ym1 = xm1ym1, xcm1ym2 = xm1ym2;
+
+        const ComputeType tmp1 =
+            ComputeType(2./3.)*(xcp1yp1 - xcm1yp1 - xcp1ym1 + xcm1ym1)-
+            ComputeType(1./12.)*(xcp2yp1 - xcm2yp1 - xcp2ym1 + xcm2ym1);
+
+        const ComputeType tmp2 =
+            ComputeType(2./3.)*(xcp1yp2 - xcm1yp2 - xcp1ym2 + xcm1ym2)-
+            ComputeType(1./12.)*(xcp2yp2 - xcm2yp2 - xcp2ym2 + xcm2ym2);
+
+        return ComputeType(2./3.)*tmp1 - ComputeType(1./12.)*tmp2;
     }
 
 
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(2,0,0)),  grid.getValue(ijk.offsetBy( 1,0,0)),
@@ -1958,7 +2175,8 @@ struct D2<CD_FOURTH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy(0, 2,0)), grid.getValue(ijk.offsetBy(0, 1,0)),
@@ -1967,7 +2185,8 @@ struct D2<CD_FOURTH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
          return difference(
              grid.getValue(ijk.offsetBy(0,0, 2)), grid.getValue(ijk.offsetBy(0, 0,1)),
@@ -1977,73 +2196,89 @@ struct D2<CD_FOURTH>
 
     // cross derivatives
     template<typename Accessor>
-    static typename Accessor::ValueType inXandY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inXandY(const Accessor& grid, const Coord& ijk)
     {
-        using ValueType = typename Accessor::ValueType;
-        typename Accessor::ValueType tmp1 =
+        using ValueType   = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        ComputeType tmp1 =
             D1<CD_4TH>::inX(grid, ijk.offsetBy(0, 1, 0)) -
             D1<CD_4TH>::inX(grid, ijk.offsetBy(0,-1, 0));
-        typename Accessor::ValueType tmp2 =
+        ComputeType tmp2 =
             D1<CD_4TH>::inX(grid, ijk.offsetBy(0, 2, 0)) -
             D1<CD_4TH>::inX(grid, ijk.offsetBy(0,-2, 0));
-        return ValueType(2./3.)*tmp1 - ValueType(1./12.)*tmp2;
+
+        return ComputeType(2./3.)*tmp1 - ComputeType(1./12.)*tmp2;
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inXandZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inXandZ(const Accessor& grid, const Coord& ijk)
     {
-        using ValueType = typename Accessor::ValueType;
-        typename Accessor::ValueType tmp1 =
+        using ValueType   = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        ComputeType tmp1 =
             D1<CD_4TH>::inX(grid, ijk.offsetBy(0, 0, 1)) -
             D1<CD_4TH>::inX(grid, ijk.offsetBy(0, 0,-1));
-        typename Accessor::ValueType tmp2 =
+        ComputeType tmp2 =
             D1<CD_4TH>::inX(grid, ijk.offsetBy(0, 0, 2)) -
             D1<CD_4TH>::inX(grid, ijk.offsetBy(0, 0,-2));
-        return ValueType(2./3.)*tmp1 - ValueType(1./12.)*tmp2;
+
+        return ComputeType(2./3.)*tmp1 - ComputeType(1./12.)*tmp2;
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inYandZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inYandZ(const Accessor& grid, const Coord& ijk)
     {
-        using ValueType = typename Accessor::ValueType;
-        typename Accessor::ValueType tmp1 =
+        using ValueType   = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        ComputeType tmp1 =
             D1<CD_4TH>::inY(grid, ijk.offsetBy(0, 0, 1)) -
             D1<CD_4TH>::inY(grid, ijk.offsetBy(0, 0,-1));
-        typename Accessor::ValueType tmp2 =
+        ComputeType tmp2 =
             D1<CD_4TH>::inY(grid, ijk.offsetBy(0, 0, 2)) -
             D1<CD_4TH>::inY(grid, ijk.offsetBy(0, 0,-2));
-        return ValueType(2./3.)*tmp1 - ValueType(1./12.)*tmp2;
+
+        return ComputeType(2./3.)*tmp1 - ComputeType(1./12.)*tmp2;
     }
 
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
-        return  difference(S.template getValue< 2, 0, 0>(), S.template getValue< 1, 0, 0>(),
-                           S.template getValue< 0, 0, 0>(),
-                           S.template getValue<-1, 0, 0>(), S.template getValue<-2, 0, 0>() );
+        return difference(S.template getValue< 2, 0, 0>(), S.template getValue< 1, 0, 0>(),
+                          S.template getValue< 0, 0, 0>(),
+                          S.template getValue<-1, 0, 0>(), S.template getValue<-2, 0, 0>() );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
-        return  difference(S.template getValue< 0, 2, 0>(), S.template getValue< 0, 1, 0>(),
-                           S.template getValue< 0, 0, 0>(),
-                           S.template getValue< 0,-1, 0>(), S.template getValue< 0,-2, 0>() );
+        return difference(S.template getValue< 0, 2, 0>(), S.template getValue< 0, 1, 0>(),
+                          S.template getValue< 0, 0, 0>(),
+                          S.template getValue< 0,-1, 0>(), S.template getValue< 0,-2, 0>() );
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
-        return  difference(S.template getValue< 0, 0, 2>(), S.template getValue< 0, 0, 1>(),
-                           S.template getValue< 0, 0, 0>(),
-                           S.template getValue< 0, 0,-1>(), S.template getValue< 0, 0,-2>() );
+        return difference(S.template getValue< 0, 0, 2>(), S.template getValue< 0, 0, 1>(),
+                          S.template getValue< 0, 0, 0>(),
+                          S.template getValue< 0, 0,-1>(), S.template getValue< 0, 0,-2>() );
     }
 
     // cross derivatives
     template<typename Stencil>
-    static typename Stencil::ValueType inXandY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inXandY(const Stencil& S)
      {
          return crossdifference(
              S.template getValue< 2, 2, 0>(), S.template getValue< 2, 1, 0>(),
@@ -2057,7 +2292,8 @@ struct D2<CD_FOURTH>
      }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inXandZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inXandZ(const Stencil& S)
     {
         return crossdifference(
             S.template getValue< 2, 0, 2>(), S.template getValue< 2, 0, 1>(),
@@ -2071,7 +2307,8 @@ struct D2<CD_FOURTH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inYandZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inYandZ(const Stencil& S)
     {
         return crossdifference(
             S.template getValue< 0, 2, 2>(), S.template getValue< 0, 2, 1>(),
@@ -2091,56 +2328,76 @@ struct D2<CD_SIXTH>
 {
     // the difference opperator
     template <typename ValueType>
-    static ValueType difference(const ValueType& xp3, const ValueType& xp2, const ValueType& xp1,
-                                const ValueType& xp0,
-                                const ValueType& xm1, const ValueType& xm2, const ValueType& xm3)
+    static typename ComputeTypeFor<ValueType>::type
+    difference(const ValueType& xp3, const ValueType& xp2, const ValueType& xp1,
+               const ValueType& xp0,
+               const ValueType& xm1, const ValueType& xm2, const ValueType& xm3)
     {
-        return  ValueType(1./90.)*(xp3 + xm3) - ValueType(3./20.)*(xp2 + xm2)
-              + ValueType(1.5)*(xp1 + xm1) - ValueType(49./18.)*xp0;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        const ComputeType xcp0 = xp0, xcp1 = xp1, xcp2 = xp2, xcp3 = xp3,
+                          xcm1 = xm1, xcm2 = xm2, xcm3 = xm3;
+
+        return ComputeType(1./90.)*(xcp3 + xcm3) - ComputeType(3./20.)*(xcp2 + xcm2)
+            + ComputeType(1.5)*(xcp1 + xcm1) - ComputeType(49./18.)*xcp0;
     }
 
     template <typename ValueType>
-    static ValueType crossdifference( const ValueType& xp1yp1,const ValueType& xm1yp1,
-                                      const ValueType& xp1ym1,const ValueType& xm1ym1,
-                                      const ValueType& xp2yp1,const ValueType& xm2yp1,
-                                      const ValueType& xp2ym1,const ValueType& xm2ym1,
-                                      const ValueType& xp3yp1,const ValueType& xm3yp1,
-                                      const ValueType& xp3ym1,const ValueType& xm3ym1,
-                                      const ValueType& xp1yp2,const ValueType& xm1yp2,
-                                      const ValueType& xp1ym2,const ValueType& xm1ym2,
-                                      const ValueType& xp2yp2,const ValueType& xm2yp2,
-                                      const ValueType& xp2ym2,const ValueType& xm2ym2,
-                                      const ValueType& xp3yp2,const ValueType& xm3yp2,
-                                      const ValueType& xp3ym2,const ValueType& xm3ym2,
-                                      const ValueType& xp1yp3,const ValueType& xm1yp3,
-                                      const ValueType& xp1ym3,const ValueType& xm1ym3,
-                                      const ValueType& xp2yp3,const ValueType& xm2yp3,
-                                      const ValueType& xp2ym3,const ValueType& xm2ym3,
-                                      const ValueType& xp3yp3,const ValueType& xm3yp3,
-                                      const ValueType& xp3ym3,const ValueType& xm3ym3 )
+    static typename ComputeTypeFor<ValueType>::type
+    crossdifference(const ValueType& xp1yp1, const ValueType& xm1yp1,
+                    const ValueType& xp1ym1, const ValueType& xm1ym1,
+                    const ValueType& xp2yp1, const ValueType& xm2yp1,
+                    const ValueType& xp2ym1, const ValueType& xm2ym1,
+                    const ValueType& xp3yp1, const ValueType& xm3yp1,
+                    const ValueType& xp3ym1, const ValueType& xm3ym1,
+                    const ValueType& xp1yp2, const ValueType& xm1yp2,
+                    const ValueType& xp1ym2, const ValueType& xm1ym2,
+                    const ValueType& xp2yp2, const ValueType& xm2yp2,
+                    const ValueType& xp2ym2, const ValueType& xm2ym2,
+                    const ValueType& xp3yp2, const ValueType& xm3yp2,
+                    const ValueType& xp3ym2, const ValueType& xm3ym2,
+                    const ValueType& xp1yp3, const ValueType& xm1yp3,
+                    const ValueType& xp1ym3, const ValueType& xm1ym3,
+                    const ValueType& xp2yp3, const ValueType& xm2yp3,
+                    const ValueType& xp2ym3, const ValueType& xm2ym3,
+                    const ValueType& xp3yp3, const ValueType& xm3yp3,
+                    const ValueType& xp3ym3, const ValueType& xm3ym3 )
     {
-        ValueType tmp1 =
-            ValueType(0.7500)*(xp1yp1 - xm1yp1 - xp1ym1 + xm1ym1) -
-            ValueType(0.1500)*(xp2yp1 - xm2yp1 - xp2ym1 + xm2ym1) +
-            ValueType(1./60.)*(xp3yp1 - xm3yp1 - xp3ym1 + xm3ym1);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType tmp2 =
-            ValueType(0.7500)*(xp1yp2 - xm1yp2 - xp1ym2 + xm1ym2) -
-            ValueType(0.1500)*(xp2yp2 - xm2yp2 - xp2ym2 + xm2ym2) +
-            ValueType(1./60.)*(xp3yp2 - xm3yp2 - xp3ym2 + xm3ym2);
+        const ComputeType xcp1yp1 = xp1yp1, xcm1yp1 = xm1yp1, xcp1ym1 = xp1ym1, xcm1ym1 = xm1ym1,
+                          xcp2yp1 = xp2yp1, xcm2yp1 = xm2yp1, xcp2ym1 = xp2ym1, xcm2ym1 = xm2ym1,
+                          xcp3yp1 = xp3yp1, xcm3yp1 = xm3yp1, xcp3ym1 = xp3ym1, xcm3ym1 = xm3ym1,
+                          xcp1yp2 = xp1yp2, xcm1yp2 = xm1yp2, xcp1ym2 = xp1ym2, xcm1ym2 = xm1ym2,
+                          xcp2yp2 = xp2yp2, xcm2yp2 = xm2yp2, xcp2ym2 = xp2ym2, xcm2ym2 = xm2ym2,
+                          xcp3yp2 = xp3yp2, xcm3yp2 = xm3yp2, xcp3ym2 = xp3ym2, xcm3ym2 = xm3ym2,
+                          xcp1yp3 = xp1yp3, xcm1yp3 = xm1yp3, xcp1ym3 = xp1ym3, xcm1ym3 = xm1ym3,
+                          xcp2yp3 = xp2yp3, xcm2yp3 = xm2yp3, xcp2ym3 = xp2ym3, xcm2ym3 = xm2ym3,
+                          xcp3yp3 = xp3yp3, xcm3yp3 = xm3yp3, xcp3ym3 = xp3ym3, xcm3ym3 = xm3ym3;
 
-        ValueType tmp3 =
-            ValueType(0.7500)*(xp1yp3 - xm1yp3 - xp1ym3 + xm1ym3) -
-            ValueType(0.1500)*(xp2yp3 - xm2yp3 - xp2ym3 + xm2ym3) +
-            ValueType(1./60.)*(xp3yp3 - xm3yp3 - xp3ym3 + xm3ym3);
+        ComputeType tmp1 =
+            ComputeType(0.7500)*(xcp1yp1 - xcm1yp1 - xcp1ym1 + xcm1ym1) -
+            ComputeType(0.1500)*(xcp2yp1 - xcm2yp1 - xcp2ym1 + xcm2ym1) +
+            ComputeType(1./60.)*(xcp3yp1 - xcm3yp1 - xcp3ym1 + xcm3ym1);
 
-        return ValueType(0.75)*tmp1 - ValueType(0.15)*tmp2 + ValueType(1./60)*tmp3;
+        ComputeType tmp2 =
+            ComputeType(0.7500)*(xcp1yp2 - xcm1yp2 - xcp1ym2 + xcm1ym2) -
+            ComputeType(0.1500)*(xcp2yp2 - xcm2yp2 - xcp2ym2 + xcm2ym2) +
+            ComputeType(1./60.)*(xcp3yp2 - xcm3yp2 - xcp3ym2 + xcm3ym2);
+
+        ComputeType tmp3 =
+            ComputeType(0.7500)*(xcp1yp3 - xcm1yp3 - xcp1ym3 + xcm1ym3) -
+            ComputeType(0.1500)*(xcp2yp3 - xcm2yp3 - xcp2ym3 + xcm2ym3) +
+            ComputeType(1./60.)*(xcp3yp3 - xcm3yp3 - xcp3ym3 + xcm3ym3);
+
+        return ComputeType(0.75)*tmp1 - ComputeType(0.15)*tmp2 + ComputeType(1./60)*tmp3;
     }
 
     // random access version
 
     template<typename Accessor>
-    static typename Accessor::ValueType inX(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inX(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy( 3, 0, 0)), grid.getValue(ijk.offsetBy( 2, 0, 0)),
@@ -2150,7 +2407,8 @@ struct D2<CD_SIXTH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inY(const Accessor& grid, const Coord& ijk)
     {
         return difference(
             grid.getValue(ijk.offsetBy( 0, 3, 0)), grid.getValue(ijk.offsetBy( 0, 2, 0)),
@@ -2160,7 +2418,8 @@ struct D2<CD_SIXTH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inZ(const Accessor& grid, const Coord& ijk)
     {
 
         return difference(
@@ -2171,57 +2430,67 @@ struct D2<CD_SIXTH>
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inXandY(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inXandY(const Accessor& grid, const Coord& ijk)
     {
-        using ValueT = typename Accessor::ValueType;
-        ValueT tmp1 =
+        using ComputeType = typename ComputeTypeFor<typename Accessor::ValueType>::type;
+
+        ComputeType tmp1 =
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0, 1, 0)) -
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0,-1, 0));
-        ValueT tmp2 =
+        ComputeType tmp2 =
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0, 2, 0)) -
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0,-2, 0));
-        ValueT tmp3 =
+        ComputeType tmp3 =
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0, 3, 0)) -
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0,-3, 0));
-        return ValueT(0.75*tmp1 - 0.15*tmp2 + 1./60*tmp3);
+
+        return ComputeType(0.75)*tmp1 - ComputeType(0.15)*tmp2 + ComputeType(1./60)*tmp3;
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inXandZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inXandZ(const Accessor& grid, const Coord& ijk)
     {
-        using ValueT = typename Accessor::ValueType;
-        ValueT tmp1 =
+        using ComputeType = typename ComputeTypeFor<typename Accessor::ValueType>::type;
+
+        ComputeType tmp1 =
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0, 0, 1)) -
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0, 0,-1));
-        ValueT tmp2 =
+        ComputeType tmp2 =
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0, 0, 2)) -
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0, 0,-2));
-        ValueT tmp3 =
+        ComputeType tmp3 =
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0, 0, 3)) -
             D1<CD_6TH>::inX(grid, ijk.offsetBy(0, 0,-3));
-        return ValueT(0.75*tmp1 - 0.15*tmp2 + 1./60*tmp3);
+
+        return ComputeType(0.75)*tmp1 - ComputeType(0.15)*tmp2 + ComputeType(1./60)*tmp3;
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType inYandZ(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    inYandZ(const Accessor& grid, const Coord& ijk)
     {
-        using ValueT = typename Accessor::ValueType;
-        ValueT tmp1 =
+        using ComputeType = typename ComputeTypeFor<typename Accessor::ValueType>::type;
+
+        ComputeType tmp1 =
             D1<CD_6TH>::inY(grid, ijk.offsetBy(0, 0, 1)) -
             D1<CD_6TH>::inY(grid, ijk.offsetBy(0, 0,-1));
-        ValueT tmp2 =
+        ComputeType tmp2 =
             D1<CD_6TH>::inY(grid, ijk.offsetBy(0, 0, 2)) -
             D1<CD_6TH>::inY(grid, ijk.offsetBy(0, 0,-2));
-        ValueT tmp3 =
+        ComputeType tmp3 =
             D1<CD_6TH>::inY(grid, ijk.offsetBy(0, 0, 3)) -
             D1<CD_6TH>::inY(grid, ijk.offsetBy(0, 0,-3));
-        return ValueT(0.75*tmp1 - 0.15*tmp2 + 1./60*tmp3);
+
+        return ComputeType(0.75)*tmp1 - ComputeType(0.15)*tmp2 + ComputeType(1./60)*tmp3;
     }
 
 
     // stencil access version
     template<typename Stencil>
-    static typename Stencil::ValueType inX(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inX(const Stencil& S)
     {
         return difference( S.template getValue< 3, 0, 0>(),  S.template getValue< 2, 0, 0>(),
                            S.template getValue< 1, 0, 0>(),  S.template getValue< 0, 0, 0>(),
@@ -2230,7 +2499,8 @@ struct D2<CD_SIXTH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inY(const Stencil& S)
     {
         return difference( S.template getValue< 0, 3, 0>(),  S.template getValue< 0, 2, 0>(),
                            S.template getValue< 0, 1, 0>(),  S.template getValue< 0, 0, 0>(),
@@ -2240,7 +2510,8 @@ struct D2<CD_SIXTH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inZ(const Stencil& S)
     {
         return difference( S.template getValue< 0, 0, 3>(),  S.template getValue< 0, 0, 2>(),
                            S.template getValue< 0, 0, 1>(),  S.template getValue< 0, 0, 0>(),
@@ -2249,7 +2520,8 @@ struct D2<CD_SIXTH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inXandY(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inXandY(const Stencil& S)
     {
         return crossdifference( S.template getValue< 1, 1, 0>(), S.template getValue<-1, 1, 0>(),
                                 S.template getValue< 1,-1, 0>(), S.template getValue<-1,-1, 0>(),
@@ -2272,7 +2544,8 @@ struct D2<CD_SIXTH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inXandZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inXandZ(const Stencil& S)
     {
         return crossdifference( S.template getValue< 1, 0, 1>(), S.template getValue<-1, 0, 1>(),
                                 S.template getValue< 1, 0,-1>(), S.template getValue<-1, 0,-1>(),
@@ -2295,7 +2568,8 @@ struct D2<CD_SIXTH>
     }
 
     template<typename Stencil>
-    static typename Stencil::ValueType inYandZ(const Stencil& S)
+    static typename ComputeTypeFor<typename Stencil::ValueType>::type
+    inYandZ(const Stencil& S)
     {
         return crossdifference( S.template getValue< 0, 1, 1>(), S.template getValue< 0,-1, 1>(),
                                 S.template getValue< 0, 1,-1>(), S.template getValue< 0,-1,-1>(),

--- a/openvdb/openvdb/math/HalfDecl.h
+++ b/openvdb/openvdb/math/HalfDecl.h
@@ -1,0 +1,30 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef OPENVDB_HALFDECL_HAS_BEEN_INCLUDED
+#define OPENVDB_HALFDECL_HAS_BEEN_INCLUDED
+
+#ifdef OPENVDB_USE_IMATH_HALF
+#ifdef OPENVDB_IMATH_VERSION
+#include <Imath/half.h>
+#else
+#include <OpenEXR/half.h>
+#endif
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace math {
+using half = half;
+}}}
+#else
+#include <openvdb/math/Half.h>
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace math {
+using half = internal::half;
+}}}
+#endif
+
+
+#endif // OPENVDB_HALFDECL_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/math/Math.h
+++ b/openvdb/openvdb/math/Math.h
@@ -10,6 +10,7 @@
 
 #include <openvdb/Platform.h>
 #include <openvdb/version.h>
+#include <openvdb/math/HalfDecl.h>
 #include <openvdb/util/Assert.h>
 #include <algorithm> // for std::max()
 #include <cassert>
@@ -145,16 +146,18 @@ template<> inline std::string negative(const std::string& val) { return val; }
 
 //@{
 /// Tolerance for floating-point comparison
-template<typename T> struct Tolerance { static T value() { return zeroVal<T>(); } };
-template<> struct Tolerance<float>    { static float value() { return 1e-8f; } };
-template<> struct Tolerance<double>   { static double value() { return 1e-15; } };
+template<typename T> struct Tolerance   { static T value() { return zeroVal<T>(); } };
+template<> struct Tolerance<math::half> { static math::half value() { return math::half(0.00097656f); } };
+template<> struct Tolerance<float>      { static float value() { return 1e-8f; } };
+template<> struct Tolerance<double>     { static double value() { return 1e-15; } };
 //@}
 
 //@{
 /// Delta for small floating-point offsets
-template<typename T> struct Delta { static T value() { return zeroVal<T>(); } };
-template<> struct Delta<float>    { static float value() { return  1e-5f; } };
-template<> struct Delta<double>   { static double value() { return 1e-9; } };
+template<typename T> struct Delta   { static T value() { return zeroVal<T>(); } };
+template<> struct Delta<math::half> { static math::half value() { return math::half(0.00390625f); } };
+template<> struct Delta<float>      { static float value() { return  1e-5f; } };
+template<> struct Delta<double>     { static double value() { return 1e-9; } };
 //@}
 
 
@@ -362,6 +365,10 @@ isApproxZero(const Type& x, const Type& tolerance)
 
 
 /// Return @c true if @a x is less than zero.
+inline bool
+isNegative(math::half& x) { return x.isNegative(); }
+
+/// Return @c true if @a x is less than zero.
 template<typename Type>
 inline bool
 isNegative(const Type& x) { return x < zeroVal<Type>(); }
@@ -375,6 +382,10 @@ inline bool
 isFinite(const float x) { return std::isfinite(x); }
 
 /// Return @c true if @a x is finite.
+inline bool
+isFinite(const math::half x) { return x.isFinite(); }
+
+/// Return @c true if @a x is finite.
 template<typename Type, typename std::enable_if<std::is_arithmetic<Type>::value, int>::type = 0>
 inline bool
 isFinite(const Type& x) { return std::isfinite(static_cast<double>(x)); }
@@ -385,6 +396,10 @@ inline bool
 isInfinite(const float x) { return std::isinf(x); }
 
 /// Return @c true if @a x is an infinity value (either positive infinity or negative infinity).
+inline bool
+isInfinite(const math::half x) { return x.isInfinity(); }
+
+/// Return @c true if @a x is an infinity value (either positive infinity or negative infinity).
 template<typename Type, typename std::enable_if<std::is_arithmetic<Type>::value, int>::type = 0>
 inline bool
 isInfinite(const Type& x) { return std::isinf(static_cast<double>(x)); }
@@ -393,6 +408,10 @@ isInfinite(const Type& x) { return std::isinf(static_cast<double>(x)); }
 /// Return @c true if @a x is a NaN (Not-A-Number) value.
 inline bool
 isNan(const float x) { return std::isnan(x); }
+
+/// Return @c true if @a x is a NaN (Not-A-Number) value.
+inline bool
+isNan(const math::half x) { return x.isNan(); }
 
 /// Return @c true if @a x is a NaN (Not-A-Number) value.
 template<typename Type, typename std::enable_if<std::is_arithmetic<Type>::value, int>::type = 0>
@@ -571,6 +590,15 @@ Pow(Type x, int n)
 
 //@{
 /// Return @a b<sup>e</sup>.
+inline math::half
+Pow(math::half b, math::half e)
+{
+    OPENVDB_ASSERT( b >= 0.0f && "Pow(half,half): base is negative" );
+    return math::half(powf(float(b),float(e)));
+}
+
+//@{
+/// Return @a b<sup>e</sup>.
 inline float
 Pow(float b, float e)
 {
@@ -589,12 +617,29 @@ Pow(double b, double e)
 
 // ==========> Max <==================
 
+namespace internal {
+
+inline const math::half&
+max_impl(const math::half& a, const math::half& b)
+{
+    return a > b ? a : b;
+}
+
+template<typename Type>
+inline const Type&
+max_impl(const Type& a, const Type& b)
+{
+    return std::max(a,b);
+}
+
+} // namespace internal
+
 /// Return the maximum of two values
 template<typename Type>
 inline const Type&
 Max(const Type& a, const Type& b)
 {
-    return std::max(a,b);
+    return internal::max_impl(a,b);
 }
 
 /// Return the maximum of three values
@@ -602,7 +647,7 @@ template<typename Type>
 inline const Type&
 Max(const Type& a, const Type& b, const Type& c)
 {
-    return std::max(std::max(a,b), c);
+    return internal::max_impl(internal::max_impl(a,b), c);
 }
 
 /// Return the maximum of four values
@@ -610,7 +655,7 @@ template<typename Type>
 inline const Type&
 Max(const Type& a, const Type& b, const Type& c, const Type& d)
 {
-    return std::max(std::max(a,b), std::max(c,d));
+    return internal::max_impl(internal::max_impl(a,b), internal::max_impl(c,d));
 }
 
 /// Return the maximum of five values
@@ -618,7 +663,7 @@ template<typename Type>
 inline const Type&
 Max(const Type& a, const Type& b, const Type& c, const Type& d, const Type& e)
 {
-    return std::max(std::max(a,b), Max(c,d,e));
+    return internal::max_impl(internal::max_impl(a,b), Max(c,d,e));
 }
 
 /// Return the maximum of six values
@@ -626,7 +671,7 @@ template<typename Type>
 inline const Type&
 Max(const Type& a, const Type& b, const Type& c, const Type& d, const Type& e, const Type& f)
 {
-    return std::max(Max(a,b,c), Max(d,e,f));
+    return internal::max_impl(Max(a,b,c), Max(d,e,f));
 }
 
 /// Return the maximum of seven values
@@ -635,7 +680,7 @@ inline const Type&
 Max(const Type& a, const Type& b, const Type& c, const Type& d,
     const Type& e, const Type& f, const Type& g)
 {
-    return std::max(Max(a,b,c,d), Max(e,f,g));
+    return internal::max_impl(Max(a,b,c,d), Max(e,f,g));
 }
 
 /// Return the maximum of eight values
@@ -644,28 +689,48 @@ inline const Type&
 Max(const Type& a, const Type& b, const Type& c, const Type& d,
     const Type& e, const Type& f, const Type& g, const Type& h)
 {
-    return std::max(Max(a,b,c,d), Max(e,f,g,h));
+    return internal::max_impl(Max(a,b,c,d), Max(e,f,g,h));
 }
 
 
 // ==========> Min <==================
 
+namespace internal {
+
+inline const math::half&
+min_impl(const math::half& a, const math::half& b)
+{
+    return a < b ? a : b;
+}
+
+template<typename Type>
+inline const Type&
+min_impl(const Type& a, const Type& b)
+{
+    return std::min(a,b);
+}
+
+} // namespace internal
+
 /// Return the minimum of two values
 template<typename Type>
 inline const Type&
-Min(const Type& a, const Type& b) { return std::min(a, b); }
+Min(const Type& a, const Type& b) { return internal::min_impl(a, b); }
 
 /// Return the minimum of three values
 template<typename Type>
 inline const Type&
-Min(const Type& a, const Type& b, const Type& c) { return std::min(std::min(a, b), c); }
+Min(const Type& a, const Type& b, const Type& c)
+{
+    return internal::min_impl(internal::min_impl(a, b), c);
+}
 
 /// Return the minimum of four values
 template<typename Type>
 inline const Type&
 Min(const Type& a, const Type& b, const Type& c, const Type& d)
 {
-    return std::min(std::min(a, b), std::min(c, d));
+    return internal::min_impl(internal::min_impl(a, b), internal::min_impl(c, d));
 }
 
 /// Return the minimum of five values
@@ -673,7 +738,7 @@ template<typename Type>
 inline const Type&
 Min(const Type& a, const Type& b, const Type& c, const Type& d, const Type& e)
 {
-    return std::min(std::min(a,b), Min(c,d,e));
+    return internal::min_impl(internal::min_impl(a,b), Min(c,d,e));
 }
 
 /// Return the minimum of six values
@@ -681,7 +746,7 @@ template<typename Type>
 inline const Type&
 Min(const Type& a, const Type& b, const Type& c, const Type& d, const Type& e, const Type& f)
 {
-    return std::min(Min(a,b,c), Min(d,e,f));
+    return internal::min_impl(Min(a,b,c), Min(d,e,f));
 }
 
 /// Return the minimum of seven values
@@ -690,7 +755,7 @@ inline const Type&
 Min(const Type& a, const Type& b, const Type& c, const Type& d,
     const Type& e, const Type& f, const Type& g)
 {
-    return std::min(Min(a,b,c,d), Min(e,f,g));
+    return internal::min_impl(Min(a,b,c,d), Min(e,f,g));
 }
 
 /// Return the minimum of eight values
@@ -699,7 +764,7 @@ inline const Type&
 Min(const Type& a, const Type& b, const Type& c, const Type& d,
     const Type& e, const Type& f, const Type& g, const Type& h)
 {
-    return std::min(Min(a,b,c,d), Min(e,f,g,h));
+    return internal::min_impl(Min(a,b,c,d), Min(e,f,g,h));
 }
 
 

--- a/openvdb/openvdb/math/Math.h
+++ b/openvdb/openvdb/math/Math.h
@@ -74,6 +74,16 @@ template<> inline std::string zeroVal<std::string>() { return ""; }
 /// Return the @c bool value that corresponds to zero.
 template<> inline constexpr bool zeroVal<bool>() { return false; }
 
+
+/// @note Extends the implementation of std::is_arithmetic to support math::half
+template<typename T>
+struct is_arithmetic : std::is_arithmetic<T> {};
+template<>
+struct is_arithmetic<math::half> : std::true_type {};
+// Helper variable template (equivalent to std::is_arithmetic_v)
+template<typename T>
+inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+
 namespace math {
 
 /// @todo These won't be needed if we eliminate StringGrids.
@@ -981,10 +991,11 @@ enum RotationOrder {
     ZXZ_ROTATION
 };
 
-template <typename S, typename T, typename = std::enable_if_t<std::is_arithmetic_v<S>&& std::is_arithmetic_v<T>>>
+template <typename S, typename T, typename = std::enable_if_t<openvdb::is_arithmetic_v<S>&& openvdb::is_arithmetic_v<T>>>
 struct promote {
     using type = typename std::common_type_t<S,T>;
 };
+
 
 /// @brief Return the index [0,1,2] of the smallest value in a 3D vector.
 /// @note This methods assumes operator[] exists.

--- a/openvdb/openvdb/math/Operators.h
+++ b/openvdb/openvdb/math/Operators.h
@@ -6,6 +6,8 @@
 #ifndef OPENVDB_MATH_OPERATORS_HAS_BEEN_INCLUDED
 #define OPENVDB_MATH_OPERATORS_HAS_BEEN_INCLUDED
 
+#include <openvdb/Types.h>
+
 #include "FiniteDifference.h"
 #include "Stencils.h"
 #include "Maps.h"
@@ -83,7 +85,8 @@ namespace internal {
 template<typename T>
 struct ReturnValue {
     using ValueType = typename T::ValueType;
-    using Vec3Type = math::Vec3<ValueType>;
+    using ComputeType = typename ComputeTypeFor<ValueType>::type;
+    using Vec3Type = math::Vec3<ComputeType>;
 };
 
 } // namespace internal
@@ -99,22 +102,26 @@ template<DScheme DiffScheme>
 struct ISGradient
 {
     // random access version
-    template<typename Accessor> static Vec3<typename Accessor::ValueType>
+    template<typename Accessor>
+    static Vec3<typename ComputeTypeFor<typename Accessor::ValueType>::type>
     result(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
-        using Vec3Type = Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = Vec3<ComputeType>;
         return Vec3Type( D1<DiffScheme>::inX(grid, ijk),
                          D1<DiffScheme>::inY(grid, ijk),
                          D1<DiffScheme>::inZ(grid, ijk) );
     }
 
     // stencil access version
-    template<typename StencilT> static Vec3<typename StencilT::ValueType>
+    template<typename StencilT>
+    static Vec3<typename ComputeTypeFor<typename StencilT::ValueType>::type>
     result(const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
-        using Vec3Type = Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = Vec3<ComputeType>;
         return Vec3Type( D1<DiffScheme>::inX(stencil),
                          D1<DiffScheme>::inY(stencil),
                          D1<DiffScheme>::inZ(stencil) );
@@ -200,11 +207,12 @@ struct ISGradientBiased
 
     // random access version
     template<typename Accessor>
-    static Vec3<typename Accessor::ValueType>
+    static Vec3<typename ComputeTypeFor<typename Accessor::ValueType>::type>
     result(const Accessor& grid, const Coord& ijk, const Vec3Bias& V)
     {
         using ValueType = typename Accessor::ValueType;
-        using Vec3Type = Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = Vec3<ComputeType>;
 
         return Vec3Type(V[0]<0 ? D1<FD>::inX(grid,ijk) : D1<BD>::inX(grid,ijk),
                         V[1]<0 ? D1<FD>::inY(grid,ijk) : D1<BD>::inY(grid,ijk),
@@ -213,11 +221,12 @@ struct ISGradientBiased
 
     // stencil access version
     template<typename StencilT>
-    static Vec3<typename StencilT::ValueType>
+    static Vec3<typename ComputeTypeFor<typename StencilT::ValueType>::type>
     result(const StencilT& stencil, const Vec3Bias& V)
     {
         using ValueType = typename StencilT::ValueType;
-        using Vec3Type = Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = Vec3<ComputeType>;
 
         return Vec3Type(V[0]<0 ? D1<FD>::inX(stencil) : D1<BD>::inX(stencil),
                         V[1]<0 ? D1<FD>::inY(stencil) : D1<BD>::inY(stencil),
@@ -235,11 +244,12 @@ struct ISGradientNormSqrd
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
-        using Vec3Type = math::Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = math::Vec3<ComputeType>;
 
         Vec3Type up   = ISGradient<FD>::result(grid, ijk);
         Vec3Type down = ISGradient<BD>::result(grid, ijk);
@@ -248,11 +258,12 @@ struct ISGradientNormSqrd
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
-        using Vec3Type = math::Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = math::Vec3<ComputeType>;
 
         Vec3Type up   = ISGradient<FD>::result(stencil);
         Vec3Type down = ISGradient<BD>::result(stencil);
@@ -266,7 +277,8 @@ struct ISGradientNormSqrd<HJWENO5_BIAS>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const Accessor& grid, const Coord& ijk)
     {
         struct GetValue
         {
@@ -307,7 +319,8 @@ struct ISGradientNormSqrd<HJWENO5_BIAS>
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const StencilT& s)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const StencilT& s)
     {
         using F4Val = simd::Float4::value_type;
 
@@ -341,6 +354,23 @@ struct ISGradientNormSqrd<HJWENO5_BIAS>
 //@}
 
 
+template<typename Accessor>
+struct GetGridComputeTypeValue
+{
+    using ValueType = typename Accessor::ValueType;
+    using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+    GetGridComputeTypeValue(const Accessor& acc): mAcc(acc) {}
+
+    inline ComputeType
+    operator()(const Coord& ijk) const
+    {
+        return static_cast<ComputeType>(mAcc.getValue(ijk));
+    }
+
+    const Accessor& mAcc;
+};
+
 //@{
 /// @brief Laplacian defined in index space, using various center-difference stencils
 template<DDScheme DiffScheme>
@@ -348,11 +378,13 @@ struct ISLaplacian
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const Accessor& grid, const Coord& ijk);
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const Accessor& grid, const Coord& ijk);
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const StencilT& stencil);
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const StencilT& stencil);
 };
 
 
@@ -361,21 +393,25 @@ struct ISLaplacian<CD_SECOND>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const Accessor& grid, const Coord& ijk)
     {
-        return  grid.getValue(ijk.offsetBy(1,0,0)) + grid.getValue(ijk.offsetBy(-1, 0, 0)) +
-                grid.getValue(ijk.offsetBy(0,1,0)) + grid.getValue(ijk.offsetBy(0, -1, 0)) +
-                grid.getValue(ijk.offsetBy(0,0,1)) + grid.getValue(ijk.offsetBy(0,  0,-1))
-                                                   - 6*grid.getValue(ijk);
+        const GetGridComputeTypeValue valueAt(grid);
+
+        return  valueAt(ijk.offsetBy(1,0,0)) + valueAt(ijk.offsetBy(-1, 0, 0)) +
+                valueAt(ijk.offsetBy(0,1,0)) + valueAt(ijk.offsetBy(0, -1, 0)) +
+                valueAt(ijk.offsetBy(0,0,1)) + valueAt(ijk.offsetBy(0,  0,-1))
+                                             - 6*valueAt(ijk);
     }
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const StencilT& stencil)
     {
-        return  stencil.template getValue< 1, 0, 0>() + stencil.template getValue<-1, 0, 0>() +
-                stencil.template getValue< 0, 1, 0>() + stencil.template getValue< 0,-1, 0>() +
-                stencil.template getValue< 0, 0, 1>() + stencil.template getValue< 0, 0,-1>()
+        return stencil.template getValue< 1, 0, 0>() + stencil.template getValue<-1, 0, 0>() +
+               stencil.template getValue< 0, 1, 0>() + stencil.template getValue< 0,-1, 0>() +
+               stencil.template getValue< 0, 0, 1>() + stencil.template getValue< 0, 0,-1>()
                                                    - 6*stencil.template getValue< 0, 0, 0>();
     }
 };
@@ -385,36 +421,44 @@ struct ISLaplacian<CD_FOURTH>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const Accessor& grid, const Coord& ijk)
     {
-        using ValueT = typename Accessor::ValueType;
-        return static_cast<ValueT>(
-            (-1./12.)*(
-                grid.getValue(ijk.offsetBy(2,0,0)) + grid.getValue(ijk.offsetBy(-2, 0, 0)) +
-                grid.getValue(ijk.offsetBy(0,2,0)) + grid.getValue(ijk.offsetBy( 0,-2, 0)) +
-                grid.getValue(ijk.offsetBy(0,0,2)) + grid.getValue(ijk.offsetBy( 0, 0,-2)) )
-            + (4./3.)*(
-                grid.getValue(ijk.offsetBy(1,0,0)) + grid.getValue(ijk.offsetBy(-1, 0, 0)) +
-                grid.getValue(ijk.offsetBy(0,1,0)) + grid.getValue(ijk.offsetBy( 0,-1, 0)) +
-                grid.getValue(ijk.offsetBy(0,0,1)) + grid.getValue(ijk.offsetBy( 0, 0,-1)) )
-            - 7.5*grid.getValue(ijk));
+        using ValueT   = typename Accessor::ValueType;
+        using ComputeT = typename ComputeTypeFor<ValueT>::type;
+
+        const GetGridComputeTypeValue valueAt(grid);
+
+        return
+            ComputeT(-1./12.)*(
+                valueAt(ijk.offsetBy(2,0,0)) + valueAt(ijk.offsetBy(-2, 0, 0)) +
+                valueAt(ijk.offsetBy(0,2,0)) + valueAt(ijk.offsetBy( 0,-2, 0)) +
+                valueAt(ijk.offsetBy(0,0,2)) + valueAt(ijk.offsetBy( 0, 0,-2)) )
+            + ComputeT(4./3.)*(
+                valueAt(ijk.offsetBy(1,0,0)) + valueAt(ijk.offsetBy(-1, 0, 0)) +
+                valueAt(ijk.offsetBy(0,1,0)) + valueAt(ijk.offsetBy( 0,-1, 0)) +
+                valueAt(ijk.offsetBy(0,0,1)) + valueAt(ijk.offsetBy( 0, 0,-1)) )
+            - ComputeT(7.5)*valueAt(ijk);
     }
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const StencilT& stencil)
     {
         using ValueT = typename StencilT::ValueType;
-        return static_cast<ValueT>(
-            (-1./12.)*(
+        using ComputeT = typename ComputeTypeFor<ValueT>::type;
+
+        return
+            ComputeT(-1./12.)*(
                 stencil.template getValue< 2, 0, 0>() + stencil.template getValue<-2, 0, 0>() +
                 stencil.template getValue< 0, 2, 0>() + stencil.template getValue< 0,-2, 0>() +
                 stencil.template getValue< 0, 0, 2>() + stencil.template getValue< 0, 0,-2>() )
-            + (4./3.)*(
+            + ComputeT(4./3.)*(
                 stencil.template getValue< 1, 0, 0>() + stencil.template getValue<-1, 0, 0>() +
                 stencil.template getValue< 0, 1, 0>() + stencil.template getValue< 0,-1, 0>() +
                 stencil.template getValue< 0, 0, 1>() + stencil.template getValue< 0, 0,-1>() )
-            - 7.5*stencil.template getValue< 0, 0, 0>());
+            - ComputeT(7.5)*stencil.template getValue< 0, 0, 0>();
     }
 };
 
@@ -423,44 +467,52 @@ struct ISLaplacian<CD_SIXTH>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const Accessor& grid, const Coord& ijk)
     {
-        using ValueT = typename Accessor::ValueType;
-        return static_cast<ValueT>(
-            (1./90.)*(
-                grid.getValue(ijk.offsetBy(3,0,0)) + grid.getValue(ijk.offsetBy(-3, 0, 0)) +
-                grid.getValue(ijk.offsetBy(0,3,0)) + grid.getValue(ijk.offsetBy( 0,-3, 0)) +
-                grid.getValue(ijk.offsetBy(0,0,3)) + grid.getValue(ijk.offsetBy( 0, 0,-3)) )
-            - (3./20.)*(
-                grid.getValue(ijk.offsetBy(2,0,0)) + grid.getValue(ijk.offsetBy(-2, 0, 0)) +
-                grid.getValue(ijk.offsetBy(0,2,0)) + grid.getValue(ijk.offsetBy( 0,-2, 0)) +
-                grid.getValue(ijk.offsetBy(0,0,2)) + grid.getValue(ijk.offsetBy( 0, 0,-2)) )
-            + 1.5 *(
-                grid.getValue(ijk.offsetBy(1,0,0)) + grid.getValue(ijk.offsetBy(-1, 0, 0)) +
-                grid.getValue(ijk.offsetBy(0,1,0)) + grid.getValue(ijk.offsetBy( 0,-1, 0)) +
-                grid.getValue(ijk.offsetBy(0,0,1)) + grid.getValue(ijk.offsetBy( 0, 0,-1)) )
-            - (3*49/18.)*grid.getValue(ijk));
+        using ValueT   = typename Accessor::ValueType;
+        using ComputeT = typename ComputeTypeFor<ValueT>::type;
+
+        const GetGridComputeTypeValue valueAt(grid);
+
+        return
+            ComputeT(1./90.)*(
+                valueAt(ijk.offsetBy(3,0,0)) + valueAt(ijk.offsetBy(-3, 0, 0)) +
+                valueAt(ijk.offsetBy(0,3,0)) + valueAt(ijk.offsetBy( 0,-3, 0)) +
+                valueAt(ijk.offsetBy(0,0,3)) + valueAt(ijk.offsetBy( 0, 0,-3)) )
+            - ComputeT(3./20.)*(
+                valueAt(ijk.offsetBy(2,0,0)) + valueAt(ijk.offsetBy(-2, 0, 0)) +
+                valueAt(ijk.offsetBy(0,2,0)) + valueAt(ijk.offsetBy( 0,-2, 0)) +
+                valueAt(ijk.offsetBy(0,0,2)) + valueAt(ijk.offsetBy( 0, 0,-2)) )
+            + ComputeT(1.5) *(
+                valueAt(ijk.offsetBy(1,0,0)) + valueAt(ijk.offsetBy(-1, 0, 0)) +
+                valueAt(ijk.offsetBy(0,1,0)) + valueAt(ijk.offsetBy( 0,-1, 0)) +
+                valueAt(ijk.offsetBy(0,0,1)) + valueAt(ijk.offsetBy( 0, 0,-1)) )
+            - ComputeT(3*49/18.)*valueAt(ijk);
     }
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const StencilT& stencil)
     {
         using ValueT = typename StencilT::ValueType;
-        return static_cast<ValueT>(
-            (1./90.)*(
+        using ComputeT = typename ComputeTypeFor<ValueT>::type;
+
+        return
+            ComputeT(1./90.)*(
                 stencil.template getValue< 3, 0, 0>() + stencil.template getValue<-3, 0, 0>() +
                 stencil.template getValue< 0, 3, 0>() + stencil.template getValue< 0,-3, 0>() +
                 stencil.template getValue< 0, 0, 3>() + stencil.template getValue< 0, 0,-3>() )
-            - (3./20.)*(
+            - ComputeT(3./20.)*(
                 stencil.template getValue< 2, 0, 0>() + stencil.template getValue<-2, 0, 0>() +
                 stencil.template getValue< 0, 2, 0>() + stencil.template getValue< 0,-2, 0>() +
                 stencil.template getValue< 0, 0, 2>() + stencil.template getValue< 0, 0,-2>() )
-            + 1.5 *(
+            + ComputeT(1.5) *(
                 stencil.template getValue< 1, 0, 0>() + stencil.template getValue<-1, 0, 0>() +
                 stencil.template getValue< 0, 1, 0>() + stencil.template getValue< 0,-1, 0>() +
                 stencil.template getValue< 0, 0, 1>() + stencil.template getValue< 0, 0,-1>() )
-            - (3*49/18.)*stencil.template getValue< 0, 0, 0>());
+            - ComputeT(3*49/18.)*stencil.template getValue< 0, 0, 0>();
     }
 };
 //@}
@@ -472,7 +524,8 @@ template<DScheme DiffScheme>
 struct ISDivergence
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const Accessor& grid, const Coord& ijk)
     {
         return D1Vec<DiffScheme>::inX(grid, ijk, 0) +
@@ -481,7 +534,8 @@ struct ISDivergence
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const StencilT& stencil)
     {
         return D1Vec<DiffScheme>::inX(stencil, 0) +
@@ -499,9 +553,11 @@ struct ISCurl
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const Accessor& grid, const Coord& ijk)
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const Accessor& grid, const Coord& ijk)
     {
-        using Vec3Type = typename Accessor::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename Accessor::ValueType>::type;
+
         return Vec3Type( D1Vec<DiffScheme>::inY(grid, ijk, 2) - //dw/dy - dv/dz
                          D1Vec<DiffScheme>::inZ(grid, ijk, 1),
                          D1Vec<DiffScheme>::inZ(grid, ijk, 0) - //du/dz - dw/dx
@@ -512,9 +568,11 @@ struct ISCurl
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const StencilT& stencil)
     {
-        using Vec3Type = typename StencilT::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename StencilT::ValueType>::type;
+
         return Vec3Type( D1Vec<DiffScheme>::inY(stencil, 2) - //dw/dy - dv/dz
                          D1Vec<DiffScheme>::inZ(stencil, 1),
                          D1Vec<DiffScheme>::inZ(stencil, 0) - //du/dz - dw/dx
@@ -537,36 +595,57 @@ struct ISMeanCurvature
     /// in &nabla; &middot; (&nabla;&Phi; / |&nabla;&Phi;|) and @a beta is |&nabla;&Phi;|.
     template<typename Accessor>
     static bool result(const Accessor& grid, const Coord& ijk,
-                       typename Accessor::ValueType& alpha,
-                       typename Accessor::ValueType& beta)
+        typename ComputeTypeFor<typename Accessor::ValueType>::type& alpha,
+        typename ComputeTypeFor<typename Accessor::ValueType>::type& beta)
     {
-        using ValueType = typename Accessor::ValueType;
+        using ValueType   = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        const ValueType Dx = D1<DiffScheme1>::inX(grid, ijk);
-        const ValueType Dy = D1<DiffScheme1>::inY(grid, ijk);
-        const ValueType Dz = D1<DiffScheme1>::inZ(grid, ijk);
+        const ComputeType Dx = D1<DiffScheme1>::inX(grid, ijk);
+        const ComputeType Dy = D1<DiffScheme1>::inY(grid, ijk);
+        const ComputeType Dz = D1<DiffScheme1>::inZ(grid, ijk);
 
-        const ValueType Dx2 = Dx*Dx;
-        const ValueType Dy2 = Dy*Dy;
-        const ValueType Dz2 = Dz*Dz;
-        const ValueType normGrad = Dx2 + Dy2 + Dz2;
-        if (normGrad <= math::Tolerance<ValueType>::value()) {
-            alpha = beta = 0;
+        const ComputeType Dx2 = Dx*Dx;
+        const ComputeType Dy2 = Dy*Dy;
+        const ComputeType Dz2 = Dz*Dz;
+        const ComputeType normGrad = Dx2 + Dy2 + Dz2;
+        if (normGrad <= math::Tolerance<ComputeType>::value()) {
+            alpha = beta = ComputeType(0);
             return false;
         }
 
-        const ValueType Dxx = D2<DiffScheme2>::inX(grid, ijk);
-        const ValueType Dyy = D2<DiffScheme2>::inY(grid, ijk);
-        const ValueType Dzz = D2<DiffScheme2>::inZ(grid, ijk);
+        const ComputeType Dxx = D2<DiffScheme2>::inX(grid, ijk);
+        const ComputeType Dyy = D2<DiffScheme2>::inY(grid, ijk);
+        const ComputeType Dzz = D2<DiffScheme2>::inZ(grid, ijk);
 
-        const ValueType Dxy = D2<DiffScheme2>::inXandY(grid, ijk);
-        const ValueType Dyz = D2<DiffScheme2>::inYandZ(grid, ijk);
-        const ValueType Dxz = D2<DiffScheme2>::inXandZ(grid, ijk);
+        const ComputeType Dxy = D2<DiffScheme2>::inXandY(grid, ijk);
+        const ComputeType Dyz = D2<DiffScheme2>::inYandZ(grid, ijk);
+        const ComputeType Dxz = D2<DiffScheme2>::inXandZ(grid, ijk);
 
         // for return
         alpha = (Dx2*(Dyy+Dzz)+Dy2*(Dxx+Dzz)+Dz2*(Dxx+Dyy)-2*(Dx*(Dy*Dxy+Dz*Dxz)+Dy*Dz*Dyz));
-        beta  = ValueType(std::sqrt(double(normGrad))); // * 1/dx
+        beta  = ComputeType(std::sqrt(double(normGrad))); // * 1/dx
         return true;
+    }
+
+    template<typename Accessor>
+    static typename std::enable_if_t<!std::is_same_v<typename Accessor::ValueType,
+                typename ComputeTypeFor<typename Accessor::ValueType>::type>, bool>
+    result(const Accessor& grid, const Coord& ijk,
+           typename Accessor::ValueType& alpha,
+           typename Accessor::ValueType& beta)
+    {
+        using ValueType   = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        ComputeType alpha_c, beta_c;
+
+        const bool res = result(grid, ijk, alpha_c, beta_c);
+
+        alpha = static_cast<ValueType>(alpha_c);
+        beta  = static_cast<ValueType>(beta_c);
+
+        return res;
     }
 
     /// @brief Stencil access version
@@ -579,31 +658,53 @@ struct ISMeanCurvature
                        typename StencilT::ValueType& beta)
     {
         using ValueType = typename StencilT::ValueType;
-        const ValueType Dx = D1<DiffScheme1>::inX(stencil);
-        const ValueType Dy = D1<DiffScheme1>::inY(stencil);
-        const ValueType Dz = D1<DiffScheme1>::inZ(stencil);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        const ValueType Dx2 = Dx*Dx;
-        const ValueType Dy2 = Dy*Dy;
-        const ValueType Dz2 = Dz*Dz;
-        const ValueType normGrad = Dx2 + Dy2 + Dz2;
-        if (normGrad <= math::Tolerance<ValueType>::value()) {
-            alpha = beta = 0;
+        const ComputeType Dx = D1<DiffScheme1>::inX(stencil);
+        const ComputeType Dy = D1<DiffScheme1>::inY(stencil);
+        const ComputeType Dz = D1<DiffScheme1>::inZ(stencil);
+
+        const ComputeType Dx2 = Dx*Dx;
+        const ComputeType Dy2 = Dy*Dy;
+        const ComputeType Dz2 = Dz*Dz;
+        const ComputeType normGrad = Dx2 + Dy2 + Dz2;
+        if (normGrad <= math::Tolerance<ComputeType>::value()) {
+            alpha = beta = ComputeType(0);
             return false;
         }
 
-        const ValueType Dxx = D2<DiffScheme2>::inX(stencil);
-        const ValueType Dyy = D2<DiffScheme2>::inY(stencil);
-        const ValueType Dzz = D2<DiffScheme2>::inZ(stencil);
+        const ComputeType Dxx = D2<DiffScheme2>::inX(stencil);
+        const ComputeType Dyy = D2<DiffScheme2>::inY(stencil);
+        const ComputeType Dzz = D2<DiffScheme2>::inZ(stencil);
 
-        const ValueType Dxy = D2<DiffScheme2>::inXandY(stencil);
-        const ValueType Dyz = D2<DiffScheme2>::inYandZ(stencil);
-        const ValueType Dxz = D2<DiffScheme2>::inXandZ(stencil);
+        const ComputeType Dxy = D2<DiffScheme2>::inXandY(stencil);
+        const ComputeType Dyz = D2<DiffScheme2>::inYandZ(stencil);
+        const ComputeType Dxz = D2<DiffScheme2>::inXandZ(stencil);
 
         // for return
         alpha = (Dx2*(Dyy+Dzz)+Dy2*(Dxx+Dzz)+Dz2*(Dxx+Dyy)-2*(Dx*(Dy*Dxy+Dz*Dxz)+Dy*Dz*Dyz));
-        beta = ValueType(std::sqrt(double(normGrad))); // * 1/dx
+        beta = ComputeType(std::sqrt(double(normGrad))); // * 1/dx
         return true;
+    }
+
+    template<typename StencilT>
+    static typename std::enable_if_t<!std::is_same_v<typename StencilT::ValueType,
+                typename ComputeTypeFor<typename StencilT::ValueType>::type>, bool>
+    result(const StencilT& stencil,
+           typename StencilT::ValueType& alpha,
+           typename StencilT::ValueType& beta)
+    {
+        using ValueType   = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        ComputeType alpha_c, beta_c;
+
+        const bool res = result(stencil, alpha_c, beta_c);
+
+        alpha = static_cast<ValueType>(alpha_c);
+        beta  = static_cast<ValueType>(beta_c);
+
+        return res;
     }
 };
 
@@ -674,11 +775,12 @@ struct Gradient<UniformScaleMap, CD_2ND>
     result(const UniformScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename internal::ReturnValue<Accessor>::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
         using Vec3Type = typename internal::ReturnValue<Accessor>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(grid, ijk) );
-        ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
-        return  iGradient * inv2dx;
+        ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+        return iGradient * inv2dx;
     }
 
     // stencil access version
@@ -687,11 +789,12 @@ struct Gradient<UniformScaleMap, CD_2ND>
     result(const UniformScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename internal::ReturnValue<StencilT>::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
         using Vec3Type = typename internal::ReturnValue<StencilT>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(stencil) );
-        ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
-        return  iGradient * inv2dx;
+        ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+        return iGradient * inv2dx;
     }
 };
 
@@ -706,11 +809,12 @@ struct Gradient<UniformScaleTranslateMap, CD_2ND>
     result(const UniformScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename internal::ReturnValue<Accessor>::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
         using Vec3Type = typename internal::ReturnValue<Accessor>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(grid, ijk) );
-        ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
-        return  iGradient * inv2dx;
+        ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+        return iGradient * inv2dx;
     }
 
     // stencil access version
@@ -719,11 +823,12 @@ struct Gradient<UniformScaleTranslateMap, CD_2ND>
     result(const UniformScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename internal::ReturnValue<StencilT>::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
         using Vec3Type = typename internal::ReturnValue<StencilT>::Vec3Type;
 
         Vec3Type iGradient( ISGradient<CD_2NDT>::result(stencil) );
-        ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
-        return  iGradient * inv2dx;
+        ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+        return iGradient * inv2dx;
     }
 };
 
@@ -824,24 +929,28 @@ template<typename MapType, BiasedGradientScheme GradScheme>
 struct GradientBiased
 {
     // random access version
-    template<typename Accessor> static math::Vec3<typename Accessor::ValueType>
+    template<typename Accessor>
+    static math::Vec3<typename ComputeTypeFor<typename Accessor::ValueType>::type>
     result(const MapType& map, const Accessor& grid, const Coord& ijk,
            const Vec3<typename Accessor::ValueType>& V)
     {
         using ValueType = typename Accessor::ValueType;
-        using Vec3Type = math::Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = math::Vec3<ComputeType>;
 
         Vec3d iGradient( ISGradientBiased<GradScheme, Vec3Type>::result(grid, ijk, V) );
         return Vec3Type(map.applyIJT(iGradient, ijk.asVec3d()));
     }
 
     // stencil access version
-    template<typename StencilT> static math::Vec3<typename StencilT::ValueType>
+    template<typename StencilT>
+    static math::Vec3<typename ComputeTypeFor<typename StencilT::ValueType>::type>
     result(const MapType& map, const StencilT& stencil,
            const Vec3<typename StencilT::ValueType>& V)
     {
         using ValueType = typename StencilT::ValueType;
-        using Vec3Type = math::Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = math::Vec3<ComputeType>;
 
         Vec3d iGradient( ISGradientBiased<GradScheme, Vec3Type>::result(stencil, V) );
         return Vec3Type(map.applyIJT(iGradient, stencil.getCenterCoord().asVec3d()));
@@ -862,11 +971,12 @@ struct GradientNormSqrd
 
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const MapType& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
-        using Vec3Type = math::Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = math::Vec3<ComputeType>;
 
         Vec3Type up   = Gradient<MapType, FD>::result(map, grid, ijk);
         Vec3Type down = Gradient<MapType, BD>::result(map, grid, ijk);
@@ -875,11 +985,12 @@ struct GradientNormSqrd
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const MapType& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
-        using Vec3Type = math::Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = math::Vec3<ComputeType>;
 
         Vec3Type up   = Gradient<MapType, FD>::result(map, stencil);
         Vec3Type down = Gradient<MapType, BD>::result(map, stencil);
@@ -893,23 +1004,25 @@ struct GradientNormSqrd<UniformScaleMap, GradScheme>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const UniformScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+        ComputeType invdxdx = ComputeType(map.getInvScaleSqr()[0]);
         return invdxdx * ISGradientNormSqrd<GradScheme>::result(grid, ijk);
     }
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const UniformScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+        ComputeType invdxdx = ComputeType(map.getInvScaleSqr()[0]);
         return invdxdx * ISGradientNormSqrd<GradScheme>::result(stencil);
     }
 };
@@ -920,23 +1033,25 @@ struct GradientNormSqrd<UniformScaleTranslateMap, GradScheme>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const UniformScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+        ComputeType invdxdx = ComputeType(map.getInvScaleSqr()[0]);
         return invdxdx * ISGradientNormSqrd<GradScheme>::result(grid, ijk);
     }
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const UniformScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+        ComputeType invdxdx = ComputeType(map.getInvScaleSqr()[0]);
         return invdxdx * ISGradientNormSqrd<GradScheme>::result(stencil);
     }
 };
@@ -949,33 +1064,37 @@ template<typename MapType, DScheme DiffScheme>
 struct Divergence
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const MapType& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
+        ComputeType div(0);
         for (int i=0; i < 3; i++) {
             Vec3d vec( D1Vec<DiffScheme>::inX(grid, ijk, i),
                        D1Vec<DiffScheme>::inY(grid, ijk, i),
                        D1Vec<DiffScheme>::inZ(grid, ijk, i) );
-            div += ValueType(map.applyIJT(vec, ijk.asVec3d())[i]);
+            div += ComputeType(map.applyIJT(vec, ijk.asVec3d())[i]);
         }
         return div;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const MapType& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
+        ComputeType div(0);
         for (int i=0; i < 3; i++) {
             Vec3d vec( D1Vec<DiffScheme>::inX(stencil, i),
                        D1Vec<DiffScheme>::inY(stencil, i),
                        D1Vec<DiffScheme>::inZ(stencil, i) );
-            div += ValueType(map.applyIJT(vec, stencil.getCenterCoord().asVec3d())[i]);
+            div += ComputeType(map.applyIJT(vec, stencil.getCenterCoord().asVec3d())[i]);
         }
         return div;
     }
@@ -987,25 +1106,19 @@ template<DScheme DiffScheme>
 struct Divergence<TranslationMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const TranslationMap&, const Accessor& grid, const Coord& ijk)
     {
-        using ValueType = typename Accessor::ValueType::value_type;
-
-        ValueType div(0);
-        div =ISDivergence<DiffScheme>::result(grid, ijk);
-        return div;
+        return ISDivergence<DiffScheme>::result(grid, ijk);
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const TranslationMap&, const StencilT& stencil)
     {
-        using ValueType = typename StencilT::ValueType::value_type;
-
-        ValueType div(0);
-        div =ISDivergence<DiffScheme>::result(stencil);
-        return div;
+        return ISDivergence<DiffScheme>::result(stencil);
     }
 };
 
@@ -1015,28 +1128,30 @@ template<DScheme DiffScheme>
 struct Divergence<UniformScaleMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const UniformScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
+        ComputeType div = ISDivergence<DiffScheme>::result(grid, ijk);
+        ComputeType invdx = ComputeType(map.getInvScale()[0]);
 
-        div =ISDivergence<DiffScheme>::result(grid, ijk);
-        ValueType invdx = ValueType(map.getInvScale()[0]);
         return div * invdx;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const UniformScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
+        ComputeType div = ISDivergence<DiffScheme>::result(stencil);
+        ComputeType invdx = ComputeType(map.getInvScale()[0]);
 
-        div =ISDivergence<DiffScheme>::result(stencil);
-        ValueType invdx = ValueType(map.getInvScale()[0]);
         return div * invdx;
     }
 };
@@ -1047,28 +1162,30 @@ template<DScheme DiffScheme>
 struct Divergence<UniformScaleTranslateMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const UniformScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
+        ComputeType div = ISDivergence<DiffScheme>::result(grid, ijk);
+        ComputeType invdx = ComputeType(map.getInvScale()[0]);
 
-        div =ISDivergence<DiffScheme>::result(grid, ijk);
-        ValueType invdx = ValueType(map.getInvScale()[0]);
         return div * invdx;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const UniformScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
+        ComputeType div = ISDivergence<DiffScheme>::result(stencil);
+        ComputeType invdx = ComputeType(map.getInvScale()[0]);
 
-        div =ISDivergence<DiffScheme>::result(stencil);
-        ValueType invdx = ValueType(map.getInvScale()[0]);
         return div * invdx;
     }
 };
@@ -1079,26 +1196,30 @@ template<>
 struct Divergence<UniformScaleMap, CD_2ND>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const UniformScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
-        div =ISDivergence<CD_2NDT>::result(grid, ijk);
-        ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+        ComputeType div = ISDivergence<CD_2NDT>::result(grid, ijk);
+        ComputeType inv2dx = ComputeType(map.getInvTwiceScale()[0]);
+
         return div * inv2dx;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const UniformScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
-        div =ISDivergence<CD_2NDT>::result(stencil);
-        ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+        ComputeType div = ISDivergence<CD_2NDT>::result(stencil);
+        ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+
         return div * inv2dx;
     }
 };
@@ -1109,28 +1230,30 @@ template<>
 struct Divergence<UniformScaleTranslateMap, CD_2ND>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const UniformScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
+        ComputeType div = ISDivergence<CD_2NDT>::result(grid, ijk);
+        ComputeType inv2dx = ComputeType(map.getInvTwiceScale()[0]);
 
-        div =ISDivergence<CD_2NDT>::result(grid, ijk);
-        ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
         return div * inv2dx;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const UniformScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
+        ComputeType div = ISDivergence<CD_2NDT>::result(stencil);
+        ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
 
-        div =ISDivergence<CD_2NDT>::result(stencil);
-        ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
         return div * inv2dx;
     }
 };
@@ -1141,29 +1264,34 @@ template<DScheme DiffScheme>
 struct Divergence<ScaleMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const ScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div = ValueType(
+        ComputeType div = ComputeType(
             D1Vec<DiffScheme>::inX(grid, ijk, 0) * (map.getInvScale()[0]) +
             D1Vec<DiffScheme>::inY(grid, ijk, 1) * (map.getInvScale()[1]) +
             D1Vec<DiffScheme>::inZ(grid, ijk, 2) * (map.getInvScale()[2]));
+
         return div;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const ScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
-        div = ValueType(
+        ComputeType div = ComputeType(
               D1Vec<DiffScheme>::inX(stencil, 0) * (map.getInvScale()[0]) +
               D1Vec<DiffScheme>::inY(stencil, 1) * (map.getInvScale()[1]) +
               D1Vec<DiffScheme>::inZ(stencil, 2) * (map.getInvScale()[2]) );
+
         return div;
     }
 };
@@ -1174,29 +1302,34 @@ template<DScheme DiffScheme>
 struct Divergence<ScaleTranslateMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const ScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div = ValueType(
+        ComputeType div = ComputeType(
             D1Vec<DiffScheme>::inX(grid, ijk, 0) * (map.getInvScale()[0]) +
             D1Vec<DiffScheme>::inY(grid, ijk, 1) * (map.getInvScale()[1]) +
             D1Vec<DiffScheme>::inZ(grid, ijk, 2) * (map.getInvScale()[2]));
+
         return div;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const ScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div(0);
-        div = ValueType(
+        ComputeType div = ComputeType(
               D1Vec<DiffScheme>::inX(stencil, 0) * (map.getInvScale()[0]) +
               D1Vec<DiffScheme>::inY(stencil, 1) * (map.getInvScale()[1]) +
               D1Vec<DiffScheme>::inZ(stencil, 2) * (map.getInvScale()[2]) );
+
         return div;
     }
 };
@@ -1207,28 +1340,34 @@ template<>
 struct Divergence<ScaleMap, CD_2ND>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const ScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div = ValueType(
+        ComputeType div = ComputeType(
             D1Vec<CD_2NDT>::inX(grid, ijk, 0) * (map.getInvTwiceScale()[0]) +
             D1Vec<CD_2NDT>::inY(grid, ijk, 1) * (map.getInvTwiceScale()[1]) +
             D1Vec<CD_2NDT>::inZ(grid, ijk, 2) * (map.getInvTwiceScale()[2]) );
+
         return div;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const ScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div = ValueType(
+        ComputeType div = ComputeType(
             D1Vec<CD_2NDT>::inX(stencil, 0) * (map.getInvTwiceScale()[0]) +
             D1Vec<CD_2NDT>::inY(stencil, 1) * (map.getInvTwiceScale()[1]) +
             D1Vec<CD_2NDT>::inZ(stencil, 2) * (map.getInvTwiceScale()[2]) );
+
         return div;
     }
 };
@@ -1239,28 +1378,34 @@ template<>
 struct Divergence<ScaleTranslateMap, CD_2ND>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType::value_type
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType::value_type>::type
     result(const ScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div = ValueType(
+        ComputeType div = ComputeType(
             D1Vec<CD_2NDT>::inX(grid, ijk, 0) * (map.getInvTwiceScale()[0]) +
             D1Vec<CD_2NDT>::inY(grid, ijk, 1) * (map.getInvTwiceScale()[1]) +
             D1Vec<CD_2NDT>::inZ(grid, ijk, 2) * (map.getInvTwiceScale()[2]) );
+
         return div;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType::value_type
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType::value_type>::type
     result(const ScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType::value_type;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType div = ValueType(
+        ComputeType div = ComputeType(
             D1Vec<CD_2NDT>::inX(stencil, 0) * (map.getInvTwiceScale()[0]) +
             D1Vec<CD_2NDT>::inY(stencil, 1) * (map.getInvTwiceScale()[1]) +
             D1Vec<CD_2NDT>::inZ(stencil, 2) * (map.getInvTwiceScale()[2]) );
+
         return div;
     }
 };
@@ -1274,10 +1419,11 @@ template<typename MapType, DScheme DiffScheme>
 struct Curl
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const MapType& map, const Accessor& grid, const Coord& ijk)
     {
-        using Vec3Type = typename Accessor::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename Accessor::ValueType>::type;
         Vec3Type mat[3];
         for (int i = 0; i < 3; i++) {
             Vec3d vec(
@@ -1293,10 +1439,11 @@ struct Curl
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const MapType& map, const StencilT& stencil)
     {
-        using Vec3Type = typename StencilT::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename StencilT::ValueType>::type;
         Vec3Type mat[3];
         for (int i = 0; i < 3; i++) {
             Vec3d vec(
@@ -1317,21 +1464,25 @@ template<DScheme DiffScheme>
 struct Curl<UniformScaleMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const UniformScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
-        using Vec3Type = typename Accessor::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename Accessor::ValueType>::type;
         using ValueType = typename Vec3Type::value_type;
+
         return ISCurl<DiffScheme>::result(grid, ijk) * ValueType(map.getInvScale()[0]);
     }
 
     // Stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const UniformScaleMap& map, const StencilT& stencil)
     {
-         using Vec3Type = typename StencilT::ValueType;
-         using ValueType = typename Vec3Type::value_type;
-         return ISCurl<DiffScheme>::result(stencil) * ValueType(map.getInvScale()[0]);
+        using Vec3Type = typename ComputeTypeFor<typename StencilT::ValueType>::type;
+        using ValueType = typename Vec3Type::value_type;
+
+        return ISCurl<DiffScheme>::result(stencil) * ValueType(map.getInvScale()[0]);
      }
 };
 
@@ -1340,20 +1491,22 @@ template<DScheme DiffScheme>
 struct Curl<UniformScaleTranslateMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const UniformScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
-        using Vec3Type = typename Accessor::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename Accessor::ValueType>::type;
         using ValueType = typename Vec3Type::value_type;
 
         return ISCurl<DiffScheme>::result(grid, ijk) * ValueType(map.getInvScale()[0]);
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const UniformScaleTranslateMap& map, const StencilT& stencil)
     {
-        using Vec3Type = typename StencilT::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename StencilT::ValueType>::type;
         using ValueType = typename Vec3Type::value_type;
 
         return ISCurl<DiffScheme>::result(stencil) * ValueType(map.getInvScale()[0]);
@@ -1365,20 +1518,22 @@ template<>
 struct Curl<UniformScaleMap, CD_2ND>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const UniformScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
-        using Vec3Type = typename Accessor::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename Accessor::ValueType>::type;
         using ValueType = typename Vec3Type::value_type;
 
         return ISCurl<CD_2NDT>::result(grid, ijk) * ValueType(map.getInvTwiceScale()[0]);
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const UniformScaleMap& map, const StencilT& stencil)
     {
-        using Vec3Type = typename StencilT::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename StencilT::ValueType>::type;
         using ValueType = typename Vec3Type::value_type;
 
         return ISCurl<CD_2NDT>::result(stencil) * ValueType(map.getInvTwiceScale()[0]);
@@ -1390,20 +1545,22 @@ template<>
 struct Curl<UniformScaleTranslateMap, CD_2ND>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const UniformScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
-        using Vec3Type = typename Accessor::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename Accessor::ValueType>::type;
         using ValueType = typename Vec3Type::value_type;
 
         return ISCurl<CD_2NDT>::result(grid, ijk) * ValueType(map.getInvTwiceScale()[0]);
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const UniformScaleTranslateMap& map, const StencilT& stencil)
     {
-        using Vec3Type = typename StencilT::ValueType;
+        using Vec3Type = typename ComputeTypeFor<typename StencilT::ValueType>::type;
         using ValueType = typename Vec3Type::value_type;
 
         return ISCurl<CD_2NDT>::result(stencil) * ValueType(map.getInvTwiceScale()[0]);
@@ -1420,18 +1577,21 @@ struct Laplacian
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const MapType& map,
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const MapType& map,
         const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
-        // all the second derivatives in index space
-        ValueType iddx  = D2<DiffScheme>::inX(grid, ijk);
-        ValueType iddy  = D2<DiffScheme>::inY(grid, ijk);
-        ValueType iddz  = D2<DiffScheme>::inZ(grid, ijk);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType iddxy = D2<DiffScheme>::inXandY(grid, ijk);
-        ValueType iddyz = D2<DiffScheme>::inYandZ(grid, ijk);
-        ValueType iddxz = D2<DiffScheme>::inXandZ(grid, ijk);
+        // all the second derivatives in index space
+        ComputeType iddx  = D2<DiffScheme>::inX(grid, ijk);
+        ComputeType iddy  = D2<DiffScheme>::inY(grid, ijk);
+        ComputeType iddz  = D2<DiffScheme>::inZ(grid, ijk);
+
+        ComputeType iddxy = D2<DiffScheme>::inXandY(grid, ijk);
+        ComputeType iddyz = D2<DiffScheme>::inYandZ(grid, ijk);
+        ComputeType iddxz = D2<DiffScheme>::inXandZ(grid, ijk);
 
         // second derivatives in index space
         Mat3d  d2_is(iddx,  iddxy, iddxz,
@@ -1451,22 +1611,25 @@ struct Laplacian
         }
 
         // the trace of the second derivative (range space) matrix is laplacian
-        return ValueType(d2_rs(0,0) + d2_rs(1,1) + d2_rs(2,2));
+        return ComputeType(d2_rs(0,0) + d2_rs(1,1) + d2_rs(2,2));
     }
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const MapType& map, const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const MapType& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
-        // all the second derivatives in index space
-        ValueType iddx  = D2<DiffScheme>::inX(stencil);
-        ValueType iddy  = D2<DiffScheme>::inY(stencil);
-        ValueType iddz  = D2<DiffScheme>::inZ(stencil);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType iddxy = D2<DiffScheme>::inXandY(stencil);
-        ValueType iddyz = D2<DiffScheme>::inYandZ(stencil);
-        ValueType iddxz = D2<DiffScheme>::inXandZ(stencil);
+        // all the second derivatives in index space
+        ComputeType iddx  = D2<DiffScheme>::inX(stencil);
+        ComputeType iddy  = D2<DiffScheme>::inY(stencil);
+        ComputeType iddz  = D2<DiffScheme>::inZ(stencil);
+
+        ComputeType iddxy = D2<DiffScheme>::inXandY(stencil);
+        ComputeType iddyz = D2<DiffScheme>::inYandZ(stencil);
+        ComputeType iddxz = D2<DiffScheme>::inXandZ(stencil);
 
         // second derivatives in index space
         Mat3d  d2_is(iddx,  iddxy, iddxz,
@@ -1486,7 +1649,7 @@ struct Laplacian
         }
 
         // the trace of the second derivative (range space) matrix is laplacian
-        return ValueType(d2_rs(0,0) + d2_rs(1,1) + d2_rs(2,2));
+        return ComputeType(d2_rs(0,0) + d2_rs(1,1) + d2_rs(2,2));
     }
 };
 
@@ -1496,7 +1659,8 @@ struct Laplacian<TranslationMap, DiffScheme>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const TranslationMap&,
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const TranslationMap&,
         const Accessor& grid, const Coord& ijk)
     {
         return ISLaplacian<DiffScheme>::result(grid, ijk);
@@ -1504,7 +1668,8 @@ struct Laplacian<TranslationMap, DiffScheme>
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const TranslationMap&, const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const TranslationMap&, const StencilT& stencil)
     {
         return ISLaplacian<DiffScheme>::result(stencil);
     }
@@ -1517,7 +1682,8 @@ struct Laplacian<UnitaryMap, DiffScheme>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const UnitaryMap&,
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const UnitaryMap&,
         const Accessor& grid, const Coord& ijk)
     {
         return ISLaplacian<DiffScheme>::result(grid, ijk);
@@ -1525,7 +1691,8 @@ struct Laplacian<UnitaryMap, DiffScheme>
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const UnitaryMap&, const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const UnitaryMap&, const StencilT& stencil)
     {
         return ISLaplacian<DiffScheme>::result(stencil);
     }
@@ -1536,20 +1703,26 @@ template<DDScheme DiffScheme>
 struct Laplacian<UniformScaleMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const UniformScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
-        ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        ComputeType invdxdx = ComputeType(map.getInvScaleSqr()[0]);
         return ISLaplacian<DiffScheme>::result(grid, ijk) * invdxdx;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const UniformScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
-        ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        ComputeType invdxdx = ComputeType(map.getInvScaleSqr()[0]);
         return ISLaplacian<DiffScheme>::result(stencil) * invdxdx;
     }
 };
@@ -1559,20 +1732,26 @@ template<DDScheme DiffScheme>
 struct Laplacian<UniformScaleTranslateMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const UniformScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
-        ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        ComputeType invdxdx = ComputeType(map.getInvScaleSqr()[0]);
         return ISLaplacian<DiffScheme>::result(grid, ijk) * invdxdx;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const UniformScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
-        ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
+        ComputeType invdxdx = ComputeType(map.getInvScaleSqr()[0]);
         return ISLaplacian<DiffScheme>::result(stencil) * invdxdx;
     }
 };
@@ -1582,37 +1761,41 @@ template<DDScheme DiffScheme>
 struct Laplacian<ScaleMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const ScaleMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
         // compute the second derivatives in index space
-        ValueType iddx = D2<DiffScheme>::inX(grid, ijk);
-        ValueType iddy = D2<DiffScheme>::inY(grid, ijk);
-        ValueType iddz = D2<DiffScheme>::inZ(grid, ijk);
+        ComputeType iddx = D2<DiffScheme>::inX(grid, ijk);
+        ComputeType iddy = D2<DiffScheme>::inY(grid, ijk);
+        ComputeType iddz = D2<DiffScheme>::inZ(grid, ijk);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
         OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
-        const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
+        const ComputeType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
         OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return value;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const ScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
         // compute the second derivatives in index space
-        ValueType iddx = D2<DiffScheme>::inX(stencil);
-        ValueType iddy = D2<DiffScheme>::inY(stencil);
-        ValueType iddz = D2<DiffScheme>::inZ(stencil);
+        ComputeType iddx = D2<DiffScheme>::inX(stencil);
+        ComputeType iddy = D2<DiffScheme>::inY(stencil);
+        ComputeType iddz = D2<DiffScheme>::inZ(stencil);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
         OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
-        const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
+        const ComputeType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
         OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return value;
     }
@@ -1623,35 +1806,41 @@ template<DDScheme DiffScheme>
 struct Laplacian<ScaleTranslateMap, DiffScheme>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const ScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
         // compute the second derivatives in index space
-        ValueType iddx = D2<DiffScheme>::inX(grid, ijk);
-        ValueType iddy = D2<DiffScheme>::inY(grid, ijk);
-        ValueType iddz = D2<DiffScheme>::inZ(grid, ijk);
+        ComputeType iddx = D2<DiffScheme>::inX(grid, ijk);
+        ComputeType iddy = D2<DiffScheme>::inY(grid, ijk);
+        ComputeType iddz = D2<DiffScheme>::inZ(grid, ijk);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
         OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
-        const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
+        const ComputeType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
         OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return value;
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const ScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
         // compute the second derivatives in index space
-        ValueType iddx = D2<DiffScheme>::inX(stencil);
-        ValueType iddy = D2<DiffScheme>::inY(stencil);
-        ValueType iddz = D2<DiffScheme>::inZ(stencil);
+        ComputeType iddx = D2<DiffScheme>::inX(stencil);
+        ComputeType iddy = D2<DiffScheme>::inY(stencil);
+        ComputeType iddz = D2<DiffScheme>::inZ(stencil);
         const Vec3d& invScaleSqr = map.getInvScaleSqr();
         OPENVDB_NO_TYPE_CONVERSION_WARNING_BEGIN
         // scale them by the appropriate 1/dx^2, 1/dy^2, 1/dz^2 and sum
-        const ValueType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
+        const ComputeType value = iddx * invScaleSqr[0] + iddy * invScaleSqr[1] + iddz * invScaleSqr[2];
         OPENVDB_NO_TYPE_CONVERSION_WARNING_END
         return value;
     }
@@ -1665,14 +1854,16 @@ template<typename MapType, DScheme DiffScheme>
 struct CPT
 {
     // random access version
-    template<typename Accessor> static math::Vec3<typename Accessor::ValueType>
+    template<typename Accessor>
+    static math::Vec3<typename ComputeTypeFor<typename Accessor::ValueType>::type>
     result(const MapType& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
-        using Vec3Type = Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = Vec3<ComputeType>;
 
         // current distance
-        ValueType d = grid.getValue(ijk);
+        ComputeType d = grid.getValue(ijk);
         // compute gradient in physical space where it is a unit normal
         // since the grid holds a distance level set.
         Vec3d vectorFromSurface(d*Gradient<MapType,DiffScheme>::result(map, grid, ijk));
@@ -1687,14 +1878,16 @@ struct CPT
     }
 
     // stencil access version
-    template<typename StencilT> static math::Vec3<typename StencilT::ValueType>
+    template<typename StencilT>
+    static math::Vec3<typename ComputeTypeFor<typename StencilT::ValueType>::type>
     result(const MapType& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
-        using Vec3Type = Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = Vec3<ComputeType>;
 
         // current distance
-        ValueType d = stencil.template getValue<0, 0, 0>();
+        ComputeType d = stencil.template getValue<0, 0, 0>();
         // compute gradient in physical space where it is a unit normal
         // since the grid holds a distance level set.
         Vec3d vectorFromSurface(d*Gradient<MapType, DiffScheme>::result(map, stencil));
@@ -1718,13 +1911,16 @@ template<typename MapType, DScheme DiffScheme>
 struct CPT_RANGE
 {
     // random access version
-    template<typename Accessor> static Vec3<typename Accessor::ValueType>
+    template<typename Accessor>
+    static math::Vec3<typename ComputeTypeFor<typename Accessor::ValueType>::type>
     result(const MapType& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
-        using Vec3Type = Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = Vec3<ComputeType>;
+
         // current distance
-        ValueType d = grid.getValue(ijk);
+        ComputeType d = grid.getValue(ijk);
         // compute gradient in physical space where it is a unit normal
         // since the grid holds a distance level set.
         Vec3Type vectorFromSurface =
@@ -1735,13 +1931,16 @@ struct CPT_RANGE
     }
 
     // stencil access version
-    template<typename StencilT> static Vec3<typename StencilT::ValueType>
+    template<typename StencilT>
+    static math::Vec3<typename ComputeTypeFor<typename StencilT::ValueType>::type>
     result(const MapType& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
-        using Vec3Type = Vec3<ValueType>;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+        using Vec3Type = Vec3<ComputeType>;
+
         // current distance
-        ValueType d = stencil.template getValue<0, 0, 0>();
+        ComputeType d = stencil.template getValue<0, 0, 0>();
         // compute gradient in physical space where it is a unit normal
         // since the grid holds a distance level set.
         Vec3Type vectorFromSurface =
@@ -1769,74 +1968,81 @@ struct MeanCurvature
                         double& alpha, double& beta)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-         // compute the gradient in index and world space
-         Vec3d d1_is(static_cast<double>(D1<DiffScheme1>::inX(grid, ijk)),
-                     static_cast<double>(D1<DiffScheme1>::inY(grid, ijk)),
-                     static_cast<double>(D1<DiffScheme1>::inZ(grid, ijk))), d1_ws;
-         if (is_linear<MapType>::value) {//resolved at compiletime
-             d1_ws = map.applyIJT(d1_is);
-         } else {
-             d1_ws = map.applyIJT(d1_is, ijk.asVec3d());
-         }
-         const double Dx2 = d1_ws(0)*d1_ws(0);
-         const double Dy2 = d1_ws(1)*d1_ws(1);
-         const double Dz2 = d1_ws(2)*d1_ws(2);
-         const double normGrad = Dx2 + Dy2 + Dz2;
-         if (normGrad <= math::Tolerance<double>::value()) {
-             alpha = beta = 0;
-             return false;
-         }
+        // compute the gradient in index and world space
+        Vec3d d1_is(static_cast<double>(D1<DiffScheme1>::inX(grid, ijk)),
+                    static_cast<double>(D1<DiffScheme1>::inY(grid, ijk)),
+                    static_cast<double>(D1<DiffScheme1>::inZ(grid, ijk))), d1_ws;
+        if (is_linear<MapType>::value) {//resolved at compiletime
+            d1_ws = map.applyIJT(d1_is);
+        } else {
+            d1_ws = map.applyIJT(d1_is, ijk.asVec3d());
+        }
+        const double Dx2 = d1_ws(0)*d1_ws(0);
+        const double Dy2 = d1_ws(1)*d1_ws(1);
+        const double Dz2 = d1_ws(2)*d1_ws(2);
+        const double normGrad = Dx2 + Dy2 + Dz2;
+        if (normGrad <= math::Tolerance<double>::value()) {
+            alpha = beta = double(0);
+            return false;
+        }
 
-         // all the second derivatives in index space
-         ValueType iddx  = D2<DiffScheme2>::inX(grid, ijk);
-         ValueType iddy  = D2<DiffScheme2>::inY(grid, ijk);
-         ValueType iddz  = D2<DiffScheme2>::inZ(grid, ijk);
+        // all the second derivatives in index space
+        ComputeType iddx  = D2<DiffScheme2>::inX(grid, ijk);
+        ComputeType iddy  = D2<DiffScheme2>::inY(grid, ijk);
+        ComputeType iddz  = D2<DiffScheme2>::inZ(grid, ijk);
 
-         ValueType iddxy = D2<DiffScheme2>::inXandY(grid, ijk);
-         ValueType iddyz = D2<DiffScheme2>::inYandZ(grid, ijk);
-         ValueType iddxz = D2<DiffScheme2>::inXandZ(grid, ijk);
+        ComputeType iddxy = D2<DiffScheme2>::inXandY(grid, ijk);
+        ComputeType iddyz = D2<DiffScheme2>::inYandZ(grid, ijk);
+        ComputeType iddxz = D2<DiffScheme2>::inXandZ(grid, ijk);
 
-         // second derivatives in index space
-         Mat3d  d2_is(iddx,  iddxy, iddxz,
-                      iddxy, iddy,  iddyz,
-                      iddxz, iddyz, iddz);
+        // second derivatives in index space
+        Mat3d  d2_is(iddx,  iddxy, iddxz,
+                     iddxy, iddy,  iddyz,
+                     iddxz, iddyz, iddz);
 
-         // convert second derivatives to world space
-         Mat3d d2_ws;
-         if (is_linear<MapType>::value) {//resolved at compiletime
-             d2_ws = map.applyIJC(d2_is);
-         } else {
-             d2_ws = map.applyIJC(d2_is, d1_is, ijk.asVec3d());
-         }
+        // convert second derivatives to world space
+        Mat3d d2_ws;
+        if (is_linear<MapType>::value) {//resolved at compiletime
+            d2_ws = map.applyIJC(d2_is);
+        } else {
+            d2_ws = map.applyIJC(d2_is, d1_is, ijk.asVec3d());
+        }
 
-         // assemble the nominator and denominator for mean curvature
-         alpha = (Dx2*(d2_ws(1,1)+d2_ws(2,2))+Dy2*(d2_ws(0,0)+d2_ws(2,2))
-                  +Dz2*(d2_ws(0,0)+d2_ws(1,1))
-                  -2*(d1_ws(0)*(d1_ws(1)*d2_ws(0,1)+d1_ws(2)*d2_ws(0,2))
-                      +d1_ws(1)*d1_ws(2)*d2_ws(1,2)));
-         beta = std::sqrt(normGrad); // * 1/dx
-         return true;
+        // assemble the nominator and denominator for mean curvature
+        alpha = (Dx2*(d2_ws(1,1)+d2_ws(2,2))+Dy2*(d2_ws(0,0)+d2_ws(2,2))
+                 +Dz2*(d2_ws(0,0)+d2_ws(1,1))
+                 -2*(d1_ws(0)*(d1_ws(1)*d2_ws(0,1)+d1_ws(2)*d2_ws(0,2))
+                     +d1_ws(1)*d1_ws(2)*d2_ws(1,2)));
+        beta = std::sqrt(normGrad); // * 1/dx
+        return true;
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType result(const MapType& map,
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const MapType& map,
         const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
         double alpha, beta;
         return compute(map, grid, ijk, alpha, beta) ?
-               ValueType(alpha/(2. *math::Pow3(beta))) : 0;
+               ComputeType(alpha/(2. *math::Pow3(beta))) : ComputeType(0);
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType normGrad(const MapType& map,
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    normGrad(const MapType& map,
         const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
         double alpha, beta;
         return compute(map, grid, ijk, alpha, beta) ?
-               ValueType(alpha/(2. *math::Pow2(beta))) : 0;
+               ComputeType(alpha/(2. *math::Pow2(beta))) : ComputeType(0);
     }
 
     /// @brief Stencil access version
@@ -1848,73 +2054,79 @@ struct MeanCurvature
                         double& alpha, double& beta)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-         // compute the gradient in index and world space
-         Vec3d d1_is(D1<DiffScheme1>::inX(stencil),
-                     D1<DiffScheme1>::inY(stencil),
-                     D1<DiffScheme1>::inZ(stencil) ), d1_ws;
-         if (is_linear<MapType>::value) {//resolved at compiletime
-             d1_ws = map.applyIJT(d1_is);
-         } else {
-             d1_ws = map.applyIJT(d1_is, stencil.getCenterCoord().asVec3d());
-         }
-         const double Dx2 = d1_ws(0)*d1_ws(0);
-         const double Dy2 = d1_ws(1)*d1_ws(1);
-         const double Dz2 = d1_ws(2)*d1_ws(2);
-         const double normGrad = Dx2 + Dy2 + Dz2;
-         if (normGrad <= math::Tolerance<double>::value()) {
-             alpha = beta = 0;
-             return false;
-         }
+        // compute the gradient in index and world space
+        Vec3d d1_is(D1<DiffScheme1>::inX(stencil),
+                    D1<DiffScheme1>::inY(stencil),
+                    D1<DiffScheme1>::inZ(stencil) ), d1_ws;
+        if (is_linear<MapType>::value) {//resolved at compiletime
+            d1_ws = map.applyIJT(d1_is);
+        } else {
+            d1_ws = map.applyIJT(d1_is, stencil.getCenterCoord().asVec3d());
+        }
+        const double Dx2 = d1_ws(0)*d1_ws(0);
+        const double Dy2 = d1_ws(1)*d1_ws(1);
+        const double Dz2 = d1_ws(2)*d1_ws(2);
+        const double normGrad = Dx2 + Dy2 + Dz2;
+        if (normGrad <= math::Tolerance<double>::value()) {
+            alpha = beta = double(0);
+            return false;
+        }
 
-         // all the second derivatives in index space
-         ValueType iddx  = D2<DiffScheme2>::inX(stencil);
-         ValueType iddy  = D2<DiffScheme2>::inY(stencil);
-         ValueType iddz  = D2<DiffScheme2>::inZ(stencil);
+        // all the second derivatives in index space
+        ComputeType iddx  = D2<DiffScheme2>::inX(stencil);
+        ComputeType iddy  = D2<DiffScheme2>::inY(stencil);
+        ComputeType iddz  = D2<DiffScheme2>::inZ(stencil);
 
-         ValueType iddxy = D2<DiffScheme2>::inXandY(stencil);
-         ValueType iddyz = D2<DiffScheme2>::inYandZ(stencil);
-         ValueType iddxz = D2<DiffScheme2>::inXandZ(stencil);
+        ComputeType iddxy = D2<DiffScheme2>::inXandY(stencil);
+        ComputeType iddyz = D2<DiffScheme2>::inYandZ(stencil);
+        ComputeType iddxz = D2<DiffScheme2>::inXandZ(stencil);
 
-         // second derivatives in index space
-         Mat3d  d2_is(iddx,  iddxy, iddxz,
-                      iddxy, iddy,  iddyz,
-                      iddxz, iddyz, iddz);
+        // second derivatives in index space
+        Mat3d  d2_is(iddx,  iddxy, iddxz,
+                     iddxy, iddy,  iddyz,
+                     iddxz, iddyz, iddz);
 
-         // convert second derivatives to world space
-         Mat3d d2_ws;
-         if (is_linear<MapType>::value) {//resolved at compiletime
-             d2_ws = map.applyIJC(d2_is);
-         } else {
-             d2_ws = map.applyIJC(d2_is, d1_is, stencil.getCenterCoord().asVec3d());
-         }
+        // convert second derivatives to world space
+        Mat3d d2_ws;
+        if (is_linear<MapType>::value) {//resolved at compiletime
+            d2_ws = map.applyIJC(d2_is);
+        } else {
+            d2_ws = map.applyIJC(d2_is, d1_is, stencil.getCenterCoord().asVec3d());
+        }
 
-         // for return
-         alpha = (Dx2*(d2_ws(1,1)+d2_ws(2,2))+Dy2*(d2_ws(0,0)+d2_ws(2,2))
-                  +Dz2*(d2_ws(0,0)+d2_ws(1,1))
-                  -2*(d1_ws(0)*(d1_ws(1)*d2_ws(0,1)+d1_ws(2)*d2_ws(0,2))
-                      +d1_ws(1)*d1_ws(2)*d2_ws(1,2)));
-         beta  = std::sqrt(normGrad); // * 1/dx
-         return true;
+        // for return
+        alpha = (Dx2*(d2_ws(1,1)+d2_ws(2,2))+Dy2*(d2_ws(0,0)+d2_ws(2,2))
+                 +Dz2*(d2_ws(0,0)+d2_ws(1,1))
+                 -2*(d1_ws(0)*(d1_ws(1)*d2_ws(0,1)+d1_ws(2)*d2_ws(0,2))
+                     +d1_ws(1)*d1_ws(2)*d2_ws(1,2)));
+        beta  = std::sqrt(normGrad); // * 1/dx
+        return true;
     }
 
     template<typename StencilT>
-    static typename StencilT::ValueType
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const MapType& map, const StencilT stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
         double alpha, beta;
         return compute(map, stencil, alpha, beta) ?
-               ValueType(alpha/(2*math::Pow3(beta))) : 0;
+               ComputeType(alpha/(2*math::Pow3(beta))) : ComputeType(0);
     }
 
     template<typename StencilT>
-    static typename StencilT::ValueType normGrad(const MapType& map, const StencilT stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    normGrad(const MapType& map, const StencilT stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
+
         double alpha, beta;
         return compute(map, stencil, alpha, beta) ?
-               ValueType(alpha/(2*math::Pow2(beta))) : 0;
+               ComputeType(alpha/(2*math::Pow2(beta))) : ComputeType(0);
     }
 };
 
@@ -1924,46 +2136,54 @@ struct MeanCurvature<TranslationMap, DiffScheme2, DiffScheme1>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const TranslationMap&,
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const TranslationMap&,
         const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         return ISMeanCurvature<DiffScheme2, DiffScheme1>::result(grid, ijk, alpha, beta) ?
-               ValueType(alpha /(2*math::Pow3(beta))) : 0;
+               ComputeType(alpha /(2*math::Pow3(beta))) : ComputeType(0);
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType normGrad(const TranslationMap&,
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    normGrad(const TranslationMap&,
         const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         return ISMeanCurvature<DiffScheme2, DiffScheme1>::result(grid, ijk, alpha, beta) ?
-               ValueType(alpha/(2*math::Pow2(beta))) : 0;
+               ComputeType(alpha/(2*math::Pow2(beta))) : ComputeType(0);
     }
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const TranslationMap&, const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const TranslationMap&, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         return ISMeanCurvature<DiffScheme2, DiffScheme1>::result(stencil, alpha, beta) ?
-               ValueType(alpha /(2*math::Pow3(beta))) : 0;
+               ComputeType(alpha /(2*math::Pow3(beta))) : ComputeType(0);
     }
 
     template<typename StencilT>
-    static typename StencilT::ValueType normGrad(const TranslationMap&, const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    normGrad(const TranslationMap&, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         return ISMeanCurvature<DiffScheme2, DiffScheme1>::result(stencil, alpha, beta) ?
-               ValueType(alpha/(2*math::Pow2(beta))) : 0;
+               ComputeType(alpha/(2*math::Pow2(beta))) : ComputeType(0);
     }
 };
 
@@ -1973,58 +2193,66 @@ struct MeanCurvature<UniformScaleMap, DiffScheme2, DiffScheme1>
 {
     // random access version
     template<typename Accessor>
-    static typename Accessor::ValueType result(const UniformScaleMap& map,
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    result(const UniformScaleMap& map,
         const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         if (ISMeanCurvature<DiffScheme2, DiffScheme1>::result(grid, ijk, alpha, beta)) {
-            ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
-            return ValueType(alpha*inv2dx/math::Pow3(beta));
+            ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+            return ComputeType(alpha*inv2dx/math::Pow3(beta));
         }
-        return 0;
+        return ComputeType(0);
     }
 
     template<typename Accessor>
-    static typename Accessor::ValueType normGrad(const UniformScaleMap& map,
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
+    normGrad(const UniformScaleMap& map,
         const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         if (ISMeanCurvature<DiffScheme2, DiffScheme1>::result(grid, ijk, alpha, beta)) {
-            ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
-            return ValueType(alpha*invdxdx/(2*math::Pow2(beta)));
+            ComputeType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+            return ComputeType(alpha*invdxdx/(2*math::Pow2(beta)));
         }
-        return 0;
+        return ComputeType(0);
     }
 
     // stencil access version
     template<typename StencilT>
-    static typename StencilT::ValueType result(const UniformScaleMap& map, const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    result(const UniformScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         if (ISMeanCurvature<DiffScheme2, DiffScheme1>::result(stencil, alpha, beta)) {
-            ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
-            return ValueType(alpha*inv2dx/math::Pow3(beta));
+            ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+            return ComputeType(alpha*inv2dx/math::Pow3(beta));
         }
-        return 0;
+        return ComputeType(0);
     }
 
     template<typename StencilT>
-    static typename StencilT::ValueType normGrad(const UniformScaleMap& map, const StencilT& stencil)
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
+    normGrad(const UniformScaleMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         if (ISMeanCurvature<DiffScheme2, DiffScheme1>::result(stencil, alpha, beta)) {
-            ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
-            return ValueType(alpha*invdxdx/(2*math::Pow2(beta)));
+            ComputeType invdxdx = ComputeType(map.getInvScaleSqr()[0]);
+            return ComputeType(alpha*invdxdx/(2*math::Pow2(beta)));
         }
-        return 0;
+        return ComputeType(0);
     }
 };
 
@@ -2033,57 +2261,65 @@ template<DDScheme DiffScheme2, DScheme DiffScheme1>
 struct MeanCurvature<UniformScaleTranslateMap, DiffScheme2, DiffScheme1>
 {
     // random access version
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     result(const UniformScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         if (ISMeanCurvature<DiffScheme2, DiffScheme1>::result(grid, ijk, alpha, beta)) {
-            ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
-            return ValueType(alpha*inv2dx/math::Pow3(beta));
+            ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+            return ComputeType(alpha*inv2dx/math::Pow3(beta));
         }
-        return 0;
+        return ComputeType(0);
     }
 
-    template<typename Accessor> static typename Accessor::ValueType
+    template<typename Accessor>
+    static typename ComputeTypeFor<typename Accessor::ValueType>::type
     normGrad(const UniformScaleTranslateMap& map, const Accessor& grid, const Coord& ijk)
     {
         using ValueType = typename Accessor::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         if (ISMeanCurvature<DiffScheme2, DiffScheme1>::result(grid, ijk, alpha, beta)) {
-            ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
-            return ValueType(alpha*invdxdx/(2*math::Pow2(beta)));
+            ComputeType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+            return ComputeType(alpha*invdxdx/(2*math::Pow2(beta)));
         }
-        return 0;
+        return ComputeType(0);
     }
 
     // stencil access version
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     result(const UniformScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         if (ISMeanCurvature<DiffScheme2, DiffScheme1>::result(stencil, alpha, beta)) {
-            ValueType inv2dx = ValueType(map.getInvTwiceScale()[0]);
-            return ValueType(alpha*inv2dx/math::Pow3(beta));
+            ComputeType inv2dx = ValueType(map.getInvTwiceScale()[0]);
+            return ComputeType(alpha*inv2dx/math::Pow3(beta));
         }
-        return 0;
+        return ComputeType(0);
     }
 
-    template<typename StencilT> static typename StencilT::ValueType
+    template<typename StencilT>
+    static typename ComputeTypeFor<typename StencilT::ValueType>::type
     normGrad(const UniformScaleTranslateMap& map, const StencilT& stencil)
     {
         using ValueType = typename StencilT::ValueType;
+        using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
-        ValueType alpha, beta;
+        ComputeType alpha, beta;
         if (ISMeanCurvature<DiffScheme2, DiffScheme1>::result(stencil, alpha, beta)) {
-            ValueType invdxdx = ValueType(map.getInvScaleSqr()[0]);
-            return ValueType(alpha*invdxdx/(2*math::Pow2(beta)));
+            ComputeType invdxdx = ValueType(map.getInvScaleSqr()[0]);
+            return ComputeType(alpha*invdxdx/(2*math::Pow2(beta)));
         }
-        return 0;
+        return ComputeType(0);
     }
 };
 

--- a/openvdb/openvdb/math/Stencils.h
+++ b/openvdb/openvdb/math/Stencils.h
@@ -16,7 +16,7 @@
 #include <algorithm>
 #include <vector>                          // for std::vector
 #include <bitset>                          // for std::bitset
-#include <openvdb/Types.h>                 // for Real
+#include <openvdb/Types.h>                 // for Real and ComputeTypeFor
 #include <openvdb/tree/ValueAccessor.h>
 
 #include "Math.h"             // for Pow2, needed by WENO and Godunov
@@ -35,9 +35,11 @@ template<typename DerivedType, typename GridT, bool IsSafe>
 class BaseStencil
 {
 public:
-    typedef GridT                                       GridType;
-    typedef typename GridT::TreeType                    TreeType;
-    typedef typename GridT::ValueType                   ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type ValueType;
+
     typedef tree::ValueAccessor<const TreeType, IsSafe> AccessorType;
     typedef std::vector<ValueType>                      BufferType;
 
@@ -243,14 +245,16 @@ namespace { // anonymous namespace for stencil-layout map
 
 
 template<typename GridT, bool IsSafe = true>
-class SevenPointStencil: public BaseStencil<SevenPointStencil<GridT, IsSafe>, GridT, IsSafe>
+class SevenPointStencil
+    : public BaseStencil<SevenPointStencil<GridT, IsSafe>, GridT, IsSafe>
 {
     typedef SevenPointStencil<GridT, IsSafe>  SelfT;
     typedef BaseStencil<SelfT, GridT, IsSafe> BaseType;
 public:
-    typedef GridT                             GridType;
-    typedef typename GridT::TreeType          TreeType;
-    typedef typename GridT::ValueType         ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     static const int SIZE = 7;
 
@@ -297,14 +301,16 @@ namespace { // anonymous namespace for stencil-layout map
 }
 
 template<typename GridT, bool IsSafe = true>
-class BoxStencil: public BaseStencil<BoxStencil<GridT, IsSafe>, GridT, IsSafe>
+class BoxStencil
+    : public BaseStencil<BoxStencil<GridT, IsSafe>, GridT, IsSafe>
 {
     typedef BoxStencil<GridT, IsSafe>         SelfT;
     typedef BaseStencil<SelfT, GridT, IsSafe> BaseType;
 public:
-    typedef GridT                             GridType;
-    typedef typename GridT::TreeType          TreeType;
-    typedef typename GridT::ValueType         ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     static const int SIZE = 8;
 
@@ -468,14 +474,15 @@ namespace { // anonymous namespace for stencil-layout map
 
 template<typename GridT, bool IsSafe = true>
 class SecondOrderDenseStencil
-    : public BaseStencil<SecondOrderDenseStencil<GridT, IsSafe>, GridT, IsSafe >
+    : public BaseStencil<SecondOrderDenseStencil<GridT, IsSafe>, GridT, IsSafe>
 {
     typedef SecondOrderDenseStencil<GridT, IsSafe> SelfT;
-    typedef BaseStencil<SelfT, GridT, IsSafe >     BaseType;
+    typedef BaseStencil<SelfT, GridT, IsSafe>      BaseType;
 public:
-    typedef GridT                                  GridType;
-    typedef typename GridT::TreeType               TreeType;
-    typedef typename GridType::ValueType           ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     static const int SIZE = 19;
 
@@ -551,11 +558,12 @@ class ThirteenPointStencil
     : public BaseStencil<ThirteenPointStencil<GridT, IsSafe>, GridT, IsSafe>
 {
     typedef ThirteenPointStencil<GridT, IsSafe> SelfT;
-    typedef BaseStencil<SelfT, GridT, IsSafe >  BaseType;
+    typedef BaseStencil<SelfT, GridT, IsSafe>   BaseType;
 public:
-    typedef GridT                               GridType;
-    typedef typename GridT::TreeType            TreeType;
-    typedef typename GridType::ValueType        ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     static const int SIZE = 13;
 
@@ -682,11 +690,12 @@ class FourthOrderDenseStencil
     : public BaseStencil<FourthOrderDenseStencil<GridT, IsSafe>, GridT, IsSafe>
 {
     typedef FourthOrderDenseStencil<GridT, IsSafe> SelfT;
-    typedef BaseStencil<SelfT, GridT, IsSafe >     BaseType;
+    typedef BaseStencil<SelfT, GridT, IsSafe>      BaseType;
 public:
-    typedef GridT                                  GridType;
-    typedef typename GridT::TreeType               TreeType;
-    typedef typename GridType::ValueType           ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     static const int SIZE = 61;
 
@@ -821,11 +830,12 @@ class NineteenPointStencil
     : public BaseStencil<NineteenPointStencil<GridT, IsSafe>, GridT, IsSafe>
 {
     typedef NineteenPointStencil<GridT, IsSafe> SelfT;
-    typedef BaseStencil<SelfT, GridT, IsSafe >  BaseType;
+    typedef BaseStencil<SelfT, GridT, IsSafe>   BaseType;
 public:
-    typedef GridT                               GridType;
-    typedef typename GridT::TreeType            TreeType;
-    typedef typename GridType::ValueType        ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     static const int SIZE = 19;
 
@@ -1037,11 +1047,12 @@ class SixthOrderDenseStencil
     : public BaseStencil<SixthOrderDenseStencil<GridT, IsSafe>, GridT, IsSafe>
 {
     typedef SixthOrderDenseStencil<GridT, IsSafe> SelfT;
-    typedef BaseStencil<SelfT, GridT, IsSafe >    BaseType;
+    typedef BaseStencil<SelfT, GridT, IsSafe>     BaseType;
 public:
-    typedef GridT                                 GridType;
-    typedef typename GridT::TreeType              TreeType;
-    typedef typename GridType::ValueType          ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     static const int SIZE = 127;
 
@@ -1228,14 +1239,16 @@ namespace { // anonymous namespace for stencil-layout map
 /// @note For optimal random access performance this class
 /// includes its own grid accessor.
 template<typename GridT, bool IsSafe = true>
-class GradStencil : public BaseStencil<GradStencil<GridT, IsSafe>, GridT, IsSafe>
+class GradStencil
+    : public BaseStencil<GradStencil<GridT, IsSafe>, GridT, IsSafe>
 {
-    typedef GradStencil<GridT, IsSafe>         SelfT;
-    typedef BaseStencil<SelfT, GridT, IsSafe > BaseType;
+    typedef GradStencil<GridT, IsSafe>        SelfT;
+    typedef BaseStencil<SelfT, GridT, IsSafe> BaseType;
 public:
-    typedef GridT                              GridType;
-    typedef typename GridT::TreeType           TreeType;
-    typedef typename GridType::ValueType       ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     static const int SIZE = 7;
 
@@ -1362,14 +1375,16 @@ private:
 /// @note For optimal random access performance this class
 /// includes its own grid accessor.
 template<typename GridT, bool IsSafe = true>
-class WenoStencil: public BaseStencil<WenoStencil<GridT, IsSafe>, GridT, IsSafe>
+class WenoStencil
+    : public BaseStencil<WenoStencil<GridT, IsSafe>, GridT, IsSafe>
 {
-    typedef WenoStencil<GridT, IsSafe>         SelfT;
-    typedef BaseStencil<SelfT, GridT, IsSafe > BaseType;
+    typedef WenoStencil<GridT, IsSafe>        SelfT;
+    typedef BaseStencil<SelfT, GridT, IsSafe> BaseType;
 public:
-    typedef GridT                              GridType;
-    typedef typename GridT::TreeType           TreeType;
-    typedef typename GridType::ValueType       ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     static const int SIZE = 19;
 
@@ -1512,14 +1527,16 @@ private:
 
 
 template<typename GridT, bool IsSafe = true>
-class CurvatureStencil: public BaseStencil<CurvatureStencil<GridT, IsSafe>, GridT, IsSafe>
+class CurvatureStencil
+    : public BaseStencil<CurvatureStencil<GridT, IsSafe>, GridT, IsSafe>
 {
     typedef CurvatureStencil<GridT, IsSafe>   SelfT;
     typedef BaseStencil<SelfT, GridT, IsSafe> BaseType;
 public:
-    typedef GridT                             GridType;
-    typedef typename GridT::TreeType          TreeType;
-    typedef typename GridT::ValueType         ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
      static const int SIZE = 19;
 
@@ -1545,7 +1562,7 @@ public:
     {
         Real alpha, normGrad;
         return this->meanCurvature(alpha, normGrad) ?
-               ValueType(alpha*mInv2Dx/math::Pow3(normGrad)) : 0;
+               ValueType(alpha*mInv2Dx/math::Pow3(normGrad)) : ValueType(0);
     }
 
     /// @brief Return the Gaussian curvature at the previously buffered location.
@@ -1556,7 +1573,7 @@ public:
     {
         Real alpha, normGrad;
         return this->gaussianCurvature(alpha, normGrad) ?
-               ValueType(alpha*mInvDx2/math::Pow4(normGrad)) : 0;
+               ValueType(alpha*mInvDx2/math::Pow4(normGrad)) : ValueType(0);
     }
 
     /// @brief Return both the mean and the Gaussian curvature at the
@@ -1571,7 +1588,7 @@ public:
           mean  = ValueType(alphaM*mInv2Dx/math::Pow3(normGrad));
           gauss = ValueType(alphaG*mInvDx2/math::Pow4(normGrad));
         } else {
-          mean = gauss = 0;
+          mean = gauss = ValueType(0);
         }
     }
 
@@ -1585,7 +1602,7 @@ public:
     {
         Real alpha, normGrad;
         return this->meanCurvature(alpha, normGrad) ?
-               ValueType(alpha*mInvDx2/(2*math::Pow2(normGrad))) : 0;
+               ValueType(alpha*mInvDx2/(2*math::Pow2(normGrad))) : ValueType(0);
     }
 
     /// Return the mean Gaussian multiplied by the norm of the
@@ -1597,7 +1614,7 @@ public:
     {
         Real alpha, normGrad;
         return this->gaussianCurvature(alpha, normGrad) ?
-               ValueType(2*alpha*mInv2Dx*mInvDx2/math::Pow3(normGrad)) : 0;
+               ValueType(2*alpha*mInv2Dx*mInvDx2/math::Pow3(normGrad)) : ValueType(0);
     }
 
     /// @brief Return both the mean and the Gaussian curvature at the
@@ -1627,7 +1644,7 @@ public:
         Real alphaM, alphaG, normGrad;
         if (this->curvatures(alphaM, alphaG, normGrad)) {
           const Real mean = alphaM*mInv2Dx/math::Pow3(normGrad);
-          const Real tmp = std::sqrt(mean*mean - alphaG*mInvDx2/math::Pow4(normGrad));
+          const Real tmp = math::Sqrt(mean*mean - alphaG*mInvDx2/math::Pow4(normGrad));
           pair.first  = ValueType(mean - tmp);
           pair.second = ValueType(mean + tmp);
         }
@@ -1761,14 +1778,16 @@ private:
 
 /// @brief Dense stencil of a given width
 template<typename GridT, bool IsSafe = true>
-class DenseStencil: public BaseStencil<DenseStencil<GridT, IsSafe>, GridT, IsSafe>
+class DenseStencil
+    : public BaseStencil<DenseStencil<GridT, IsSafe>, GridT, IsSafe>
 {
     typedef DenseStencil<GridT, IsSafe>       SelfT;
     typedef BaseStencil<SelfT, GridT, IsSafe> BaseType;
 public:
-    typedef GridT                             GridType;
-    typedef typename GridT::TreeType          TreeType;
-    typedef typename GridType::ValueType      ValueType;
+    typedef GridT                    GridType;
+    typedef typename GridT::TreeType TreeType;
+
+    typedef typename ComputeTypeFor<typename GridT::ValueType>::type  ValueType;
 
     DenseStencil(const GridType& grid, int halfWidth)
         : BaseType(grid, /*size=*/math::Pow3(2 * halfWidth + 1))

--- a/openvdb/openvdb/math/Vec3.h
+++ b/openvdb/openvdb/math/Vec3.h
@@ -663,11 +663,13 @@ using Vec3i = Vec3<int32_t>;
 using Vec3ui = Vec3<uint32_t>;
 using Vec3s = Vec3<float>;
 using Vec3d = Vec3<double>;
+using Vec3h = Vec3<math::half>;
 
 OPENVDB_IS_POD(Vec3i)
 OPENVDB_IS_POD(Vec3ui)
 OPENVDB_IS_POD(Vec3s)
 OPENVDB_IS_POD(Vec3d)
+OPENVDB_IS_POD(Vec3h)
 
 } // namespace math
 } // namespace OPENVDB_VERSION_NAME

--- a/openvdb/openvdb/openvdb.h
+++ b/openvdb/openvdb/openvdb.h
@@ -98,7 +98,7 @@ using IntegerGridTypes = TypeList<Int32Grid, Int64Grid>;
 /// The scalar Grid types which OpenVDB will register by default. This is a
 /// combination of native floating point and integer grid types. Note that
 /// this list does not include Bool or Mask Grids.
-using NumericGridTypes  = RealGridTypes::Append<IntegerGridTypes>;
+using NumericGridTypes  = ExtendedRealGridTypes::Append<IntegerGridTypes>;
 /// The Vec3 Grid types which OpenVDB will register by default.
 using Vec3GridTypes     = TypeList<Vec3IGrid, Vec3SGrid, Vec3DGrid>;
 

--- a/openvdb/openvdb/openvdb.h
+++ b/openvdb/openvdb/openvdb.h
@@ -120,11 +120,12 @@ template <typename T> using ToTreeType = typename T::TreeType;
 }
 /// @name Lists of native Tree Types
 /// @{
-using RealTreeTypes    = RealGridTypes::Transform<internal::ToTreeType>;
-using IntegerTreeTypes = IntegerGridTypes::Transform<internal::ToTreeType>;
-using NumericTreeTypes = NumericGridTypes::Transform<internal::ToTreeType>;
-using Vec3TreeTypes    = Vec3GridTypes::Transform<internal::ToTreeType>;
-using TreeTypes        = GridTypes::Transform<internal::ToTreeType>;
+using RealTreeTypes            = RealGridTypes::Transform<internal::ToTreeType>;
+using ExtendedRealTreeTypes    = ExtendedRealGridTypes::Transform<internal::ToTreeType>;
+using IntegerTreeTypes         = IntegerGridTypes::Transform<internal::ToTreeType>;
+using NumericTreeTypes         = NumericGridTypes::Transform<internal::ToTreeType>;
+using Vec3TreeTypes            = Vec3GridTypes::Transform<internal::ToTreeType>;
+using TreeTypes                = GridTypes::Transform<internal::ToTreeType>;
 /// @}
 
 

--- a/openvdb/openvdb/openvdb.h
+++ b/openvdb/openvdb/openvdb.h
@@ -53,6 +53,7 @@ namespace io { class DelayedLoadMetadata; }
 using BoolTree     = tree::Tree4<bool,        5, 4, 3>::Type;
 using DoubleTree   = tree::Tree4<double,      5, 4, 3>::Type;
 using FloatTree    = tree::Tree4<float,       5, 4, 3>::Type;
+using HalfTree     = tree::Tree4<Half,        5, 4, 3>::Type;
 using Int32Tree    = tree::Tree4<int32_t,     5, 4, 3>::Type;
 using Int64Tree    = tree::Tree4<int64_t,     5, 4, 3>::Type;
 using MaskTree     = tree::Tree4<ValueMask,   5, 4, 3>::Type;
@@ -73,6 +74,7 @@ using VectorTree   = Vec3fTree;
 using BoolGrid     = Grid<BoolTree>;
 using DoubleGrid   = Grid<DoubleTree>;
 using FloatGrid    = Grid<FloatTree>;
+using HalfGrid     = Grid<HalfTree>;
 using Int32Grid    = Grid<Int32Tree>;
 using Int64Grid    = Grid<Int64Tree>;
 using MaskGrid     = Grid<MaskTree>;
@@ -88,7 +90,7 @@ using VectorGrid   = Vec3fGrid;
 /// @name Lists of native Grid Types
 /// @{
 /// The floating point Grid types which OpenVDB will register by default.
-using RealGridTypes   = TypeList<FloatGrid, DoubleGrid>;
+using RealGridTypes   = TypeList<HalfGrid, FloatGrid, DoubleGrid>;
 /// The integer Grid types which OpenVDB will register by default.
 using IntegerGridTypes = TypeList<Int32Grid, Int64Grid>;
 /// The scalar Grid types which OpenVDB will register by default. This is a
@@ -204,6 +206,7 @@ using MetaTypes = TypeList<
     BoolMetadata,
     DoubleMetadata,
     FloatMetadata,
+    HalfMetadata,
     Int32Metadata,
     Int64Metadata,
     StringMetadata,

--- a/openvdb/openvdb/openvdb.h
+++ b/openvdb/openvdb/openvdb.h
@@ -90,7 +90,9 @@ using VectorGrid   = Vec3fGrid;
 /// @name Lists of native Grid Types
 /// @{
 /// The floating point Grid types which OpenVDB will register by default.
-using RealGridTypes   = TypeList<HalfGrid, FloatGrid, DoubleGrid>;
+using RealGridTypes   = TypeList<FloatGrid, DoubleGrid>;
+/// The extended floating point Grid types which OpenVDB will register by default.
+using ExtendedRealGridTypes = RealGridTypes::Append<HalfGrid>;
 /// The integer Grid types which OpenVDB will register by default.
 using IntegerGridTypes = TypeList<Int32Grid, Int64Grid>;
 /// The scalar Grid types which OpenVDB will register by default. This is a

--- a/openvdb/openvdb/tools/FastSweeping.h
+++ b/openvdb/openvdb/tools/FastSweeping.h
@@ -30,6 +30,7 @@
 //#define BENCHMARK_FAST_SWEEPING
 
 #include <openvdb/openvdb.h>
+#include <openvdb/Types.h>
 #include <openvdb/Platform.h>
 #include <openvdb/math/Math.h> // for Abs() and isExactlyEqual()
 #include <openvdb/math/Stencils.h> // for GradStencil
@@ -460,7 +461,7 @@ maskSdf(const GridT &sdfGrid,
 template<typename SdfGridT, typename ExtValueT = typename SdfGridT::ValueType>
 class FastSweeping
 {
-    static_assert(std::is_floating_point<typename SdfGridT::ValueType>::value,
+    static_assert(openvdb::is_floating_point<typename SdfGridT::ValueType>::value,
                   "FastSweeping requires SdfGridT to have floating-point values");
     // Defined types related to the signed distance (or fog) grid
     using SdfValueT = typename SdfGridT::ValueType;

--- a/openvdb/openvdb/tools/LevelSetAdvect.h
+++ b/openvdb/openvdb/tools/LevelSetAdvect.h
@@ -15,6 +15,7 @@
 #include "LevelSetTracker.h"
 #include "VelocityFields.h" // for EnrightField
 #include <openvdb/Platform.h>
+#include <openvdb/Types.h> // for ComputeTypeFor
 #include <openvdb/math/FiniteDifference.h>
 #include <openvdb/util/Assert.h>
 //#include <openvdb/util/CpuTimer.h>
@@ -80,6 +81,7 @@ public:
     using LeafType = typename TrackerT::LeafType;
     using BufferType = typename TrackerT::BufferType;
     using ValueType = typename TrackerT::ValueType;
+    using ComputeType = typename TrackerT::ComputeType;
     using VectorType = typename FieldT::VectorType;
 
     /// Main constructor
@@ -134,7 +136,7 @@ public:
     /// final time, time1. If time0>time1 backward advection is performed.
     ///
     /// @return number of CFL iterations used to advect from time0 to time1
-    size_t advect(ValueType time0, ValueType time1);
+    size_t advect(ComputeType time0, ComputeType time1);
 
 private:
     // disallow copy construction and copy by assignment!
@@ -154,7 +156,7 @@ private:
         virtual ~Advect() { if (mIsMaster) this->clearField(); }
         /// Advect the level set from its current time, time0, to its final time, time1.
         /// @return number of CFL iterations
-        size_t advect(ValueType time0, ValueType time1);
+        size_t advect(ComputeType time0, ComputeType time1);
         /// Used internally by tbb::parallel_for()
         void operator()(const LeafRange& r) const
         {
@@ -164,13 +166,13 @@ private:
         /// method calling tbb
         void cook(const char* msg, size_t swapBuffer = 0);
         /// Sample field and return the CFL time step
-        typename GridT::ValueType sampleField(ValueType time0, ValueType time1);
-        template <bool Aligned> void sample(const LeafRange& r, ValueType t0, ValueType t1);
-        inline void sampleXformed(const LeafRange& r, ValueType t0, ValueType t1)
+        ComputeType sampleField(ComputeType time0, ComputeType time1);
+        template <bool Aligned> void sample(const LeafRange& r, ComputeType t0, ComputeType t1);
+        inline void sampleXformed(const LeafRange& r, ComputeType t0, ComputeType t1)
         {
             this->sample<false>(r, t0, t1);
         }
-        inline void sampleAligned(const LeafRange& r, ValueType t0, ValueType t1)
+        inline void sampleAligned(const LeafRange& r, ComputeType t0, ComputeType t1)
         {
             this->sample<true>(r, t0, t1);
         }
@@ -178,11 +180,11 @@ private:
         // Convex combination of Phi and a forward Euler advection steps:
         // Phi(result) = alpha * Phi(phi) + (1-alpha) * (Phi(0) - dt * Speed(speed)*|Grad[Phi(0)]|);
         template <int Nominator, int Denominator>
-        void euler(const LeafRange&, ValueType, Index, Index);
-        inline void euler01(const LeafRange& r, ValueType t) {this->euler<0,1>(r, t, 0, 1);}
-        inline void euler12(const LeafRange& r, ValueType t) {this->euler<1,2>(r, t, 1, 1);}
-        inline void euler34(const LeafRange& r, ValueType t) {this->euler<3,4>(r, t, 1, 2);}
-        inline void euler13(const LeafRange& r, ValueType t) {this->euler<1,3>(r, t, 1, 2);}
+        void euler(const LeafRange&, ComputeType, Index, Index);
+        inline void euler01(const LeafRange& r, ComputeType t) {this->euler<0,1>(r, t, 0, 1);}
+        inline void euler12(const LeafRange& r, ComputeType t) {this->euler<1,2>(r, t, 1, 1);}
+        inline void euler34(const LeafRange& r, ComputeType t) {this->euler<3,4>(r, t, 1, 2);}
+        inline void euler13(const LeafRange& r, ComputeType t) {this->euler<1,3>(r, t, 1, 2);}
 
         LevelSetAdvection& mParent;
         VectorType*        mVelocity;
@@ -193,16 +195,16 @@ private:
     }; // end of private Advect struct
 
     template<math::BiasedGradientScheme SpatialScheme>
-    size_t advect1(ValueType time0, ValueType time1);
+    size_t advect1(ComputeType time0, ComputeType time1);
 
     template<math::BiasedGradientScheme SpatialScheme,
              math::TemporalIntegrationScheme TemporalScheme>
-    size_t advect2(ValueType time0, ValueType time1);
+    size_t advect2(ComputeType time0, ComputeType time1);
 
     template<math::BiasedGradientScheme SpatialScheme,
              math::TemporalIntegrationScheme TemporalScheme,
              typename MapType>
-    size_t advect3(ValueType time0, ValueType time1);
+    size_t advect3(ComputeType time0, ComputeType time1);
 
     TrackerT                        mTracker;
     //each thread needs a deep copy of the field since it might contain a ValueAccessor
@@ -215,7 +217,7 @@ private:
 
 template<typename GridT, typename FieldT, typename InterruptT>
 size_t
-LevelSetAdvection<GridT, FieldT, InterruptT>::advect(ValueType time0, ValueType time1)
+LevelSetAdvection<GridT, FieldT, InterruptT>::advect(ComputeType time0, ComputeType time1)
 {
     switch (mSpatialScheme) {
     case math::FIRST_BIAS:
@@ -238,7 +240,7 @@ LevelSetAdvection<GridT, FieldT, InterruptT>::advect(ValueType time0, ValueType 
 template<typename GridT, typename FieldT, typename InterruptT>
 template<math::BiasedGradientScheme SpatialScheme>
 size_t
-LevelSetAdvection<GridT, FieldT, InterruptT>::advect1(ValueType time0, ValueType time1)
+LevelSetAdvection<GridT, FieldT, InterruptT>::advect1(ComputeType time0, ComputeType time1)
 {
     switch (mTemporalScheme) {
     case math::TVD_RK1:
@@ -257,7 +259,7 @@ LevelSetAdvection<GridT, FieldT, InterruptT>::advect1(ValueType time0, ValueType
 template<typename GridT, typename FieldT, typename InterruptT>
 template<math::BiasedGradientScheme SpatialScheme, math::TemporalIntegrationScheme TemporalScheme>
 size_t
-LevelSetAdvection<GridT, FieldT, InterruptT>::advect2(ValueType time0, ValueType time1)
+LevelSetAdvection<GridT, FieldT, InterruptT>::advect2(ComputeType time0, ComputeType time1)
 {
     const math::Transform& trans = mTracker.grid().transform();
     if (trans.mapType() == math::UniformScaleMap::mapType()) {
@@ -282,7 +284,7 @@ template<
     math::TemporalIntegrationScheme TemporalScheme,
     typename MapT>
 size_t
-LevelSetAdvection<GridT, FieldT, InterruptT>::advect3(ValueType time0, ValueType time1)
+LevelSetAdvection<GridT, FieldT, InterruptT>::advect3(ComputeType time0, ComputeType time1)
 {
     Advect<MapT, SpatialScheme, TemporalScheme> tmp(*this);
     return tmp.advect(time0, time1);
@@ -338,7 +340,7 @@ template<
 inline size_t
 LevelSetAdvection<GridT, FieldT, InterruptT>::
 Advect<MapT, SpatialScheme, TemporalScheme>::
-advect(ValueType time0, ValueType time1)
+advect(ComputeType time0, ComputeType time1)
 {
     namespace ph = std::placeholders;
 
@@ -352,7 +354,7 @@ advect(ValueType time0, ValueType time1)
         mParent.mTracker.leafs().rebuildAuxBuffers(TemporalScheme == math::TVD_RK3 ? 2 : 1);
         //timer.stop();
 
-        const ValueType dt = this->sampleField(time0, time1);
+        const ComputeType dt = this->sampleField(time0, time1);
         if ( math::isZero(dt) ) break;//V is essentially zero so terminate
 
         OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN //switch is resolved at compile-time
@@ -423,10 +425,10 @@ template<
     typename MapT,
     math::BiasedGradientScheme SpatialScheme,
     math::TemporalIntegrationScheme TemporalScheme>
-inline typename GridT::ValueType
+inline typename LevelSetAdvection<GridT, FieldT, InterruptT>::ComputeType
 LevelSetAdvection<GridT, FieldT, InterruptT>::
 Advect<MapT, SpatialScheme, TemporalScheme>::
-sampleField(ValueType time0, ValueType time1)
+sampleField(ComputeType time0, ComputeType time1)
 {
     namespace ph = std::placeholders;
 
@@ -448,19 +450,19 @@ sampleField(ValueType time0, ValueType time1)
     this->cook("Sampling advection field");
 
     // Find the extrema of the magnitude of the velocities
-    ValueType maxAbsV = 0;
+    ComputeType maxAbsV = 0;
     VectorType* v = mVelocity;
     for (size_t i = 0; i < voxelCount; ++i, ++v) {
-        maxAbsV = math::Max(maxAbsV, ValueType(v->lengthSqr()));
+        maxAbsV = math::Max(maxAbsV, ComputeType(v->lengthSqr()));
     }
 
     // Compute the CFL number
-    if (math::isApproxZero(maxAbsV, math::Delta<ValueType>::value())) return ValueType(0);
-    static const ValueType CFL = (TemporalScheme == math::TVD_RK1 ? ValueType(0.3) :
-        TemporalScheme == math::TVD_RK2 ? ValueType(0.9) :
-        ValueType(1.0))/math::Sqrt(ValueType(3.0));
-    const ValueType dt = math::Abs(time1 - time0), dx = mParent.mTracker.voxelSize();
-    return math::Min(dt, ValueType(CFL*dx/math::Sqrt(maxAbsV)));
+    if (math::isApproxZero(maxAbsV, math::Delta<ComputeType>::value())) return ComputeType(0);
+    static const ValueType CFL = (TemporalScheme == math::TVD_RK1 ? ComputeType(0.3) :
+        TemporalScheme == math::TVD_RK2 ? ComputeType(0.9) :
+        ComputeType(1.0))/math::Sqrt(ComputeType(3.0));
+    const ComputeType dt = math::Abs(time1 - time0), dx = mParent.mTracker.voxelSize();
+    return math::Min(dt, ComputeType(CFL*dx/math::Sqrt(maxAbsV)));
 }
 
 
@@ -473,7 +475,7 @@ template<bool Aligned>
 inline void
 LevelSetAdvection<GridT, FieldT, InterruptT>::
 Advect<MapT, SpatialScheme, TemporalScheme>::
-sample(const LeafRange& range, ValueType time0, ValueType time1)
+sample(const LeafRange& range, ComputeType time0, ComputeType time1)
 {
     const bool isForward = time0 < time1;
     using VoxelIterT = typename LeafType::ValueOnCIter;
@@ -544,15 +546,15 @@ template <int Nominator, int Denominator>
 inline void
 LevelSetAdvection<GridT, FieldT, InterruptT>::
 Advect<MapT, SpatialScheme, TemporalScheme>::
-euler(const LeafRange& range, ValueType dt, Index phiBuffer, Index resultBuffer)
+euler(const LeafRange& range, ComputeType dt, Index phiBuffer, Index resultBuffer)
 {
     using SchemeT = math::BIAS_SCHEME<SpatialScheme>;
     using StencilT = typename SchemeT::template ISStencil<GridType>::StencilType;
     using VoxelIterT = typename LeafType::ValueOnCIter;
     using GradT = math::GradientBiased<MapT, SpatialScheme>;
 
-    static const ValueType Alpha = ValueType(Nominator)/ValueType(Denominator);
-    static const ValueType Beta  = ValueType(1) - Alpha;
+    static const ComputeType Alpha = ComputeType(Nominator)/ComputeType(Denominator);
+    static const ComputeType Beta  = ComputeType(1) - Alpha;
 
     mParent.mTracker.checkInterrupter();
     const MapT& map = *mMap;
@@ -564,9 +566,9 @@ euler(const LeafRange& range, ValueType dt, Index phiBuffer, Index resultBuffer)
         for (VoxelIterT voxelIter = leafIter->cbeginValueOn(); voxelIter; ++voxelIter, ++vel) {
             const Index i = voxelIter.pos();
             stencil.moveTo(voxelIter);
-            const ValueType a =
-                stencil.getValue() - dt * vel->dot(GradT::result(map, stencil, *vel));
-            result[i] = Nominator ? Alpha * phi[i] + Beta * a : a;
+            const ComputeType a =
+                stencil.getValue() - dt * ComputeType(vel->dot(GradT::result(map, stencil, *vel)));
+            result[i] = Nominator ? ValueType(Alpha * phi[i] + Beta * a) : ValueType(a);
         }//loop over active voxels in the leaf of the mask
     }//loop over leafs of the level set
 }
@@ -583,6 +585,7 @@ euler(const LeafRange& range, ValueType dt, Index phiBuffer, Index resultBuffer)
 #include <openvdb/util/ExplicitInstantiation.h>
 #endif
 
+OPENVDB_INSTANTIATE_CLASS LevelSetAdvection<HalfGrid, DiscreteField<Vec3SGrid, BoxSampler>, util::NullInterrupter>;
 OPENVDB_INSTANTIATE_CLASS LevelSetAdvection<FloatGrid, DiscreteField<Vec3SGrid, BoxSampler>, util::NullInterrupter>;
 OPENVDB_INSTANTIATE_CLASS LevelSetAdvection<DoubleGrid, DiscreteField<Vec3SGrid, BoxSampler>, util::NullInterrupter>;
 

--- a/openvdb/openvdb/tools/LevelSetFilter.h
+++ b/openvdb/openvdb/tools/LevelSetFilter.h
@@ -17,6 +17,7 @@
 
 #include "LevelSetTracker.h"
 #include "Interpolation.h"
+#include <openvdb/Types.h> // for ComputeTypeFor
 #include <algorithm> // for std::max()
 #include <functional>
 #include <type_traits>
@@ -44,8 +45,9 @@ public:
     using MaskType = MaskT;
     using TreeType = typename GridType::TreeType;
     using ValueType = typename TreeType::ValueType;
+    using ComputeType = typename ComputeTypeFor<ValueType>::type;
     using AlphaType = typename MaskType::ValueType;
-    static_assert(std::is_floating_point<AlphaType>::value,
+    static_assert(openvdb::is_floating_point<AlphaType>::value,
         "LevelSetFilter requires a mask grid with floating-point values");
 
     /// @brief Main constructor from a grid
@@ -133,7 +135,7 @@ public:
     /// @brief Offset the level set by the specified (world) distance.
     /// @param offset Value of the offset.
     /// @param mask Optional alpha mask.
-    void offset(ValueType offset, const MaskType* mask = nullptr)
+    void offset(ComputeType offset, const MaskType* mask = nullptr)
     {
         Filter f(this, mask); f.offset(offset);
     }
@@ -173,7 +175,7 @@ private:
         using BufferT = typename tree::LeafManager<TreeType>::BufferType;
         using LeafRange = typename tree::LeafManager<TreeType>::LeafRange;
         using LeafIterT = typename LeafRange::Iterator;
-        using AlphaMaskT = tools::AlphaMask<GridT, MaskT>;
+        using AlphaMaskT = tools::AlphaMask<GridT, MaskT, tools::BoxSampler>;
 
         Filter(LevelSetFilter* parent, const MaskType* mask) : mParent(parent), mMask(mask) {}
         Filter(const Filter&) = default;
@@ -186,7 +188,7 @@ private:
         void laplacian();
         void meanCurvature();
         void fillet();
-        void offset(ValueType value);
+        void offset(ComputeType value);
         void operator()(const LeafRange& r) const
         {
             if (mTask) mTask(const_cast<Filter*>(this), r);
@@ -206,17 +208,17 @@ private:
         template <size_t Axis>
         struct Avg {
             Avg(const GridT& grid, Int32 w) :
-                acc(grid.tree()), width(w), frac(1/ValueType(2*w+1)) {}
-            inline ValueType operator()(Coord xyz)
+                acc(grid.tree()), width(w), frac(1/ComputeType(2*w+1)) {}
+            inline ComputeType operator()(Coord xyz)
             {
-                ValueType sum = zeroVal<ValueType>();
+                ComputeType sum = zeroVal<ComputeType>();
                 Int32& i = xyz[Axis], j = i + width;
-                for (i -= width; i <= j; ++i) sum += acc.getValue(xyz);
+                for (i -= width; i <= j; ++i) sum += ComputeType(acc.getValue(xyz));
                 return sum*frac;
             }
             typename GridT::ConstAccessor acc;
             const Int32 width;
-            const ValueType frac;
+            const ComputeType frac;
         };
 
         template<typename AvgT>
@@ -230,7 +232,7 @@ private:
         void meanCurvatureImpl(const LeafRange&);
         void filletImpl(const LeafRange&);
         void laplacianImpl(const LeafRange&);
-        void offsetImpl(const LeafRange&, ValueType);
+        void offsetImpl(const LeafRange&, ComputeType);
 
         LevelSetFilter* mParent;
         const MaskType* mMask;
@@ -354,16 +356,17 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::laplacian()
 
 template<typename GridT, typename MaskT, typename InterruptT>
 inline void
-LevelSetFilter<GridT, MaskT, InterruptT>::Filter::offset(ValueType value)
+LevelSetFilter<GridT, MaskT, InterruptT>::Filter::offset(ComputeType value)
 {
     mParent->startInterrupter("Offsetting level set");
 
     mParent->leafs().removeAuxBuffers();// no auxiliary buffers required
 
-    const ValueType CFL = ValueType(0.5) * mParent->voxelSize(), offset = openvdb::math::Abs(value);
-    ValueType dist = 0.0;
-    while (offset-dist > ValueType(0.001)*CFL && mParent->checkInterrupter()) {
-        const ValueType delta = openvdb::math::Min(offset-dist, CFL);
+    const ComputeType CFL = ComputeType(0.5) * mParent->voxelSize(),
+                      offset = openvdb::math::Abs(value);
+    ComputeType dist = 0.0;
+    while (offset-dist > ComputeType(0.001)*CFL && mParent->checkInterrupter()) {
+        const ComputeType delta = openvdb::math::Min(offset-dist, CFL);
         dist += delta;
 
         mTask = std::bind(&Filter::offsetImpl,
@@ -386,7 +389,7 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::meanCurvatureImpl(const LeafRa
 {
     mParent->checkInterrupter();
     //const float CFL = 0.9f, dt = CFL * mDx * mDx / 6.0f;
-    const ValueType dx = mParent->voxelSize(), dt = math::Pow2(dx) / ValueType(3.0);
+    const ComputeType dx = mParent->voxelSize(), dt = math::Pow2(dx) / ComputeType(3.0);
     math::CurvatureStencil<GridType> stencil(mParent->grid(), dx);
     if (mMask) {
         typename AlphaMaskT::FloatType a, b;
@@ -397,7 +400,8 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::meanCurvatureImpl(const LeafRa
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 if (alpha(iter.getCoord(), a, b)) {
                     stencil.moveTo(iter);
-                    const ValueType phi0 = *iter, phi1 = phi0 + dt*stencil.meanCurvatureNormGrad();
+                    const ComputeType phi0 = ComputeType(*iter),
+                                      phi1 = phi0 + dt*stencil.meanCurvatureNormGrad();
                     buffer[iter.pos()] = b * phi0 + a * phi1;
                 }
             }
@@ -407,7 +411,7 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::meanCurvatureImpl(const LeafRa
             ValueType* buffer = leafIter.buffer(1).data();
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 stencil.moveTo(iter);
-                buffer[iter.pos()] = *iter + dt*stencil.meanCurvatureNormGrad();
+                buffer[iter.pos()] = ComputeType(*iter) + dt*stencil.meanCurvatureNormGrad();
             }
         }
     }
@@ -423,7 +427,7 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::filletImpl(const LeafRange& ra
 {
     mParent->checkInterrupter();
 
-    const ValueType dx = mParent->voxelSize(), dt = math::Pow2(dx) / ValueType(3);
+    const ValueType dx = mParent->voxelSize(), dt = math::Pow2(dx) / ComputeType(3);
     math::CurvatureStencil<GridType> stencil(mParent->grid(), dx);
 
     if (mMask) {
@@ -436,10 +440,10 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::filletImpl(const LeafRange& ra
                 if (alpha(iter.getCoord(), a, b)) {
                     stencil.moveTo(iter);
 
-                    const ValueType kappa = stencil.principalCurvatures().first;
+                    const ComputeType kappa = stencil.principalCurvatures().first;
 
-                    const ValueType phi0 = *iter,
-                                    phi1 = phi0 + math::Min(ValueType(0), dt*kappa);
+                    const ComputeType phi0 = ComputeType(*iter),
+                                      phi1 = phi0 + math::Min(ComputeType(0), dt*kappa);
                     buffer[iter.pos()] = b * phi0 + a * phi1;
                 }
             }
@@ -450,10 +454,10 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::filletImpl(const LeafRange& ra
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 stencil.moveTo(iter);
 
-                const ValueType kappa = stencil.principalCurvatures().first;
+                const ComputeType kappa = stencil.principalCurvatures().first;
 
                 if (math::isNegative(kappa))
-                    buffer[iter.pos()] = *iter + dt*kappa;
+                    buffer[iter.pos()] = ComputeType(*iter) + dt*kappa;
             }
         }
     }
@@ -472,7 +476,7 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::laplacianImpl(const LeafRange&
 {
     mParent->checkInterrupter();
     //const float CFL = 0.9f, half_dt = CFL * mDx * mDx / 12.0f;
-    const ValueType dx = mParent->voxelSize(), dt = math::Pow2(dx) / ValueType(6.0);
+    const ComputeType dx = mParent->voxelSize(), dt = math::Pow2(dx) / ComputeType(6.0);
     math::GradStencil<GridType> stencil(mParent->grid(), dx);
     if (mMask) {
         typename AlphaMaskT::FloatType a, b;
@@ -483,7 +487,8 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::laplacianImpl(const LeafRange&
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 if (alpha(iter.getCoord(), a, b)) {
                     stencil.moveTo(iter);
-                    const ValueType phi0 = *iter, phi1 = phi0 + dt*stencil.laplacian();
+                    const ComputeType phi0 = ComputeType(*iter),
+                                      phi1 = phi0 + dt*stencil.laplacian();
                     buffer[iter.pos()] = b * phi0 + a * phi1;
                 }
             }
@@ -493,7 +498,7 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::laplacianImpl(const LeafRange&
             ValueType* buffer = leafIter.buffer(1).data();
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 stencil.moveTo(iter);
-                buffer[iter.pos()] = *iter + dt*stencil.laplacian();
+                buffer[iter.pos()] = ComputeType(*iter) + dt*stencil.laplacian();
             }
         }
     }
@@ -503,7 +508,7 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::laplacianImpl(const LeafRange&
 template<typename GridT, typename MaskT, typename InterruptT>
 inline void
 LevelSetFilter<GridT, MaskT, InterruptT>::Filter::offsetImpl(
-    const LeafRange& range, ValueType offset)
+    const LeafRange& range, ComputeType offset)
 {
     mParent->checkInterrupter();
     if (mMask) {
@@ -512,13 +517,14 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::offsetImpl(
                          mParent->maxMask(), mParent->isMaskInverted());
         for (LeafIterT leafIter=range.begin(); leafIter; ++leafIter) {
             for (VoxelIterT iter = leafIter->beginValueOn(); iter; ++iter) {
-                if (alpha(iter.getCoord(), a, b)) iter.setValue(*iter + a*offset);
+                if (alpha(iter.getCoord(), a, b))
+                    iter.setValue(ComputeType(*iter) + a*offset);
             }
         }
     } else {
         for (LeafIterT leafIter=range.begin(); leafIter; ++leafIter) {
             for (VoxelIterT iter = leafIter->beginValueOn(); iter; ++iter) {
-                iter.setValue(*iter + offset);
+                iter.setValue(ComputeType(*iter) + offset);
             }
         }
     }
@@ -540,7 +546,7 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::medianImpl(const LeafRange& ra
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 if (alpha(iter.getCoord(), a, b)) {
                     stencil.moveTo(iter);
-                    buffer[iter.pos()] = b * (*iter) + a * stencil.median();
+                    buffer[iter.pos()] = b * ComputeType(*iter) + a * stencil.median();
                 }
             }
         }
@@ -571,7 +577,7 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::boxImpl(const LeafRange& range
             ValueType* buffer = leafIter.buffer(1).data();
             for (VoxelCIterT iter = leafIter->cbeginValueOn(); iter; ++iter) {
                 const Coord xyz = iter.getCoord();
-                if (alpha(xyz, a, b)) buffer[iter.pos()] = b * (*iter)+ a * avg(xyz);
+                if (alpha(xyz, a, b)) buffer[iter.pos()] = b * ComputeType(*iter)+ a * avg(xyz);
             }
         }
     } else {
@@ -596,6 +602,7 @@ LevelSetFilter<GridT, MaskT, InterruptT>::Filter::boxImpl(const LeafRange& range
 #include <openvdb/util/ExplicitInstantiation.h>
 #endif
 
+OPENVDB_INSTANTIATE_CLASS LevelSetFilter<HalfGrid, HalfGrid, util::NullInterrupter>;
 OPENVDB_INSTANTIATE_CLASS LevelSetFilter<FloatGrid, FloatGrid, util::NullInterrupter>;
 OPENVDB_INSTANTIATE_CLASS LevelSetFilter<DoubleGrid, FloatGrid, util::NullInterrupter>;
 

--- a/openvdb/openvdb/tools/LevelSetMorph.h
+++ b/openvdb/openvdb/tools/LevelSetMorph.h
@@ -13,6 +13,7 @@
 
 #include "LevelSetTracker.h"
 #include "Interpolation.h" // for BoxSampler, etc.
+#include <openvdb/Types.h> // for ComputeTypeFor
 #include <openvdb/math/FiniteDifference.h>
 #include <functional>
 #include <limits>
@@ -54,6 +55,7 @@ public:
     using LeafType = typename TrackerT::LeafType;
     using BufferType = typename TrackerT::BufferType;
     using ValueType = typename TrackerT::ValueType;
+    using ComputeType = typename ComputeTypeFor<ValueType>::type;
 
     /// Main constructor
     LevelSetMorphing(GridT& sourceGrid, const GridT& targetGrid, InterruptT* interrupt = nullptr)
@@ -119,11 +121,11 @@ public:
 
     /// @brief Return the minimum value of the mask to be used for the
     /// derivation of a smooth alpha value.
-    ValueType minMask() const { return mMinMask; }
+    ComputeType minMask() const { return mMinMask; }
 
     /// @brief Return the maximum value of the mask to be used for the
     /// derivation of a smooth alpha value.
-    ValueType maxMask() const { return mDeltaMask + mMinMask; }
+    ComputeType maxMask() const { return mDeltaMask + mMinMask; }
 
     /// @brief Define the range for the (optional) scalar mask.
     /// @param min Minimum value of the range.
@@ -132,7 +134,7 @@ public:
     /// respectfully zero and one, and values inside the range maps
     /// smoothly to 0->1 (unless of course the mask is inverted).
     /// @throw ValueError if @a min is not smaller than @a max.
-    void setMaskRange(ValueType min, ValueType max)
+    void setMaskRange(ComputeType min, ComputeType max)
     {
         if (!(min < max)) OPENVDB_THROW(ValueError, "Invalid mask range (expects min < max)");
         mMinMask   = min;
@@ -150,7 +152,7 @@ public:
     /// final time, @a time1. If @a time0 > @a time1, perform backward advection.
     ///
     /// @return the number of CFL iterations used to advect from @a time0 to @a time1
-    size_t advect(ValueType time0, ValueType time1);
+    size_t advect(ComputeType time0, ComputeType time1);
 
 private:
 
@@ -159,22 +161,22 @@ private:
     LevelSetMorphing& operator=(const LevelSetMorphing&);// not implemented
 
     template<math::BiasedGradientScheme SpatialScheme>
-    size_t advect1(ValueType time0, ValueType time1);
+    size_t advect1(ComputeType time0, ComputeType time1);
 
     template<math::BiasedGradientScheme SpatialScheme,
              math::TemporalIntegrationScheme TemporalScheme>
-    size_t advect2(ValueType time0, ValueType time1);
+    size_t advect2(ComputeType time0, ComputeType time1);
 
     template<math::BiasedGradientScheme SpatialScheme,
              math::TemporalIntegrationScheme TemporalScheme,
              typename MapType>
-    size_t advect3(ValueType time0, ValueType time1);
+    size_t advect3(ComputeType time0, ComputeType time1);
 
     TrackerT                        mTracker;
     const GridT                    *mTarget, *mMask;
     math::BiasedGradientScheme      mSpatialScheme;
     math::TemporalIntegrationScheme mTemporalScheme;
-    ValueType                       mMinMask, mDeltaMask;
+    ComputeType                     mMinMask, mDeltaMask;
     bool                            mInvertMask;
 
     // This templated private class implements all the level set magic.
@@ -192,7 +194,7 @@ private:
         virtual ~Morph() {}
         /// Advect the level set from its current time, time0, to its final time, time1.
         /// @return number of CFL iterations
-        size_t advect(ValueType time0, ValueType time1);
+        size_t advect(ComputeType time0, ComputeType time1);
         /// Used internally by tbb::parallel_for()
         void operator()(const LeafRange& r) const
         {
@@ -214,22 +216,23 @@ private:
         void cook(ThreadingMode mode, size_t swapBuffer = 0);
 
         /// Sample field and return the CFT time step
-        typename GridT::ValueType sampleSpeed(ValueType time0, ValueType time1, Index speedBuffer);
+        ComputeType sampleSpeed(ComputeType time0,
+                                ComputeType time1, Index speedBuffer);
         void sampleXformedSpeed(const LeafRange& r, Index speedBuffer);
         void sampleAlignedSpeed(const LeafRange& r, Index speedBuffer);
 
         // Convex combination of Phi and a forward Euler advection steps:
         // Phi(result) = alpha * Phi(phi) + (1-alpha) * (Phi(0) - dt * Speed(speed)*|Grad[Phi(0)]|);
         template <int Nominator, int Denominator>
-        void euler(const LeafRange&, ValueType, Index, Index, Index);
-        inline void euler01(const LeafRange& r, ValueType t, Index s) {this->euler<0,1>(r,t,0,1,s);}
-        inline void euler12(const LeafRange& r, ValueType t) {this->euler<1,2>(r, t, 1, 1, 2);}
-        inline void euler34(const LeafRange& r, ValueType t) {this->euler<3,4>(r, t, 1, 2, 3);}
-        inline void euler13(const LeafRange& r, ValueType t) {this->euler<1,3>(r, t, 1, 2, 3);}
+        void euler(const LeafRange&, ComputeType, Index, Index, Index);
+        inline void euler01(const LeafRange& r, ComputeType t, Index s) {this->euler<0,1>(r,t,0,1,s);}
+        inline void euler12(const LeafRange& r, ComputeType t) {this->euler<1,2>(r, t, 1, 1, 2);}
+        inline void euler34(const LeafRange& r, ComputeType t) {this->euler<3,4>(r, t, 1, 2, 3);}
+        inline void euler13(const LeafRange& r, ComputeType t) {this->euler<1,3>(r, t, 1, 2, 3);}
 
         using FuncType = typename std::function<void (Morph*, const LeafRange&)>;
         LevelSetMorphing* mParent;
-        ValueType         mMinAbsS, mMaxAbsS;
+        ComputeType       mMinAbsS, mMaxAbsS;
         const MapT*       mMap;
         FuncType          mTask;
     }; // end of private Morph struct
@@ -238,7 +241,7 @@ private:
 
 template<typename GridT, typename InterruptT>
 inline size_t
-LevelSetMorphing<GridT, InterruptT>::advect(ValueType time0, ValueType time1)
+LevelSetMorphing<GridT, InterruptT>::advect(ComputeType time0, ComputeType time1)
 {
     switch (mSpatialScheme) {
     case math::FIRST_BIAS:
@@ -264,7 +267,7 @@ LevelSetMorphing<GridT, InterruptT>::advect(ValueType time0, ValueType time1)
 template<typename GridT, typename InterruptT>
 template<math::BiasedGradientScheme SpatialScheme>
 inline size_t
-LevelSetMorphing<GridT, InterruptT>::advect1(ValueType time0, ValueType time1)
+LevelSetMorphing<GridT, InterruptT>::advect1(ComputeType time0, ComputeType time1)
 {
     switch (mTemporalScheme) {
     case math::TVD_RK1:
@@ -284,7 +287,7 @@ template<typename GridT, typename InterruptT>
 template<math::BiasedGradientScheme SpatialScheme,
          math::TemporalIntegrationScheme TemporalScheme>
 inline size_t
-LevelSetMorphing<GridT, InterruptT>::advect2(ValueType time0, ValueType time1)
+LevelSetMorphing<GridT, InterruptT>::advect2(ComputeType time0, ComputeType time1)
 {
     const math::Transform& trans = mTracker.grid().transform();
     if (trans.mapType() == math::UniformScaleMap::mapType()) {
@@ -307,7 +310,7 @@ template<math::BiasedGradientScheme SpatialScheme,
          math::TemporalIntegrationScheme TemporalScheme,
          typename MapT>
 inline size_t
-LevelSetMorphing<GridT, InterruptT>::advect3(ValueType time0, ValueType time1)
+LevelSetMorphing<GridT, InterruptT>::advect3(ComputeType time0, ComputeType time1)
 {
     Morph<MapT, SpatialScheme, TemporalScheme> tmp(*this);
     return tmp.advect(time0, time1);
@@ -324,7 +327,7 @@ LevelSetMorphing<GridT, InterruptT>::
 Morph<MapT, SpatialScheme, TemporalScheme>::
 Morph(LevelSetMorphing<GridT, InterruptT>& parent)
     : mParent(&parent)
-    , mMinAbsS(ValueType(1e-6))
+    , mMinAbsS(ComputeType(1e-6))
     , mMap(parent.mTracker.grid().transform().template constMap<MapT>().get())
     , mTask(nullptr)
 {
@@ -366,7 +369,7 @@ template <typename MapT, math::BiasedGradientScheme SpatialScheme,
 inline size_t
 LevelSetMorphing<GridT, InterruptT>::
 Morph<MapT, SpatialScheme, TemporalScheme>::
-advect(ValueType time0, ValueType time1)
+advect(ComputeType time0, ComputeType time1)
 {
     namespace ph = std::placeholders;
 
@@ -377,7 +380,7 @@ advect(ValueType time0, ValueType time1)
     while (time0 < time1 && mParent->mTracker.checkInterrupter()) {
         mParent->mTracker.leafs().rebuildAuxBuffers(auxBuffers);
 
-        const ValueType dt = this->sampleSpeed(time0, time1, auxBuffers);
+        const ComputeType dt = this->sampleSpeed(time0, time1, auxBuffers);
         if ( math::isZero(dt) ) break;//V is essentially zero so terminate
 
         OPENVDB_NO_UNREACHABLE_CODE_WARNING_BEGIN //switch is resolved at compile-time
@@ -447,16 +450,16 @@ advect(ValueType time0, ValueType time1)
 template<typename GridT, typename InterruptT>
 template<typename MapT, math::BiasedGradientScheme SpatialScheme,
          math::TemporalIntegrationScheme TemporalScheme>
-inline typename GridT::ValueType
+inline typename LevelSetMorphing<GridT, InterruptT>::ComputeType
 LevelSetMorphing<GridT, InterruptT>::
 Morph<MapT, SpatialScheme, TemporalScheme>::
-sampleSpeed(ValueType time0, ValueType time1, Index speedBuffer)
+sampleSpeed(ComputeType time0, ComputeType time1, Index speedBuffer)
 {
     namespace ph = std::placeholders;
 
     mMaxAbsS = mMinAbsS;
     const size_t leafCount = mParent->mTracker.leafs().leafCount();
-    if (leafCount==0 || time0 >= time1) return ValueType(0);
+    if (leafCount==0 || time0 >= time1) return ComputeType(0);
 
     const math::Transform& xform  = mParent->mTracker.grid().transform();
     if (mParent->mTarget->transform() == xform &&
@@ -466,12 +469,12 @@ sampleSpeed(ValueType time0, ValueType time1, Index speedBuffer)
         mTask = std::bind(&Morph::sampleXformedSpeed, ph::_1, ph::_2, speedBuffer);
     }
     this->cook(PARALLEL_REDUCE);
-    if (math::isApproxEqual(mMinAbsS, mMaxAbsS)) return ValueType(0);//speed is essentially zero
-    static const ValueType CFL = (TemporalScheme == math::TVD_RK1 ? ValueType(0.3) :
-                                  TemporalScheme == math::TVD_RK2 ? ValueType(0.9) :
-                                  ValueType(1.0))/math::Sqrt(ValueType(3.0));
-    const ValueType dt = math::Abs(time1 - time0), dx = mParent->mTracker.voxelSize();
-    return math::Min(dt, ValueType(CFL*dx/mMaxAbsS));
+    if (math::isApproxEqual(mMinAbsS, mMaxAbsS)) return ComputeType(0);//speed is essentially zero
+    static const ComputeType CFL = (TemporalScheme == math::TVD_RK1 ? ComputeType(0.3) :
+                                    TemporalScheme == math::TVD_RK2 ? ComputeType(0.9) :
+                                    ComputeType(1.0))/math::Sqrt(ComputeType(3.0));
+    const ComputeType dt = math::Abs(time1 - time0), dx = mParent->mTracker.voxelSize();
+    return math::Min(dt, ComputeType(CFL*dx/mMaxAbsS));
 }
 
 template<typename GridT, typename InterruptT>
@@ -498,12 +501,12 @@ sampleXformedSpeed(const LeafRange& range, Index speedBuffer)
                 ValueType& s = speed[voxelIter.pos()];
                 s -= target.wsSample(map.applyMap(voxelIter.getCoord().asVec3d()));
                 if (!math::isApproxZero(s)) isZero = false;
-                mMaxAbsS = math::Max(mMaxAbsS, math::Abs(s));
+                mMaxAbsS = math::Max(mMaxAbsS, ComputeType(math::Abs(s)));
             }
             if (isZero) speed[0] = std::numeric_limits<ValueType>::max();//tag first voxel
         }
     } else {
-        const ValueType min = mParent->mMinMask, invNorm = 1.0f/(mParent->mDeltaMask);
+        const ComputeType min = mParent->mMinMask, invNorm = 1.0f/(mParent->mDeltaMask);
         const bool invMask = mParent->isMaskInverted();
         typename GridT::ConstAccessor maskAcc = mParent->mMask->getAccessor();
         SamplerT mask(maskAcc,  mParent->mMask->transform());
@@ -512,12 +515,12 @@ sampleXformedSpeed(const LeafRange& range, Index speedBuffer)
             bool isZero = true;
             for (VoxelIterT voxelIter = leafIter->cbeginValueOn(); voxelIter; ++voxelIter) {
                 const Vec3R xyz = map.applyMap(voxelIter.getCoord().asVec3d());//world space
-                const ValueType a = math::SmoothUnitStep((mask.wsSample(xyz)-min)*invNorm);
+                const ComputeType a = math::SmoothUnitStep((mask.wsSample(xyz)-min)*invNorm);
                 ValueType& s = speed[voxelIter.pos()];
                 s -= target.wsSample(xyz);
-                s *= invMask ? 1 - a : a;
+                s *= invMask ? ValueType(1 - a) : ValueType(a);
                 if (!math::isApproxZero(s)) isZero = false;
-                mMaxAbsS = math::Max(mMaxAbsS, math::Abs(s));
+                mMaxAbsS = math::Max(mMaxAbsS, ComputeType(math::Abs(s)));
             }
             if (isZero) speed[0] = std::numeric_limits<ValueType>::max();//tag first voxel
         }
@@ -546,12 +549,12 @@ sampleAlignedSpeed(const LeafRange& range, Index speedBuffer)
                 ValueType& s = speed[voxelIter.pos()];
                 s -= target.getValue(voxelIter.getCoord());
                 if (!math::isApproxZero(s)) isZero = false;
-                mMaxAbsS = math::Max(mMaxAbsS, math::Abs(s));
+                mMaxAbsS = math::Max(mMaxAbsS, ComputeType(math::Abs(s)));
             }
             if (isZero) speed[0] = std::numeric_limits<ValueType>::max();//tag first voxel
         }
     } else {
-        const ValueType min = mParent->mMinMask, invNorm = 1.0f/(mParent->mDeltaMask);
+        const ComputeType min = mParent->mMinMask, invNorm = 1.0f/(mParent->mDeltaMask);
         const bool invMask = mParent->isMaskInverted();
         typename GridT::ConstAccessor mask = mParent->mMask->getAccessor();
         for (typename LeafRange::Iterator leafIter = range.begin(); leafIter; ++leafIter) {
@@ -559,12 +562,12 @@ sampleAlignedSpeed(const LeafRange& range, Index speedBuffer)
             bool isZero = true;
             for (VoxelIterT voxelIter = leafIter->cbeginValueOn(); voxelIter; ++voxelIter) {
                 const Coord ijk = voxelIter.getCoord();//index space
-                const ValueType a = math::SmoothUnitStep((mask.getValue(ijk)-min)*invNorm);
+                const ComputeType a = math::SmoothUnitStep((mask.getValue(ijk)-min)*invNorm);
                 ValueType& s = speed[voxelIter.pos()];
                 s -= target.getValue(ijk);
-                s *= invMask ? 1 - a : a;
+                s *= invMask ? ValueType(1 - a) : ValueType(a);
                 if (!math::isApproxZero(s)) isZero = false;
-                mMaxAbsS = math::Max(mMaxAbsS, math::Abs(s));
+                mMaxAbsS = math::Max(mMaxAbsS, ComputeType(math::Abs(s)));
             }
             if (isZero) speed[0] = std::numeric_limits<ValueType>::max();//tag first voxel
         }
@@ -605,9 +608,9 @@ template<typename MapT, math::BiasedGradientScheme SpatialScheme,
          math::TemporalIntegrationScheme TemporalScheme>
 template <int Nominator, int Denominator>
 inline void
-LevelSetMorphing<GridT,InterruptT>::
+LevelSetMorphing<GridT, InterruptT>::
 Morph<MapT, SpatialScheme, TemporalScheme>::
-euler(const LeafRange& range, ValueType dt,
+euler(const LeafRange& range, ComputeType dt,
       Index phiBuffer, Index resultBuffer, Index speedBuffer)
 {
     using SchemeT = math::BIAS_SCHEME<SpatialScheme>;
@@ -615,8 +618,8 @@ euler(const LeafRange& range, ValueType dt,
     using VoxelIterT = typename LeafType::ValueOnCIter;
     using NumGrad = math::GradientNormSqrd<MapT, SpatialScheme>;
 
-    static const ValueType Alpha = ValueType(Nominator)/ValueType(Denominator);
-    static const ValueType Beta  = ValueType(1) - Alpha;
+    static const ComputeType Alpha = ComputeType(Nominator)/ComputeType(Denominator);
+    static const ComputeType Beta  = ComputeType(1) - Alpha;
 
     mParent->mTracker.checkInterrupter();
     const MapT& map = *mMap;
@@ -631,8 +634,9 @@ euler(const LeafRange& range, ValueType dt,
             const Index n = voxelIter.pos();
             if (math::isApproxZero(speed[n])) continue;
             stencil.moveTo(voxelIter);
-            const ValueType v = stencil.getValue() - dt * speed[n] * NumGrad::result(map, stencil);
-            result[n] = Nominator ? Alpha * phi[n] + Beta * v : v;
+            const ComputeType v = ComputeType(stencil.getValue()) -
+                dt * ComputeType(speed[n]) * ComputeType(NumGrad::result(map, stencil));
+            result[n] = Nominator ? ValueType(Alpha * phi[n] + Beta * v) : ValueType(v);
         }//loop over active voxels in the leaf of the mask
     }//loop over leafs of the level set
 }
@@ -649,6 +653,7 @@ euler(const LeafRange& range, ValueType dt,
 #include <openvdb/util/ExplicitInstantiation.h>
 #endif
 
+OPENVDB_INSTANTIATE_CLASS LevelSetMorphing<HalfGrid, util::NullInterrupter>;
 OPENVDB_INSTANTIATE_CLASS LevelSetMorphing<FloatGrid, util::NullInterrupter>;
 OPENVDB_INSTANTIATE_CLASS LevelSetMorphing<DoubleGrid, util::NullInterrupter>;
 

--- a/openvdb/openvdb/tools/LevelSetSphere.h
+++ b/openvdb/openvdb/tools/LevelSetSphere.h
@@ -14,7 +14,7 @@
 
 #include <openvdb/openvdb.h>
 #include <openvdb/Grid.h>
-#include <openvdb/Types.h>
+#include <openvdb/Types.h> // for ComputeTypeFor
 #include <openvdb/math/Math.h>
 #include <openvdb/util/NullInterrupter.h>
 
@@ -90,8 +90,9 @@ class LevelSetSphere
 public:
     using TreeT  = typename GridT::TreeType;
     using ValueT = typename GridT::ValueType;
-    using Vec3T  = typename math::Vec3<ValueT>;
-    static_assert(std::is_floating_point<ValueT>::value,
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
+    using Vec3T  = typename math::Vec3<ComputeT>;
+    static_assert(openvdb::is_floating_point<ValueT>::value,
         "level set grids must have scalar, floating-point value types");
 
     /// @brief Constructor
@@ -104,7 +105,7 @@ public:
     /// @note If the radius of the sphere is smaller than
     /// 1.5*voxelSize, i.e. the sphere is smaller than the Nyquist
     /// frequency of the grid, it is ignored!
-    LevelSetSphere(ValueT radius, const Vec3T &center, InterruptT* interrupt = nullptr)
+    LevelSetSphere(ComputeT radius, const Vec3T &center, InterruptT* interrupt = nullptr)
         : mRadius(radius), mCenter(center), mInterrupt(interrupt)
     {
         if (mRadius<=0) OPENVDB_THROW(ValueError, "radius must be positive");
@@ -115,7 +116,7 @@ public:
     /// @param voxelSize  Size of voxels in world units
     /// @param halfWidth  Half-width of narrow-band in voxel units
     /// @param threaded   If true multi-threading is enabled (true by default)
-    typename GridT::Ptr getLevelSet(ValueT voxelSize, ValueT halfWidth, bool threaded = true)
+    typename GridT::Ptr getLevelSet(ComputeT voxelSize, ComputeT halfWidth, bool threaded = true)
     {
         mGrid = createLevelSet<GridT>(voxelSize, halfWidth);
         this->rasterSphere(voxelSize, halfWidth, threaded);
@@ -124,7 +125,7 @@ public:
     }
 
 private:
-    void rasterSphere(ValueT dx, ValueT w, bool threaded)
+    void rasterSphere(ComputeT dx, ComputeT w, bool threaded)
     {
         if (!(dx>0.0f)) OPENVDB_THROW(ValueError, "voxel size must be positive");
         if (!(w>1)) OPENVDB_THROW(ValueError, "half-width must be larger than one");
@@ -158,16 +159,16 @@ private:
             // Compute signed distances to sphere using leapfrogging in k
             for (i = r.begin(); i != r.end(); ++i) {
                 if (util::wasInterrupted(mInterrupt)) return;
-                const auto x2 = math::Pow2(ValueT(i) - c[0]);
+                const auto x2 = math::Pow2(ComputeT(i) - c[0]);
                 for (j = jmin; j <= jmax; ++j) {
-                    const auto x2y2 = math::Pow2(ValueT(j) - c[1]) + x2;
+                    const auto x2y2 = math::Pow2(ComputeT(j) - c[1]) + x2;
                     for (k = kmin; k <= kmax; k += m) {
                         m = 1;
                         // Distance in voxel units to sphere
-                        const auto v = math::Sqrt(x2y2 + math::Pow2(ValueT(k)-c[2]))-r0;
+                        const auto v = math::Sqrt(x2y2 + math::Pow2(ComputeT(k)-c[2]))-r0;
                         const auto d = math::Abs(v);
                         if (d < w) { // inside narrow band
-                            acc.setValue(ijk, dx*v);// distance in world units
+                            acc.setValue(ijk, ValueT(dx*v));// distance in world units
                         } else { // outside narrow band
                             m += math::Floor(d-w);// leapfrog
                         }
@@ -220,13 +221,16 @@ typename GridType::Ptr
 createLevelSetSphere(float radius, const openvdb::Vec3f& center, float voxelSize,
     float halfWidth, InterruptT* interrupt, bool threaded)
 {
+    using ValueT   = typename GridType::ValueType;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
+    using Vec3T    = typename math::Vec3<ComputeT>;
+
     // GridType::ValueType is required to be a floating-point scalar.
-    static_assert(std::is_floating_point<typename GridType::ValueType>::value,
+    static_assert(openvdb::is_floating_point<ValueT>::value,
         "level set grids must have scalar, floating-point value types");
 
-    using ValueT = typename GridType::ValueType;
-    LevelSetSphere<GridType, InterruptT> factory(ValueT(radius), center, interrupt);
-    return factory.getLevelSet(ValueT(voxelSize), ValueT(halfWidth), threaded);
+    LevelSetSphere<GridType, InterruptT> factory(ComputeT(radius), Vec3T(center), interrupt);
+    return factory.getLevelSet(ComputeT(voxelSize), ComputeT(halfWidth), threaded);
 }
 
 

--- a/openvdb/openvdb/tools/LevelSetTracker.h
+++ b/openvdb/openvdb/tools/LevelSetTracker.h
@@ -12,7 +12,7 @@
 #ifndef OPENVDB_TOOLS_LEVEL_SET_TRACKER_HAS_BEEN_INCLUDED
 #define OPENVDB_TOOLS_LEVEL_SET_TRACKER_HAS_BEEN_INCLUDED
 
-#include <openvdb/Types.h>
+#include <openvdb/Types.h> // for ComputeTypeFor
 #include <openvdb/Grid.h>
 #include <openvdb/math/Math.h>
 #include <openvdb/math/FiniteDifference.h>
@@ -53,7 +53,8 @@ enum class TrimMode {
 
 
 /// @brief Performs multi-threaded interface tracking of narrow band level sets
-template<typename GridT, typename InterruptT = util::NullInterrupter>
+template<typename GridT,
+         typename InterruptT = util::NullInterrupter>
 class LevelSetTracker
 {
 public:
@@ -63,11 +64,13 @@ public:
     using TreeType = typename GridT::TreeType;
     using LeafType = typename TreeType::LeafNodeType;
     using ValueType = typename TreeType::ValueType;
+    using ComputeType = typename ComputeTypeFor<ValueType>::type;
     using LeafManagerType = typename tree::LeafManager<TreeType>; // leafs + buffers
     using LeafRange = typename LeafManagerType::LeafRange;
     using BufferType = typename LeafManagerType::BufferType;
     using MaskTreeType = typename TreeType::template ValueConverter<ValueMask>::Type;
-    static_assert(std::is_floating_point<ValueType>::value,
+    static_assert(openvdb::is_floating_point<ValueType>::value
+               && openvdb::is_floating_point<ComputeType>::value,
         "LevelSetTracker requires a level set grid with floating-point values");
 
     /// Lightweight struct that stores the state of the LevelSetTracker
@@ -132,7 +135,7 @@ public:
     bool resize(Index halfWidth = static_cast<Index>(LEVEL_SET_HALF_WIDTH));
 
     /// @brief Return the half width of the narrow band in floating-point voxel units.
-    ValueType getHalfWidth() const { return mGrid->background()/mDx; }
+    ValueType getHalfWidth() const { return ComputeType(mGrid->background())/mDx; }
 
     /// @brief Return the state of the tracker (see struct defined above)
     State getState() const { return mState; }
@@ -232,7 +235,7 @@ private:
         void eval(StencilT& stencil, const ValueType* phi, ValueType* result, Index n) const;
         LevelSetTracker& mTracker;
         const MaskT*     mMask;
-        const ValueType  mDt, mInvDx;
+        const ComputeType  mDt, mInvDx;
         typename std::function<void (Normalizer*, const LeafRange&)> mTask;
     }; // Normalizer struct
 
@@ -247,12 +250,12 @@ private:
     // a list of the current LeafNodes! The auxiliary buffers on the
     // other hand always have to be allocated locally, since some
     // methods need them and others don't!
-    GridType*        mGrid;
-    LeafManagerType* mLeafs;
-    InterruptT*      mInterrupter;
-    const ValueType  mDx;
-    State            mState;
-    TrimMode         mTrimMode = TrimMode::kAll;
+    GridType*          mGrid;
+    LeafManagerType*   mLeafs;
+    InterruptT*        mInterrupter;
+    const ComputeType  mDx;
+    State              mState;
+    TrimMode           mTrimMode = TrimMode::kAll;
 }; // end of LevelSetTracker class
 
 template<typename GridT, typename InterruptT>
@@ -261,7 +264,7 @@ LevelSetTracker(GridT& grid, InterruptT* interrupt):
     mGrid(&grid),
     mLeafs(new LeafManagerType(grid.tree())),
     mInterrupter(interrupt),
-    mDx(static_cast<ValueType>(grid.voxelSize()[0])),
+    mDx(static_cast<ComputeType>(grid.voxelSize()[0])),
     mState()
 {
     if ( !grid.hasUniformVoxels() ) {
@@ -328,7 +331,8 @@ dilate(int iterations)
         for (int i=0; i < iterations; ++i) {
             MaskTreeType mask0(mGrid->tree(), false, TopologyCopy());
             tools::dilateActiveValues( *mLeafs, 1, tools::NN_FACE, tools::IGNORE_TILES);
-            tools::changeLevelSetBackground(this->leafs(), mDx + mGrid->background());
+            tools::changeLevelSetBackground(this->leafs(),
+                                            ValueType(mDx + ComputeType(mGrid->background())));
             MaskTreeType mask(mGrid->tree(), false, TopologyCopy());
             mask.topologyDifference(mask0);
             this->normalize(&mask);
@@ -344,7 +348,7 @@ erode(int iterations)
     tools::erodeActiveValues(*mLeafs, iterations, tools::NN_FACE, tools::IGNORE_TILES);
     tools::pruneLevelSet(mLeafs->tree());
     mLeafs->rebuildLeafArray();
-    const ValueType background = mGrid->background() - ValueType(iterations) * mDx;
+    const ValueType background = ComputeType(mGrid->background()) - ComputeType(iterations) * mDx;
     tools::changeLevelSetBackground(this->leafs(), background);
 }
 
@@ -473,7 +477,8 @@ LevelSetTracker<GridT, InterruptT>::Trim<Trimming>::trim()
 template<typename GridT, typename InterruptT>
 template<lstrack::TrimMode Trimming>
 inline void
-LevelSetTracker<GridT, InterruptT>::Trim<Trimming>::operator()(const LeafRange& range) const
+LevelSetTracker<GridT, InterruptT>::
+Trim<Trimming>::operator()(const LeafRange& range) const
 {
     mTracker.checkInterrupter();
     const ValueType gamma = mTracker.mGrid->background();
@@ -518,9 +523,10 @@ Normalizer<SpatialScheme, TemporalScheme, MaskT>::
 Normalizer(LevelSetTracker& tracker, const MaskT* mask)
     : mTracker(tracker)
     , mMask(mask)
-    , mDt(tracker.voxelSize()*(TemporalScheme == math::TVD_RK1 ? 0.3f :
+    , mDt(ComputeType(tracker.grid().voxelSize()[0]) *
+                              (TemporalScheme == math::TVD_RK1 ? 0.3f :
                                TemporalScheme == math::TVD_RK2 ? 0.9f : 1.0f))
-    , mInvDx(1.0f/tracker.voxelSize())
+    , mInvDx(1.0f/ComputeType(tracker.grid().voxelSize()[0]))
     , mTask(nullptr)
 {
 }
@@ -631,15 +637,15 @@ Normalizer<SpatialScheme, TemporalScheme, MaskT>::
 eval(StencilT& stencil, const ValueType* phi, ValueType* result, Index n) const
 {
     using GradientT = typename math::ISGradientNormSqrd<SpatialScheme>;
-    static const ValueType alpha = ValueType(Nominator)/ValueType(Denominator);
-    static const ValueType beta  = ValueType(1) - alpha;
+    static const ComputeType alpha = ComputeType(Nominator)/ComputeType(Denominator);
+    static const ComputeType beta  = ComputeType(1) - alpha;
 
-    const ValueType normSqGradPhi = GradientT::result(stencil);
-    const ValueType phi0 = stencil.getValue();
-    ValueType v = phi0 / ( math::Sqrt(math::Pow2(phi0) + normSqGradPhi) +
-                           math::Tolerance<ValueType>::value() );
-    v = phi0 - mDt * v * (math::Sqrt(normSqGradPhi) * mInvDx - 1.0f);
-    result[n] = Nominator ? alpha * phi[n] + beta * v : v;
+    const ComputeType normSqGradPhi = GradientT::result(stencil);
+    const ComputeType phi0 = stencil.getValue();
+    ComputeType v = phi0 / ( math::Sqrt(math::Pow2(phi0) + normSqGradPhi) +
+                             math::Tolerance<ComputeType>::value() );
+    v = phi0 - mDt * v * (math::Sqrt(normSqGradPhi) * mInvDx - ComputeType(1));
+    result[n] = Nominator ? ComputeType(alpha * ComputeType(phi[n]) + beta * v) : v;
 }
 
 template<typename GridT, typename InterruptT>
@@ -648,7 +654,7 @@ template<math::BiasedGradientScheme      SpatialScheme,
          typename MaskT>
 template <int Nominator, int Denominator>
 inline void
-LevelSetTracker<GridT,InterruptT>::
+LevelSetTracker<GridT, InterruptT>::
 Normalizer<SpatialScheme, TemporalScheme, MaskT>::
 euler(const LeafRange& range, Index phiBuffer, Index resultBuffer)
 {
@@ -687,6 +693,7 @@ euler(const LeafRange& range, Index phiBuffer, Index resultBuffer)
 #include <openvdb/util/ExplicitInstantiation.h>
 #endif
 
+OPENVDB_INSTANTIATE_CLASS LevelSetTracker<HalfGrid, util::NullInterrupter>;
 OPENVDB_INSTANTIATE_CLASS LevelSetTracker<FloatGrid, util::NullInterrupter>;
 OPENVDB_INSTANTIATE_CLASS LevelSetTracker<DoubleGrid, util::NullInterrupter>;
 

--- a/openvdb/openvdb/tools/LevelSetUtil.h
+++ b/openvdb/openvdb/tools/LevelSetUtil.h
@@ -461,7 +461,8 @@ struct SDFVoxelsToFogVolume {
 
             ValueType* values = node.buffer().data();
             for (Index i = 0; i < LeafNodeType::SIZE; ++i) {
-                values[i] = values[i] > ValueType(0.0) ? ValueType(0.0) : values[i] * mWeight;
+                values[i] = values[i] > ValueType(0.0) ?
+                    ValueType(0.0) : ValueType(values[i] * mWeight);
                 if (values[i] > ValueType(0.0)) node.setValueOn(i);
             }
 

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -17,8 +17,9 @@
 #define OPENVDB_TOOLS_MESH_TO_VOLUME_HAS_BEEN_INCLUDED
 
 #include <openvdb/Platform.h>
-#include <openvdb/Types.h>
+#include <openvdb/Types.h> // for ComputeTypeFor
 #include <openvdb/math/FiniteDifference.h> // for GodunovsNormSqrd
+#include <openvdb/math/Math.h> // for isFinite(), isNan()
 #include <openvdb/math/Proximity.h> // for closestPointOnTriangleToPoint
 #include <openvdb/util/NullInterrupter.h>
 #include <openvdb/util/Util.h>
@@ -39,7 +40,6 @@
 #include <tbb/task_arena.h>
 
 #include <algorithm> // for std::sort()
-#include <cmath> // for std::isfinite(), std::isnan()
 #include <deque>
 #include <limits>
 #include <memory>
@@ -2942,27 +2942,28 @@ template<typename TreeType>
 struct Renormalize
 {
     using LeafNodeType = typename TreeType::LeafNodeType;
-    using ValueType = typename TreeType::ValueType;
+    using ValueType    = typename TreeType::ValueType;
+    using ComputeType  = typename ComputeTypeFor<ValueType>::type;
 
     Renormalize(const TreeType& tree, const std::vector<LeafNodeType*>& nodes,
         ValueType* buffer, ValueType voxelSize)
         : mTree(&tree)
         , mNodes(nodes.empty() ? nullptr : &nodes[0])
         , mBuffer(buffer)
-        , mVoxelSize(voxelSize)
+        , mVoxelSize(static_cast<ComputeType>(voxelSize))
     {
     }
 
     void operator()(const tbb::blocked_range<size_t>& range) const
     {
-        using Vec3Type = math::Vec3<ValueType>;
+        using Vec3Type = math::Vec3<ComputeType>;
 
         tree::ValueAccessor<const TreeType> acc(*mTree);
 
         Coord ijk;
         Vec3Type up, down;
 
-        const ValueType dx = mVoxelSize, invDx = ValueType(1.0) / mVoxelSize;
+        const ComputeType dx = mVoxelSize, invDx = ComputeType(1.0) / mVoxelSize;
 
         for (size_t n = range.begin(), N = range.end(); n < N; ++n) {
 
@@ -2971,24 +2972,24 @@ struct Renormalize
             typename LeafNodeType::ValueOnCIter iter = mNodes[n]->cbeginValueOn();
             for (; iter; ++iter) {
 
-                const ValueType phi0 = *iter;
+                const ComputeType phi0 = static_cast<ComputeType>(*iter);
 
                 ijk = iter.getCoord();
 
-                up[0] = acc.getValue(ijk.offsetBy(1, 0, 0)) - phi0;
-                up[1] = acc.getValue(ijk.offsetBy(0, 1, 0)) - phi0;
-                up[2] = acc.getValue(ijk.offsetBy(0, 0, 1)) - phi0;
+                up[0] = static_cast<ComputeType>(acc.getValue(ijk.offsetBy(1, 0, 0))) - phi0;
+                up[1] = static_cast<ComputeType>(acc.getValue(ijk.offsetBy(0, 1, 0))) - phi0;
+                up[2] = static_cast<ComputeType>(acc.getValue(ijk.offsetBy(0, 0, 1))) - phi0;
 
-                down[0] = phi0 - acc.getValue(ijk.offsetBy(-1, 0, 0));
-                down[1] = phi0 - acc.getValue(ijk.offsetBy(0, -1, 0));
-                down[2] = phi0 - acc.getValue(ijk.offsetBy(0, 0, -1));
+                down[0] = phi0 - static_cast<ComputeType>(acc.getValue(ijk.offsetBy(-1, 0, 0)));
+                down[1] = phi0 - static_cast<ComputeType>(acc.getValue(ijk.offsetBy(0, -1, 0)));
+                down[2] = phi0 - static_cast<ComputeType>(acc.getValue(ijk.offsetBy(0, 0, -1)));
 
-                const ValueType normSqGradPhi = math::GodunovsNormSqrd(phi0 > 0.0, down, up);
+                const ComputeType normSqGradPhi = math::GodunovsNormSqrd(phi0 > 0.0, down, up);
 
-                const ValueType diff = math::Sqrt(normSqGradPhi) * invDx - ValueType(1.0);
-                const ValueType S = phi0 / (math::Sqrt(math::Pow2(phi0) + normSqGradPhi));
+                const ComputeType diff = math::Sqrt(normSqGradPhi) * invDx - ValueType(1.0);
+                const ComputeType S = phi0 / (math::Sqrt(math::Pow2(phi0) + normSqGradPhi));
 
-                bufferData[iter.pos()] = phi0 - dx * S * diff;
+                bufferData[iter.pos()] = static_cast<ValueType>(phi0 - dx * S * diff);
             }
         }
     }
@@ -2998,7 +2999,7 @@ private:
     LeafNodeType const * const * const mNodes;
     ValueType                  * const mBuffer;
 
-    const ValueType mVoxelSize;
+    const ComputeType mVoxelSize;
 };
 
 
@@ -3023,7 +3024,7 @@ struct MinCombine
 
             for (; iter; ++iter) {
                 ValueType& val = const_cast<ValueType&>(iter.getValue());
-                val = std::min(val, bufferData[iter.pos()]);
+                val = math::Min(val, bufferData[iter.pos()]);
             }
         }
     }
@@ -3348,7 +3349,7 @@ meshToVolume(
 
     // Note: inf interior width is all right, this value makes the converter fill
     // interior regions with distance values.
-    if (!std::isfinite(exteriorWidth) || std::isnan(interiorWidth)) {
+    if (!math::isFinite(exteriorWidth) || math::isNan(interiorWidth)) {
         std::stringstream msg;
         msg << "Illegal narrow band width: exterior = " << exteriorWidth
             << ", interior = " << interiorWidth;
@@ -3358,7 +3359,7 @@ meshToVolume(
 
     const ValueType voxelSize = ValueType(transform.voxelSize()[0]);
 
-    if (!std::isfinite(voxelSize) || math::isZero(voxelSize)) {
+    if (!math::isFinite(voxelSize) || math::isZero(voxelSize)) {
         std::stringstream msg;
         msg << "Illegal transform, voxel size = " << voxelSize;
         OPENVDB_LOG_DEBUG(msg.str());
@@ -3429,7 +3430,6 @@ meshToVolume(
     // The progress estimates are based on the observed average time for a few different
     // test cases and is only intended to provide some rough progression feedback to the user.
     if (interrupter.wasInterrupted(30)) return distGrid;
-
 
     //////////
 

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -3659,7 +3659,7 @@ meshToVolume(
 
 /// @internal This overload is enabled only for grids with a scalar, floating-point ValueType.
 template<typename GridType, typename Interrupter>
-inline typename std::enable_if<std::is_floating_point<typename GridType::ValueType>::value,
+inline typename std::enable_if<openvdb::is_floating_point<typename GridType::ValueType>::value,
     typename GridType::Ptr>::type
 doMeshConversion(
     Interrupter& interrupter,
@@ -3732,7 +3732,7 @@ doMeshConversion(
 /// @internal This overload is enabled only for grids that do not have a scalar,
 /// floating-point ValueType.
 template<typename GridType, typename Interrupter>
-inline typename std::enable_if<!std::is_floating_point<typename GridType::ValueType>::value,
+inline typename std::enable_if<!openvdb::is_floating_point<typename GridType::ValueType>::value,
     typename GridType::Ptr>::type
 doMeshConversion(
     Interrupter&,

--- a/openvdb/openvdb/tools/RayIntersector.h
+++ b/openvdb/openvdb/tools/RayIntersector.h
@@ -91,7 +91,7 @@ public:
     using TreeT = typename GridT::TreeType;
 
     static_assert(NodeLevel >= -1 && NodeLevel < int(TreeT::DEPTH)-1, "NodeLevel out of range");
-    static_assert(std::is_floating_point<ValueT>::value,
+    static_assert(openvdb::is_floating_point<ValueT>::value,
         "level set grids must have scalar, floating-point value types");
 
     /// @brief Constructor

--- a/openvdb/openvdb/tools/RayTracer.h
+++ b/openvdb/openvdb/tools/RayTracer.h
@@ -155,7 +155,7 @@ public:
     using ValueType = typename GridType::ValueType;
     using AccessorType = typename GridType::ConstAccessor;
     using SamplerType = tools::GridSampler<AccessorType, SamplerT>;
-    static_assert(std::is_floating_point<ValueType>::value,
+    static_assert(openvdb::is_floating_point<ValueType>::value,
         "VolumeRender requires a floating-point-valued grid");
 
     /// @brief Constructor taking an intersector and a base camera.
@@ -1083,6 +1083,7 @@ OPENVDB_REAL_TREE_INSTANTIATE(_FUNCTION)
 OPENVDB_REAL_TREE_INSTANTIATE(_FUNCTION)
 #undef _FUNCTION
 
+OPENVDB_INSTANTIATE_CLASS VolumeRender<tools::VolumeRayIntersector<HalfGrid>, tools::BoxSampler>;
 OPENVDB_INSTANTIATE_CLASS VolumeRender<tools::VolumeRayIntersector<FloatGrid>, tools::BoxSampler>;
 OPENVDB_INSTANTIATE_CLASS VolumeRender<tools::VolumeRayIntersector<DoubleGrid>, tools::BoxSampler>;
 

--- a/openvdb/openvdb/tools/SignedFloodFill.h
+++ b/openvdb/openvdb/tools/SignedFloodFill.h
@@ -85,7 +85,7 @@ public:
     using ValueT = typename TreeOrLeafManagerT::ValueType;
     using RootT = typename TreeOrLeafManagerT::RootNodeType;
     using LeafT = typename TreeOrLeafManagerT::LeafNodeType;
-    static_assert(std::is_signed<ValueT>::value,
+    static_assert(openvdb::is_signed<ValueT>::value,
         "signed flood fill is supported only for signed value grids");
 
     SignedFloodFillOp(const TreeOrLeafManagerT& tree, Index minLevel = 0)
@@ -215,7 +215,7 @@ private:
 
 template<typename TreeOrLeafManagerT>
 inline
-typename std::enable_if<std::is_signed<typename TreeOrLeafManagerT::ValueType>::value, void>::type
+typename std::enable_if_t<openvdb::is_signed<typename TreeOrLeafManagerT::ValueType>::value, void>
 doSignedFloodFill(TreeOrLeafManagerT& tree,
                   typename TreeOrLeafManagerT::ValueType outsideValue,
                   typename TreeOrLeafManagerT::ValueType insideValue,
@@ -231,7 +231,7 @@ doSignedFloodFill(TreeOrLeafManagerT& tree,
 // Dummy (no-op) implementation for unsigned types
 template <typename TreeOrLeafManagerT>
 inline
-typename std::enable_if<!std::is_signed<typename TreeOrLeafManagerT::ValueType>::value, void>::type
+typename std::enable_if_t<!openvdb::is_signed<typename TreeOrLeafManagerT::ValueType>::value, void>
 doSignedFloodFill(TreeOrLeafManagerT&,
                   const typename TreeOrLeafManagerT::ValueType&,
                   const typename TreeOrLeafManagerT::ValueType&,

--- a/openvdb/openvdb/tools/VolumeAdvect.h
+++ b/openvdb/openvdb/tools/VolumeAdvect.h
@@ -13,7 +13,7 @@
 #ifndef OPENVDB_TOOLS_VOLUME_ADVECT_HAS_BEEN_INCLUDED
 #define OPENVDB_TOOLS_VOLUME_ADVECT_HAS_BEEN_INCLUDED
 
-#include <openvdb/Types.h>
+#include <openvdb/Types.h> // for ComputeTypeFor
 #include <openvdb/math/Math.h>
 #include <openvdb/util/NullInterrupter.h>
 #include <openvdb/util/Assert.h>
@@ -365,6 +365,7 @@ struct VolumeAdvection<VelocityGridT, StaggeredVelocity, InterrupterType>::Advec
     using TreeT = typename VolumeGridT::TreeType;
     using AccT = typename VolumeGridT::ConstAccessor;
     using ValueT = typename TreeT::ValueType;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
     using LeafManagerT = typename tree::LeafManager<TreeT>;
     using LeafNodeT = typename LeafManagerT::LeafNodeType;
     using LeafRangeT = typename LeafManagerT::LeafRange;
@@ -443,12 +444,13 @@ struct VolumeAdvection<VelocityGridT, StaggeredVelocity, InterrupterType>::Advec
                 const ValueT* in0 = leaf->buffer().data();
                 for (VoxelIterT voxelIter = leafIter->beginValueOn(); voxelIter; ++voxelIter) {
                     const Index i = voxelIter.pos();
-                    out0[i] += RealT(0.5) * ( in0[i] - out1[i] );
+                    out0[i] += RealT(0.5) * ( ComputeT(in0[i]) - ComputeT(out1[i]) );
                 }
             } else {
                 for (VoxelIterT voxelIter = leafIter->beginValueOn(); voxelIter; ++voxelIter) {
                     const Index i = voxelIter.pos();
-                    out0[i] += RealT(0.5) * ( acc.getValue(voxelIter.getCoord()) - out1[i] );
+                    out0[i] += RealT(0.5) *
+                        (ComputeT(acc.getValue(voxelIter.getCoord())) - ComputeT(out1[i]));
                 }//loop over active voxels
             }
         }//loop over leaf nodes
@@ -467,12 +469,13 @@ struct VolumeAdvection<VelocityGridT, StaggeredVelocity, InterrupterType>::Advec
                 const ValueT* in0 = leaf->buffer().data();
                 for (VoxelIterT voxelIter = leafIter->beginValueOn(); voxelIter; ++voxelIter) {
                     const Index i = voxelIter.pos();
-                    out0[i] = RealT(0.5)*( RealT(3)*in0[i] - out1[i] );
+                    out0[i] = RealT(0.5)*( RealT(3)*ComputeT(in0[i]) - ComputeT(out1[i]) );
                 }//loop over active voxels
             } else {
                 for (VoxelIterT voxelIter = leafIter->beginValueOn(); voxelIter; ++voxelIter) {
                     const Index i = voxelIter.pos();
-                    out0[i] = RealT(0.5)*( RealT(3)*acc.getValue(voxelIter.getCoord()) - out1[i] );
+                    out0[i] = RealT(0.5)*(
+                        RealT(3)*ComputeT(acc.getValue(voxelIter.getCoord())) - ComputeT(out1[i]));
                 }//loop over active voxels
             }
         }//loop over leaf nodes
@@ -498,7 +501,7 @@ struct VolumeAdvection<VelocityGridT, StaggeredVelocity, InterrupterType>::Advec
         if (mParent->interrupt()) return;
         const bool doLimiter = mParent->isLimiterOn();
         const bool doClamp = mParent->mLimiter == Scheme::CLAMP;
-        ValueT data[2][2][2], vMin, vMax;
+        ComputeT data[2][2][2], vMin, vMax;
         const math::Transform& xform = mInGrid->transform();
         AccT acc = mInGrid->getAccessor();
         const ValueT backg = mInGrid->background();
@@ -516,14 +519,15 @@ struct VolumeAdvection<VelocityGridT, StaggeredVelocity, InterrupterType>::Advec
                     BoxSampler::getValues(data, acc, ijk);
                     BoxSampler::extrema(data, vMin, vMax);
                     if ( doClamp ) {
-                        value = math::Clamp( value, vMin, vMax);
-                    } else if (value < vMin || value > vMax ) {
+                        value = math::Clamp( ComputeT(value), vMin, vMax);
+                    } else if (ComputeT(value) < vMin || ComputeT(value) > vMax ) {
                         iPos -= Vec3R(ijk[0], ijk[1], ijk[2]);//unit coordinates
                         value = BoxSampler::trilinearInterpolation( data, iPos );
                     }
                 }
 
-                if (math::isApproxEqual(value, backg, math::Delta<ValueT>::value())) {
+                if (math::isApproxEqual(ComputeT(value), ComputeT(backg),
+                                        math::Delta<ComputeT>::value())) {
                     value = backg;
                     leafIter->setValueOff( voxelIter.pos() );
                 }
@@ -553,10 +557,12 @@ struct VolumeAdvection<VelocityGridT, StaggeredVelocity, InterrupterType>::Advec
 OPENVDB_INSTANTIATE_CLASS VolumeAdvection<Vec3SGrid, true, util::NullInterrupter>;
 OPENVDB_INSTANTIATE_CLASS VolumeAdvection<Vec3SGrid, false, util::NullInterrupter>;
 
+OPENVDB_INSTANTIATE HalfGrid::Ptr VolumeAdvection<Vec3SGrid, true, util::NullInterrupter>::advect<HalfGrid, Sampler<1, false>>(const HalfGrid&, double);
 OPENVDB_INSTANTIATE FloatGrid::Ptr VolumeAdvection<Vec3SGrid, true, util::NullInterrupter>::advect<FloatGrid, Sampler<1, false>>(const FloatGrid&, double);
 OPENVDB_INSTANTIATE DoubleGrid::Ptr VolumeAdvection<Vec3SGrid, true, util::NullInterrupter>::advect<DoubleGrid, Sampler<1, false>>(const DoubleGrid&, double);
 OPENVDB_INSTANTIATE Vec3SGrid::Ptr VolumeAdvection<Vec3SGrid, true, util::NullInterrupter>::advect<Vec3SGrid, Sampler<1, false>>(const Vec3SGrid&, double);
 
+OPENVDB_INSTANTIATE HalfGrid::Ptr VolumeAdvection<Vec3SGrid, false, util::NullInterrupter>::advect<HalfGrid, Sampler<1, false>>(const HalfGrid&, double);
 OPENVDB_INSTANTIATE FloatGrid::Ptr VolumeAdvection<Vec3SGrid, false, util::NullInterrupter>::advect<FloatGrid, Sampler<1, false>>(const FloatGrid&, double);
 OPENVDB_INSTANTIATE DoubleGrid::Ptr VolumeAdvection<Vec3SGrid, false, util::NullInterrupter>::advect<DoubleGrid, Sampler<1, false>>(const DoubleGrid&, double);
 OPENVDB_INSTANTIATE Vec3SGrid::Ptr VolumeAdvection<Vec3SGrid, false, util::NullInterrupter>::advect<Vec3SGrid, Sampler<1, false>>(const Vec3SGrid&, double);

--- a/openvdb/openvdb/tools/VolumeToMesh.h
+++ b/openvdb/openvdb/tools/VolumeToMesh.h
@@ -4621,7 +4621,7 @@ doVolumeToMesh(
     double adaptivity,
     bool relaxDisorientedTriangles)
 {
-    static_assert(std::is_scalar<typename GridType::ValueType>::value,
+    static_assert(openvdb::is_arithmetic<typename GridType::ValueType>::value,
         "volume to mesh conversion is supported only for scalar grids");
 
     VolumeToMesh mesher(isovalue, adaptivity, relaxDisorientedTriangles);

--- a/openvdb/openvdb/tools/VolumeToSpheres.h
+++ b/openvdb/openvdb/tools/VolumeToSpheres.h
@@ -1004,6 +1004,7 @@ ClosestSurfacePoint<GridT>::searchAndReplace(std::vector<Vec3R>& points,
 #include <openvdb/util/ExplicitInstantiation.h>
 #endif
 
+OPENVDB_INSTANTIATE_CLASS ClosestSurfacePoint<HalfGrid>;
 OPENVDB_INSTANTIATE_CLASS ClosestSurfacePoint<FloatGrid>;
 OPENVDB_INSTANTIATE_CLASS ClosestSurfacePoint<DoubleGrid>;
 

--- a/openvdb/openvdb/tools/impl/ConvexVoxelizer.h
+++ b/openvdb/openvdb/tools/impl/ConvexVoxelizer.h
@@ -80,8 +80,9 @@ private:
 ///     using BaseT::mXYData;
 ///     using BaseT::tileCeil;
 ///
-///     using ValueT = typename BaseT::ValueT;
-///     using Vec3T  = typename BaseT::Vec3T;
+///     using ValueT   = typename BaseT::ValueT;
+///     using Vec3T    = typename BaseT::Vec3T;
+///     using ComputeT = typename BaseT::ComputeT;
 ///
 /// public:
 ///
@@ -108,7 +109,7 @@ private:
 ///
 /// private:
 ///
-///     inline ValueT
+///     inline ComputeT
 ///     signedDistance(const Vec3T& p) const
 ///     {
 ///         return (p - mPt).length() - mRad;
@@ -119,30 +120,30 @@ private:
 ///     {
 ///         mXYData.reset(mX - mORad, mX + mORad, step);
 ///
-///         for (ValueT x = tileCeil(mX - mORad, step); x <= mX + mORad; x += step)
+///         for (ComputeT x = tileCeil(mX - mORad, step); x <= mX + mORad; x += step)
 ///             mXYData.expandYRange(x, BaseT::circleBottom(mX, mY, mORad, x),
 ///                 BaseT::circleTop(mX, mY, mORad, x));
 ///     }
 ///
-///     std::function<bool(ValueT&, ValueT&, const ValueT&, const ValueT&)> sphereBottomTop =
-///     [this](ValueT& zb, ValueT& zt, const ValueT& x, const ValueT& y)
+///     std::function<bool(ComputeT&, ComputeT&, const ComputeT&, const ComputeT&)> sphereBottomTop =
+///     [this](ComputeT& zb, ComputeT& zt, const ComputeT& x, const ComputeT& y)
 ///     {
 ///         zb = BaseT::sphereBottom(mX, mY, mZ, mORad, x, y);
 ///         zt = BaseT::sphereTop(mX, mY, mZ, mORad, x, y);
 ///
-///         return std::isfinite(zb) && std::isfinite(zt);
+///         return math::isFinite(zb) && math::isFinite(zt);
 ///     };
 ///
 ///     template <typename ScalarT>
 ///     inline void
 ///     initialize(const math::Vec3<ScalarT>& pt, const ScalarT& r)
 ///     {
-///         const ValueT vx = BaseT::voxelSize(),
-///                      hw = BaseT::halfWidth();
+///         const ComputeT vx = BaseT::voxelSize(),
+///                        hw = BaseT::halfWidth();
 ///
 ///         // sphere data in index space
 ///         mPt = Vec3T(pt)/vx;
-///         mRad = ValueT(r)/vx;
+///         mRad = ComputeT(r)/vx;
 ///
 ///         mX = mPt.x(); mY = mPt.y(); mZ = mPt.z();
 ///
@@ -153,7 +154,7 @@ private:
 ///     }
 ///
 ///     Vec3T mPt;
-///     ValueT mRad, mORad, mX, mY, mZ;
+///     ComputeT mRad, mORad, mX, mY, mZ;
 /// };
 ///
 /// // usage:
@@ -181,11 +182,14 @@ class ConvexVoxelizer
 
 protected:
 
-    using ValueT = typename GridType::ValueType;
-    using Vec3T  = math::Vec3<ValueT>;
-    using Vec2T  = math::Vec2<ValueT>;
+    using ValueT   = typename GridType::ValueType;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
+    using Vec3T    = math::Vec3<ComputeT>;
+    using Vec2T    = math::Vec2<ComputeT>;
 
-    static_assert(std::is_floating_point<ValueT>::value);
+    static_assert(openvdb::is_floating_point<ValueT>::value
+               && openvdb::is_floating_point<ComputeT>::value,
+        "level set grids must have scalar, floating-point value types");
 
 public:
 
@@ -200,10 +204,10 @@ public:
     /// meaning the voxel size and background value need to be set prior to voxelization
     ConvexVoxelizer(GridPtr& grid, const bool& threaded = false, InterruptType* interrupter = nullptr)
     : mGrid(grid)
-    , mVox(ValueT((grid->voxelSize())[0]))
-    , mHw(ValueT(grid->background()/(grid->voxelSize())[0]))
-    , mBg(grid->background())
-    , mNegBg(-(grid->background()))
+    , mVox(ComputeT((grid->voxelSize())[0]))
+    , mHw(ComputeT(grid->background())/ComputeT((grid->voxelSize())[0]))
+    , mBg(ComputeT(grid->background()))
+    , mNegBg(ComputeT(-(grid->background())))
     , mSerial(!threaded)
     , mInterrupter(interrupter)
     {
@@ -212,10 +216,10 @@ public:
     virtual ~ConvexVoxelizer() = default;
 
     /// @brief Return the voxel size of the grid.
-    inline ValueT voxelSize() const { return mVox; }
+    inline ComputeT voxelSize() const { return mVox; }
 
     /// @brief Return the half width of the narrow-band level set.
-    inline ValueT halfWidth() const { return mHw; }
+    inline ComputeT halfWidth() const { return mHw; }
 
 private:
 
@@ -287,7 +291,7 @@ protected:
     /// @brief Computes the signed distance from a point to the convex region in index space.
     ///
     /// @param p The point in 3D space for which to compute the signed distance.
-    inline ValueT signedDistance(const Vec3T&) const { return ValueT(0); }
+    inline ComputeT signedDistance(const Vec3T&) const { return ComputeT(0); }
 
     /// @brief Computes the signed distance for tiles in index space,
     /// considering the center of the tile.
@@ -299,7 +303,7 @@ protected:
     /// A tile might not fully fit in an open prism but might fit in the union of a prism and wedge,
     /// and so in this case it might make sense to use the sdf for an offset triangle on tiles
     /// during the open prism scan.
-    inline ValueT
+    inline ComputeT
     tilePointSignedDistance(const Vec3T& p) const
     {
         return static_cast<const Derived*>(this)->signedDistance(p);
@@ -314,8 +318,8 @@ protected:
     /// @param[in] y The y ordinate of the infinte line.
     /// @return true if an intersection occurs; otherwise false.
     /// @note The derived class can override this lambda to implement different behavior for degenerate cases.
-    std::function<bool(ValueT&, ValueT&, const ValueT&, const ValueT&)> bottomTop =
-        [](ValueT&, ValueT&, const ValueT&, const ValueT&) { return false; };
+    std::function<bool(ComputeT&, ComputeT&, const ComputeT&, const ComputeT&)> bottomTop =
+        [](ComputeT&, ComputeT&, const ComputeT&, const ComputeT&) { return false; };
 
     // ------------ utilities ------------
 
@@ -323,14 +327,14 @@ protected:
     /// @param x Input value.
     /// @param step Tile step size.
     /// @return The ceiling of the value based on the tile size.
-    inline static ValueT
-    tileCeil(const ValueT& x, const ValueT& step)
+    inline static ComputeT
+    tileCeil(const ComputeT& x, const ComputeT& step)
     {
-        const ValueT offset = ValueT(0.5) * (step - ValueT(1));
+        const ValueT offset = ComputeT(0.5) * (step - ComputeT(1));
 
-        return step == ValueT(1)
-            ? static_cast<ValueT>(math::Ceil(perturbDown(x)))
-            : step * static_cast<ValueT>(math::Ceil(perturbDown((x - offset)/step))) + offset;
+        return step == ComputeT(1)
+            ? static_cast<ComputeT>(math::Ceil(perturbDown(x)))
+            : step * static_cast<ComputeT>(math::Ceil(perturbDown((x - offset)/step))) + offset;
     }
 
     /// @brief Rounds an input scalar up to the nearest valid ordinate of tile of a specified size.
@@ -339,12 +343,12 @@ protected:
     /// @param step Tile step size.
     /// @return The ceiling of the value based on the tile size.
     template <typename T>
-    inline static ValueT
-    tileCeil(const ValueT& x, const T& step)
+    inline static ComputeT
+    tileCeil(const ComputeT& x, const T& step)
     {
         static_assert(std::is_integral<T>::value, "Index must be an integral type");
 
-        const ValueT s = static_cast<ValueT>(step);
+        const ComputeT s = static_cast<ComputeT>(step);
 
         return tileCeil(x, s);
     }
@@ -353,14 +357,14 @@ protected:
     /// @param x Input value.
     /// @param step Tile step size.
     /// @return The ceiling of the value based on the tile size.
-    inline static ValueT
-    tileFloor(const ValueT& x, const ValueT& step)
+    inline static ComputeT
+    tileFloor(const ComputeT& x, const ComputeT& step)
     {
-        const ValueT offset = ValueT(0.5) * (step - ValueT(1));
+        const ValueT offset = ComputeT(0.5) * (step - ComputeT(1));
 
-        return step == ValueT(1)
-            ? static_cast<ValueT>(math::Floor(perturbUp(x)))
-            : step * static_cast<ValueT>(math::Floor(perturbUp((x - offset)/step))) + offset;
+        return step == ComputeT(1)
+            ? static_cast<ComputeT>(math::Floor(perturbUp(x)))
+            : step * static_cast<ComputeT>(math::Floor(perturbUp((x - offset)/step))) + offset;
     }
 
     /// @brief Rounds an input scalar down to the nearest valid ordinate of tile of a specified size.
@@ -369,12 +373,12 @@ protected:
     /// @param step Tile step size.
     /// @return The ceiling of the value based on the tile size.
     template <typename T>
-    inline static ValueT
-    tileFloor(const ValueT& x, const T& step)
+    inline static ComputeT
+    tileFloor(const ComputeT& x, const T& step)
     {
         static_assert(std::is_integral<T>::value, "Index must be an integral type");
 
-        const ValueT s = static_cast<ValueT>(step);
+        const ComputeT s = static_cast<ComputeT>(step);
 
         return tileFloor(x, s);
     }
@@ -385,9 +389,9 @@ protected:
     /// @param r Radius of the circle.
     /// @param x X-coordinate for which to compute the bottom y-coordinate.
     /// @return The y-coordinate at the bottom of the circle for the given x position.
-    inline static ValueT
-    circleBottom(const ValueT& x0, const ValueT& y0,
-                 const ValueT& r, const ValueT& x)
+    inline static ComputeT
+    circleBottom(const ComputeT& x0, const ComputeT& y0,
+                 const ComputeT& r, const ComputeT& x)
     {
         return y0 - math::Sqrt(math::Pow2(r) - math::Pow2(x-x0));
     }
@@ -398,9 +402,9 @@ protected:
     /// @param r Radius of the circle.
     /// @param x X-coordinate for which to compute the top y-coordinate.
     /// @return The y-coordinate at the top of the circle for the given x position.
-    inline static ValueT
-    circleTop(const ValueT& x0, const ValueT& y0,
-              const ValueT& r, const ValueT& x)
+    inline static ComputeT
+    circleTop(const ComputeT& x0, const ComputeT& y0,
+              const ComputeT& r, const ComputeT& x)
     {
         return y0 + math::Sqrt(math::Pow2(r) - math::Pow2(x-x0));
     }
@@ -413,9 +417,9 @@ protected:
     /// @param x X-coordinate for which to compute the bottom z-coordinate.
     /// @param y Y-coordinate for which to compute the bottom z-coordinate.
     /// @return The z-coordinate at the bottom of the sphere for the given (x, y) position.
-    inline static ValueT
-    sphereBottom(const ValueT& x0, const ValueT& y0, const ValueT& z0,
-                 const ValueT& r, const ValueT& x, const ValueT& y)
+    inline static ComputeT
+    sphereBottom(const ComputeT& x0, const ComputeT& y0, const ComputeT& z0,
+                 const ComputeT& r, const ComputeT& x, const ComputeT& y)
     {
         return z0 - math::Sqrt(math::Pow2(r) - math::Pow2(x-x0) - math::Pow2(y-y0));
     }
@@ -428,9 +432,9 @@ protected:
     /// @param x X-coordinate for which to compute the top z-coordinate.
     /// @param y Y-coordinate for which to compute the top z-coordinate.
     /// @return The z-coordinate at the top of the sphere for the given (x, y) position.
-    inline static ValueT
-    sphereTop(const ValueT& x0, const ValueT& y0, const ValueT& z0,
-              const ValueT& r, const ValueT& x, const ValueT& y)
+    inline static ComputeT
+    sphereTop(const ComputeT& x0, const ComputeT& y0, const ComputeT& z0,
+              const ComputeT& r, const ComputeT& x, const ComputeT& y)
     {
         return z0 + math::Sqrt(math::Pow2(r) - math::Pow2(x-x0) - math::Pow2(y-y0));
     }
@@ -454,7 +458,7 @@ protected:
         /// @param xmin The lower bound of the x range.
         /// @param xmax The upper bound of the x range.
         /// @param step The step size between x values. Defaults to 1.
-        XYRangeData(const ValueT& xmin, const ValueT& xmax, const Index& step = 1)
+        XYRangeData(const ComputeT& xmin, const ComputeT& xmax, const Index& step = 1)
         {
             reset(xmin, xmax, step);
         }
@@ -467,7 +471,7 @@ protected:
         /// @param ymax The new maximum y value to compare with and possibly update
         /// the current maximum at x.
         inline void
-        expandYRange(const ValueT& x, const ValueT& ymin, const ValueT& ymax)
+        expandYRange(const ComputeT& x, const ComputeT& ymin, const ComputeT& ymax)
         {
             expandYMin(x, ymin);
             expandYMax(x, ymax);
@@ -478,11 +482,11 @@ protected:
         /// @param x The x value.
         /// @param ymin The minimum y value to possibly be set.
         inline void
-        expandYMin(const ValueT& x, const ValueT& ymin)
+        expandYMin(const ComputeT& x, const ComputeT& ymin)
         {
             const Index i = worldToIndex(x);
 
-            if (std::isfinite(ymin) && ymin < mYMins[i])
+            if (math::isFinite(ymin) && ymin < mYMins[i])
                 mYMins[i] = ymin;
         }
 
@@ -491,11 +495,11 @@ protected:
         /// @param x The x value.
         /// @param ymax The maximum y value to possibly be set.
         inline void
-        expandYMax(const ValueT& x, const ValueT& ymax)
+        expandYMax(const ComputeT& x, const ComputeT& ymax)
         {
             const Index i = worldToIndex(x);
 
-            if (std::isfinite(ymax) && ymax > mYMaxs[i])
+            if (math::isFinite(ymax) && ymax > mYMaxs[i])
                 mYMaxs[i] = ymax;
         }
 
@@ -504,9 +508,9 @@ protected:
         /// @param x The x value.
         /// @param y The y value to use for expanding the range.
         inline void
-        expandYRange(const ValueT& x, const ValueT& y)
+        expandYRange(const ComputeT& x, const ComputeT& y)
         {
-            if (std::isfinite(y)) {
+            if (math::isFinite(y)) {
                 const Index i = worldToIndex(x);
 
                 if (y < mYMins[i])
@@ -522,7 +526,7 @@ protected:
         /// @param x The x value.
         /// @param ymin The minimum y value to reset.
         inline void
-        setYMin(const ValueT& x, const ValueT& ymin)
+        setYMin(const ComputeT& x, const ComputeT& ymin)
         {
             const Index i = worldToIndex(x);
 
@@ -534,7 +538,7 @@ protected:
         /// @param x The x value.
         /// @param ymax The maximum y value to reset.
         inline void
-        setYMax(const ValueT& x, const ValueT& ymax)
+        setYMax(const ComputeT& x, const ComputeT& ymax)
         {
             const Index i = worldToIndex(x);
 
@@ -544,7 +548,7 @@ protected:
         /// @brief Clears the y range for a given x value, setting it to an empty interval.
         /// @param x The x value.
         inline void
-        clearYRange(const ValueT& x)
+        clearYRange(const ComputeT& x)
         {
             const Index i = worldToIndex(x);
 
@@ -574,12 +578,12 @@ protected:
         /// @param xmax The upper bound of the x range.
         /// @param step The step size between x values. Defaults to 1.
         inline void
-        reset(const ValueT& xmin, const ValueT& xmax, const Index& step = 1)
+        reset(const ComputeT& xmin, const ComputeT& xmax, const Index& step = 1)
         {
             assert(step != 0);
 
             mStep = step;
-            mStepInv = ValueT(1)/static_cast<ValueT>(mStep);
+            mStepInv = ComputeT(1)/static_cast<ComputeT>(mStep);
 
             mXStart = tileCeil(xmin, mStep);
             mXEnd = tileFloor(xmax, mStep);
@@ -600,38 +604,38 @@ protected:
 
         /// @brief Retrieves the starting x value in the range.
         /// @return The start of the x range.
-        inline ValueT start() const { return mXStart; }
+        inline ComputeT start() const { return mXStart; }
 
         /// @brief Retrieves the ending x value in the range.
         /// @return The end of the x range.
-        inline ValueT end() const { return mXEnd; }
+        inline ComputeT end() const { return mXEnd; }
 
         /// @brief Converts an index to its corresponding x value.
         /// @param i The index value.
         /// @return The corresponding x value.
-        inline ValueT getX(const Index& i) const { return indexToWorld(i); }
+        inline ComputeT getX(const Index& i) const { return indexToWorld(i); }
 
         /// @brief Gets the minimum y value for a given index.
         /// @param i The index value.
         /// @return The minimum y value.
-        inline ValueT getYMin(const Index& i) const { assert(i < mSize); return mYMins[i]; }
+        inline ComputeT getYMin(const Index& i) const { assert(i < mSize); return mYMins[i]; }
 
         /// @brief Gets the maximum y value for a given index.
         /// @param i The index value.
         /// @return The maximum y value.
-        inline ValueT getYMax(const Index& i) const { assert(i < mSize); return mYMaxs[i]; }
+        inline ComputeT getYMax(const Index& i) const { assert(i < mSize); return mYMaxs[i]; }
 
         /// @brief Gets the minimum y value for a given x value.
         /// @param x The x value.
         /// @return The minimum y value at the given x.
         /// @note @c x is rounded to the nearest value in the x range.
-        inline ValueT getYMin(const ValueT& x) const { return mYMins[worldToIndex(x)]; }
+        inline ComputeT getYMin(const ValueT& x) const { return mYMins[worldToIndex(x)]; }
 
         /// @brief Gets the maximum y value for a given x value.
         /// @param x The x value.
         /// @return The maximum y value at the given x.
         /// @note @c x is rounded to the nearest value in the x range.
-        inline ValueT getYMax(const ValueT& x) const { return mYMaxs[worldToIndex(x)]; }
+        inline ComputeT getYMax(const ValueT& x) const { return mYMaxs[worldToIndex(x)]; }
 
         /// @brief Retrieves the x, ymin, and ymax values for a given index.
         /// @param x Output parameter for the x value.
@@ -639,7 +643,7 @@ protected:
         /// @param ymax Output parameter for the maximum y value.
         /// @param i The index to query.
         inline void
-        XYData(ValueT& x, ValueT& ymin, ValueT& ymax, const Index& i) const
+        XYData(ComputeT& x, ComputeT& ymin, ComputeT& ymax, const Index& i) const
         {
             x = indexToWorld(i);
             ymin = mYMins[i];
@@ -668,10 +672,10 @@ protected:
         {
             assert(mStep == xydata.step());
 
-            const ValueT start = xydata.start(), end = xydata.end();
+            const ComputeT start = xydata.start(), end = xydata.end();
 
-            const std::vector<ValueT>& ymins = xydata.mYMins;
-            const std::vector<ValueT>& ymaxs = xydata.mYMaxs;
+            const std::vector<ComputeT>& ymins = xydata.mYMins;
+            const std::vector<ComputeT>& ymaxs = xydata.mYMaxs;
 
             if (start < mXStart) {
                 const Index n = indexDistance(mXStart, start);
@@ -708,7 +712,7 @@ protected:
             }
 
             if (i == mSize) {
-                mSize = 0; mXStart = ValueT(0); mXEnd = ValueT(0);
+                mSize = 0; mXStart = ComputeT(0); mXEnd = ComputeT(0);
                 mYMins.clear(); mYMaxs.clear();
                 return;
             }
@@ -724,8 +728,8 @@ protected:
                 return;
 
             mSize -= i + j;
-            mXStart += ValueT(i * mStep);
-            mXEnd -= ValueT(j * mStep);
+            mXStart += ComputeT(i * mStep);
+            mXEnd -= ComputeT(j * mStep);
 
             if (i > 0) {
                 mYMins.erase(mYMins.begin(), mYMins.begin() + i);
@@ -740,18 +744,18 @@ protected:
 
     private:
 
-        inline static const ValueT
-            MINVALUE = std::numeric_limits<ValueT>::lowest(),
-            MAXVALUE = std::numeric_limits<ValueT>::max();
+        inline static const ComputeT
+            MINVALUE = std::numeric_limits<ComputeT>::lowest(),
+            MAXVALUE = std::numeric_limits<ComputeT>::max();
 
         inline Index
-        indexDistance(const ValueT& a, const ValueT& b)
+        indexDistance(const ComputeT& a, const ComputeT& b)
         {
             return Index(math::Round(mStepInv*math::Abs(a - b)));
         }
 
         inline Index
-        worldToIndex(const ValueT& x) const
+        worldToIndex(const ComputeT& x) const
         {
             const Index i = Index(math::Round(mStepInv*(x - mXStart)));
             assert(i < mSize);
@@ -759,19 +763,19 @@ protected:
             return i;
         }
 
-        inline ValueT
+        inline ComputeT
         indexToWorld(const Index i) const
         {
             assert(i < mSize);
 
-            return mXStart + ValueT(i * mStep);
+            return mXStart + ComputeT(i * mStep);
         }
 
         Index mStep, mSize;
 
-        ValueT mStepInv, mXStart, mXEnd;
+        ComputeT mStepInv, mXStart, mXEnd;
 
-        std::vector<ValueT> mYMins, mYMaxs;
+        std::vector<ComputeT> mYMins, mYMaxs;
 
     }; // class XYRangeData
 
@@ -782,20 +786,20 @@ protected:
 private:
 
 #define EPS 0.0005f
-    inline static ValueT perturbDown(const ValueT& x) { return x - ValueT(EPS); }
-    inline static ValueT perturbUp(const ValueT& x) { return x + ValueT(EPS); }
+    inline static ComputeT perturbDown(const ComputeT& x) { return x - ComputeT(EPS); }
+    inline static ComputeT perturbUp(const ComputeT& x) { return x + ComputeT(EPS); }
 #undef EPS
 
-    inline static ValueT
-    voxelCeil(const ValueT& x)
+    inline static ComputeT
+    voxelCeil(const ComputeT& x)
     {
-        return static_cast<ValueT>(math::Ceil(perturbDown(x)));
+        return static_cast<ComputeT>(math::Ceil(perturbDown(x)));
     }
 
-    inline static ValueT
-    voxelFloor(const ValueT& x)
+    inline static ComputeT
+    voxelFloor(const ComputeT& x)
     {
-        return static_cast<ValueT>(math::Floor(perturbUp(x)));
+        return static_cast<ComputeT>(math::Floor(perturbUp(x)));
     }
 
     // skips the need for negative tile population and internal leap frogging
@@ -900,27 +904,27 @@ private:
     iterateYZ(const Index& i, CacheLastLeafAccessor& acc)
     {
         // initialize x value and y-range
-        ValueT x, yb, yt;
+        ComputeT x, yb, yt;
         mXYData.XYData(x, yb, yt, i);
 
-        if (!std::isfinite(yb) || !std::isfinite(yt))
+        if (!math::isFinite(yb) || !math::isFinite(yt))
             return;
 
-        ValueT zb, zt;
+        ComputeT zb, zt;
 
-        for (ValueT y = voxelCeil(yb); y <= perturbUp(yt); ++y) {
+        for (ComputeT y = voxelCeil(yb); y <= perturbUp(yt); ++y) {
             if (!bottomTop(zb, zt, x, y))
                 continue;
 
             Coord ijk(Int32(x), Int32(y), Int32(0));
-            Vec3T p(x, y, ValueT(0));
+            Vec3T p(x, y, ComputeT(0));
 
             ijk[2] = Int32(voxelCeil(zb))-1;
             acc.reset(ijk);
 
-            for (ValueT z = voxelCeil(zb); z <= perturbUp(zt); ++z) {
+            for (ComputeT z = voxelCeil(zb); z <= perturbUp(zt); ++z) {
                 ijk[2] = Int32(z);
-                const ValueT val = acc.template getValue<1>(ijk);
+                const ComputeT val = ComputeT(acc.template getValue<1>(ijk));
 
                 if (val == mNegBg) {
                     if constexpr (LeapFrog) acc.template leapUp<false>(ijk, z);
@@ -928,12 +932,12 @@ private:
                 }
 
                 p[2] = z;
-                const ValueT dist = mVox * invokeSignedDistance(p);
+                const ComputeT dist = mVox * invokeSignedDistance(p);
 
                 if (dist <= mNegBg) {
-                    acc.template setValueOff<1,false>(ijk, mNegBg);
+                    acc.template setValueOff<1,false>(ijk, ValueT(mNegBg));
                 } else if (dist < val) {
-                    acc.template setValueOn<1,false>(ijk, dist);
+                    acc.template setValueOn<1,false>(ijk, ValueT(dist));
                 } else { // dist >= val
                     acc.template checkReset<1>(ijk);
                 }
@@ -948,37 +952,37 @@ private:
     iterateNoTilesYZ(const Index& i, CacheLastLeafAccessor& acc)
     {
         // initialize x value and y-range
-        ValueT x, yb, yt;
+        ComputeT x, yb, yt;
         mXYData.XYData(x, yb, yt, i);
 
-        if (!std::isfinite(yb) || !std::isfinite(yt))
+        if (!math::isFinite(yb) || !math::isFinite(yt))
             return;
 
-        ValueT zb, zt;
+        ComputeT zb, zt;
 
-        for (ValueT y = voxelCeil(yb); y <= perturbUp(yt); ++y) {
+        for (ComputeT y = voxelCeil(yb); y <= perturbUp(yt); ++y) {
             if (!bottomTop(zb, zt, x, y))
                 continue;
 
             Coord ijk(Int32(x), Int32(y), Int32(0));
-            Vec3T p(x, y, ValueT(0));
+            Vec3T p(x, y, ComputeT(0));
 
             bool early_break = false;
-            ValueT z_stop;
+            ComputeT z_stop;
 
             ijk[2] = Int32(voxelCeil(zb))-1;
             acc.reset(ijk);
-            for (ValueT z = voxelCeil(zb); z <= perturbUp(zt); ++z) {
+            for (ComputeT z = voxelCeil(zb); z <= perturbUp(zt); ++z) {
                 ijk[2] = Int32(z);
                 p[2] = z;
-                const ValueT dist = mVox * invokeSignedDistance(p);
+                const ComputeT dist = mVox * invokeSignedDistance(p);
 
                 if (dist <= mNegBg) {
                     early_break = true;
                     z_stop = z;
                     break;
                 } else if (dist < mBg) {
-                    acc.template setValueOn<1>(ijk, dist);
+                    acc.template setValueOn<1>(ijk, ValueT(dist));
                 } else { // dist >= mBg
                     acc.template checkReset<1>(ijk);
                 }
@@ -986,15 +990,15 @@ private:
             if (early_break) {
                 ijk[2] = Int32(voxelFloor(zt))+1;
                 acc.reset(ijk);
-                for (ValueT z = voxelFloor(zt); z > z_stop; --z) {
+                for (ComputeT z = voxelFloor(zt); z > z_stop; --z) {
                     ijk[2] = Int32(z);
                     p[2] = z;
-                    const ValueT dist = mVox * invokeSignedDistance(p);
+                    const ComputeT dist = mVox * invokeSignedDistance(p);
 
                     if (dist <= mNegBg) {
                         break;
                     } else if (dist < mBg) {
-                        acc.template setValueOn<-1>(ijk, dist);
+                        acc.template setValueOn<-1>(ijk, ValueT(dist));
                     } else { // dist >= mBg
                         acc.template checkReset<-1>(ijk);
                     }
@@ -1024,25 +1028,25 @@ private:
     tileIterateYZ(const Index& i, AccessorT& acc)
     {
         // initialize x value and y-range
-        ValueT x, yb, yt;
+        ComputeT x, yb, yt;
         mXYData.XYData(x, yb, yt, i);
 
-        if (!std::isfinite(yb) || !std::isfinite(yt))
+        if (!math::isFinite(yb) || !math::isFinite(yt))
             return;
 
         static const Index TILESIZE = NodeT::DIM;
 
-        ValueT zb, zt;
+        ComputeT zb, zt;
 
-        for (ValueT y = tileCeil(yb, TILESIZE); y <= perturbUp(yt); y += TILESIZE) {
+        for (ComputeT y = tileCeil(yb, TILESIZE); y <= perturbUp(yt); y += TILESIZE) {
             if (!bottomTop(zb, zt, x, y))
                 continue;
 
             Coord ijk(Int32(x), Int32(y), Int32(0));
-            Vec3T p(x, y, ValueT(0));
+            Vec3T p(x, y, ComputeT(0));
 
             bool tiles_added = false;
-            ValueT z = tileCeil(zb, TILESIZE) - 2*TILESIZE;
+            ComputeT z = tileCeil(zb, TILESIZE) - 2*TILESIZE;
             while (z <= tileFloor(zt, TILESIZE) + TILESIZE) {
                 ijk[2] = Int32(z);
                 p[2] = z;
@@ -1058,13 +1062,13 @@ private:
 
     template <typename NodeT, int dir>
     inline bool
-    leapFrogToNextTile(const Coord& ijk, ValueT& z, AccessorT& acc) const
+    leapFrogToNextTile(const Coord& ijk, ComputeT& z, AccessorT& acc) const
     {
         static const int offset  = NodeT::DIM;
         static const int nodeDepth = int(TreeT::DEPTH - NodeT::LEVEL - 1);
 
         // we have not encountered an already populated tile
-        if (acc.getValue(ijk) != mNegBg) {
+        if (ComputeT(acc.getValue(ijk)) != mNegBg) {
             z += dir*offset;
             return false;
         }
@@ -1077,11 +1081,11 @@ private:
             return false;
         }
 
-        const ValueT sz = ValueT(mTileSizes[depth]);
+        const ComputeT sz = ComputeT(mTileSizes[depth]);
 
         z = dir > 0
-            ? sz * ValueT(math::Ceil(z/sz)) + ValueT(0.5)*(offset-1)
-            : sz * ValueT(math::Floor(z/sz)) - ValueT(0.5)*(offset+1);
+            ? sz * ComputeT(math::Ceil(z/sz)) + ComputeT(0.5)*(offset-1)
+            : sz * ComputeT(math::Floor(z/sz)) - ComputeT(0.5)*(offset+1);
 
         return true;
     }
@@ -1107,10 +1111,10 @@ private:
     {
         static const Index TILESIZE = NodeT::DIM;
 
-        static const ValueT R1 = ValueT(0.500)*(TILESIZE-1),
-                            R2 = ValueT(0.866)*(TILESIZE-1);
+        static const ComputeT R1 = ComputeT(0.500)*(TILESIZE-1),
+                              R2 = ComputeT(0.866)*(TILESIZE-1);
 
-        const ValueT dist = invokeTilePointSignedDistance(p);
+        const ComputeT dist = invokeTilePointSignedDistance(p);
 
         // fast positive criterion: circumsribed ball is in the object
         if (dist <= -R2-mHw)
@@ -1379,7 +1383,7 @@ private:
 
     const std::vector<int> mTileSizes = treeTileSizes();
 
-    const ValueT mVox, mHw, mBg, mNegBg;
+    const ComputeT mVox, mHw, mBg, mNegBg;
 
     // misc
 

--- a/openvdb/openvdb/tools/impl/LevelSetDilatedMeshImpl.h
+++ b/openvdb/openvdb/tools/impl/LevelSetDilatedMeshImpl.h
@@ -21,6 +21,7 @@
 #include <openvdb/tools/Prune.h>
 
 #include <openvdb/Grid.h>
+#include <openvdb/Types.h> // for ComputeTypeFor
 #include <openvdb/math/Math.h>
 #include <openvdb/util/NullInterrupter.h>
 
@@ -62,8 +63,9 @@ class OpenTriangularPrismVoxelizer
     using BaseT::mXYData;
     using BaseT::tileCeil;
 
-    using ValueT = typename BaseT::ValueT;
-    using Vec3T  = typename BaseT::Vec3T;
+    using ValueT   = typename BaseT::ValueT;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
+    using Vec3T    = typename BaseT::Vec3T;
 
 public:
 
@@ -100,7 +102,7 @@ public:
     operator()(const math::Vec3<ScalarType>& pt1, const math::Vec3<ScalarType>& pt2,
                const math::Vec3<ScalarType>& pt3, const ScalarType& radius)
     {
-        static_assert(std::is_floating_point<ScalarType>::value);
+        static_assert(openvdb::is_floating_point<ScalarType>::value);
 
         if (initialize(pt1, pt2, pt3, radius))
             BaseT::iterate();
@@ -111,11 +113,11 @@ private:
     inline void
     setXYRangeData(const Index& step = 1)
     {
-        const ValueT &x1 = mPts[0].x(), &x2 = mPts[1].x(), &x3 = mPts[2].x(),
-                     &x4 = mPts[3].x(), &x5 = mPts[4].x(), &x6 = mPts[5].x();
+        const ComputeT &x1 = mPts[0].x(), &x2 = mPts[1].x(), &x3 = mPts[2].x(),
+                       &x4 = mPts[3].x(), &x5 = mPts[4].x(), &x6 = mPts[5].x();
 
-        const ValueT xmin = math::Min(x1, x2, x3, x4, x5, x6);
-        const ValueT xmax = math::Max(x1, x2, x3, x4, x5, x6);
+        const ComputeT xmin = math::Min(x1, x2, x3, x4, x5, x6);
+        const ComputeT xmax = math::Max(x1, x2, x3, x4, x5, x6);
         mXYData.reset(xmin, xmax, step);
 
         // TODO add logic to ignore edges in the interior of the projection
@@ -138,18 +140,18 @@ private:
     inline void
     setXYSegmentRangeData(const Index& step = 1)
     {
-        const ValueT &x1 = mPts[i].x(), &x2 = mPts[j].x();
+        const ComputeT &x1 = mPts[i].x(), &x2 = mPts[j].x();
 
         // nothing to do if segment does not span across more than on voxel in x
         // other segments will handle this segment's range
         if (tileCeil(x1, step) == tileCeil(x2, step))
             return;
 
-        const ValueT x_start = tileCeil(math::Min(x1, x2), step),
-                     x_end = math::Max(x1, x2),
-                     stepv = ValueT(step);
+        const ComputeT x_start = tileCeil(math::Min(x1, x2), step),
+                       x_end = math::Max(x1, x2),
+                       stepv = ValueT(step);
 
-        for (ValueT x = x_start; x <= x_end; x += stepv) {
+        for (ComputeT x = x_start; x <= x_end; x += stepv) {
             if constexpr (MinMax <= 0)
                 mXYData.expandYMin(x, line2D<i,j>(x));
             if constexpr (MinMax >= 0)
@@ -158,7 +160,7 @@ private:
     }
 
     // simply offset distance to the center plane, we may assume any CPQ falls in inside the prism
-    inline ValueT
+    inline ComputeT
     signedDistance(const Vec3T& p) const
     {
         return math::Abs(mTriNrml.dot(p - mA)) - mRad;
@@ -166,14 +168,14 @@ private:
 
     // allows for tiles to poke outside of the open prism into the tubes
     // adaptation of udTriangle at https://iquilezles.org/articles/distfunctions/
-    inline ValueT
+    inline ComputeT
     tilePointSignedDistance(const Vec3T& p) const
     {
         const Vec3T pa = p - mA,
                     pb = p - mB,
                     pc = p - mC;
 
-        const ValueT udist =
+        const ComputeT udist =
             math::Sign(mBAXNrml.dot(pa)) +
             math::Sign(mCBXNrml.dot(pb)) +
             math::Sign(mACXNrml.dot(pc)) < 2
@@ -192,14 +194,14 @@ private:
     inline bool
     tileCanFit(const Index& dim) const
     {
-        return mRad >= BaseT::halfWidth() + ValueT(0.5) * (ValueT(dim)-ValueT(1));
+        return mRad >= BaseT::halfWidth() + ComputeT(0.5) * (ComputeT(dim)-ComputeT(1));
     }
 
-    std::function<bool(ValueT&, ValueT&, const ValueT&, const ValueT&)> prismBottomTop =
-    [this](ValueT& zb, ValueT& zt, const ValueT& x, const ValueT& y)
+    std::function<bool(ComputeT&, ComputeT&, const ComputeT&, const ComputeT&)> prismBottomTop =
+    [this](ComputeT& zb, ComputeT& zt, const ComputeT& x, const ComputeT& y)
     {
-        zb = std::numeric_limits<ValueT>::lowest();
-        zt = std::numeric_limits<ValueT>::max();
+        zb = std::numeric_limits<ComputeT>::lowest();
+        zt = std::numeric_limits<ComputeT>::max();
 
         // TODO with proper book keeping we can know apriori which 2 indexes will set zb & zt
         //      basically figure out a poor man's cylindrical decomposition...
@@ -214,12 +216,12 @@ private:
 
     template<Index i>
     inline void
-    setPlaneBottomTop(ValueT& zb, ValueT& zt, const ValueT& x, const ValueT& y) const
+    setPlaneBottomTop(ComputeT& zb, ComputeT& zt, const ComputeT& x, const ComputeT& y) const
     {
         if (math::isApproxZero(mFaceNrmls[i].z()))
             return;
 
-        const ValueT z = mPlaneXCoeffs[i]*x + mPlaneYCoeffs[i]*y + mPlaneOffsets[i];
+        const ComputeT z = mPlaneXCoeffs[i]*x + mPlaneYCoeffs[i]*y + mPlaneOffsets[i];
 
         if (mFaceNrmls[i].z() < 0) {
             if (zb < z)
@@ -237,8 +239,8 @@ private:
     initialize(const math::Vec3<ScalarType>& pt1, const math::Vec3<ScalarType>& pt2,
                const math::Vec3<ScalarType>& pt3, const ScalarType& r)
     {
-        const ValueT vx = BaseT::voxelSize(),
-                     hw = BaseT::halfWidth();
+        const ComputeT vx = BaseT::voxelSize(),
+                       hw = BaseT::halfWidth();
 
         mA = Vec3T(pt1)/vx;
         mB = Vec3T(pt2)/vx;
@@ -260,14 +262,14 @@ private:
         mCBNorm2 = math::isApproxZero(mCB.lengthSqr()) ? mCB : mCB/mCB.lengthSqr();
         mACNorm2 = math::isApproxZero(mAC.lengthSqr()) ? mAC : mAC/mAC.lengthSqr();
 
-        const ValueT len = mTriNrml.length();
+        const ComputeT len = mTriNrml.length();
         if (math::isApproxZero(len)) {
             return false; // nothing to voxelize, prism has no volume
         } else {
             mTriNrml /= len;
         }
 
-        const ValueT hwRad = mRad + hw;
+        const ComputeT hwRad = mRad + hw;
         if (math::isApproxZero(hwRad) || hwRad < 0)
             return false; // nothing to voxelize, prism has no volume
 
@@ -294,8 +296,8 @@ private:
 
             for (Index i = 0; i < 5; ++i) {
                 if (!math::isApproxZero(mFaceNrmls[i].z())) {
-                    const ValueT cx = mFaceNrmls[i].x()/mFaceNrmls[i].z(),
-                                 cy = mFaceNrmls[i].y()/mFaceNrmls[i].z();
+                    const ComputeT cx = mFaceNrmls[i].x()/mFaceNrmls[i].z(),
+                                   cy = mFaceNrmls[i].y()/mFaceNrmls[i].z();
                     const Vec3T p = mPts[p_ind[i]];
                     mPlaneXCoeffs[i] = -cx;
                     mPlaneYCoeffs[i] = -cy;
@@ -312,13 +314,13 @@ private:
     // ------------ general utilities ------------
 
     template <Index i, Index j>
-    ValueT
+    ComputeT
     line2D(const ValueT& x) const
     {
-        const ValueT &x1 = mPts[i].x(), &y1 = mPts[i].y(),
-                     &x2 = mPts[j].x(), &y2 = mPts[j].y();
+        const ComputeT &x1 = mPts[i].x(), &y1 = mPts[i].y(),
+                       &x2 = mPts[j].x(), &y2 = mPts[j].y();
 
-        const ValueT m = (y2-y1)/(x2-x1);
+        const ComputeT m = (y2-y1)/(x2-x1);
 
         return y1 + m * (x-x1);
     }
@@ -326,7 +328,7 @@ private:
     // ------------ private members ------------
 
     Vec3T mA, mB, mC;
-    ValueT mRad;
+    ComputeT mRad;
 
     Vec3T mBA, mCB, mAC;
     Vec3T mBAXNrml, mCBXNrml, mACXNrml;
@@ -337,9 +339,9 @@ private:
     Vec3T mTriNrml;
     std::vector<Vec3T> mFaceNrmls = std::vector<Vec3T>(5);
 
-    std::vector<ValueT> mPlaneXCoeffs = std::vector<ValueT>(5),
-                        mPlaneYCoeffs = std::vector<ValueT>(5),
-                        mPlaneOffsets = std::vector<ValueT>(5);
+    std::vector<ComputeT> mPlaneXCoeffs = std::vector<ValueT>(5),
+                          mPlaneYCoeffs = std::vector<ValueT>(5),
+                          mPlaneOffsets = std::vector<ValueT>(5);
 
 }; // class OpenTriangularPrismVoxelizer
 
@@ -367,9 +369,10 @@ class OpenCapsuleWedgeVoxelizer
     using BaseT::mXYData;
     using BaseT::tileCeil;
 
-    using ValueT = typename BaseT::ValueT;
-    using Vec3T  = typename BaseT::Vec3T;
-    using Vec2T  = typename BaseT::Vec2T;
+    using ValueT   = typename BaseT::ValueT;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
+    using Vec3T    = typename BaseT::Vec3T;
+    using Vec2T    = typename BaseT::Vec2T;
 
 public:
 
@@ -410,7 +413,7 @@ public:
         const ScalarType& radius, const math::Vec3<ScalarType>& nrml1,
         const math::Vec3<ScalarType>& nrml2)
     {
-        static_assert(std::is_floating_point<ScalarType>::value);
+        static_assert(openvdb::is_floating_point<ScalarType>::value);
 
         if (initialize(pt1, pt2, radius, nrml1, nrml2))
             BaseT::iterate();
@@ -422,7 +425,7 @@ private:
     inline void
     setXYRangeData(const Index& step = 1)
     {
-        const ValueT stepv = ValueT(step);
+        const ComputeT stepv = ValueT(step);
 
         // degenerate
         if (mX1 - mORad > mX2 + mORad) {
@@ -434,67 +437,67 @@ private:
         if (mIsVertical) {
             mXYData.reset(mX1 - mORad, mX1 + mORad, step);
 
-            for (ValueT x = tileCeil(mX1 - mORad, step); x <= mX1 + mORad; x += stepv)
+            for (ComputeT x = tileCeil(mX1 - mORad, step); x <= mX1 + mORad; x += stepv)
                 mXYData.expandYRange(x, circle1Bottom(x), circle1Top(x));
 
             intersectWithXYWedgeLines();
             return;
         }
 
-        const ValueT v = math::Min(mORad, mORad * math::Abs(mYdiff)/mXYNorm);
+        const ComputeT v = math::Min(mORad, mORad * math::Abs(mYdiff)/mXYNorm);
 
-        const ValueT a0 = mX1 - mORad,
-                     a1 = mX1 - v,
-                     a2 = mX1 + v,
-                     a3 = mX2 - v,
-                     a4 = mX2 + v,
-                     a5 = mX2 + mORad;
+        const ComputeT a0 = mX1 - mORad,
+                       a1 = mX1 - v,
+                       a2 = mX1 + v,
+                       a3 = mX2 - v,
+                       a4 = mX2 + v,
+                       a5 = mX2 + mORad;
 
-        const ValueT tc0 = tileCeil(a0, step),
-                     tc1 = tileCeil(a1, step),
-                     tc2 = tileCeil(a2, step),
-                     tc3 = tileCeil(a3, step),
-                     tc4 = tileCeil(a4, step);
+        const ComputeT tc0 = tileCeil(a0, step),
+                       tc1 = tileCeil(a1, step),
+                       tc2 = tileCeil(a2, step),
+                       tc3 = tileCeil(a3, step),
+                       tc4 = tileCeil(a4, step);
 
         mXYData.reset(a0, a5, step);
 
-        for (ValueT x = tc0; x <= a1; x += stepv)
+        for (ComputeT x = tc0; x <= a1; x += stepv)
             mXYData.expandYRange(x, circle1Bottom(x), circle1Top(x));
 
         if (!math::isApproxZero(mXdiff)) {
             if (mY1 > mY2) {
-                for (ValueT x = tc1; x <= math::Min(a2, a3); x += stepv)
+                for (ComputeT x = tc1; x <= math::Min(a2, a3); x += stepv)
                     mXYData.expandYRange(x, lineBottom(x), circle1Top(x));
             } else {
-                for (ValueT x = tc1; x <= math::Min(a2, a3); x += stepv)
+                for (ComputeT x = tc1; x <= math::Min(a2, a3); x += stepv)
                     mXYData.expandYRange(x, circle1Bottom(x), lineTop(x));
             }
         }
 
         if (a2 < a3) {
-            for (ValueT x = tc2; x <= a3; x += stepv)
+            for (ComputeT x = tc2; x <= a3; x += stepv)
                 mXYData.expandYRange(x, lineBottom(x), lineTop(x));
         } else {
             if (mY2 <= mY1) {
-                for (ValueT x = tc3; x <= a2; x += stepv)
+                for (ComputeT x = tc3; x <= a2; x += stepv)
                     mXYData.expandYRange(x, circle2Bottom(x), circle1Top(x));
             } else {
-                for (ValueT x = tc3; x <= a2; x += stepv)
+                for (ComputeT x = tc3; x <= a2; x += stepv)
                     mXYData.expandYRange(x, circle1Bottom(x), circle2Top(x));
             }
         }
 
         if (!math::isApproxZero(mXdiff)) {
             if (mY1 > mY2) {
-                for (ValueT x = math::Max(tc2, tc3); x <= a4; x += stepv)
+                for (ComputeT x = math::Max(tc2, tc3); x <= a4; x += stepv)
                     mXYData.expandYRange(x, circle2Bottom(x), lineTop(x));
             } else {
-                for (ValueT x = math::Max(tc2, tc3); x <= a4; x += stepv)
+                for (ComputeT x = math::Max(tc2, tc3); x <= a4; x += stepv)
                     mXYData.expandYRange(x, lineBottom(x), circle2Top(x));
             }
         }
 
-        for (ValueT x = tc4; x <= a5; x += stepv)
+        for (ComputeT x = tc4; x <= a5; x += stepv)
             mXYData.expandYRange(x, circle2Bottom(x), circle2Top(x));
 
         intersectWithXYStrip();
@@ -509,7 +512,7 @@ private:
             return;
 
         const Vec3T &pp1 = mPlanePts[0], &pp2 = mPlanePts[1];
-        const ValueT &vx = mV.x(), &vy = mV.y();
+        const ComputeT &vx = mV.x(), &vy = mV.y();
 
         Vec2T n = Vec2T(-vy, vx).unitSafe();
         Vec3T cvec = mORad * Vec3T(-vy, vx, ValueT(0)).unitSafe();
@@ -522,9 +525,9 @@ private:
         const Vec3T cpmin(mPt1 - cvec), cpmax(mPt1 + cvec);
 
         if (math::isApproxZero(mXdiff)) {
-            const ValueT px = mPt1.x(),
-                         xmin = math::Min(px, pp1.x(), pp2.x()),
-                         xmax = math::Max(px, pp1.x(), pp2.x());
+            const ComputeT px = mPt1.x(),
+                           xmin = math::Min(px, pp1.x(), pp2.x()),
+                           xmax = math::Max(px, pp1.x(), pp2.x());
 
             if (!inWedge(cpmin))
                 intersectWithXYHalfSpace(n.x() < 0 ? n : -n, Vec2T(xmin, ValueT(0)));
@@ -532,12 +535,12 @@ private:
             if (!inWedge(cpmax))
                 intersectWithXYHalfSpace(n.x() > 0 ? n : -n, Vec2T(xmax, ValueT(0)));
         } else {
-            const ValueT m = mYdiff/mXdiff;
-            const ValueT y1 = mPt1.y() - m * mPt1.x(),
-                         y2 = pp1.y() - m * pp1.x(),
-                         y3 = pp2.y() - m * pp2.x();
-            const ValueT ymin = math::Min(y1, y2, y3),
-                         ymax = math::Max(y1, y2, y3);
+            const ComputeT m = mYdiff/mXdiff;
+            const ComputeT y1 = mPt1.y() - m * mPt1.x(),
+                           y2 = pp1.y() - m * pp1.x(),
+                           y3 = pp2.y() - m * pp2.x();
+            const ComputeT ymin = math::Min(y1, y2, y3),
+                           ymax = math::Max(y1, y2, y3);
 
             if (!inWedge(vy <= 0 ? cpmin : cpmax))
                 intersectWithXYHalfSpace(n.y() < 0 ? n : -n, Vec2T(ValueT(0), ymin));
@@ -581,11 +584,11 @@ private:
             return;
 
         if (math::isApproxZero(n.y())) {
-            const ValueT &px = p.x();
+            const ComputeT &px = p.x();
             if (n.x() < 0) {
                 const Index m = mXYData.size();
                 for (Index i = 0; i < m; ++i) {
-                    const ValueT x = mXYData.getX(i);
+                    const ComputeT x = mXYData.getX(i);
 
                     if (x < px) mXYData.clearYRange(x);
                     else break;
@@ -593,7 +596,7 @@ private:
             } else {
                 Index i = mXYData.size()-1;
                 while (true) {
-                    const ValueT x = mXYData.getX(i);
+                    const ComputeT x = mXYData.getX(i);
 
                     if (x > px) mXYData.clearYRange(x);
                     else break;
@@ -606,13 +609,13 @@ private:
             const bool set_min = n.y() < 0;
             const Index m = mXYData.size();
 
-            const ValueT b = -n.x()/n.y();
-            const ValueT a = p.y() - b * p.x();
+            const ComputeT b = -n.x()/n.y();
+            const ComputeT a = p.y() - b * p.x();
 
-            ValueT x, ymin, ymax;
+            ComputeT x, ymin, ymax;
             for (Index i = 0; i < m; ++i) {
                 mXYData.XYData(x, ymin, ymax, i);
-                const ValueT yint = a + b * x;
+                const ComputeT yint = a + b * x;
 
                 if (ymin <= yint && yint <= ymax) {
                     if (set_min) mXYData.setYMin(x, yint);
@@ -632,16 +635,16 @@ private:
     signedDistance(const Vec3T& p) const
     {
         const Vec3T w = p - mPt1;
-        const ValueT dot = w.dot(mV);
+        const ComputeT dot = w.dot(mV);
 
         // carefully short circuit with a fuzzy tolerance, which avoids division by small mVLenSqr
-        if (dot <= math::Tolerance<ValueT>::value())
+        if (dot <= math::Tolerance<ComputeT>::value())
             return w.length() - mRad;
 
         if (dot >= mVLenSqr)
             return (p - mPt2).length() - mRad;
 
-        const ValueT t = w.dot(mV)/mVLenSqr;
+        const ComputeT t = w.dot(mV)/mVLenSqr;
 
         return (w - t * mV).length() - mRad;
     }
@@ -649,27 +652,27 @@ private:
     inline bool
     tileCanFit(const Index& dim) const
     {
-        return mRad >= BaseT::halfWidth() + ValueT(0.5) * (ValueT(dim)-ValueT(1));
+        return mRad >= BaseT::halfWidth() + ComputeT(0.5) * (ComputeT(dim)-ComputeT(1));
     }
 
-    std::function<bool(ValueT&, ValueT&, const ValueT&, const ValueT&)> capsuleBottomTopVertical =
-    [this](ValueT& zb, ValueT& zt, const ValueT& x, const ValueT& y)
+    std::function<bool(ComputeT&, ComputeT&, const ComputeT&, const ComputeT&)> capsuleBottomTopVertical =
+    [this](ComputeT& zb, ComputeT& zt, const ComputeT& x, const ComputeT& y)
     {
         zb = BaseT::sphereBottom(mX1, mY1, math::Min(mZ1, mZ2), mORad, x, y);
         zt = BaseT::sphereTop(mX2, mY2, math::Max(mZ1, mZ2), mORad, x, y);
 
-        return std::isfinite(zb) && std::isfinite(zt);
+        return math::isFinite(zb) && math::isFinite(zt);
     };
 
-    std::function<bool(ValueT&, ValueT&, const ValueT&, const ValueT&)> capsuleBottomTop =
-    [this](ValueT& zb, ValueT& zt, const ValueT& x, const ValueT& y)
+    std::function<bool(ComputeT&, ComputeT&, const ComputeT&, const ComputeT&)> capsuleBottomTop =
+    [this](ComputeT& zb, ComputeT& zt, const ComputeT& x, const ComputeT& y)
     {
-        ValueT cylptb, cylptt;
+        ComputeT cylptb, cylptt;
         if (!infiniteCylinderBottomTop(cylptb, cylptt, x, y))
             return false;
 
-        const ValueT dotb = (Vec3T(x, y, cylptb) - mPt1).dot(mV);
-        const ValueT dott = (Vec3T(x, y, cylptt) - mPt1).dot(mV);
+        const ComputeT dotb = (Vec3T(x, y, cylptb) - mPt1).dot(mV);
+        const ComputeT dott = (Vec3T(x, y, cylptt) - mPt1).dot(mV);
 
         if (dotb < 0)
             zb = sphere1Bottom(x, y);
@@ -685,7 +688,7 @@ private:
         else
             zt = cylptt;
 
-        if (!std::isfinite(zb) || !std::isfinite(zt))
+        if (!math::isFinite(zb) || !math::isFinite(zt))
             return false;
 
         intersectWedge<0,1>(zb, zt, x, y);
@@ -696,14 +699,14 @@ private:
 
     template<Index i, Index j>
     inline void
-    intersectWedge(ValueT& zb, ValueT& zt, const ValueT& x, const ValueT& y)
+    intersectWedge(ComputeT& zb, ComputeT& zt, const ComputeT& x, const ComputeT& y)
     {
         const Vec3T& n0 = mPlaneNrmls[i];
 
         if (math::isApproxZero(n0.z()))
             return;
 
-        const ValueT zp = mPlaneXCoeffs[i]*x + mPlaneYCoeffs[i]*y + mPlaneOffsets[i];
+        const ComputeT zp = mPlaneXCoeffs[i]*x + mPlaneYCoeffs[i]*y + mPlaneOffsets[i];
 
         if (zb <= zp && zp <= zt && inHalfSpace<j>(Vec3T(x, y, zp))) {
             if (n0.z() < 0)
@@ -714,7 +717,7 @@ private:
     }
 
     inline bool
-    inWedge(const ValueT& x, const ValueT& y, const ValueT& z)
+    inWedge(const ComputeT& x, const ComputeT& y, const ComputeT& z)
     {
         return inWedge(Vec3T(x, y, z));
     }
@@ -732,31 +735,31 @@ private:
         // allow points within a fuzzy fractional (index space) distance to the halfspace
         // this ensures the seams between open wedges and open prisms are completely filled in
         // assumes mPlaneNrmls[i] is a unit vector
-        static const ValueT VOXFRAC = 0.125;
+        static const ComputeT VOXFRAC = 0.125;
 
         return mPlaneNrmls[i].dot(pt-mPt1) <= VOXFRAC;
     }
 
     // assumes tube is not vertical!
     inline bool
-    infiniteCylinderBottomTop(ValueT& cylptb, ValueT& cylptt,
-        const ValueT& x, const ValueT& y) const
+    infiniteCylinderBottomTop(ComputeT& cylptb, ComputeT& cylptt,
+        const ComputeT& x, const ComputeT& y) const
     {
         const Vec2T q(x, y);
 
         const Vec2T qproj = mPt12d + mV2d*((q - mPt12d).dot(mV2d))/mXYNorm2;
 
-        const ValueT t = mX1 != mX2 ? (qproj[0] - mX1)/mXdiff : (qproj[1] - mY1)/mYdiff;
+        const ComputeT t = mX1 != mX2 ? (qproj[0] - mX1)/mXdiff : (qproj[1] - mY1)/mYdiff;
 
         const Vec3T qproj3D = mPt1 + t * mV;
 
-        const ValueT d2 = (q - qproj).lengthSqr();
+        const ComputeT d2 = (q - qproj).lengthSqr();
 
         // outside of cylinder's 2D projection
         if (mORad2 < d2)
             return false;
 
-        const ValueT h = math::Sqrt((mORad2 - d2) * mVLenSqr/mXYNorm2);
+        const ComputeT h = math::Sqrt((mORad2 - d2) * mVLenSqr/mXYNorm2);
 
         cylptb = qproj3D[2] - h;
         cylptt = qproj3D[2] + h;
@@ -764,62 +767,62 @@ private:
         return true;
     }
 
-    inline ValueT
-    lineBottom(const ValueT& x) const
+    inline ComputeT
+    lineBottom(const ComputeT& x) const
     {
         return mY1 + (mYdiff*(x-mX1) - mORad * mXYNorm)/mXdiff;
     }
 
-    inline ValueT
-    lineTop(const ValueT& x) const
+    inline ComputeT
+    lineTop(const ComputeT& x) const
     {
         return mY1 + (mYdiff*(x-mX1) + mORad * mXYNorm)/mXdiff;
     }
 
-    inline ValueT
-    circle1Bottom(const ValueT& x) const
+    inline ComputeT
+    circle1Bottom(const ComputeT& x) const
     {
         return BaseT::circleBottom(mX1, mY1, mORad, x);
     }
 
-    inline ValueT
-    circle1Top(const ValueT& x) const
+    inline ComputeT
+    circle1Top(const ComputeT& x) const
     {
         return BaseT::circleTop(mX1, mY1, mORad, x);
     }
 
-    inline ValueT
-    circle2Bottom(const ValueT& x) const
+    inline ComputeT
+    circle2Bottom(const ComputeT& x) const
     {
         return BaseT::circleBottom(mX2, mY2, mORad, x);
     }
 
-    inline ValueT
-    circle2Top(const ValueT& x) const
+    inline ComputeT
+    circle2Top(const ComputeT& x) const
     {
         return BaseT::circleTop(mX2, mY2, mORad, x);
     }
 
-    inline ValueT
-    sphere1Bottom(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere1Bottom(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereBottom(mX1, mY1, mZ1, mORad, x, y);
     }
 
-    inline ValueT
-    sphere1Top(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere1Top(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereTop(mX1, mY1, mZ1, mORad, x, y);
     }
 
-    inline ValueT
-    sphere2Bottom(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere2Bottom(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereBottom(mX2, mY2, mZ2, mORad, x, y);
     }
 
-    inline ValueT
-    sphere2Top(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere2Top(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereTop(mX2, mY2, mZ2, mORad, x, y);
     }
@@ -832,8 +835,8 @@ private:
         const ScalarType& r, const math::Vec3<ScalarType>& nrml1,
         const math::Vec3<ScalarType>& nrml2)
     {
-        const ValueT vx = BaseT::voxelSize(),
-                     hw = BaseT::halfWidth();
+        const ComputeT vx = BaseT::voxelSize(),
+                       hw = BaseT::halfWidth();
 
         // forces x1 <= x2
         if (pt1[0] <= pt2[0]) {
@@ -844,7 +847,7 @@ private:
             mPt2 = Vec3T(pt1)/vx;
         }
 
-        mRad = ValueT(r)/vx;
+        mRad = ComputeT(r)/vx;
 
         // padded radius used to populate the outer halfwidth of the sdf
         mORad  = mRad + hw;
@@ -897,13 +900,13 @@ private:
                 mDirVectors[1] = -mDirVectors[0];
             } else {
                 if (mPlaneNrmls[1].dot(mDirVectors[0]) > 0)
-                    mDirVectors[0] *= ValueT(-1);
+                    mDirVectors[0] *= ComputeT(-1);
                 if (mPlaneNrmls[0].dot(mDirVectors[1]) > 0)
-                    mDirVectors[1] *= ValueT(-1);
+                    mDirVectors[1] *= ComputeT(-1);
             }
 
-            mPlanePts[0] = mPt1 + mDirVectors[0] + ValueT(0.025) * mPlaneNrmls[0];
-            mPlanePts[1] = mPt1 + mDirVectors[1] + ValueT(0.025) * mPlaneNrmls[1];
+            mPlanePts[0] = mPt1 + mDirVectors[0] + ComputeT(0.025) * mPlaneNrmls[0];
+            mPlanePts[1] = mPt1 + mDirVectors[1] + ComputeT(0.025) * mPlaneNrmls[1];
         }
 
         {
@@ -913,8 +916,8 @@ private:
 
             for (Index i = 0; i < 2; ++i) {
                 if (!math::isApproxZero(mPlaneNrmls[i].z())) {
-                    const ValueT cx = mPlaneNrmls[i].x()/mPlaneNrmls[i].z(),
-                                 cy = mPlaneNrmls[i].y()/mPlaneNrmls[i].z();
+                    const ComputeT cx = mPlaneNrmls[i].x()/mPlaneNrmls[i].z(),
+                                   cy = mPlaneNrmls[i].y()/mPlaneNrmls[i].z();
                     const Vec3T p = mPlanePts[i];
                     mPlaneXCoeffs[i] = -cx;
                     mPlaneYCoeffs[i] = -cy;
@@ -948,19 +951,19 @@ private:
 
     Vec2T mPt12d, mPt22d, mV2d;
 
-    ValueT mORad, mORad2, mRad, mVLenSqr, mXdiff, mYdiff, mZdiff, mXYNorm, mXYNorm2;
+    ComputeT mORad, mORad2, mRad, mVLenSqr, mXdiff, mYdiff, mZdiff, mXYNorm, mXYNorm2;
 
-    ValueT mX1, mY1, mZ1, mX2, mY2, mZ2;
+    ComputeT mX1, mY1, mZ1, mX2, mY2, mZ2;
 
     bool mIsVertical;
 
     std::vector<Vec3T> mPlaneNrmls = std::vector<Vec3T>(2),
-                  mDirVectors = std::vector<Vec3T>(2),
-                  mPlanePts   = std::vector<Vec3T>(2);
+                       mDirVectors = std::vector<Vec3T>(2),
+                       mPlanePts   = std::vector<Vec3T>(2);
 
-    std::vector<ValueT> mPlaneXCoeffs = std::vector<ValueT>(2),
-                  mPlaneYCoeffs = std::vector<ValueT>(2),
-                  mPlaneOffsets = std::vector<ValueT>(2);
+    std::vector<ComputeT> mPlaneXCoeffs = std::vector<ValueT>(2),
+                          mPlaneYCoeffs = std::vector<ValueT>(2),
+                          mPlaneOffsets = std::vector<ValueT>(2);
 
 }; // class OpenCapsuleWedgeVoxelizer
 
@@ -1209,6 +1212,9 @@ class DilatedMeshVoxelizer {
     using TreeT = typename GridType::TreeType;
     using LeafT = typename TreeT::LeafNodeType;
 
+    using ValueT = typename GridType::ValueType;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
+
     using PartitionerT = tools::PointPartitioner<Index32, LeafT::LOG2DIM>;
 
     using PrismVoxelizer = OpenTriangularPrismVoxelizer<GridType, InterruptT>;
@@ -1218,6 +1224,7 @@ class DilatedMeshVoxelizer {
 
     using Vec3T = math::Vec3<ScalarType>;
 
+    static_assert(openvdb::is_floating_point<ValueT>::value);
     static_assert(std::is_floating_point<ScalarType>::value);
 
 public:
@@ -1331,11 +1338,11 @@ private:
     {
         lvlset::CapsuleVoxelizer<GridType, InterruptT> voxelizer(mGrid, false);
 
-        ScalarType d1 = (p2-p1).lengthSqr(),
-                   d2 = (p3-p2).lengthSqr(),
-                   d3 = (p1-p3).lengthSqr();
+        ComputeT d1 = ComputeT((p2-p1).lengthSqr()),
+                 d2 = ComputeT((p3-p2).lengthSqr()),
+                 d3 = ComputeT((p1-p3).lengthSqr());
 
-        ScalarType maxd = math::Max(d1, d2, d3);
+        ComputeT maxd = math::Max(d1, d2, d3);
 
         if (maxd == d1)
             voxelizer(p1, p2, mRad);
@@ -1528,7 +1535,7 @@ createLevelSetDilatedMesh(
 
     using Voxelizer = typename lvlset::DilatedMeshVoxelizer<GridType, ScalarType, InterruptT>;
 
-    static_assert(std::is_floating_point<ValueT>::value,
+    static_assert(openvdb::is_floating_point<ValueT>::value,
         "createLevelSetDilatedMesh must return a scalar grid");
 
     if (voxelSize <= 0) OPENVDB_THROW(ValueError, "voxel size must be positive");
@@ -1555,7 +1562,7 @@ createLevelSetDilatedMesh(
 
     using ValueT = typename GridType::ValueType;
 
-    static_assert(std::is_floating_point<ValueT>::value,
+    static_assert(openvdb::is_floating_point<ValueT>::value,
         "createLevelSetDilatedMesh must return a scalar grid");
 
     if (voxelSize <= 0) OPENVDB_THROW(ValueError, "voxel size must be positive");
@@ -1587,7 +1594,7 @@ createLevelSetDilatedMesh(const std::vector<math::Vec3<ScalarType>>& vertices,
 
     using ValueT = typename GridType::ValueType;
 
-    static_assert(std::is_floating_point<ValueT>::value,
+    static_assert(openvdb::is_floating_point<ValueT>::value,
         "createLevelSetDilatedMesh must return a scalar grid");
 
     if (voxelSize <= 0) OPENVDB_THROW(ValueError, "voxel size must be positive");

--- a/openvdb/openvdb/tools/impl/LevelSetTubesImpl.h
+++ b/openvdb/openvdb/tools/impl/LevelSetTubesImpl.h
@@ -20,7 +20,7 @@
 #include <openvdb/tools/Prune.h>
 
 #include <openvdb/Grid.h>
-#include <openvdb/Types.h>
+#include <openvdb/Types.h> // for ComputeTypeFor
 #include <openvdb/math/Math.h>
 #include <openvdb/util/NullInterrupter.h>
 
@@ -62,9 +62,10 @@ class CapsuleVoxelizer
     using BaseT::mXYData;
     using BaseT::tileCeil;
 
-    using ValueT = typename BaseT::ValueT;
-    using Vec3T  = typename BaseT::Vec3T;
-    using Vec2T  = typename BaseT::Vec2T;
+    using ValueT   = typename BaseT::ValueT;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
+    using Vec3T    = typename BaseT::Vec3T;
+    using Vec2T    = typename BaseT::Vec2T;
 
 public:
 
@@ -99,7 +100,7 @@ public:
     operator()(const math::Vec3<ScalarType>& pt1,
                const math::Vec3<ScalarType>& pt2, const ScalarType& r)
     {
-        static_assert(std::is_floating_point<ScalarType>::value);
+        static_assert(openvdb::is_floating_point<ScalarType>::value);
 
         initialize(pt1, pt2, r);
 
@@ -170,7 +171,7 @@ private:
     inline void
     setXYRangeData(const Index& step = 1)
     {
-        const ValueT stepv = ValueT(step);
+        const ComputeT stepv = ComputeT(step);
 
         // degenerate
         if (mX1 - mORad > mX2 + mORad) {
@@ -182,76 +183,76 @@ private:
         if (mIsVertical) {
             mXYData.reset(mX1 - mORad, mX1 + mORad, step);
 
-            for (ValueT x = tileCeil(mX1 - mORad, step); x <= mX1 + mORad; x += stepv)
+            for (ComputeT x = tileCeil(mX1 - mORad, step); x <= mX1 + mORad; x += stepv)
                 mXYData.expandYRange(x, circle1Bottom(x), circle1Top(x));
             return;
         }
 
-        const ValueT v = math::Min(mORad, mORad * math::Abs(mYdiff)/mXYNorm);
+        const ComputeT v = math::Min(mORad, mORad * math::Abs(mYdiff)/mXYNorm);
 
-        const ValueT a0 = mX1 - mORad,
-                     a1 = mX1 - v,
-                     a2 = mX1 + v,
-                     a3 = mX2 - v,
-                     a4 = mX2 + v,
-                     a5 = mX2 + mORad;
+        const ComputeT a0 = mX1 - mORad,
+                       a1 = mX1 - v,
+                       a2 = mX1 + v,
+                       a3 = mX2 - v,
+                       a4 = mX2 + v,
+                       a5 = mX2 + mORad;
 
-        const ValueT tc0 = tileCeil(a0, step),
-                     tc1 = tileCeil(a1, step),
-                     tc2 = tileCeil(a2, step),
-                     tc3 = tileCeil(a3, step),
-                     tc4 = tileCeil(a4, step);
+        const ComputeT tc0 = tileCeil(a0, step),
+                       tc1 = tileCeil(a1, step),
+                       tc2 = tileCeil(a2, step),
+                       tc3 = tileCeil(a3, step),
+                       tc4 = tileCeil(a4, step);
 
         mXYData.reset(a0, a5, step);
 
-        for (ValueT x = tc0; x <= a1; x += stepv)
+        for (ComputeT x = tc0; x <= a1; x += stepv)
             mXYData.expandYRange(x, circle1Bottom(x), circle1Top(x));
 
         if (!math::isApproxZero(mXdiff)) {
             if (mY1 > mY2) {
-                for (ValueT x = tc1; x <= math::Min(a2, a3); x += stepv)
+                for (ComputeT x = tc1; x <= math::Min(a2, a3); x += stepv)
                     mXYData.expandYRange(x, lineBottom(x), circle1Top(x));
             } else {
-                for (ValueT x = tc1; x <= math::Min(a2, a3); x += stepv)
+                for (ComputeT x = tc1; x <= math::Min(a2, a3); x += stepv)
                     mXYData.expandYRange(x, circle1Bottom(x), lineTop(x));
             }
         }
 
         if (a2 < a3) {
-            for (ValueT x = tc2; x <= a3; x += stepv)
+            for (ComputeT x = tc2; x <= a3; x += stepv)
                 mXYData.expandYRange(x, lineBottom(x), lineTop(x));
         } else {
             if (mY2 <= mY1) {
-                for (ValueT x = tc3; x <= a2; x += stepv)
+                for (ComputeT x = tc3; x <= a2; x += stepv)
                     mXYData.expandYRange(x, circle2Bottom(x), circle1Top(x));
             } else {
-                for (ValueT x = tc3; x <= a2; x += stepv)
+                for (ComputeT x = tc3; x <= a2; x += stepv)
                     mXYData.expandYRange(x, circle1Bottom(x), circle2Top(x));
             }
         }
 
         if (!math::isApproxZero(mXdiff)) {
             if (mY1 > mY2) {
-                for (ValueT x = math::Max(tc2, tc3); x <= a4; x += stepv)
+                for (ComputeT x = math::Max(tc2, tc3); x <= a4; x += stepv)
                     mXYData.expandYRange(x, circle2Bottom(x), lineTop(x));
             } else {
-                for (ValueT x = math::Max(tc2, tc3); x <= a4; x += stepv)
+                for (ComputeT x = math::Max(tc2, tc3); x <= a4; x += stepv)
                     mXYData.expandYRange(x, lineBottom(x), circle2Top(x));
             }
         }
 
-        for (ValueT x = tc4; x <= a5; x += stepv)
+        for (ComputeT x = tc4; x <= a5; x += stepv)
             mXYData.expandYRange(x, circle2Bottom(x), circle2Top(x));
 
         mXYData.trim();
     }
 
     // distance in index space
-    inline ValueT
+    inline ComputeT
     signedDistance(const Vec3T& p) const
     {
         const Vec3T  w = p - mPt1;
-        const ValueT dot = w.dot(mV);
+        const ComputeT dot = w.dot(mV);
 
         // carefully short circuit with a fuzzy tolerance, which avoids division by small mVLenSqr
         if (dot <= math::Tolerance<ValueT>::value())
@@ -260,7 +261,7 @@ private:
         if (dot >= mVLenSqr)
             return (p - mPt2).length() - mRad;
 
-        const ValueT t = w.dot(mV)/mVLenSqr;
+        const ComputeT t = w.dot(mV)/mVLenSqr;
 
         return (w - t * mV).length() - mRad;
     }
@@ -268,34 +269,34 @@ private:
     inline bool
     tileCanFit(const Index& dim) const
     {
-        return mRad >= BaseT::halfWidth() + ValueT(0.70711) * (ValueT(dim)-ValueT(1));
+        return mRad >= BaseT::halfWidth() + ComputeT(0.70711) * (ComputeT(dim)-ComputeT(1));
     }
 
     // vertical capsule
     // for a given x,y pair, find the z-range of a tube
     //   z-range is bottom sphere cap to the top sphere cap in vertical case
-    std::function<bool(ValueT&, ValueT&, const ValueT&, const ValueT&)> capsuleBottomTopVertical =
-    [this](ValueT& zb, ValueT& zt, const ValueT& x, const ValueT& y)
+    std::function<bool(ComputeT&, ComputeT&, const ComputeT&, const ComputeT&)> capsuleBottomTopVertical =
+    [this](ComputeT& zb, ComputeT& zt, const ComputeT& x, const ComputeT& y)
     {
         zb = BaseT::sphereBottom(mX1, mY1, math::Min(mZ1, mZ2), mORad, x, y);
         zt = BaseT::sphereTop(mX2, mY2, math::Max(mZ1, mZ2), mORad, x, y);
 
-        return std::isfinite(zb) && std::isfinite(zt);
+        return math::isFinite(zb) && math::isFinite(zt);
     };
 
     // non vertical capsule
     // for a given x,y pair, find the z-range of a tube
     //   first find the z-range as if its an infinite cylinder
     //   then for each z-range endpoint, determine if it should be on a sphere cap
-    std::function<bool(ValueT&, ValueT&, const ValueT&, const ValueT&)> capsuleBottomTop =
-    [this](ValueT& zb, ValueT& zt, const ValueT& x, const ValueT& y)
+    std::function<bool(ComputeT&, ComputeT&, const ComputeT&, const ComputeT&)> capsuleBottomTop =
+    [this](ComputeT& zb, ComputeT& zt, const ComputeT& x, const ComputeT& y)
     {
-        ValueT cylptb, cylptt;
+        ComputeT cylptb, cylptt;
         if (!infiniteCylinderBottomTop(cylptb, cylptt, x, y))
             return false;
 
-        const ValueT dotb = (Vec3T(x, y, cylptb) - mPt1).dot(mV);
-        const ValueT dott = (Vec3T(x, y, cylptt) - mPt1).dot(mV);
+        const ComputeT dotb = (Vec3T(x, y, cylptb) - mPt1).dot(mV);
+        const ComputeT dott = (Vec3T(x, y, cylptt) - mPt1).dot(mV);
 
         if (dotb < 0)
             zb = sphere1Bottom(x, y);
@@ -311,28 +312,28 @@ private:
         else
             zt = cylptt;
 
-        return std::isfinite(zb) && std::isfinite(zt);
+        return math::isFinite(zb) && math::isFinite(zt);
     };
 
     // assumes capsule is not vertical!
     inline bool
-    infiniteCylinderBottomTop(ValueT& cylptb, ValueT& cylptt, const ValueT& x, const ValueT& y) const
+    infiniteCylinderBottomTop(ComputeT& cylptb, ComputeT& cylptt, const ComputeT& x, const ComputeT& y) const
     {
         const Vec2T q(x, y);
 
         const Vec2T qproj = mPt12d + mV2d*((q - mPt12d).dot(mV2d))/mXYNorm2;
 
-        const ValueT t = mX1 != mX2 ? (qproj[0] - mX1)/mXdiff : (qproj[1] - mY1)/mYdiff;
+        const ComputeT t = mX1 != mX2 ? (qproj[0] - mX1)/mXdiff : (qproj[1] - mY1)/mYdiff;
 
         const Vec3T qproj3D = mPt1 + t * mV;
 
-        const ValueT d2 = (q - qproj).lengthSqr();
+        const ComputeT d2 = (q - qproj).lengthSqr();
 
         // outside of cylinder's 2D projection
         if (mORad2 < d2)
             return false;
 
-        const ValueT h = math::Sqrt((mORad2 - d2) * mVLenSqr/mXYNorm2);
+        const ComputeT h = math::Sqrt((mORad2 - d2) * mVLenSqr/mXYNorm2);
 
         cylptb = qproj3D[2] - h;
         cylptt = qproj3D[2] + h;
@@ -340,62 +341,62 @@ private:
         return true;
     }
 
-    inline ValueT
-    lineBottom(const ValueT& x) const
+    inline ComputeT
+    lineBottom(const ComputeT& x) const
     {
         return mY1 + (mYdiff*(x-mX1) - mORad * mXYNorm)/mXdiff;
     }
 
-    inline ValueT
-    lineTop(const ValueT& x) const
+    inline ComputeT
+    lineTop(const ComputeT& x) const
     {
         return mY1 + (mYdiff*(x-mX1) + mORad * mXYNorm)/mXdiff;
     }
 
-    inline ValueT
-    circle1Bottom(const ValueT& x) const
+    inline ComputeT
+    circle1Bottom(const ComputeT& x) const
     {
         return BaseT::circleBottom(mX1, mY1, mORad, x);
     }
 
-    inline ValueT
-    circle1Top(const ValueT& x) const
+    inline ComputeT
+    circle1Top(const ComputeT& x) const
     {
         return BaseT::circleTop(mX1, mY1, mORad, x);
     }
 
-    inline ValueT
-    circle2Bottom(const ValueT& x) const
+    inline ComputeT
+    circle2Bottom(const ComputeT& x) const
     {
         return BaseT::circleBottom(mX2, mY2, mORad, x);
     }
 
-    inline ValueT
-    circle2Top(const ValueT& x) const
+    inline ComputeT
+    circle2Top(const ComputeT& x) const
     {
         return BaseT::circleTop(mX2, mY2, mORad, x);
     }
 
-    inline ValueT
-    sphere1Bottom(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere1Bottom(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereBottom(mX1, mY1, mZ1, mORad, x, y);
     }
 
-    inline ValueT
-    sphere1Top(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere1Top(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereTop(mX1, mY1, mZ1, mORad, x, y);
     }
 
-    inline ValueT
-    sphere2Bottom(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere2Bottom(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereBottom(mX2, mY2, mZ2, mORad, x, y);
     }
 
-    inline ValueT
-    sphere2Top(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere2Top(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereTop(mX2, mY2, mZ2, mORad, x, y);
     }
@@ -407,8 +408,8 @@ private:
     initialize(const math::Vec3<ScalarType>& pt1,
                const math::Vec3<ScalarType>& pt2, const ScalarType& r)
     {
-        const ValueT vx = BaseT::voxelSize(),
-                     hw = BaseT::halfWidth();
+        const ComputeT vx = BaseT::voxelSize(),
+                       hw = BaseT::halfWidth();
 
         if (pt1[0] <= pt2[0]) {
             mPt1 = Vec3T(pt1)/vx;
@@ -418,7 +419,7 @@ private:
             mPt2 = Vec3T(pt1)/vx;
         }
 
-        mRad = ValueT(r)/vx;
+        mRad = ComputeT(r)/vx;
 
         // padded radius used to populate the outer halfwidth of the sdf
         mORad  = mRad + hw;
@@ -453,9 +454,9 @@ private:
 
     Vec2T mPt12d, mPt22d, mV2d;
 
-    ValueT mORad, mORad2, mRad, mVLenSqr, mXdiff, mYdiff, mZdiff, mXYNorm, mXYNorm2;
+    ComputeT mORad, mORad2, mRad, mVLenSqr, mXdiff, mYdiff, mZdiff, mXYNorm, mXYNorm2;
 
-    ValueT mX1, mY1, mZ1, mX2, mY2, mZ2;
+    ComputeT mX1, mY1, mZ1, mX2, mY2, mZ2;
 
     bool mIsVertical;
 
@@ -484,9 +485,10 @@ class TaperedCapsuleVoxelizer
     using BaseT::mXYData;
     using BaseT::tileCeil;
 
-    using ValueT = typename BaseT::ValueT;
-    using Vec3T  = typename BaseT::Vec3T;
-    using Vec2T  = typename BaseT::Vec2T;
+    using ValueT   = typename BaseT::ValueT;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
+    using Vec3T    = typename BaseT::Vec3T;
+    using Vec2T    = typename BaseT::Vec2T;
 
 public:
 
@@ -547,17 +549,17 @@ private:
     inline void
     setXYRangeData(const Index& step = 1)
     {
-        const ValueT stepv = ValueT(step);
+        const ComputeT stepv = ComputeT(step);
 
         // short circuit when one circle is in the other
         if (mXYNorm2 <= mRdiff2) {
             if (mX1 - mORad1 <= mX2 - mORad2) {
                 mXYData.reset(mX1 - mORad1, mX1 + mORad1, step);
-                for (ValueT x = tileCeil(mX1 - mORad1, step); x <= mX1 + mORad1; x += stepv)
+                for (ComputeT x = tileCeil(mX1 - mORad1, step); x <= mX1 + mORad1; x += stepv)
                     mXYData.expandYRange(x, circle1Bottom(x), circle1Top(x));
             } else {
                 mXYData.reset(mX2 - mORad2, mX2 + mORad2, step);
-                for (ValueT x = tileCeil(mX2 - mORad2, step); x <= mX2 + mORad2; x += stepv)
+                for (ComputeT x = tileCeil(mX2 - mORad2, step); x <= mX2 + mORad2; x += stepv)
                     mXYData.expandYRange(x, circle2Bottom(x), circle2Top(x));
             }
             return;
@@ -587,15 +589,15 @@ private:
     inline bool
     pullyPoints(Vec2T& p1t, Vec2T& p2t, Vec2T& p1b, Vec2T& p2b) const
     {
-        const ValueT diff = mXYNorm2 - mRdiff2;
+        const ComputeT diff = mXYNorm2 - mRdiff2;
         if (diff < 0)
             return false;
 
-        const ValueT alpha = std::atan2(mYdiff, mXdiff),
-                     theta = std::atan2(math::Sqrt(diff), mRdiff);
+        const ComputeT alpha = std::atan2(mYdiff, mXdiff),
+                       theta = std::atan2(math::Sqrt(diff), mRdiff);
 
-        const ValueT sin1 = math::Sin(theta + alpha), sin2 = math::Sin(theta - alpha),
-                     cos1 = math::Cos(theta + alpha), cos2 = math::Cos(theta - alpha);
+        const ComputeT sin1 = math::Sin(theta + alpha), sin2 = math::Sin(theta - alpha),
+                       cos1 = math::Cos(theta + alpha), cos2 = math::Cos(theta - alpha);
 
         p1t.x() = mX1 + mORad1*cos1; p1t.y() = mY1 + mORad1*sin1;
         p2t.x() = mX2 + mORad2*cos1; p2t.y() = mY2 + mORad2*sin1;
@@ -606,9 +608,9 @@ private:
     }
 
     inline void
-    setLineXYData(const Vec2T& q1, const Vec2T& q2, const ValueT& step)
+    setLineXYData(const Vec2T& q1, const Vec2T& q2, const ComputeT& step)
     {
-        if (math::Abs(q1.x() - q2.x()) < math::Tolerance<ValueT>::value()) {
+        if (math::Abs(q1.x() - q2.x()) < math::Tolerance<ComputeT>::value()) {
             ValueT x = tileCeil(q1.x(), step);
             if (q1.x() == x) {
                 mXYData.expandYRange(x, q1.y());
@@ -616,15 +618,15 @@ private:
             }
         } else {
             const bool q1_left = q1.x() < q2.x();
-            const ValueT &x1 = q1_left ? q1.x() : q2.x(),
-                         &y1 = q1_left ? q1.y() : q2.y(),
-                         &x2 = q1_left ? q2.x() : q1.x(),
-                         &y2 = q1_left ? q2.y() : q1.y();
+            const ComputeT &x1 = q1_left ? q1.x() : q2.x(),
+                           &y1 = q1_left ? q1.y() : q2.y(),
+                           &x2 = q1_left ? q2.x() : q1.x(),
+                           &y2 = q1_left ? q2.y() : q1.y();
 
-            ValueT m = (y2 - y1)/(x2 - x1),
-                   x = tileCeil(x1, step),
-                   y = y1 + m * (x-x1),
-                   delta = m * step;
+            ComputeT m = (y2 - y1)/(x2 - x1),
+                     x = tileCeil(x1, step),
+                     y = y1 + m * (x-x1),
+                     delta = m * step;
             for (; x <= x2; x += step, y += delta)
                 mXYData.expandYRange(x, y);
         }
@@ -632,12 +634,12 @@ private:
 
     inline void
     setCircleXYData(const Vec2T& q1, const Vec2T& q2,
-        const ValueT& step, const bool is_pt1)
+        const ComputeT& step, const bool is_pt1)
     {
-        const Vec3T  &p1 = is_pt1 ? mPt1 : mPt2;
-        const ValueT &r1 = is_pt1 ? mORad1 : mORad2;
+        const Vec3T    &p1 = is_pt1 ? mPt1 : mPt2;
+        const ComputeT &r1 = is_pt1 ? mORad1 : mORad2;
 
-        const std::vector<ValueT> xs = {
+        const std::vector<ComputeT> xs = {
             tileCeil(p1.x() - r1, step),
             tileCeil(math::Min(q1.x(), q2.x()), step),
             tileCeil(math::Max(q1.x(), q2.x()), step),
@@ -651,40 +653,40 @@ private:
     }
 
     inline void
-    setCircleHiXYData(const ValueT& x1, const ValueT& x2,
-        const ValueT& step, const bool& is_pt1)
+    setCircleHiXYData(const ComputeT& x1, const ComputeT& x2,
+        const ComputeT& step, const bool& is_pt1)
     {
-        const ValueT x_test = static_cast<ValueT>(math::Floor(ValueT(0.5)*(x1+x2)));
+        const ComputeT x_test = static_cast<ValueT>(math::Floor(ComputeT(0.5)*(x1+x2)));
 
         if (is_pt1) {
             // if |x2-x1| is small, our test point might be too close to the pulley point
             if (math::Abs(x2-x1) < 5 || mXYData.getYMax(x_test) <= circle1Top(x_test)) {
-                for (ValueT x = x1; x < x2; x += step)
+                for (ComputeT x = x1; x < x2; x += step)
                     mXYData.expandYMax(x, circle1Top(x));
             }
         } else {
             if (math::Abs(x2-x1) < 5 || mXYData.getYMax(x_test) <= circle2Top(x_test)) {
-                for (ValueT x = x1; x < x2; x += step)
+                for (ComputeT x = x1; x < x2; x += step)
                     mXYData.expandYMax(x, circle2Top(x));
             }
         }
     }
 
     inline void
-    setCircleLoXYData(const ValueT& x1, const ValueT& x2,
-        const ValueT& step, const bool& is_pt1)
+    setCircleLoXYData(const ComputeT& x1, const ComputeT& x2,
+        const ComputeT& step, const bool& is_pt1)
     {
-        const ValueT x_test = static_cast<ValueT>(math::Floor(ValueT(0.5)*(x1+x2)));
+        const ComputeT x_test = static_cast<ValueT>(math::Floor(ComputeT(0.5)*(x1+x2)));
 
         if (is_pt1) {
             // if |x2-x1| is small, our test point might be too close to the pulley point
             if (math::Abs(x2-x1) < 5 || mXYData.getYMin(x_test) >= circle1Bottom(x_test)) {
-                for (ValueT x = x1; x < x2; x += step)
+                for (ComputeT x = x1; x < x2; x += step)
                     mXYData.expandYMin(x, circle1Bottom(x));
             }
         } else {
             if (math::Abs(x2-x1) < 5 || mXYData.getYMin(x_test) >= circle2Bottom(x_test)) {
-                for (ValueT x = x1; x < x2; x += step)
+                for (ComputeT x = x1; x < x2; x += step)
                     mXYData.expandYMin(x, circle2Bottom(x));
             }
         }
@@ -692,21 +694,21 @@ private:
 
     // Round Cone: https://iquilezles.org/articles/distfunctions/
     // distance in index space
-    inline ValueT
+    inline ComputeT
     signedDistance(const Vec3T& p) const
     {
-        const Vec3T  w  = p - mPt1;
-        const ValueT y  = w.dot(mV),
-                     z  = y - mVLenSqr,
-                     x2 = (w*mVLenSqr - mV*y).lengthSqr(),
-                     y2 = y*y*mVLenSqr,
-                     z2 = z*z*mVLenSqr,
-                     k  = mRdiff2*x2; // should multiply by sgn(mRdiff), but it's always positive
+        const Vec3T    w  = p - mPt1;
+        const ComputeT y  = w.dot(mV),
+                       z  = y - mVLenSqr,
+                       x2 = (w*mVLenSqr - mV*y).lengthSqr(),
+                       y2 = y*y*mVLenSqr,
+                       z2 = z*z*mVLenSqr,
+                       k  = mRdiff2*x2; // should multiply by sgn(mRdiff), but it's always positive
 
-        if (ValueT(math::Sign(z))*mA2*z2 >= k)
+        if (ComputeT(math::Sign(z))*mA2*z2 >= k)
             return math::Sqrt(x2 + z2)*mInvVLenSqr - mRad2;
 
-        if (ValueT(math::Sign(y))*mA2*y2 <= k)
+        if (ComputeT(math::Sign(y))*mA2*y2 <= k)
             return math::Sqrt(x2 + y2)*mInvVLenSqr - mRad1;
 
         return (math::Sqrt(x2*mA2*mInvVLenSqr) + y*mRdiff)*mInvVLenSqr - mRad1;
@@ -716,11 +718,11 @@ private:
     tileCanFit(const Index& dim) const
     {
         // we know mRad1 >= mRad2
-        return mRad1 >= BaseT::halfWidth() + ValueT(0.70711) * (ValueT(dim)-ValueT(1));
+        return mRad1 >= BaseT::halfWidth() + ComputeT(0.70711) * (ComputeT(dim)-ComputeT(1));
     }
 
-    std::function<bool(ValueT&, ValueT&, const ValueT&, const ValueT&)> taperedCapsuleBottomTop =
-    [this](ValueT& zb, ValueT& zt, const ValueT& x, const ValueT& y)
+    std::function<bool(ComputeT&, ComputeT&, const ComputeT&, const ComputeT&)> taperedCapsuleBottomTop =
+    [this](ComputeT& zb, ComputeT& zt, const ComputeT& x, const ComputeT& y)
     {
         const Vec2T q(x, y);
 
@@ -734,8 +736,8 @@ private:
 
         if (in_ball2) {
             if (in_ball1) {
-                const ValueT zt2 = sphere2Top(x, y),
-                             zb2 = 2.0f*mZ2 - zt2;
+                const ComputeT zt2 = sphere2Top(x, y),
+                               zb2 = 2.0f*mZ2 - zt2;
 
                 zt = math::Max(zt, zt2);
                 zb = math::Min(zb, zb2);
@@ -757,7 +759,7 @@ private:
             }
         }
 
-        ValueT conezb = 0.0f, conezt = 0.0f;
+        ComputeT conezb = ComputeT(0), conezt = ComputeT(0);
         int cint_cnt;
         openConeFrustumBottomTop(conezb, conezt, cint_cnt, x, y);
 
@@ -796,8 +798,8 @@ private:
     // https://www.geometrictools.com/Documentation/IntersectionLineCone.pdf
     // works in double precision in case the cone tapers very slowly (r1 ~ r2)
     inline void
-    openConeFrustumBottomTop(ValueT& conezb, ValueT& conezt, int& cint_cnt,
-        const ValueT& x, const ValueT& y) const
+    openConeFrustumBottomTop(ComputeT& conezb, ComputeT& conezt, int& cint_cnt,
+        const ComputeT& x, const ComputeT& y) const
     {
         cint_cnt = 0;
         const Vec3d p(double(x), double(y), mRayZ);
@@ -808,23 +810,23 @@ private:
         const double c1 = mGamma * diff.z() - mConeD.z() * ddotdiff;
         const double c0 = ddotdiff * ddotdiff - mGamma * diff.lengthSqr();
 
-        if (mC2 != 0.0f) {
+        if (mC2 != 0.0) {
             const double delta = c1*c1 - c0*mC2;
-            if (delta >= 0.0f) {
+            if (delta >= 0.0) {
                 const double sqrt = math::Sqrt(delta);
                 const double t1 = mC2Inv*(-c1 + sqrt);
                 if (validFrustumRange(t1, ddotdiff)) {
                     cint_cnt++;
-                    conezb = ValueT(mRayZ - t1);
+                    conezb = ComputeT(mRayZ - t1);
                 }
                 const double t2 = mC2Inv*(-c1 - sqrt);
                 if (validFrustumRange(t2, ddotdiff)) {
                     cint_cnt++;
                     if (cint_cnt == 2 && t1 > t2)
-                        conezt = ValueT(mRayZ - t2);
+                        conezt = ComputeT(mRayZ - t2);
                     else {
                         conezt = conezb;
-                        conezb = ValueT(mRayZ - t2);
+                        conezb = ComputeT(mRayZ - t2);
                     }
                 }
             }
@@ -832,7 +834,7 @@ private:
             const double t = -c0/(2.0f*c1);
             if (validFrustumRange(t, ddotdiff)) {
                 cint_cnt = 1;
-                conezb = ValueT(mRayZ - t);
+                conezb = ComputeT(mRayZ - t);
             }
         }
 
@@ -847,50 +849,50 @@ private:
         return mH1 <= h && h <= mH2;
     }
 
-    inline ValueT
-    circle1Bottom(const ValueT& x) const
+    inline ComputeT
+    circle1Bottom(const ComputeT& x) const
     {
         return BaseT::circleBottom(mX1, mY1, mORad1, x);
     }
 
-    inline ValueT
-    circle1Top(const ValueT& x) const
+    inline ComputeT
+    circle1Top(const ComputeT& x) const
     {
         return BaseT::circleTop(mX1, mY1, mORad1, x);
     }
 
-    inline ValueT
-    circle2Bottom(const ValueT& x) const
+    inline ComputeT
+    circle2Bottom(const ComputeT& x) const
     {
         return BaseT::circleBottom(mX2, mY2, mORad2, x);
     }
 
-    inline ValueT
-    circle2Top(const ValueT& x) const
+    inline ComputeT
+    circle2Top(const ComputeT& x) const
     {
         return BaseT::circleTop(mX2, mY2, mORad2, x);
     }
 
-    inline ValueT
-    sphere1Bottom(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere1Bottom(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereBottom(mX1, mY1, mZ1, mORad1, x, y);
     }
 
-    inline ValueT
-    sphere1Top(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere1Top(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereTop(mX1, mY1, mZ1, mORad1, x, y);
     }
 
-    inline ValueT
-    sphere2Bottom(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere2Bottom(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereBottom(mX2, mY2, mZ2, mORad2, x, y);
     }
 
-    inline ValueT
-    sphere2Top(const ValueT& x, const ValueT& y) const
+    inline ComputeT
+    sphere2Top(const ComputeT& x, const ComputeT& y) const
     {
         return BaseT::sphereTop(mX2, mY2, mZ2, mORad2, x, y);
     }
@@ -902,20 +904,20 @@ private:
     initialize(const math::Vec3<ScalarType>& pt1, const math::Vec3<ScalarType>& pt2,
                const ScalarType& r1, const ScalarType& r2)
     {
-        const ValueT vx = BaseT::voxelSize(),
-                     hw = BaseT::halfWidth();
+        const ComputeT vx = BaseT::voxelSize(),
+                       hw = BaseT::halfWidth();
 
         // enforce mRad1 > mRad2
         if (r2 <= r1) {
             mPt1 = Vec3T(pt1)/vx;
             mPt2 = Vec3T(pt2)/vx;
-            mRad1 = ValueT(r1)/vx;
-            mRad2 = ValueT(r2)/vx;
+            mRad1 = ComputeT(r1)/vx;
+            mRad2 = ComputeT(r2)/vx;
         } else {
             mPt1 = Vec3T(pt2)/vx;
             mPt2 = Vec3T(pt1)/vx;
-            mRad1 = ValueT(r2)/vx;
-            mRad2 = ValueT(r1)/vx;
+            mRad1 = ComputeT(r2)/vx;
+            mRad2 = ComputeT(r1)/vx;
         }
 
         // padded radii used to populate the outer halfwidth of the sdf
@@ -945,7 +947,7 @@ private:
 
         mV = mPt2 - mPt1;
         mVLenSqr = mV.lengthSqr();
-        mInvVLenSqr = mVLenSqr != ValueT(0) ? ValueT(1)/mVLenSqr : ValueT(1);
+        mInvVLenSqr = mVLenSqr != ComputeT(0) ? ComputeT(1)/mVLenSqr : ComputeT(1);
 
         mX1 = mPt1[0]; mY1 = mPt1[1]; mZ1 = mPt1[2];
         mX2 = mPt2[0]; mY2 = mPt2[1]; mZ2 = mPt2[2];
@@ -960,7 +962,7 @@ private:
 
         mXYNorm2  = math::Pow2(mXdiff) + math::Pow2(mYdiff);
         mXYNorm   = math::Sqrt(mXYNorm2);
-        mIXYNorm2 = mXYNorm2 != ValueT(0) ? ValueT(1)/mXYNorm2 : ValueT(1);
+        mIXYNorm2 = mXYNorm2 != ComputeT(0) ? ComputeT(1)/mXYNorm2 : ComputeT(1);
 
         // mRdiff is non negative
         mRdiff  = mRad1 - mRad2;
@@ -999,10 +1001,10 @@ private:
 
     Vec2T mPt12d, mPt22d, mV2d;
 
-    ValueT mORad1, mORad2, mORad1Sqr, mORad2Sqr, mRad1, mRad2, mVLenSqr, mInvVLenSqr,
-           mXdiff, mYdiff, mZdiff, mXYNorm, mXYNorm2, mIXYNorm2, mRdiff, mRdiff2, mA2;
+    ComputeT mORad1, mORad2, mORad1Sqr, mORad2Sqr, mRad1, mRad2, mVLenSqr, mInvVLenSqr,
+             mXdiff, mYdiff, mZdiff, mXYNorm, mXYNorm2, mIXYNorm2, mRdiff, mRdiff2, mA2;
 
-    ValueT mX1, mY1, mZ1, mX2, mY2, mZ2;
+    ComputeT mX1, mY1, mZ1, mX2, mY2, mZ2;
 
     // some members are stored explicitly as double because when
     // the cone tapers very slowly (r1 ~ r2), then csc(cone_angle) can be very large
@@ -1029,10 +1031,14 @@ class TubeComplexVoxelizer {
     using TreeT = typename GridType::TreeType;
     using LeafT = typename TreeT::LeafNodeType;
 
+    using ValueT = typename GridType::ValueType;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
+
     using PartitionerT = tools::PointPartitioner<Index32, LeafT::LOG2DIM>;
 
     using Vec3T = math::Vec3<ScalarType>;
 
+    static_assert(openvdb::is_floating_point<ValueT>::value);
     static_assert(std::is_floating_point<ScalarType>::value);
 
 public:
@@ -1301,7 +1307,7 @@ createLevelSetTubeComplex(const std::vector<math::Vec3<ScalarType>>& vertices,
 
     using ComplexVoxelizer = typename lvlset::TubeComplexVoxelizer<GridType, ScalarType, InterruptT>;
 
-    static_assert(std::is_floating_point<ValueT>::value,
+    static_assert(openvdb::is_floating_point<ValueT>::value,
         "createLevelSetTubeComplex must return a scalar grid");
 
     if (voxelSize <= 0) OPENVDB_THROW(ValueError, "voxel size must be positive");
@@ -1334,7 +1340,7 @@ createLevelSetTubeComplex(const std::vector<math::Vec3<ScalarType>>& vertices,
     using CapsuleComplexVoxelizer = typename lvlset::TubeComplexVoxelizer<GridType, ScalarType, InterruptT, true>;
     using TaperedCapsuleComplexVoxelizer = typename lvlset::TubeComplexVoxelizer<GridType, ScalarType, InterruptT, false>;
 
-    static_assert(std::is_floating_point<ValueT>::value,
+    static_assert(openvdb::is_floating_point<ValueT>::value,
         "createLevelSetTubeComplex must return a scalar grid");
 
     if (voxelSize <= 0) OPENVDB_THROW(ValueError, "voxel size must be positive");
@@ -1401,12 +1407,13 @@ createLevelSetCapsule(const math::Vec3<ScalarType>& pt1, const math::Vec3<Scalar
 {
     static_assert(std::is_floating_point<ScalarType>::value);
 
-    using GridPtr = typename GridType::Ptr;
-    using ValueT = typename GridType::ValueType;
+    using GridPtr  = typename GridType::Ptr;
+    using ValueT   = typename GridType::ValueType;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
 
     using CapsuleVoxelizer = typename lvlset::CapsuleVoxelizer<GridType, InterruptT>;
 
-    static_assert(std::is_floating_point<ValueT>::value,
+    static_assert(openvdb::is_floating_point<ComputeT>::value,
         "createLevelSetCapsule must return a scalar grid");
 
     if (voxelSize <= 0) OPENVDB_THROW(ValueError, "voxel size must be positive");
@@ -1440,13 +1447,14 @@ createLevelSetTaperedCapsule(const math::Vec3<ScalarType>& pt1, const math::Vec3
 {
     static_assert(std::is_floating_point<ScalarType>::value);
 
-    using GridPtr = typename GridType::Ptr;
-    using ValueT = typename GridType::ValueType;
+    using GridPtr  = typename GridType::Ptr;
+    using ValueT   = typename GridType::ValueType;
+    using ComputeT = typename ComputeTypeFor<ValueT>::type;
 
     using CapsuleVoxelizer = typename lvlset::CapsuleVoxelizer<GridType, InterruptT>;
     using TaperedCapsuleVoxelizer = typename lvlset::TaperedCapsuleVoxelizer<GridType, InterruptT>;
 
-    static_assert(std::is_floating_point<ValueT>::value,
+    static_assert(openvdb::is_floating_point<ComputeT>::value,
         "createLevelSetTaperedCapsule must return a scalar grid");
 
     if (voxelSize <= 0) OPENVDB_THROW(ValueError, "voxel size must be positive");

--- a/openvdb/openvdb/unittest/TestMath.cc
+++ b/openvdb/openvdb/unittest/TestMath.cc
@@ -13,6 +13,186 @@ class TestMath: public ::testing::Test
 {
 };
 
+// Testing the operators within the member functions of Vec3
+template<typename ValueT>
+void testMemberOperatorsImpl()
+{
+    using namespace openvdb;
+    using Vec3T = math::Vec3<ValueT>;
+
+    {
+        Vec3T vecA(ValueT(3.14f), ValueT(2.18f), ValueT(-299792458.f));
+
+        // Alternative indexed the elements
+        EXPECT_EQ(vecA(0), ValueT(3.14f));
+        EXPECT_EQ(vecA(1), ValueT(2.18f));
+        EXPECT_EQ(vecA(2), ValueT(-299792458.f));
+
+        // Assignment operator
+        Vec3T vecB = vecA;
+        EXPECT_EQ(vecB(0), vecA(0));
+        EXPECT_EQ(vecB(1), vecA(1));
+        EXPECT_EQ(vecB(2), vecA(2));
+
+        // Negation operator
+        Vec3T vecC = -vecA;
+        EXPECT_EQ(vecC(0), -vecA(0));
+        EXPECT_EQ(vecC(1), -vecA(1));
+        EXPECT_EQ(vecC(2), -vecA(2));
+
+        // Multiply each element of the vector by a scalar
+        Vec3T vecD = vecA;
+        const ValueT gr = ValueT(1.618034f); // golden ratio
+        vecD *= gr;
+        EXPECT_EQ(vecD(0), ValueT(gr * vecA(0)));
+        EXPECT_EQ(vecD(1), ValueT(gr * vecA(1)));
+        EXPECT_EQ(vecD(2), ValueT(gr * vecA(2)));
+
+        // Multiply each element of the vector by the corresponding element
+        Vec3T vecE = vecA;
+        Vec3T vecF(ValueT(-2.5f), ValueT(1.2f), ValueT(3.14159f));
+        vecE *= vecF;
+        EXPECT_EQ(vecE(0), ValueT(vecA(0) * vecF(0)));
+        EXPECT_EQ(vecE(1), ValueT(vecA(1) * vecF(1)));
+        EXPECT_EQ(vecE(2), ValueT(vecA(2) * vecF(2)));
+
+        // Divide each element of the vector by a scalar
+        Vec3T vecG = vecA;
+        vecG /= gr;
+        EXPECT_EQ(vecG(0), ValueT(vecA(0) / gr));
+        EXPECT_EQ(vecG(1), ValueT(vecA(1) / gr));
+        EXPECT_EQ(vecG(2), ValueT(vecA(2) / gr));
+
+        // Divide each element of the vector by the corresponding element of the given vector
+        Vec3T vecH = vecA;
+        vecH /= vecF;
+        EXPECT_EQ(vecH(0), ValueT(vecA(0) / vecF(0)));
+        EXPECT_EQ(vecH(1), ValueT(vecA(1) / vecF(1)));
+        EXPECT_EQ(vecH(2), ValueT(vecA(2) / vecF(2)));
+
+        // Add a scalar to each element of the vector
+        Vec3T vecI = vecA;
+        vecI += gr;
+        EXPECT_EQ(vecI(0), ValueT(vecA(0) + gr));
+        EXPECT_EQ(vecI(1), ValueT(vecA(1) + gr));
+        EXPECT_EQ(vecI(2), ValueT(vecA(2) + gr));
+
+        // Add each element of the given vector to the corresponding element of this vector
+        Vec3T vecJ = vecA;
+        vecJ += vecF;
+        EXPECT_EQ(vecJ(0), ValueT(vecA(0) + vecF(0)));
+        EXPECT_EQ(vecJ(1), ValueT(vecA(1) + vecF(1)));
+        EXPECT_EQ(vecJ(2), ValueT(vecA(2) + vecF(2)));
+
+        // Subtract a scalar from each element of this vector
+        Vec3T vecK = vecA;
+        vecK -= gr;
+        EXPECT_EQ(vecK(0), ValueT(vecA(0) - gr));
+        EXPECT_EQ(vecK(1), ValueT(vecA(1) - gr));
+        EXPECT_EQ(vecK(2), ValueT(vecA(2) - gr));
+
+        // Subtract each element of the given vector from the corresponding element of this vector
+        Vec3T vecL = vecA;
+        vecL -= vecF;
+        EXPECT_EQ(vecL(0), ValueT(vecA(0) - vecF(0)));
+        EXPECT_EQ(vecL(1), ValueT(vecA(1) - vecF(1)));
+        EXPECT_EQ(vecL(2), ValueT(vecA(2) - vecF(2)));
+    }
+}
+
+TEST_F(TestMath, testMemberOperators)
+{
+    using namespace openvdb;
+
+    testMemberOperatorsImpl<math::half>();
+    testMemberOperatorsImpl<float>();
+    testMemberOperatorsImpl<double>();
+}
+
+
+template<typename ValueT>
+void testFreeFunctionsOperatorsImpl()
+{
+    using namespace openvdb;
+    using Vec3T = math::Vec3<ValueT>;
+
+    {
+        Vec3T vecA(ValueT(1),ValueT(2),ValueT(3));
+        Vec3T vecB(ValueT(3),ValueT(4),ValueT(5));
+        const ValueT gr = ValueT(1.618034f); // golden ratio
+
+        /// Check equality operator, does exact floating point comparisons ==
+        bool eqRes = vecA == vecB;
+        EXPECT_FALSE(eqRes);
+
+        /// Check inequality operator, does exact floating point comparisons !=
+        bool ineqRes = vecA != vecB;
+        EXPECT_TRUE(ineqRes);
+
+        /// Check multiplication: scalar * vec
+        Vec3T sclrMultA = gr * vecA;
+        EXPECT_EQ(sclrMultA(0), ValueT(vecA(0) * gr));
+        EXPECT_EQ(sclrMultA(1), ValueT(vecA(1) * gr));
+        EXPECT_EQ(sclrMultA(2), ValueT(vecA(2) * gr));
+
+        /// Check multiplication: vec * scalar
+        Vec3T sclrMultB = vecA * gr;
+        EXPECT_EQ(sclrMultB(0), ValueT(vecA(0) * gr));
+        EXPECT_EQ(sclrMultB(1), ValueT(vecA(1) * gr));
+        EXPECT_EQ(sclrMultB(2), ValueT(vecA(2) * gr));
+
+        /// Check multiplication vec0 * vec1
+        Vec3T multRes = vecA * vecB;
+        EXPECT_EQ(multRes, Vec3T(ValueT(3), ValueT(8), ValueT(15)));
+
+        /// Check: scalar / vec
+        Vec3T sclrDivA = gr / vecA;
+        EXPECT_EQ(sclrDivA(0), ValueT(gr / vecA(0)));
+        EXPECT_EQ(sclrDivA(1), ValueT(gr / vecA(1)));
+        EXPECT_EQ(sclrDivA(2), ValueT(gr / vecA(2)));
+
+        /// Check: vec / scalar
+        Vec3T scalarDivB = vecA / gr;
+        EXPECT_EQ(scalarDivB(0), ValueT(vecA(0) / gr));
+        EXPECT_EQ(scalarDivB(1), ValueT(vecA(1) / gr));
+        EXPECT_EQ(scalarDivB(2), ValueT(vecA(2) / gr));
+
+        /// Check element-wise div: vec0 / vec1
+        Vec3T divRes = vecA / vecB;
+        EXPECT_EQ(divRes(0), ValueT(ValueT(vecA(0)) / ValueT(vecB(0))));
+        EXPECT_EQ(divRes(1), ValueT(ValueT(vecA(1)) / ValueT(vecB(1))));
+        EXPECT_EQ(divRes(2), ValueT(ValueT(vecA(2)) / ValueT(vecB(2))));
+
+        /// Check addition: vec0 + vec1
+        Vec3T addRes = vecA + vecB;
+        EXPECT_EQ(addRes, Vec3T(ValueT(4), ValueT(6), ValueT(8)));
+
+        /// Check scalar addition: a + vec
+        Vec3T addSclrRes = vecA + gr;
+        EXPECT_EQ(addSclrRes(0), ValueT(vecA(0) + gr));
+        EXPECT_EQ(addSclrRes(1), ValueT(vecA(1) + gr));
+        EXPECT_EQ(addSclrRes(2), ValueT(vecA(2) + gr));
+
+        /// Check element-wise subtraction: vec0 - vec1
+        Vec3T subtractRes = vecA - vecB;
+        EXPECT_EQ(subtractRes, Vec3T(ValueT(-2), ValueT(-2), ValueT(-2)));
+
+        /// Check scalar subtraction: vec0 - a
+        Vec3T subSclrRes = vecA - gr;
+        EXPECT_EQ(subSclrRes(0), ValueT(vecA(0) - gr));
+        EXPECT_EQ(subSclrRes(1), ValueT(vecA(1) - gr));
+        EXPECT_EQ(subSclrRes(2), ValueT(vecA(2) - gr));
+    }
+}
+
+TEST_F(TestMath, testFreeFunctionOperators)
+{
+    using namespace openvdb;
+    testFreeFunctionsOperatorsImpl<math::half>();
+    testFreeFunctionsOperatorsImpl<float>();
+    testFreeFunctionsOperatorsImpl<double>();
+}
+
 
 // This suite of tests obviously needs to be expanded!
 TEST_F(TestMath, testAll)
@@ -23,6 +203,7 @@ TEST_F(TestMath, testAll)
         EXPECT_EQ(math::Sign( 3   ), 1);
         EXPECT_EQ(math::Sign(-1.0 ),-1);
         EXPECT_EQ(math::Sign( 0.0f), 0);
+        EXPECT_EQ(math::Sign(math::half(0.)), 0);
     }
     {// SignChange
         EXPECT_TRUE( math::SignChange( -1, 1));


### PR DESCRIPTION
**What are the most important things that I should take-away from this PR at the code-level?**
We want to make progress on making `HalfGrid` native in `OpenVDB`. This means:
- We have `HalfDecl.h` that brings in **either** an `OpenEXR half` type or the `internal half` type that we have in `openvdb`. It's good to note at this point that this type is included in `math.h` and `Vec3.h`.
- We have a few type-traits functions and class to handle "specialization" with Half.
- We have an `ExtendedRealGridTypes` in `Types.h`. This is used to build `NumericGridTypes`, which is used to build `GridTypes`. The function `openvdb::initialize` makes sure that `HalfGrid` is registered (by calling `GridTypes::foreach<RegisterGrid>()`).
- These tools work with `HalfGrid`:

**What `type_traits` functions/idioms do you add?**
- Adds `openvdb::is_floating_point` which inherits from `std::is_floating_point`. Itd allows specialization for `Half` type.
- Adds `openvdb::is_signed` which inherits from `std::is_signed`. It allows specialization for `Half` type.
- Adds a trait class called `ComputeTypeFor` to convert `Half -> float`, `Vec2H -> Vec2s`, `Vec3H -> Vec3s`, Vec4H -> Vec4s`.

**What medium tests did you do?**
    - authoring `sphere level set`
    - authoring `platonic solid level set`
    - change level set background
    - level set measure
    - mesh to volume
    - volume to mesh
    - rendering half grid using `vdb_render` (to test interpolation)
