### PR TITLE
NanoVDB : Rename padding to blindDataCount

### DIFF
--- a/nanovdb/nanovdb/python/PyIO.cc
+++ b/nanovdb/nanovdb/python/PyIO.cc
@@ -39,7 +39,7 @@ void defineFileGridMetaData(nb::module_& m)
         .def_prop_ro("tileCount",
                      [](io::FileMetaData& metaData) { return std::make_tuple(metaData.tileCount[0], metaData.tileCount[1], metaData.tileCount[2]); })
         .def_ro("codec", &io::FileMetaData::codec)
-        .def_ro("padding", &io::FileMetaData::padding)
+        .def_ro("blindDataCount", &io::FileMetaData::blindDataCount)
         .def_ro("version", &io::FileMetaData::version);
 
     nb::bind_vector<std::vector<io::FileMetaData>>(m, "FileMetaDataVector");

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -358,7 +358,7 @@ class TestReadWriteGrids(unittest.TestCase):
             self.assertIsInstance(metadata.nodeCount, tuple)
             self.assertIsInstance(metadata.tileCount, tuple)
             self.assertEqual(metadata.codec, nanovdb.io.Codec.NONE)
-            self.assertEqual(metadata.padding, 0)
+            self.assertEqual(metadata.blindDataCount, 0)
             self.assertEqual(metadata.version, nanovdb.Version())
 
     def test_read_write_grid(self):
@@ -428,7 +428,7 @@ class TestDeviceReadWriteGrids(unittest.TestCase):
             self.assertIsInstance(metadata.nodeCount, tuple)
             self.assertIsInstance(metadata.tileCount, tuple)
             self.assertEqual(metadata.codec, nanovdb.io.Codec.NONE)
-            self.assertEqual(metadata.padding, 0)
+            self.assertEqual(metadata.blindDataCount, 0)
             self.assertEqual(metadata.version, nanovdb.Version())
 
     def test_read_write_grid(self):


### PR DESCRIPTION
Hello,

I made a simple patch to address https://github.com/AcademySoftwareFoundation/openvdb/issues/2134

Kind regards