### PR TITLE
Fix minor spelling issues in Convex tools

### DIFF
--- a/openvdb/openvdb/tools/impl/ConvexVoxelizer.h
+++ b/openvdb/openvdb/tools/impl/ConvexVoxelizer.h
@@ -310,8 +310,8 @@ protected:
     ///
     /// @param[out] zb Reference to the z ordinate where the bottom intersection occurs.
     /// @param[out] zt Reference to the z ordinate where the top intersection occurs.
-    /// @param[in] x The x ordinate of the infinte line.
-    /// @param[in] y The y ordinate of the infinte line.
+    /// @param[in] x The x ordinate of the infinite line.
+    /// @param[in] y The y ordinate of the infinite line.
     /// @return true if an intersection occurs; otherwise false.
     /// @note The derived class can override this lambda to implement different behavior for degenerate cases.
     std::function<bool(ValueT&, ValueT&, const ValueT&, const ValueT&)> bottomTop =
@@ -1112,7 +1112,7 @@ private:
 
         const ValueT dist = invokeTilePointSignedDistance(p);
 
-        // fast positive criterion: circumsribed ball is in the object
+        // fast positive criterion: circumscribed ball is in the object
         if (dist <= -R2-mHw)
             return true;
 

--- a/openvdb/openvdb/tools/impl/LevelSetTubesImpl.h
+++ b/openvdb/openvdb/tools/impl/LevelSetTubesImpl.h
@@ -121,7 +121,7 @@ private:
     //
     //
     // This routine projects the tube on the xy-plane, giving a stadium shape.
-    // It detemines the x-scan range, and the y-range for each x-value.
+    // It determines the x-scan range, and the y-range for each x-value.
     // The x-range is divided into intervals depending on if each y endpoint hits a circle or line.
     //
     // The x-range is partitioned by ordinates a0, a1, a2, a3, a4, a5


### PR DESCRIPTION
This is pulled from https://github.com/AcademySoftwareFoundation/openvdb/pull/2108 and I believe because there are changes to the openvdb/ codebase, this PR is causing the NanoVDB PR to rebuild lots of additional GHA workflows (core library, ax, houdini, etc) that is contributing to the large amount of build and workflows and caches we are consuming at the moment. Once this PR is merged, we can merge master into that PR2108 to eliminate these openvdb/ changes from that PR and reduce the GHA workflows needed for that PR.

@kmuseth @ghurstunither 