### PR TITLE
Fix unit test assertions

### DIFF
--- a/openvdb/openvdb/math/Quat.h
+++ b/openvdb/openvdb/math/Quat.h
@@ -112,7 +112,7 @@ public:
     /// unit vector
     Quat(const Vec3<T> &axis, T angle)
     {
-        OPENVDB_ASSERT(isApproxEqual(axis.length(), T(1)));
+        OPENVDB_ASSERT(isApproxEqual(axis.length(), T(1), T(1.0e-7)));
 
         T s = T(sin(angle*T(0.5)));
 

--- a/openvdb/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/openvdb/unittest/TestAttributeArray.cc
@@ -314,7 +314,8 @@ TEST_F(TestAttributeArray, testAttributeArray)
         EXPECT_EQ(4.6, attr2.get(9));
     }
 
-#ifdef NDEBUG
+    // the following tests are not run when asserts are enabled
+#ifndef OPENVDB_ENABLE_ASSERTS
     { // test setUnsafe and getUnsafe on uniform arrays
         AttributeArrayD::Ptr attr(new AttributeArrayD(50));
 

--- a/openvdb/openvdb/unittest/TestPointDataLeaf.cc
+++ b/openvdb/openvdb/unittest/TestPointDataLeaf.cc
@@ -383,8 +383,8 @@ TEST_F(TestPointDataLeaf, testOffsets)
 
 TEST_F(TestPointDataLeaf, testSetValue)
 {
-    // the following tests are not run when in debug mode due to assertions firing
-#ifdef NDEBUG
+    // the following tests are not run when asserts are enabled
+#ifndef OPENVDB_ENABLE_ASSERTS
     LeafType leaf(openvdb::Coord(0, 0, 0));
 
     openvdb::Coord xyz(0, 0, 0);


### PR DESCRIPTION
This addresses two main issues related to assertions:

* Seemingly a bug in the quaternion unit test was causing an assertion to fire for one of the unit tests, because the default tolerance of 1e-8 was being used. I have slightly loosened this to 1e-7 and this fixes this issue (cannot answer why this hasn't been a problem until now, as far as I can tell nothing has touched this code for a long time).
* Assertions have been uncoupled from debug mode for some time. Some of the unit tests still had a check for NDEBUG to gate specific tests which would otherwise fire assertions. This prevents the unit tests from passing when assertions are enabled in release mode.