### PR TITLE
Use direct download instead of yum repos to install texlive

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,9 +46,7 @@ jobs:
     - name: nanobind
       run: ./ci/install_nanobind.sh 2.5.0
     - name: install_latex
-      run: |
-        dnf install -y epel-release
-        dnf install -y texlive-latex-bin texlive-dvips texlive-collection-fontsrecommended texlive-collection-latexrecommended
+      run: ./ci/install_texlive.sh
     - name: build
       run: >
         ./ci/build.sh -v

--- a/ci/install_texlive.sh
+++ b/ci/install_texlive.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+# Download the TeX Live installer
+wget https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+
+# Extract
+tar xzf install-tl-unx.tar.gz
+rm install-tl-unx.tar.gz
+cd install-tl-*
+
+# Run the installer with no docs or source installation
+./install-tl --no-interaction --no-doc-install --no-src-install --scheme=minimal
+
+# Export the texlive PATH to GITHUB_PATH
+TEXLIVE_PATH=/usr/local/texlive/2025/bin/x86_64-linux
+export PATH=${TEXLIVE_PATH}:${PATH}
+echo "${TEXLIVE_PATH}" >> $GITHUB_PATH
+
+# Install the required packages
+tlmgr install latex-bin dvips collection-fontsrecommended collection-latexrecommended
+
+# Validate that installing dvips and latex has been successful
+dvips --version
+latex --version


### PR DESCRIPTION
This should resolve the ongoing sporadic issues with yum for installing latex/dvips.