### PR TITLE
Fix GHA CI install for Latex

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,8 @@ jobs:
       run: ./ci/install_nanobind.sh 2.0.0
     - name: install_latex
       run: |
-        yum -y install texlive-latex-bin texlive-dvips texlive-collection-fontsrecommended texlive-collection-latexrecommended
+        dnf install -y epel-release
+        dnf install -y texlive-latex-bin texlive-dvips texlive-collection-fontsrecommended texlive-collection-latexrecommended
     - name: build
       run: >
         ./ci/build.sh -v


### PR DESCRIPTION
Latex install now needs the EPEL release packages on Rocky 8 (which is what our containers are based on). Also, use dnf instead of yum.