### PR TITLE
Update all existing unit tests to use Grid I/O methods

### DIFF
--- a/openvdb/openvdb/unittest/TestFile.cc
+++ b/openvdb/openvdb/unittest/TestFile.cc
@@ -44,7 +44,7 @@
 class TestFile: public ::testing::Test
 {
 public:
-    void SetUp() override {}
+    void SetUp() override { openvdb::initialize(); }
     void TearDown() override { openvdb::uninitialize(); }
 
     void testHeader();
@@ -126,8 +126,6 @@ TestFile::testWriteGrid()
     tree.setValue(Coord(0, 0, 0), 5);
 
     // Add some metadata.
-    Metadata::clearRegistry();
-    StringMetadata::registerType();
     const std::string meta0Val, meta1Val("Hello, world.");
     Metadata::Ptr stringMetadata = Metadata::createMetadata(typeNameAsString<std::string>());
     EXPECT_TRUE(stringMetadata);
@@ -157,22 +155,6 @@ TestFile::testWriteGrid()
     io::setCurrentVersion(istr);
 
     GridBase::Ptr gd2_grid;
-    EXPECT_THROW(gd2.read(istr), openvdb::LookupError);
-
-    // Register the grid and the transform and the blocks.
-    GridBase::clearRegistry();
-    GridType::registerGrid();
-
-    // Register transform maps
-    math::MapRegistry::clear();
-    math::AffineMap::registerMap();
-    math::ScaleMap::registerMap();
-    math::UniformScaleMap::registerMap();
-    math::TranslationMap::registerMap();
-    math::ScaleTranslateMap::registerMap();
-    math::UniformScaleTranslateMap::registerMap();
-    math::NonlinearFrustumMap::registerMap();
-
     istr.seekg(0, std::ios_base::beg);
     EXPECT_NO_THROW(gd2_grid = gd2.read(istr));
 
@@ -207,10 +189,6 @@ TestFile::testWriteGrid()
     EXPECT_EQ(
         grid->baseTree().treeDepth(), gd2_grid->baseTree().treeDepth());
 
-    //EXPECT_EQ(0.1, gd2_grid->getTransform()->getVoxelSizeX());
-    //EXPECT_EQ(0.1, gd2_grid->getTransform()->getVoxelSizeY());
-    //EXPECT_EQ(0.1, gd2_grid->getTransform()->getVoxelSizeZ());
-
     // Read in the data blocks.
     gd2.seekToBlocks(istr);
     gd2_grid->readBuffers(istr);
@@ -220,10 +198,6 @@ TestFile::testWriteGrid()
     EXPECT_EQ(5, tree2->getValue(Coord(0, 0, 0)));
 
     EXPECT_EQ(1, tree2->getValue(Coord(1000, 1000, 16000)));
-    // Clear registries.
-    GridBase::clearRegistry();
-    Metadata::clearRegistry();
-    math::MapRegistry::clear();
 
     remove("something.vdb2");
 }
@@ -275,20 +249,6 @@ TestFile::testWriteMultipleGrids()
     EXPECT_TRUE(gd2.getGridPos() != 0);
     EXPECT_TRUE(gd2.getBlockPos() != 0);
     EXPECT_TRUE(gd2.getEndPos() != 0);
-
-    // register the grid
-    GridBase::clearRegistry();
-    GridType::registerGrid();
-
-    // register maps
-    math::MapRegistry::clear();
-    math::AffineMap::registerMap();
-    math::ScaleMap::registerMap();
-    math::UniformScaleMap::registerMap();
-    math::TranslationMap::registerMap();
-    math::ScaleTranslateMap::registerMap();
-    math::UniformScaleTranslateMap::registerMap();
-    math::NonlinearFrustumMap::registerMap();
 
     // Read in the first grid descriptor.
     GridDescriptor gd_in;
@@ -377,10 +337,6 @@ TestFile::testWriteMultipleGrids()
     EXPECT_EQ(10, grid2_in->getValue(Coord(0, 0, 0)));
     EXPECT_EQ(2, grid2_in->getValue(Coord(100000, 100000, 16000)));
 
-    // Clear registries.
-    GridBase::clearRegistry();
-
-    math::MapRegistry::clear();
     remove("something.vdb2");
 }
 TEST_F(TestFile, testWriteMultipleGrids) { testWriteMultipleGrids(); }
@@ -393,12 +349,6 @@ TEST_F(TestFile, testWriteFloatAsHalf)
 
     using TreeType = Vec3STree;
     using GridType = Grid<TreeType>;
-
-    // Register all grid types.
-    initialize();
-    // Ensure that the registry is cleared on exit.
-    struct Local { static void uninitialize(char*) { openvdb::uninitialize(); } };
-    SharedPtr<char> onExit(nullptr, Local::uninitialize);
 
     // Create two test grids.
     GridType::Ptr grid1 = createGrid<GridType>(/*bg=*/Vec3s(1, 1, 1));
@@ -459,9 +409,6 @@ TEST_F(TestFile, testWriteFloatAsHalf)
 TEST_F(TestFile, testWriteInstancedGrids)
 {
     using namespace openvdb;
-
-    // Register data types.
-    openvdb::initialize();
 
     // Remove something.vdb2 when done. We must declare this here before the
     // other grid smart_ptr's because we re-use them in the test several times.
@@ -680,19 +627,6 @@ TestFile::testReadGridDescriptors()
     file.writeGrid(gd, grid, ostr, /*seekable=*/true);
     file.writeGrid(gd2, grid2, ostr, /*seekable=*/true);
 
-    // Register the grid and the transform and the blocks.
-    GridBase::clearRegistry();
-    GridType::registerGrid();
-    // register maps
-    math::MapRegistry::clear();
-    math::AffineMap::registerMap();
-    math::ScaleMap::registerMap();
-    math::UniformScaleMap::registerMap();
-    math::TranslationMap::registerMap();
-    math::ScaleTranslateMap::registerMap();
-    math::UniformScaleTranslateMap::registerMap();
-    math::NonlinearFrustumMap::registerMap();
-
     // Read in the grid descriptors.
     File file2("something.vdb2");
     std::istringstream istr(ostr.str(), std::ios_base::binary);
@@ -716,10 +650,6 @@ TestFile::testReadGridDescriptors()
     EXPECT_EQ(gd2.getBlockPos(), file2gd.getBlockPos());
     EXPECT_EQ(gd2.getEndPos(), file2gd.getEndPos());
 
-    // Clear registries.
-    GridBase::clearRegistry();
-    math::MapRegistry::clear();
-
     remove("something.vdb2");
 }
 TEST_F(TestFile, testReadGridDescriptors) { testReadGridDescriptors(); }
@@ -731,9 +661,6 @@ TEST_F(TestFile, testGridNaming)
     using namespace openvdb::io;
 
     using TreeType = Int32Tree;
-
-    // Register data types.
-    openvdb::initialize();
 
     logging::LevelScope suppressLogging{logging::Level::Fatal};
 
@@ -947,19 +874,6 @@ TestFile::testEmptyGridIO()
     EXPECT_EQ(gd.getEndPos(), gd.getBlockPos());
     EXPECT_EQ(gd2.getEndPos(), gd2.getBlockPos());
 
-    // Register the grid and the transform and the blocks.
-    GridBase::clearRegistry();
-    GridType::registerGrid();
-    // register maps
-    math::MapRegistry::clear();
-    math::AffineMap::registerMap();
-    math::ScaleMap::registerMap();
-    math::UniformScaleMap::registerMap();
-    math::TranslationMap::registerMap();
-    math::ScaleTranslateMap::registerMap();
-    math::UniformScaleTranslateMap::registerMap();
-    math::NonlinearFrustumMap::registerMap();
-
     // Read in the grid descriptors.
     File file2(filename);
     std::istringstream istr(ostr.str(), std::ios_base::binary);
@@ -1002,10 +916,6 @@ TestFile::testEmptyGridIO()
     EXPECT_EQ(gd2.getGridPos(), file2gd.getGridPos());
     EXPECT_EQ(gd2.getBlockPos(), file2gd.getBlockPos());
     EXPECT_EQ(gd2.getEndPos(), file2gd.getEndPos());
-
-    // Clear registries.
-    GridBase::clearRegistry();
-    math::MapRegistry::clear();
 }
 TEST_F(TestFile, testEmptyGridIO) { testEmptyGridIO(); }
 
@@ -1055,23 +965,6 @@ void TestFile::testOpen()
     EXPECT_TRUE(meta.metaValue<std::string>("author") == "Einstein");
     EXPECT_EQ(2009, meta.metaValue<int32_t>("year"));
 
-    // Register grid and transform.
-    GridBase::clearRegistry();
-    IntGrid::registerGrid();
-    FloatGrid::registerGrid();
-    Metadata::clearRegistry();
-    StringMetadata::registerType();
-    Int32Metadata::registerType();
-    // register maps
-    math::MapRegistry::clear();
-    math::AffineMap::registerMap();
-    math::ScaleMap::registerMap();
-    math::UniformScaleMap::registerMap();
-    math::TranslationMap::registerMap();
-    math::ScaleTranslateMap::registerMap();
-    math::UniformScaleTranslateMap::registerMap();
-    math::NonlinearFrustumMap::registerMap();
-
     // Write the vdb out to a file.
     io::File vdbfile("something.vdb2");
     vdbfile.write(grids, meta);
@@ -1120,11 +1013,6 @@ void TestFile::testOpen()
     EXPECT_THROW(vdbfile2.open(), openvdb::IoError);
     EXPECT_THROW(vdbfile2.inputStream(), openvdb::IoError);
 
-    // Clear registries.
-    GridBase::clearRegistry();
-    Metadata::clearRegistry();
-    math::MapRegistry::clear();
-
     // Test closing the file.
     vdbfile.close();
     EXPECT_TRUE(vdbfile.isOpen() == false);
@@ -1166,11 +1054,6 @@ TEST_F(TestFile, testGetMetadata)
     meta.insertMeta("author", StringMetadata("Einstein"));
     meta.insertMeta("year", Int32Metadata(2009));
 
-    // Adjust registry before writing.
-    Metadata::clearRegistry();
-    StringMetadata::registerType();
-    Int32Metadata::registerType();
-
     // Write the vdb out to a file.
     io::File vdbfile("something.vdb2");
     vdbfile.write(grids, meta);
@@ -1186,9 +1069,6 @@ TEST_F(TestFile, testGetMetadata)
 
     EXPECT_TRUE(meta2->metaValue<std::string>("author") == "Einstein");
     EXPECT_EQ(2009, meta2->metaValue<int32_t>("year"));
-
-    // Clear registry.
-    Metadata::clearRegistry();
 
     remove("something.vdb2");
 }
@@ -1234,9 +1114,6 @@ TEST_F(TestFile, testReadAll)
     grids.push_back(grid1);
     grids.push_back(grid2);
 
-    // Register grid and transform.
-    openvdb::initialize();
-
     // Write the vdb out to a file.
     io::File vdbfile("something.vdb2");
     vdbfile.write(grids, meta);
@@ -1276,11 +1153,6 @@ TEST_F(TestFile, testReadAll)
     EXPECT_NEAR(10, temperature->getValue(Coord(0, 0, 0)), /*tolerance=*/0);
     EXPECT_NEAR(11, temperature->getValue(Coord(0, 100, 0)), /*tolerance=*/0);
 
-    // Clear registries.
-    GridBase::clearRegistry();
-    Metadata::clearRegistry();
-    math::MapRegistry::clear();
-
     vdbfile2.close();
 
     remove("something.vdb2");
@@ -1294,11 +1166,6 @@ TEST_F(TestFile, testWriteOpenFile)
     MetaMap::Ptr meta(new MetaMap);
     meta->insertMeta("author", StringMetadata("Einstein"));
     meta->insertMeta("year", Int32Metadata(2009));
-
-    // Register metadata
-    Metadata::clearRegistry();
-    StringMetadata::registerType();
-    Int32Metadata::registerType();
 
     // Write the metadata out to a file.
     io::File vdbfile("something.vdb2");
@@ -1330,9 +1197,6 @@ TEST_F(TestFile, testWriteOpenFile)
 
     EXPECT_NO_THROW(vdbfile2.write(*grids));
 
-    // Clear registries.
-    Metadata::clearRegistry();
-
     remove("something.vdb2");
 }
 
@@ -1340,8 +1204,6 @@ TEST_F(TestFile, testWriteOpenFile)
 TEST_F(TestFile, testReadGridMetadata)
 {
     using namespace openvdb;
-
-    openvdb::initialize();
 
     const char* filename = "testReadGridMetadata.vdb2";
     SharedPtr<const char> scopedFile(filename, ::remove);
@@ -1512,9 +1374,6 @@ TEST_F(TestFile, testReadGrid)
     grids.push_back(grid);
     grids.push_back(grid2);
 
-    // Register grid and transform.
-    openvdb::initialize();
-
     // Write the vdb out to a file.
     io::File vdbfile("something.vdb2");
     vdbfile.write(grids, meta);
@@ -1548,11 +1407,6 @@ TEST_F(TestFile, testReadGrid)
 
     EXPECT_NEAR(5,typedDensity->getValue(Coord(0, 0, 0)), /*tolerance=*/0);
     EXPECT_NEAR(6,typedDensity->getValue(Coord(100, 0, 0)), /*tolerance=*/0);
-
-    // Clear registries.
-    GridBase::clearRegistry();
-    Metadata::clearRegistry();
-    math::MapRegistry::clear();
 
     vdbfile2.close();
 
@@ -1603,9 +1457,6 @@ validateClippedGrid(const GridT& clipped, const typename GridT::ValueType& fg)
 TEST_F(TestFile, testReadClippedGrid)
 {
     using namespace openvdb;
-
-    // Register types.
-    openvdb::initialize();
 
     // World-space clipping region
     const BBoxd clipBox(Vec3d(4.0, 4.0, -6.0), Vec3d(4.9, 4.9, 6.0));
@@ -1958,23 +1809,6 @@ TEST_F(TestFile, testHasGrid)
     grids.push_back(grid);
     grids.push_back(grid2);
 
-    // Register grid and transform.
-    GridBase::clearRegistry();
-    IntGrid::registerGrid();
-    FloatGrid::registerGrid();
-    Metadata::clearRegistry();
-    StringMetadata::registerType();
-    Int32Metadata::registerType();
-    // register maps
-    math::MapRegistry::clear();
-    math::AffineMap::registerMap();
-    math::ScaleMap::registerMap();
-    math::UniformScaleMap::registerMap();
-    math::TranslationMap::registerMap();
-    math::ScaleTranslateMap::registerMap();
-    math::UniformScaleTranslateMap::registerMap();
-    math::NonlinearFrustumMap::registerMap();
-
     // Write the vdb out to a file.
     io::File vdbfile("something.vdb2");
     vdbfile.write(grids, meta);
@@ -1989,11 +1823,6 @@ TEST_F(TestFile, testHasGrid)
     EXPECT_TRUE(vdbfile2.hasGrid("temperature"));
     EXPECT_TRUE(!vdbfile2.hasGrid("Temperature"));
     EXPECT_TRUE(!vdbfile2.hasGrid("densitY"));
-
-    // Clear registries.
-    GridBase::clearRegistry();
-    Metadata::clearRegistry();
-    math::MapRegistry::clear();
 
     vdbfile2.close();
 
@@ -2039,9 +1868,6 @@ TEST_F(TestFile, testNameIterator)
     grid = createGrid(ftree);
     grid->setName("level_set");
     grids.push_back(grid);
-
-    // Register types.
-    openvdb::initialize();
 
     const char* filename = "testNameIterator.vdb2";
     SharedPtr<const char> scopedFile(filename, ::remove);
@@ -2089,9 +1915,6 @@ TEST_F(TestFile, testCompression)
     using namespace openvdb::io;
 
     using IntGrid = openvdb::Int32Grid;
-
-    // Register types.
-    openvdb::initialize();
 
     // Create reference grids.
     IntGrid::Ptr intGrid = IntGrid::create(/*background=*/0);
@@ -2302,9 +2125,6 @@ TEST_F(TestFile, testAsync)
 {
     using namespace openvdb;
 
-    // Register types.
-    openvdb::initialize();
-
     // Create a grid.
     FloatGrid::Ptr lsGrid = createLevelSet<FloatGrid>();
     unittest_util::makeSphere(/*dim=*/Coord(100), /*ctr=*/Vec3f(50, 50, 50), /*r=*/20.0,
@@ -2422,8 +2242,6 @@ TEST_F(TestFile, testAsync)
 // (see https://github.com/Blosc/c-blosc/pull/63).
 TEST_F(TestFile, testBlosc)
 {
-    openvdb::initialize();
-
     const unsigned char rawdata[] = {
         0x93, 0xb0, 0x49, 0xaf, 0x62, 0xad, 0xe3, 0xaa, 0xe4, 0xa5, 0x43, 0x20, 0x24,
         0x29, 0xc9, 0xaf, 0xee, 0xad, 0x0b, 0xac, 0x3d, 0xa8, 0x1f, 0x99, 0x53, 0x27,

--- a/openvdb/openvdb/unittest/TestLeafBool.cc
+++ b/openvdb/openvdb/unittest/TestLeafBool.cc
@@ -5,6 +5,7 @@
 #include <openvdb/Types.h>
 #include <openvdb/tools/Filter.h>
 #include <openvdb/util/logging.h>
+#include <openvdb/io/io.h>
 #include "util.h" // for unittest_util::makeSphere()
 #include <gtest/gtest.h>
 #include <set>
@@ -293,26 +294,49 @@ TEST_F(TestLeafBool, testIO)
     leaf.setValueOn(openvdb::Coord(0, 1, 0));
     leaf.setValueOn(openvdb::Coord(1, 0, 0));
 
-    std::ostringstream ostr(std::ios_base::binary);
+    // read and write topology to disk
 
-    leaf.writeBuffers(ostr);
+    {
+        // create a grid with the leaf for topology testing
+        typedef openvdb::Grid<openvdb::tree::Tree<openvdb::tree::RootNode<
+            openvdb::tree::InternalNode<openvdb::tree::InternalNode<LeafType, 4>, 5>>>> BoolGrid;
+        BoolGrid::Ptr grid = BoolGrid::create();
+        grid->setName("bool_leaf");
+        grid->tree().addLeaf(new LeafType(leaf));
 
-    leaf.setValueOff(openvdb::Coord(0, 1, 0));
-    leaf.setValueOn(openvdb::Coord(0, 1, 1));
+        openvdb::GridCPtrVec grids;
+        grids.push_back(grid);
 
-    std::istringstream istr(ostr.str(), std::ios_base::binary);
-    // Since the input stream doesn't include a VDB header with file format version info,
-    // tag the input stream explicitly with the current version number.
-    openvdb::io::setCurrentVersion(istr);
+        // write to file
+        {
+            openvdb::io::File file("leaf_bool.vdb");
+            file.write(grids);
+            file.close();
+        }
 
-    leaf.readBuffers(istr);
+        // read grid from file
+        BoolGrid::Ptr gridFromDisk;
+        {
+            openvdb::io::File file("leaf_bool.vdb");
+            file.open();
+            openvdb::GridBase::Ptr baseGrid = file.readGrid("bool_leaf");
+            file.close();
 
-    EXPECT_EQ(origin, leaf.origin());
+            gridFromDisk = openvdb::gridPtrCast<BoolGrid>(baseGrid);
+        }
 
-    EXPECT_TRUE(leaf.isValueOn(openvdb::Coord(0, 1, 0)));
-    EXPECT_TRUE(leaf.isValueOn(openvdb::Coord(1, 0, 0)));
+        LeafType* leaf2 = gridFromDisk->tree().probeLeaf(origin);
+        EXPECT_TRUE(leaf2);
 
-    EXPECT_TRUE(leaf.onVoxelCount() == 2);
+        // check topology and values match
+
+        EXPECT_EQ(origin, leaf2->origin());
+        EXPECT_TRUE(leaf2->isValueOn(openvdb::Coord(0, 1, 0)));
+        EXPECT_TRUE(leaf2->isValueOn(openvdb::Coord(1, 0, 0)));
+        EXPECT_TRUE(leaf2->onVoxelCount() == 2);
+
+        remove("leaf_bool.vdb");
+    }
 }
 
 

--- a/openvdb/openvdb/unittest/TestLeafBool.cc
+++ b/openvdb/openvdb/unittest/TestLeafBool.cc
@@ -340,6 +340,35 @@ TEST_F(TestLeafBool, testIO)
 }
 
 
+TEST_F(TestLeafBool, testTreeIO)
+{
+    LeafType leaf(openvdb::Coord(1, 3, 5));
+    const openvdb::Coord origin = leaf.origin();
+
+    leaf.setValueOn(openvdb::Coord(0, 1, 0));
+    leaf.setValueOn(openvdb::Coord(1, 0, 0));
+
+    std::ostringstream ostr(std::ios_base::binary);
+
+    leaf.writeBuffers(ostr);
+
+    leaf.setValueOff(openvdb::Coord(0, 1, 0));
+    leaf.setValueOn(openvdb::Coord(0, 1, 1));
+
+    std::istringstream istr(ostr.str(), std::ios_base::binary);
+    openvdb::io::setCurrentVersion(istr);
+
+    leaf.readBuffers(istr);
+
+    EXPECT_EQ(origin, leaf.origin());
+
+    EXPECT_TRUE(leaf.isValueOn(openvdb::Coord(0, 1, 0)));
+    EXPECT_TRUE(leaf.isValueOn(openvdb::Coord(1, 0, 0)));
+
+    EXPECT_TRUE(leaf.onVoxelCount() == 2);
+}
+
+
 TEST_F(TestLeafBool, testConstructors)
 {
     using openvdb::Coord;

--- a/openvdb/openvdb/unittest/TestLeafIO.cc
+++ b/openvdb/openvdb/unittest/TestLeafIO.cc
@@ -17,6 +17,7 @@ class TestLeafIO
 {
 public:
     static void testBuffer();
+    static void testTreeIO();
 };
 
 template<typename T>
@@ -74,6 +75,35 @@ TestLeafIO<T>::testBuffer()
 
         remove("leaf_io.vdb");
     }
+}
+
+
+template<typename T>
+void
+TestLeafIO<T>::testTreeIO()
+{
+    using LeafT = openvdb::tree::LeafNode<T, 3>;
+    LeafT leaf(openvdb::Coord(0, 0, 0));
+
+    leaf.setValueOn(openvdb::Coord(0, 1, 0), T(1));
+    leaf.setValueOn(openvdb::Coord(1, 0, 0), T(1));
+
+    std::ostringstream ostr(std::ios_base::binary);
+
+    leaf.writeBuffers(ostr);
+
+    leaf.setValueOn(openvdb::Coord(0, 1, 0), T(0));
+    leaf.setValueOn(openvdb::Coord(0, 1, 1), T(1));
+
+    std::istringstream istr(ostr.str(), std::ios_base::binary);
+    openvdb::io::setCurrentVersion(istr);
+
+    leaf.readBuffers(istr);
+
+    EXPECT_NEAR(T(1), leaf.getValue(openvdb::Coord(0, 1, 0)), /*tolerance=*/0);
+    EXPECT_NEAR(T(1), leaf.getValue(openvdb::Coord(1, 0, 0)), /*tolerance=*/0);
+
+    EXPECT_TRUE(leaf.onVoxelCount() == 2);
 }
 
 
@@ -143,4 +173,37 @@ TEST_F(TestLeafIOTest, testBufferVec3R)
 
         remove("leaf_vec3r.vdb");
     }
+}
+
+TEST_F(TestLeafIOTest, testTreeIOInt) { TestLeafIO<int>::testTreeIO(); }
+TEST_F(TestLeafIOTest, testTreeIOFloat) { TestLeafIO<float>::testTreeIO(); }
+TEST_F(TestLeafIOTest, testTreeIODouble) { TestLeafIO<double>::testTreeIO(); }
+TEST_F(TestLeafIOTest, testTreeIOBool) { TestLeafIO<bool>::testTreeIO(); }
+TEST_F(TestLeafIOTest, testTreeIOByte) { TestLeafIO<openvdb::Byte>::testTreeIO(); }
+
+
+TEST_F(TestLeafIOTest, testTreeIOVec3R)
+{
+    using LeafT = openvdb::tree::LeafNode<openvdb::Vec3R, 3>;
+    LeafT leaf(openvdb::Coord(0, 0, 0));
+
+    leaf.setValueOn(openvdb::Coord(0, 1, 0), openvdb::Vec3R(1, 1, 1));
+    leaf.setValueOn(openvdb::Coord(1, 0, 0), openvdb::Vec3R(1, 1, 1));
+
+    std::ostringstream ostr(std::ios_base::binary);
+
+    leaf.writeBuffers(ostr);
+
+    leaf.setValueOn(openvdb::Coord(0, 1, 0), openvdb::Vec3R(0, 0, 0));
+    leaf.setValueOn(openvdb::Coord(0, 1, 1), openvdb::Vec3R(1, 1, 1));
+
+    std::istringstream istr(ostr.str(), std::ios_base::binary);
+    openvdb::io::setCurrentVersion(istr);
+
+    leaf.readBuffers(istr);
+
+    EXPECT_TRUE(leaf.getValue(openvdb::Coord(0, 1, 0)) == openvdb::Vec3R(1, 1, 1));
+    EXPECT_TRUE(leaf.getValue(openvdb::Coord(1, 0, 0)) == openvdb::Vec3R(1, 1, 1));
+
+    EXPECT_TRUE(leaf.onVoxelCount() == 2);
 }

--- a/openvdb/openvdb/unittest/TestLeafIO.cc
+++ b/openvdb/openvdb/unittest/TestLeafIO.cc
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <openvdb/Exceptions.h>
+#include <openvdb/openvdb.h>
 #include <openvdb/tree/LeafNode.h>
 #include <openvdb/Types.h>
+#include <openvdb/io/io.h>
 #include <gtest/gtest.h>
 
 #include <cctype> // for toupper()
@@ -21,35 +23,65 @@ template<typename T>
 void
 TestLeafIO<T>::testBuffer()
 {
-    openvdb::tree::LeafNode<T, 3> leaf(openvdb::Coord(0, 0, 0));
+    using LeafT = openvdb::tree::LeafNode<T, 3>;
+    LeafT leaf(openvdb::Coord(0, 0, 0));
+    const openvdb::Coord origin = leaf.origin();
 
     leaf.setValueOn(openvdb::Coord(0, 1, 0), T(1));
     leaf.setValueOn(openvdb::Coord(1, 0, 0), T(1));
 
-    std::ostringstream ostr(std::ios_base::binary);
+    // read and write topology to disk
 
-    leaf.writeBuffers(ostr);
+    {
+        // create a grid with the leaf for topology testing
+        typedef openvdb::Grid<openvdb::tree::Tree<openvdb::tree::RootNode<
+            openvdb::tree::InternalNode<openvdb::tree::InternalNode<LeafT, 4>, 5>>>> GridType;
+        if (!GridType::isRegistered()) GridType::registerGrid();
 
-    leaf.setValueOn(openvdb::Coord(0, 1, 0), T(0));
-    leaf.setValueOn(openvdb::Coord(0, 1, 1), T(1));
+        typename GridType::Ptr grid = GridType::create();
+        grid->setName("leaf_io");
+        grid->tree().addLeaf(new LeafT(leaf));
 
-    std::istringstream istr(ostr.str(), std::ios_base::binary);
+        openvdb::GridCPtrVec grids;
+        grids.push_back(grid);
 
-    // Since the input stream doesn't include a VDB header with file format version info,
-    // tag the input stream explicitly with the current version number.
-    openvdb::io::setCurrentVersion(istr);
+        // write to file
+        {
+            openvdb::io::File file("leaf_io.vdb");
+            file.write(grids);
+            file.close();
+        }
 
-    leaf.readBuffers(istr);
+        // read grid from file
+        typename GridType::Ptr gridFromDisk;
+        {
+            openvdb::io::File file("leaf_io.vdb");
+            file.open();
+            openvdb::GridBase::Ptr baseGrid = file.readGrid("leaf_io");
+            file.close();
 
-    EXPECT_NEAR(T(1), leaf.getValue(openvdb::Coord(0, 1, 0)), /*tolerance=*/0);
-    EXPECT_NEAR(T(1), leaf.getValue(openvdb::Coord(1, 0, 0)), /*tolerance=*/0);
+            gridFromDisk = openvdb::gridPtrCast<GridType>(baseGrid);
+        }
 
-    EXPECT_TRUE(leaf.onVoxelCount() == 2);
+        LeafT* leaf2 = gridFromDisk->tree().probeLeaf(origin);
+        EXPECT_TRUE(leaf2);
+
+        // check topology and values match
+
+        EXPECT_NEAR(T(1), leaf2->getValue(openvdb::Coord(0, 1, 0)), /*tolerance=*/0);
+        EXPECT_NEAR(T(1), leaf2->getValue(openvdb::Coord(1, 0, 0)), /*tolerance=*/0);
+        EXPECT_TRUE(leaf2->onVoxelCount() == 2);
+
+        remove("leaf_io.vdb");
+    }
 }
 
 
 class TestLeafIOTest: public ::testing::Test
 {
+public:
+    void SetUp() override { openvdb::initialize(); }
+    void TearDown() override { openvdb::uninitialize(); }
 };
 
 
@@ -62,28 +94,53 @@ TEST_F(TestLeafIOTest, testBufferByte) { TestLeafIO<openvdb::Byte>::testBuffer()
 
 TEST_F(TestLeafIOTest, testBufferVec3R)
 {
-    openvdb::tree::LeafNode<openvdb::Vec3R, 3> leaf(openvdb::Coord(0, 0, 0));
+    using LeafT = openvdb::tree::LeafNode<openvdb::Vec3R, 3>;
+    LeafT leaf(openvdb::Coord(0, 0, 0));
+    const openvdb::Coord origin = leaf.origin();
 
     leaf.setValueOn(openvdb::Coord(0, 1, 0), openvdb::Vec3R(1, 1, 1));
     leaf.setValueOn(openvdb::Coord(1, 0, 0), openvdb::Vec3R(1, 1, 1));
 
-    std::ostringstream ostr(std::ios_base::binary);
+    // read and write topology to disk
 
-    leaf.writeBuffers(ostr);
+    {
+        // create a grid with the leaf for topology testing
+        typedef openvdb::Grid<openvdb::tree::Tree<openvdb::tree::RootNode<
+            openvdb::tree::InternalNode<openvdb::tree::InternalNode<LeafT, 4>, 5>>>> GridType;
+        GridType::Ptr grid = GridType::create();
+        grid->setName("leaf_vec3r");
+        grid->tree().addLeaf(new LeafT(leaf));
 
-    leaf.setValueOn(openvdb::Coord(0, 1, 0), openvdb::Vec3R(0, 0, 0));
-    leaf.setValueOn(openvdb::Coord(0, 1, 1), openvdb::Vec3R(1, 1, 1));
+        openvdb::GridCPtrVec grids;
+        grids.push_back(grid);
 
-    std::istringstream istr(ostr.str(), std::ios_base::binary);
+        // write to file
+        {
+            openvdb::io::File file("leaf_vec3r.vdb");
+            file.write(grids);
+            file.close();
+        }
 
-    // Since the input stream doesn't include a VDB header with file format version info,
-    // tag the input stream explicitly with the current version number.
-    openvdb::io::setCurrentVersion(istr);
+        // read grid from file
+        GridType::Ptr gridFromDisk;
+        {
+            openvdb::io::File file("leaf_vec3r.vdb");
+            file.open();
+            openvdb::GridBase::Ptr baseGrid = file.readGrid("leaf_vec3r");
+            file.close();
 
-    leaf.readBuffers(istr);
+            gridFromDisk = openvdb::gridPtrCast<GridType>(baseGrid);
+        }
 
-    EXPECT_TRUE(leaf.getValue(openvdb::Coord(0, 1, 0)) == openvdb::Vec3R(1, 1, 1));
-    EXPECT_TRUE(leaf.getValue(openvdb::Coord(1, 0, 0)) == openvdb::Vec3R(1, 1, 1));
+        LeafT* leaf2 = gridFromDisk->tree().probeLeaf(origin);
+        EXPECT_TRUE(leaf2);
 
-    EXPECT_TRUE(leaf.onVoxelCount() == 2);
+        // check topology and values match
+
+        EXPECT_TRUE(leaf2->getValue(openvdb::Coord(0, 1, 0)) == openvdb::Vec3R(1, 1, 1));
+        EXPECT_TRUE(leaf2->getValue(openvdb::Coord(1, 0, 0)) == openvdb::Vec3R(1, 1, 1));
+        EXPECT_TRUE(leaf2->onVoxelCount() == 2);
+
+        remove("leaf_vec3r.vdb");
+    }
 }

--- a/openvdb/openvdb/unittest/TestLeafMask.cc
+++ b/openvdb/openvdb/unittest/TestLeafMask.cc
@@ -6,6 +6,7 @@
 #include <openvdb/tools/Filter.h>
 #include <openvdb/tree/LeafNode.h>
 #include <openvdb/util/logging.h>
+#include <openvdb/io/io.h>
 #include "util.h" // for unittest_util::makeSphere()
 #include <gtest/gtest.h>
 #include <set>
@@ -290,26 +291,49 @@ TEST_F(TestLeafMask, testIO)
     leaf.setValueOn(openvdb::Coord(0, 1, 0));
     leaf.setValueOn(openvdb::Coord(1, 0, 0));
 
-    std::ostringstream ostr(std::ios_base::binary);
+    // read and write topology to disk
 
-    leaf.writeBuffers(ostr);
+    {
+        // create a grid with the leaf for topology testing
+        typedef openvdb::Grid<openvdb::tree::Tree<openvdb::tree::RootNode<
+            openvdb::tree::InternalNode<openvdb::tree::InternalNode<LeafType, 4>, 5>>>> MaskGrid;
+        MaskGrid::Ptr grid = MaskGrid::create();
+        grid->setName("leaf_mask");
+        grid->tree().addLeaf(new LeafType(leaf));
 
-    leaf.setValueOff(openvdb::Coord(0, 1, 0));
-    leaf.setValueOn(openvdb::Coord(0, 1, 1));
+        openvdb::GridCPtrVec grids;
+        grids.push_back(grid);
 
-    std::istringstream istr(ostr.str(), std::ios_base::binary);
-    // Since the input stream doesn't include a VDB header with file format version info,
-    // tag the input stream explicitly with the current version number.
-    openvdb::io::setCurrentVersion(istr);
+        // write to file
+        {
+            openvdb::io::File file("leaf_mask.vdb");
+            file.write(grids);
+            file.close();
+        }
 
-    leaf.readBuffers(istr);
+        // read grid from file
+        MaskGrid::Ptr gridFromDisk;
+        {
+            openvdb::io::File file("leaf_mask.vdb");
+            file.open();
+            openvdb::GridBase::Ptr baseGrid = file.readGrid("leaf_mask");
+            file.close();
 
-    EXPECT_EQ(origin, leaf.origin());
+            gridFromDisk = openvdb::gridPtrCast<MaskGrid>(baseGrid);
+        }
 
-    EXPECT_TRUE(leaf.isValueOn(openvdb::Coord(0, 1, 0)));
-    EXPECT_TRUE(leaf.isValueOn(openvdb::Coord(1, 0, 0)));
+        LeafType* leaf2 = gridFromDisk->tree().probeLeaf(origin);
+        EXPECT_TRUE(leaf2);
 
-    EXPECT_TRUE(leaf.onVoxelCount() == 2);
+        // check topology and values match
+
+        EXPECT_EQ(origin, leaf2->origin());
+        EXPECT_TRUE(leaf2->isValueOn(openvdb::Coord(0, 1, 0)));
+        EXPECT_TRUE(leaf2->isValueOn(openvdb::Coord(1, 0, 0)));
+        EXPECT_TRUE(leaf2->onVoxelCount() == 2);
+
+        remove("leaf_mask.vdb");
+    }
 }
 
 

--- a/openvdb/openvdb/unittest/TestLeafMask.cc
+++ b/openvdb/openvdb/unittest/TestLeafMask.cc
@@ -337,6 +337,35 @@ TEST_F(TestLeafMask, testIO)
 }
 
 
+TEST_F(TestLeafMask, testTreeIO)
+{
+    LeafType leaf(openvdb::Coord(1, 3, 5));
+    const openvdb::Coord origin = leaf.origin();
+
+    leaf.setValueOn(openvdb::Coord(0, 1, 0));
+    leaf.setValueOn(openvdb::Coord(1, 0, 0));
+
+    std::ostringstream ostr(std::ios_base::binary);
+
+    leaf.writeBuffers(ostr);
+
+    leaf.setValueOff(openvdb::Coord(0, 1, 0));
+    leaf.setValueOn(openvdb::Coord(0, 1, 1));
+
+    std::istringstream istr(ostr.str(), std::ios_base::binary);
+    openvdb::io::setCurrentVersion(istr);
+
+    leaf.readBuffers(istr);
+
+    EXPECT_EQ(origin, leaf.origin());
+
+    EXPECT_TRUE(leaf.isValueOn(openvdb::Coord(0, 1, 0)));
+    EXPECT_TRUE(leaf.isValueOn(openvdb::Coord(1, 0, 0)));
+
+    EXPECT_TRUE(leaf.onVoxelCount() == 2);
+}
+
+
 TEST_F(TestLeafMask, testTopologyCopy)
 {
     using openvdb::Coord;

--- a/openvdb/openvdb/unittest/TestMultiResGrid.cc
+++ b/openvdb/openvdb/unittest/TestMultiResGrid.cc
@@ -208,6 +208,8 @@ TEST_F(TestMultiResGrid, testIO)
 {
     using namespace openvdb;
 
+    openvdb::initialize();
+
     const float radius = 1.0f;
     const Vec3f center(0.0f, 0.0f, 0.0f);
     const float voxelSize = 0.01f;
@@ -243,7 +245,6 @@ TEST_F(TestMultiResGrid, testIO)
     outputFile.close();
 
     // Read grids
-    openvdb::initialize();
     openvdb::io::File file( filename );
     file.open();
     GridPtrVecPtr grids = file.getGrids();

--- a/openvdb/openvdb/unittest/TestPointDataLeaf.cc
+++ b/openvdb/openvdb/unittest/TestPointDataLeaf.cc
@@ -1276,6 +1276,97 @@ TEST_F(TestPointDataLeaf, testIO)
 }
 
 
+TEST_F(TestPointDataLeaf, testTreeIO)
+{
+    using AttributeVec3s    = TypedAttributeArray<openvdb::Vec3s>;
+    using AttributeF        = TypedAttributeArray<float>;
+
+    using Descriptor = AttributeSet::Descriptor;
+
+    Descriptor::Ptr descrA = Descriptor::create(AttributeVec3s::attributeType());
+
+    const size_t size = LeafType::NUM_VOXELS;
+
+    LeafType leaf(openvdb::Coord(0, 0, 0));
+    leaf.initializeAttributes(descrA, /*arrayLength=*/size/2);
+
+    descrA = descrA->duplicateAppend("density", AttributeF::attributeType());
+    leaf.appendAttribute(leaf.attributeSet().descriptor(), descrA, descrA->find("density"));
+
+    leaf.setOffsetOn(1, 10);
+    leaf.setOffsetOn(4, 20);
+    leaf.setOffsetOn(7, 5);
+
+    TypedAttributeArray<float>& attr =
+        TypedAttributeArray<float>::cast(leaf.attributeArray("density"));
+
+    attr.set(0, 5.0f);
+    attr.set(50, 2.0f);
+    attr.set(51, 8.1f);
+
+    {
+        LeafType leaf2(openvdb::Coord(0, 0, 0));
+
+        std::ostringstream ostr(std::ios_base::binary);
+        leaf.writeTopology(ostr);
+
+        std::istringstream istr(ostr.str(), std::ios_base::binary);
+        leaf2.readTopology(istr);
+
+        EXPECT_EQ(leaf.onVoxelCount(), leaf2.onVoxelCount());
+        EXPECT_TRUE(leaf2.isValueOn(4));
+        EXPECT_TRUE(!leaf2.isValueOn(5));
+
+        EXPECT_EQ(leaf2.getValue(4), ValueType(0));
+        EXPECT_EQ(leaf2.attributeSet().size(), size_t(0));
+    }
+
+    {
+        LeafType leaf2(openvdb::Coord(0, 0, 0));
+
+        io::StreamMetadata::Ptr streamMetadata(new io::StreamMetadata);
+
+        std::ostringstream ostr(std::ios_base::binary);
+        io::setStreamMetadataPtr(ostr, streamMetadata);
+        io::setDataCompression(ostr, io::COMPRESS_BLOSC);
+        leaf.writeTopology(ostr);
+        for (Index b = 0; b < leaf.buffers(); b++) {
+            uint32_t pass = (uint32_t(leaf.buffers()) << 16) | uint32_t(b);
+            streamMetadata->setPass(pass);
+            leaf.writeBuffers(ostr);
+        }
+        {
+            streamMetadata->setPass(1000);
+            leaf.writeBuffers(ostr);
+
+            io::StreamMetadata::Ptr meta;
+            io::setStreamMetadataPtr(ostr, meta);
+            EXPECT_THROW(leaf.writeBuffers(ostr), openvdb::IoError);
+        }
+
+        std::istringstream istr(ostr.str(), std::ios_base::binary);
+        io::setStreamMetadataPtr(istr, streamMetadata);
+        io::setDataCompression(istr, io::COMPRESS_BLOSC);
+
+        io::setCurrentVersion(istr);
+
+        leaf2.readTopology(istr);
+        for (Index b = 0; b < leaf.buffers(); b++) {
+            uint32_t pass = (uint32_t(leaf.buffers()) << 16) | uint32_t(b);
+            streamMetadata->setPass(pass);
+            leaf2.readBuffers(istr);
+        }
+
+        EXPECT_EQ(leaf.onVoxelCount(), leaf2.onVoxelCount());
+        EXPECT_TRUE(leaf2.isValueOn(4));
+        EXPECT_TRUE(!leaf2.isValueOn(5));
+
+        EXPECT_EQ(leaf2.getValue(4), ValueType(20));
+        EXPECT_EQ(leaf2.attributeSet().size(), size_t(2));
+    }
+}
+
+
 TEST_F(TestPointDataLeaf, testSwap)
 {
     using AttributeVec3s    = TypedAttributeArray<openvdb::Vec3s>;

--- a/openvdb/openvdb/unittest/TestPointDataLeaf.cc
+++ b/openvdb/openvdb/unittest/TestPointDataLeaf.cc
@@ -1058,76 +1058,93 @@ TEST_F(TestPointDataLeaf, testIO)
     // read and write topology to disk
 
     {
-        LeafType leaf2(openvdb::Coord(0, 0, 0));
+        // create a grid with the leaf for topology testing
+        PointDataGrid::Ptr grid = PointDataGrid::create();
+        grid->setName("points");
+        grid->tree().addLeaf(new LeafType(leaf));
 
-        std::ostringstream ostr(std::ios_base::binary);
-        leaf.writeTopology(ostr);
+        openvdb::GridCPtrVec grids;
+        grids.push_back(grid);
 
-        std::istringstream istr(ostr.str(), std::ios_base::binary);
-        leaf2.readTopology(istr);
+        // write to file
+        {
+            io::File file("leaf_topology.vdb");
+            file.write(grids);
+            file.close();
+        }
+
+        // read grid from file
+        PointDataGrid::Ptr gridFromDisk;
+        {
+            io::File file("leaf_topology.vdb");
+            file.open();
+            openvdb::GridBase::Ptr baseGrid = file.readGrid("points");
+            file.close();
+
+            gridFromDisk = openvdb::gridPtrCast<PointDataGrid>(baseGrid);
+        }
+
+        LeafType* leaf2 = gridFromDisk->tree().probeLeaf(openvdb::Coord(0, 0, 0));
+        EXPECT_TRUE(leaf2);
 
         // check topology matches
 
-        EXPECT_EQ(leaf.onVoxelCount(), leaf2.onVoxelCount());
-        EXPECT_TRUE(leaf2.isValueOn(4));
-        EXPECT_TRUE(!leaf2.isValueOn(5));
+        EXPECT_EQ(leaf.onVoxelCount(), leaf2->onVoxelCount());
+        EXPECT_TRUE(leaf2->isValueOn(4));
+        EXPECT_TRUE(!leaf2->isValueOn(5));
 
-        // check only topology (values and attributes still empty)
+        // check that values and attributes are correctly read
 
-        EXPECT_EQ(leaf2.getValue(4), ValueType(0));
-        EXPECT_EQ(leaf2.attributeSet().size(), size_t(0));
+        EXPECT_EQ(leaf2->getValue(4), ValueType(20));
+        EXPECT_EQ(leaf2->attributeSet().size(), size_t(2));
+
+        remove("leaf_topology.vdb");
     }
 
     // read and write buffers to disk
 
     {
-        LeafType leaf2(openvdb::Coord(0, 0, 0));
+        // create a grid with the leaf for buffer testing
+        PointDataGrid::Ptr grid = PointDataGrid::create();
+        grid->setName("points");
+        grid->tree().addLeaf(new LeafType(leaf));
 
-        io::StreamMetadata::Ptr streamMetadata(new io::StreamMetadata);
+        openvdb::GridCPtrVec grids;
+        grids.push_back(grid);
 
-        std::ostringstream ostr(std::ios_base::binary);
-        io::setStreamMetadataPtr(ostr, streamMetadata);
-        io::setDataCompression(ostr, io::COMPRESS_BLOSC);
-        leaf.writeTopology(ostr);
-        for (Index b = 0; b < leaf.buffers(); b++) {
-            uint32_t pass = (uint32_t(leaf.buffers()) << 16) | uint32_t(b);
-            streamMetadata->setPass(pass);
-            leaf.writeBuffers(ostr);
-        }
-        { // error checking
-            streamMetadata->setPass(1000);
-            leaf.writeBuffers(ostr);
-
-            io::StreamMetadata::Ptr meta;
-            io::setStreamMetadataPtr(ostr, meta);
-            EXPECT_THROW(leaf.writeBuffers(ostr), openvdb::IoError);
+        // write to file
+        {
+            io::File file("leaf_buffers.vdb");
+            file.write(grids);
+            file.close();
         }
 
-        std::istringstream istr(ostr.str(), std::ios_base::binary);
-        io::setStreamMetadataPtr(istr, streamMetadata);
-        io::setDataCompression(istr, io::COMPRESS_BLOSC);
+        // read grid from file
+        PointDataGrid::Ptr gridFromDisk;
+        {
+            io::File file("leaf_buffers.vdb");
+            file.open();
+            openvdb::GridBase::Ptr baseGrid = file.readGrid("points");
+            file.close();
 
-        // Since the input stream doesn't include a VDB header with file format version info,
-        // tag the input stream explicitly with the current version number.
-        io::setCurrentVersion(istr);
-
-        leaf2.readTopology(istr);
-        for (Index b = 0; b < leaf.buffers(); b++) {
-            uint32_t pass = (uint32_t(leaf.buffers()) << 16) | uint32_t(b);
-            streamMetadata->setPass(pass);
-            leaf2.readBuffers(istr);
+            gridFromDisk = openvdb::gridPtrCast<PointDataGrid>(baseGrid);
         }
+
+        LeafType* leaf2 = gridFromDisk->tree().probeLeaf(openvdb::Coord(0, 0, 0));
+        EXPECT_TRUE(leaf2);
 
         // check topology matches
 
-        EXPECT_EQ(leaf.onVoxelCount(), leaf2.onVoxelCount());
-        EXPECT_TRUE(leaf2.isValueOn(4));
-        EXPECT_TRUE(!leaf2.isValueOn(5));
+        EXPECT_EQ(leaf.onVoxelCount(), leaf2->onVoxelCount());
+        EXPECT_TRUE(leaf2->isValueOn(4));
+        EXPECT_TRUE(!leaf2->isValueOn(5));
 
-        // check only topology (values and attributes still empty)
+        // check values and attributes are correctly read
 
-        EXPECT_EQ(leaf2.getValue(4), ValueType(20));
-        EXPECT_EQ(leaf2.attributeSet().size(), size_t(2));
+        EXPECT_EQ(leaf2->getValue(4), ValueType(20));
+        EXPECT_EQ(leaf2->attributeSet().size(), size_t(2));
+
+        remove("leaf_buffers.vdb");
     }
 
     { // test multi-buffer IO

--- a/openvdb/openvdb/unittest/TestStream.cc
+++ b/openvdb/openvdb/unittest/TestStream.cc
@@ -36,25 +36,7 @@ protected:
 void
 TestStream::SetUp()
 {
-    openvdb::uninitialize();
-
-    openvdb::Int32Grid::registerGrid();
-    openvdb::FloatGrid::registerGrid();
-
-    openvdb::StringMetadata::registerType();
-    openvdb::Int32Metadata::registerType();
-    openvdb::Int64Metadata::registerType();
-    openvdb::Vec3IMetadata::registerType();
-
-    // Register maps
-    openvdb::math::MapRegistry::clear();
-    openvdb::math::AffineMap::registerMap();
-    openvdb::math::ScaleMap::registerMap();
-    openvdb::math::UniformScaleMap::registerMap();
-    openvdb::math::TranslationMap::registerMap();
-    openvdb::math::ScaleTranslateMap::registerMap();
-    openvdb::math::UniformScaleTranslateMap::registerMap();
-    openvdb::math::NonlinearFrustumMap::registerMap();
+    openvdb::initialize();
 }
 
 

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -790,6 +790,58 @@ TEST_F(TestTree, testIO)
 }
 
 
+TEST_F(TestTree, testTreeIO)
+{
+    const char* filename = "testTreeIO.dbg";
+    openvdb::SharedPtr<const char> scopedFile(filename, ::remove);
+    {
+        ValueType background=5.0f;
+        RootNodeType root_node(background);
+        root_node.setValueOn(openvdb::Coord(5,10,20),0.234f);
+        root_node.setValueOn(openvdb::Coord(50000,20000,30000),4.5678f);
+
+        std::ofstream os(filename, std::ios_base::binary);
+        root_node.writeTopology(os);
+        root_node.writeBuffers(os);
+        EXPECT_TRUE(!os.fail());
+    }
+    {
+        ValueType background=2.0f;
+        RootNodeType root_node(background);
+        ASSERT_DOUBLES_EXACTLY_EQUAL(background, root_node.getValue(openvdb::Coord(5,10,20)));
+        {
+            std::ifstream is(filename, std::ios_base::binary);
+            openvdb::io::setCurrentVersion(is);
+            root_node.readTopology(is);
+            root_node.readBuffers(is);
+            EXPECT_TRUE(!is.fail());
+        }
+
+        ASSERT_DOUBLES_EXACTLY_EQUAL(0.234f, root_node.getValue(openvdb::Coord(5,10,20)));
+        ASSERT_DOUBLES_EXACTLY_EQUAL(5.0f, root_node.getValue(openvdb::Coord(5,11,20)));
+        ValueType sum=0.0f;
+        for (RootNodeType::ChildOnIter root_iter = root_node.beginChildOn();
+            root_iter.test(); ++root_iter)
+        {
+            for (InternalNodeType2::ChildOnIter internal_iter2 = root_iter->beginChildOn();
+                internal_iter2.test(); ++internal_iter2)
+            {
+                for (InternalNodeType1::ChildOnIter internal_iter1 =
+                    internal_iter2->beginChildOn(); internal_iter1.test(); ++internal_iter1)
+                {
+                    for (LeafNodeType::ValueOnIter block_iter =
+                        internal_iter1->beginValueOn(); block_iter.test(); ++block_iter)
+                    {
+                        sum += *block_iter;
+                    }
+                }
+            }
+        }
+        ASSERT_DOUBLES_EXACTLY_EQUAL(sum, (0.234f + 4.5678f));
+    }
+}
+
+
 TEST_F(TestTree, testNegativeIndexing)
 {
     ValueType background=5.0f;

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -731,37 +731,44 @@ TEST_F(TestTree, testIterators)
 
 TEST_F(TestTree, testIO)
 {
-    const char* filename = "testIO.dbg";
+    using TreeType = openvdb::tree::Tree<RootNodeType>;
+    using GridType = openvdb::Grid<TreeType>;
+
+    const char* filename = "testIO.vdb";
     openvdb::SharedPtr<const char> scopedFile(filename, ::remove);
     {
         ValueType background=5.0f;
-        RootNodeType root_node(background);
-        root_node.setValueOn(openvdb::Coord(5,10,20),0.234f);
-        root_node.setValueOn(openvdb::Coord(50000,20000,30000),4.5678f);
+        GridType::Ptr grid = GridType::create(background);
+        grid->setName("test_grid");
+        grid->tree().setValueOn(openvdb::Coord(5,10,20),0.234f);
+        grid->tree().setValueOn(openvdb::Coord(50000,20000,30000),4.5678f);
 
-        std::ofstream os(filename, std::ios_base::binary);
-        root_node.writeTopology(os);
-        root_node.writeBuffers(os);
-        EXPECT_TRUE(!os.fail());
+        openvdb::GridCPtrVec grids;
+        grids.push_back(grid);
+
+        openvdb::io::File file(filename);
+        file.write(grids);
+        file.close();
     }
     {
         ValueType background=2.0f;
-        RootNodeType root_node(background);
-        ASSERT_DOUBLES_EXACTLY_EQUAL(background, root_node.getValue(openvdb::Coord(5,10,20)));
+        GridType::Ptr grid = GridType::create(background);
+        ASSERT_DOUBLES_EXACTLY_EQUAL(background, grid->tree().getValue(openvdb::Coord(5,10,20)));
+
         {
-            std::ifstream is(filename, std::ios_base::binary);
-            // Since the test file doesn't include a VDB header with file format version info,
-            // tag the input stream explicitly with the current version number.
-            openvdb::io::setCurrentVersion(is);
-            root_node.readTopology(is);
-            root_node.readBuffers(is);
-            EXPECT_TRUE(!is.fail());
+            openvdb::io::File file(filename);
+            file.open();
+            openvdb::GridBase::Ptr baseGrid = file.readGrid("test_grid");
+            file.close();
+
+            grid = openvdb::gridPtrCast<GridType>(baseGrid);
+            EXPECT_TRUE(grid.get() != nullptr);
         }
 
-        ASSERT_DOUBLES_EXACTLY_EQUAL(0.234f, root_node.getValue(openvdb::Coord(5,10,20)));
-        ASSERT_DOUBLES_EXACTLY_EQUAL(5.0f, root_node.getValue(openvdb::Coord(5,11,20)));
+        ASSERT_DOUBLES_EXACTLY_EQUAL(0.234f, grid->tree().getValue(openvdb::Coord(5,10,20)));
+        ASSERT_DOUBLES_EXACTLY_EQUAL(5.0f, grid->tree().getValue(openvdb::Coord(5,11,20)));
         ValueType sum=0.0f;
-        for (RootNodeType::ChildOnIter root_iter = root_node.beginChildOn();
+        for (RootNodeType::ChildOnIter root_iter = grid->tree().root().beginChildOn();
             root_iter.test(); ++root_iter)
         {
             for (InternalNodeType2::ChildOnIter internal_iter2 = root_iter->beginChildOn();

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -7,6 +7,7 @@
 #include <openvdb/tools/ValueTransformer.h> // for tools::setValueOnMin(), et al.
 #include <openvdb/tree/LeafNode.h>
 #include <openvdb/io/Compression.h> // for io::RealToHalf
+#include <openvdb/io/Stream.h>
 #include <openvdb/math/Math.h> // for Abs()
 #include <openvdb/openvdb.h>
 #include <openvdb/util/CpuTimer.h>
@@ -104,6 +105,10 @@ TEST_F(TestTree, testChangeBackground)
 
 TEST_F(TestTree, testHalf)
 {
+    // explicitly register these grid types as they are not registered by default
+    openvdb::Grid<openvdb::Vec2STree>::registerGrid();
+    openvdb::Grid<openvdb::Vec2DTree>::registerGrid();
+
     testWriteHalf<openvdb::FloatTree>();
     testWriteHalf<openvdb::DoubleTree>();
     testWriteHalf<openvdb::Vec2STree>();
@@ -125,27 +130,54 @@ TestTree::testWriteHalf()
     using GridType = openvdb::Grid<TreeType>;
     using ValueT = typename TreeType::ValueType;
     ValueT background(5);
-    GridType grid(background);
+    typename GridType::Ptr grid = GridType::create(background);
+    grid->setName("density");
 
     unittest_util::makeSphere<GridType>(openvdb::Coord(64, 64, 64),
                                         openvdb::Vec3f(35, 30, 40),
-                                        /*radius=*/10, grid,
+                                        /*radius=*/10, *grid,
                                         /*dx=*/1.0f, unittest_util::SPHERE_DENSE);
-    EXPECT_TRUE(!grid.tree().empty());
+    EXPECT_TRUE(!grid->tree().empty());
+
+    // find stream and grid header position for save as float
+
+    size_t headerSize = 0;
+    {
+        std::ostringstream outFull(std::ios_base::binary);
+        openvdb::io::Stream streamFull(outFull);
+        streamFull.write({});
+        openvdb::io::GridDescriptor gd(grid->getName(), grid->type());
+        gd.writeHeader(outFull);
+        headerSize = outFull.str().size();
+    }
+
+    // find stream and grid header position for save as half
+
+    size_t halfHeaderSize = 0;
+    {
+        std::ostringstream outHalf(std::ios_base::binary);
+        openvdb::io::Stream streamHalf(outHalf);
+        streamHalf.write({});
+        openvdb::io::GridDescriptor gdHalf(grid->getName(), grid->type(), /*half=*/true);
+        gdHalf.writeHeader(outHalf);
+        halfHeaderSize = outHalf.str().size();
+    }
 
     // Write grid blocks in both float and half formats.
     std::ostringstream outFull(std::ios_base::binary);
-    grid.setSaveFloatAsHalf(false);
-    grid.writeBuffers(outFull);
+    openvdb::io::Stream streamFull(outFull);
+    grid->setSaveFloatAsHalf(false);
+    streamFull.write({grid});
     outFull.flush();
-    const size_t fullBytes = outFull.str().size();
+    const size_t fullBytes = outFull.str().size() - headerSize;
     if (fullBytes == 0) FAIL() << "wrote empty full float buffers";
 
     std::ostringstream outHalf(std::ios_base::binary);
-    grid.setSaveFloatAsHalf(true);
-    grid.writeBuffers(outHalf);
+    openvdb::io::Stream streamHalf(outHalf);
+    grid->setSaveFloatAsHalf(true);
+    streamHalf.write({grid});
     outHalf.flush();
-    const size_t halfBytes = outHalf.str().size();
+    const size_t halfBytes = outHalf.str().size() - halfHeaderSize;
     if (halfBytes == 0) FAIL() << "wrote empty half float buffers";
 
     if (openvdb::io::RealToHalf<ValueT>::isReal) {
@@ -166,22 +198,26 @@ TestTree::testWriteHalf()
     // then write it out again in half float format.  Verify that the resulting file
     // is identical to the original half float file.
     {
-        openvdb::Grid<TreeType> gridCopy(grid);
-        gridCopy.setSaveFloatAsHalf(true);
         std::istringstream is(outHalf.str(), std::ios_base::binary);
+        openvdb::io::Stream streamHalf2(is);
 
-        // Since the input stream doesn't include a VDB header with file format version info,
-        // tag the input stream explicitly with the current version number.
-        openvdb::io::setCurrentVersion(is);
-
-        gridCopy.readBuffers(is);
+        openvdb::GridPtrVecPtr grids = streamHalf2.getGrids();
+        openvdb::GridBase::Ptr gridCopy = (*grids)[0];
+        gridCopy->setSaveFloatAsHalf(true);
 
         std::ostringstream outDiff(std::ios_base::binary);
-        gridCopy.writeBuffers(outDiff);
+        openvdb::io::Stream streamDiff(outDiff);
+        streamDiff.write({gridCopy});
         outDiff.flush();
 
-        if (outHalf.str() != outDiff.str()) {
-            FAIL() << "half-from-full and half-from-half buffers differ";
+        // Compare the two buffers, skipping the header region
+        {
+            const std::string s1 = outHalf.str().substr(halfHeaderSize);
+            const std::string s2 = outDiff.str().substr(halfHeaderSize);
+            if (s1 != s2)
+            {
+                FAIL() << "half-from-full and half-from-half buffers differ";
+            }
         }
     }
 }

--- a/pendingchanges/removeleafiotests.txt
+++ b/pendingchanges/removeleafiotests.txt
@@ -1,0 +1,3 @@
+OpenVDB:
+  Improvements:
+  - Remove direct testing of Tree I/O methods in favor of indirect testing using the Grid I/O.


### PR DESCRIPTION
This removes all the direct Tree I/O methods (RootNode, LeafNode, etc) from the unit tests instead relying on indirect testing via the Grid I/O methods.