### PR TITLE
Switch NanoVDB tests to using macos 14 runners

### DIFF
--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -164,12 +164,7 @@ jobs:
           ./ci/build.sh -v
           --build-type=${{ matrix.config.build }}
           --components=core,nano,nanotest,nanoexam,nanobench,nanotool
-          --cargs=\"
-              -DUSE_EXPLICIT_INSTANTIATION=OFF
-              -DNANOVDB_USE_CUDA=OFF
-              -DNANOVDB_USE_OPENVDB=ON
-              -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
-              \"
+          --cargs=\'-DUSE_EXPLICIT_INSTANTIATION=OFF -DNANOVDB_USE_CUDA=OFF -DNANOVDB_USE_OPENVDB=ON -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install \'
       - name: test
         run: cd build && ctest -V -E ".*cuda.*|.*mgpu.*"
 


### PR DESCRIPTION
Switching NanoVDB tests to macos 14 runners In support of fixing failing tests in #2108.