### PR TITLE
Use unit vector for Ray in TestLevelSetRayIntersector

### DIFF
--- a/openvdb/openvdb/unittest/TestLevelSetRayIntersector.cc
+++ b/openvdb/openvdb/unittest/TestLevelSetRayIntersector.cc
@@ -322,7 +322,7 @@ TEST_F(TestLevelSetRayIntersector, testMissedIntersections)
     tools::LevelSetRayIntersector<FloatGrid> lsri(*ls);
 
     // Create a ray that misses the sphere, but intersects the bounding box
-    const Vec3T dir(-2.0, -2.0, 3.0); // Ray crossing the sphere
+    const Vec3T dir = Vec3T(-2.0, -2.0, 3.0).unit(); // Ray crossing the sphere
     const Vec3T eye(12.0, 12.0, 12.0); // Starting point
     const RayT ray(eye, dir);
 


### PR DESCRIPTION
@Idclip reported that there is a unit-test failing due to fp tolerances in debug mode. Example is:  https://github.com/AcademySoftwareFoundation/openvdb/actions/runs/18772327264/job/53622625184. I was able to reproduce the error locally. Changing the ray direction to have unit-length fixes the error locally.