### PR TITLE
Add const mask access to bool LeafBuffer

### DIFF
--- a/openvdb/openvdb/tree/LeafBuffer.h
+++ b/openvdb/openvdb/tree/LeafBuffer.h
@@ -514,6 +514,9 @@ public:
     /// @warning This method should only be used by experts seeking low-level optimizations.
     const WordType* data() const { return const_cast<LeafBuffer*>(this)->data(); }
 
+    /// @brief Return raw LeafBuffer data
+    const NodeMaskType& storage() const { return mData; }
+
 private:
     // Allow the parent LeafNode to access this buffer's data.
     template<typename, Index> friend class LeafNode;

--- a/openvdb/openvdb/unittest/TestLeafBool.cc
+++ b/openvdb/openvdb/unittest/TestLeafBool.cc
@@ -55,6 +55,15 @@ TEST_F(TestLeafBool, testGetValue)
             EXPECT_EQ(~LeafType::Buffer::WordType(0), w[n]);
         }
     }
+    {// test const Buffer::mask()
+        LeafType leaf(openvdb::Coord(0, 0, 0), /*background=*/false);
+        leaf.fill(true);
+        const LeafType& cleaf = leaf;
+        const LeafType::Buffer::NodeMaskType& storage = cleaf.buffer().storage();
+        for (openvdb::Index n = 0; n < LeafType::Buffer::WORD_COUNT; ++n) {
+            EXPECT_EQ(~LeafType::Buffer::WordType(0), storage.template getWord<LeafType::Buffer::WordType>(n));
+        }
+    }
 }
 
 

--- a/pendingchanges/bool_mask_access.txt
+++ b/pendingchanges/bool_mask_access.txt
@@ -1,0 +1,3 @@
+API changes:
+- Add LeafBuffer<bool, Log2Dim>::storage() for direct const access to the
+  raw data buffer when using the bool LeafNode.


### PR DESCRIPTION
This extends the bool partial specialization of LeafBuffer to allow direct const access to the mask outside of the Tree hierarchy classes.