### PR TITLE
Add MeshToGrid: CUDA triangle mesh to NanoVDB UDF/IndexGrid converter

### DIFF
--- a/nanovdb/nanovdb/examples/CMakeLists.txt
+++ b/nanovdb/nanovdb/examples/CMakeLists.txt
@@ -113,6 +113,7 @@ nanovdb_example(NAME "ex_dilate_nanovdb_cuda" OPENVDB)
 nanovdb_example(NAME "ex_merge_nanovdb_cuda" OPENVDB)
 nanovdb_example(NAME "ex_refine_nanovdb_cuda" OPENVDB)
 nanovdb_example(NAME "ex_coarsen_nanovdb_cuda" OPENVDB)
+nanovdb_example(NAME "ex_mesh_to_grid_cuda" OPENVDB)
 
 if(CUDAToolkit_FOUND)
   nanovdb_example(NAME "ex_make_mgpu_nanovdb") # requires cuRAND

--- a/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda.cpp
+++ b/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda.cpp
@@ -30,7 +30,7 @@ void readOBJ(const std::string& filename,
     std::vector<openvdb::Vec3s>& points,
     std::vector<openvdb::Vec3I>& triangles,
     std::vector<openvdb::Vec4I>& quads)
-{             
+{
     std::ifstream file(filename);
     if (!file.is_open()) {
         OPENVDB_THROW(openvdb::IoError, "Failed to open OBJ file: " + filename);
@@ -44,7 +44,7 @@ void readOBJ(const std::string& filename,
         std::istringstream iss(line);
         std::string type;
         iss >> type;
-        
+
         if (type == "v") {
             float x, y, z;
             iss >> x >> y >> z;
@@ -52,44 +52,44 @@ void readOBJ(const std::string& filename,
         } else if (type == "f") {
             std::vector<int> faceIndices;
             std::string vertexData;
-            
+
             while (iss >> vertexData) {
                 // Isolate the vertex index (everything before the first slash)
                 size_t slashPos = vertexData.find('/');
                 std::string indexStr = vertexData.substr(0, slashPos);
-                
+
                 if (indexStr.empty()) continue;
 
                 int raw_idx = std::stoi(indexStr);
                 int actual_idx = 0;
-                
+
                 // Handle negative indices: relative to the number of points parsed so far
                 if (raw_idx < 0) {
-                    actual_idx = points.size() + raw_idx; 
+                    actual_idx = points.size() + raw_idx;
                 } else {
                     // Standard positive indices: OBJ is 1-based, convert to 0-based for C++
-                    actual_idx = raw_idx - 1; 
+                    actual_idx = raw_idx - 1;
                 }
 
                 // Strict bounds checking to prevent segfaults
                 if (actual_idx < 0 || actual_idx >= points.size()) {
-                    OPENVDB_THROW(openvdb::ValueError, 
-                        "OBJ parse error on line " + std::to_string(lineNumber) + 
-                        ": Face index out of bounds (Raw: " + std::to_string(raw_idx) + 
-                        ", Computed: " + std::to_string(actual_idx) + ", Total Points: " + 
+                    OPENVDB_THROW(openvdb::ValueError,
+                        "OBJ parse error on line " + std::to_string(lineNumber) +
+                        ": Face index out of bounds (Raw: " + std::to_string(raw_idx) +
+                        ", Computed: " + std::to_string(actual_idx) + ", Total Points: " +
                         std::to_string(points.size()) + ")");
                 }
 
-                faceIndices.push_back(actual_idx); 
+                faceIndices.push_back(actual_idx);
             }
-            
+
             // Add to the appropriate OpenVDB list
             if (faceIndices.size() == 3) {
                 triangles.push_back(openvdb::Vec3I(faceIndices[0], faceIndices[1], faceIndices[2]));
             } else if (faceIndices.size() == 4) {
                 quads.push_back(openvdb::Vec4I(faceIndices[0], faceIndices[1], faceIndices[2], faceIndices[3]));
             } else if (faceIndices.size() > 4) {
-                std::cerr << "Warning on line " << lineNumber << ": Skipping face with " 
+                std::cerr << "Warning on line " << lineNumber << ": Skipping face with "
                           << faceIndices.size() << " vertices. Triangulate your mesh!" << std::endl;
             }
         }
@@ -121,8 +121,8 @@ int main(int argc, char *argv[])
         // Read the OBJ file
         std::cout << "Reading " << inputFile << "..." << std::endl;
         readOBJ(inputFile, openvdb_points, openvdb_triangles, quads);
-        std::cout << "Loaded " << openvdb_points.size() << " vertices, " 
-                  << openvdb_triangles.size() << " openvdb_triangles, and " 
+        std::cout << "Loaded " << openvdb_points.size() << " vertices, "
+                  << openvdb_triangles.size() << " openvdb_triangles, and "
                   << quads.size() << " quads." << std::endl;
 
         // Initialize OpenVDB
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
         // Cast the raw pointers from the std::vector data
         const auto* nano_pts_data = reinterpret_cast<const nanovdb::Vec3f*>(openvdb_points.data());
         const auto* nano_tris_data = reinterpret_cast<const nanovdb::Vec3i*>(openvdb_triangles.data());
-        
+
         // Initialize the thrust vectors using the casted pointer ranges
         thrust::universal_vector<nanovdb::Vec3f> nanovdb_points(nano_pts_data, nano_pts_data + openvdb_points.size());
         thrust::universal_vector<nanovdb::Vec3i> nanovdb_triangles(nano_tris_data, nano_tris_data + openvdb_triangles.size());

--- a/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda.cpp
+++ b/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // the following files are from OpenVDB
-#include <openvdb/tools/Morphology.h>
 #include <openvdb/util/CpuTimer.h>
 #include <openvdb/tools/MeshToVolume.h>
 
@@ -112,7 +111,7 @@ int main(int argc, char *argv[])
             outputFile = argv[2];
         float voxelSize = 0.001f;
         if (argc > 3)
-            voxelSize = atof(argv[3]);
+            voxelSize = std::stof(argv[3]);
 
         std::vector<openvdb::Vec3s> openvdb_points;
         std::vector<openvdb::Vec3I> openvdb_triangles;
@@ -122,7 +121,7 @@ int main(int argc, char *argv[])
         std::cout << "Reading " << inputFile << "..." << std::endl;
         readOBJ(inputFile, openvdb_points, openvdb_triangles, quads);
         std::cout << "Loaded " << openvdb_points.size() << " vertices, "
-                  << openvdb_triangles.size() << " openvdb_triangles, and "
+                  << openvdb_triangles.size() << " triangles, and "
                   << quads.size() << " quads." << std::endl;
 
         // Initialize OpenVDB
@@ -139,7 +138,6 @@ int main(int argc, char *argv[])
         openvdb::FloatGrid::Ptr grid = openvdb::tools::meshToUnsignedDistanceField<openvdb::FloatGrid>(
             *transform, openvdb_points, openvdb_triangles, quads, halfband);
         cpuTimer.stop();
-
 
         // Write the Grid to a VDB File
         grid->setName("UnsignedDistanceField");
@@ -160,7 +158,6 @@ int main(int argc, char *argv[])
         thrust::universal_vector<nanovdb::Vec3i> nanovdb_triangles(nano_tris_data, nano_tris_data + openvdb_triangles.size());
 
         // Convert OpenVDB transform to nanovdb::Map
-
         const auto openvdb_mat4 = transform->baseMap()->getAffineMap()->getMat4();
         nanovdb::Map map;
         map.set(openvdb_mat4, openvdb_mat4.inverse());

--- a/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda.cpp
+++ b/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda.cpp
@@ -1,0 +1,182 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+// the following files are from OpenVDB
+#include <openvdb/tools/Morphology.h>
+#include <openvdb/util/CpuTimer.h>
+#include <openvdb/tools/MeshToVolume.h>
+
+// the following files are from NanoVDB
+#include <nanovdb/NanoVDB.h>
+
+#include <thrust/universal_vector.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+template<typename BuildT>
+void mainMeshToGrid(
+    const nanovdb::Vec3f *devicePoints,
+    const int pointCount,
+    const nanovdb::Vec3i *deviceTriangles,
+    const int triangleCount,
+    const nanovdb::Map map,
+    const openvdb::FloatGrid::Ptr refGrid);
+
+void readOBJ(const std::string& filename,
+    std::vector<openvdb::Vec3s>& points,
+    std::vector<openvdb::Vec3I>& triangles,
+    std::vector<openvdb::Vec4I>& quads)
+{             
+    std::ifstream file(filename);
+    if (!file.is_open()) {
+        OPENVDB_THROW(openvdb::IoError, "Failed to open OBJ file: " + filename);
+    }
+
+    std::string line;
+    int lineNumber = 0;
+
+    while (std::getline(file, line)) {
+        lineNumber++;
+        std::istringstream iss(line);
+        std::string type;
+        iss >> type;
+        
+        if (type == "v") {
+            float x, y, z;
+            iss >> x >> y >> z;
+            points.push_back(openvdb::Vec3s(x, y, z));
+        } else if (type == "f") {
+            std::vector<int> faceIndices;
+            std::string vertexData;
+            
+            while (iss >> vertexData) {
+                // Isolate the vertex index (everything before the first slash)
+                size_t slashPos = vertexData.find('/');
+                std::string indexStr = vertexData.substr(0, slashPos);
+                
+                if (indexStr.empty()) continue;
+
+                int raw_idx = std::stoi(indexStr);
+                int actual_idx = 0;
+                
+                // Handle negative indices: relative to the number of points parsed so far
+                if (raw_idx < 0) {
+                    actual_idx = points.size() + raw_idx; 
+                } else {
+                    // Standard positive indices: OBJ is 1-based, convert to 0-based for C++
+                    actual_idx = raw_idx - 1; 
+                }
+
+                // Strict bounds checking to prevent segfaults
+                if (actual_idx < 0 || actual_idx >= points.size()) {
+                    OPENVDB_THROW(openvdb::ValueError, 
+                        "OBJ parse error on line " + std::to_string(lineNumber) + 
+                        ": Face index out of bounds (Raw: " + std::to_string(raw_idx) + 
+                        ", Computed: " + std::to_string(actual_idx) + ", Total Points: " + 
+                        std::to_string(points.size()) + ")");
+                }
+
+                faceIndices.push_back(actual_idx); 
+            }
+            
+            // Add to the appropriate OpenVDB list
+            if (faceIndices.size() == 3) {
+                triangles.push_back(openvdb::Vec3I(faceIndices[0], faceIndices[1], faceIndices[2]));
+            } else if (faceIndices.size() == 4) {
+                quads.push_back(openvdb::Vec4I(faceIndices[0], faceIndices[1], faceIndices[2], faceIndices[3]));
+            } else if (faceIndices.size() > 4) {
+                std::cerr << "Warning on line " << lineNumber << ": Skipping face with " 
+                          << faceIndices.size() << " vertices. Triangulate your mesh!" << std::endl;
+            }
+        }
+    }
+}
+
+/// @brief This example depends on OpenVDB, NanoVDB, and CUDA
+int main(int argc, char *argv[])
+{
+    using BuildT = nanovdb::ValueOnIndex;
+
+    openvdb::util::CpuTimer cpuTimer;
+
+    try {
+
+        if (argc<2) OPENVDB_THROW(openvdb::ValueError, "usage: "+std::string(argv[0])+" input.obj [output.vdb]\n");
+        std::string inputFile = argv[1];
+        std::string outputFile = "output.vdb";
+        if (argc > 2)
+            outputFile = argv[2];
+        float voxelSize = 0.001f;
+        if (argc > 3)
+            voxelSize = atof(argv[3]);
+
+        std::vector<openvdb::Vec3s> openvdb_points;
+        std::vector<openvdb::Vec3I> openvdb_triangles;
+        std::vector<openvdb::Vec4I> quads;
+
+        // Read the OBJ file
+        std::cout << "Reading " << inputFile << "..." << std::endl;
+        readOBJ(inputFile, openvdb_points, openvdb_triangles, quads);
+        std::cout << "Loaded " << openvdb_points.size() << " vertices, " 
+                  << openvdb_triangles.size() << " openvdb_triangles, and " 
+                  << quads.size() << " quads." << std::endl;
+
+        // Initialize OpenVDB
+        openvdb::initialize();
+
+        // Setup Grid Transform (Voxel Size)
+        openvdb::math::Transform::Ptr transform =
+            openvdb::math::Transform::createLinearTransform(voxelSize);
+
+        // Convert Mesh to Unsigned Distance Field (UDF)
+        // halfband specifies the half-width of the narrow band in voxel units
+        float halfband = 3.0f;
+        cpuTimer.start("Converting mesh to OpenVDB unsigned distance field");
+        openvdb::FloatGrid::Ptr grid = openvdb::tools::meshToUnsignedDistanceField<openvdb::FloatGrid>(
+            *transform, openvdb_points, openvdb_triangles, quads, halfband);
+        cpuTimer.stop();
+
+
+        // Write the Grid to a VDB File
+        grid->setName("UnsignedDistanceField");
+        grid->print(std::cout, 2);
+        std::cout << "Writing to " << outputFile << "..." << std::endl;
+        openvdb::GridPtrVec grids;
+        grids.push_back(grid);
+        openvdb::io::File file(outputFile);
+        file.write(grids);
+        file.close();
+
+        // Cast the raw pointers from the std::vector data
+        const auto* nano_pts_data = reinterpret_cast<const nanovdb::Vec3f*>(openvdb_points.data());
+        const auto* nano_tris_data = reinterpret_cast<const nanovdb::Vec3i*>(openvdb_triangles.data());
+        
+        // Initialize the thrust vectors using the casted pointer ranges
+        thrust::universal_vector<nanovdb::Vec3f> nanovdb_points(nano_pts_data, nano_pts_data + openvdb_points.size());
+        thrust::universal_vector<nanovdb::Vec3i> nanovdb_triangles(nano_tris_data, nano_tris_data + openvdb_triangles.size());
+
+        // Convert OpenVDB transform to nanovdb::Map
+
+        const auto openvdb_mat4 = transform->baseMap()->getAffineMap()->getMat4();
+        nanovdb::Map map;
+        map.set(openvdb_mat4, openvdb_mat4.inverse());
+
+        mainMeshToGrid<BuildT>(
+            nanovdb_points.data().get(),
+            nanovdb_points.size(),
+            nanovdb_triangles.data().get(),
+            nanovdb_triangles.size(),
+            map,
+            grid);
+
+        return 0;
+    }
+    catch (const std::exception& e) {
+        std::cerr << "An exception occurred: \"" << e.what() << "\"" << std::endl;
+    }
+    return 0;
+}

--- a/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda_kernels.cu
+++ b/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda_kernels.cu
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <limits>
-#include <array>
 #include <vector>
 
 
@@ -36,29 +35,33 @@ void mainMeshToGrid(
     converter.setVerbose(1);
     auto [handle, sidecar] = converter.getHandleAndUDF();
 
-
-
-    // --- Voxel-level UDF correctness check ---
-    // Download NanoVDB grid to host for CPU-side analysis
+    // --- Comparison against OpenVDB reference ---
+    // Download NanoVDB grid to host for CPU-side analysis.
     std::vector<char> hostBuf(handle.bufferSize());
     cudaCheck(cudaMemcpy(hostBuf.data(), handle.deviceData(), handle.bufferSize(), cudaMemcpyDeviceToHost));
     const auto *nanoGrid = reinterpret_cast<const nanovdb::NanoGrid<BuildT>*>(hostBuf.data());
 
-    std::cout << "\n--- Voxel-level UDF correctness check ---" << std::endl;
+    // Download sidecar.
+    const uint64_t sidecarFloats = sidecar.size() / sizeof(float);
+    std::vector<float> hostSidecar(sidecarFloats);
+    cudaCheck(cudaMemcpy(hostSidecar.data(), sidecar.deviceData(),
+                         sidecar.size(), cudaMemcpyDeviceToHost));
 
     // Encode a voxel coord as a sortable int64_t key.
-    // Coords fit well within 20 bits per axis for typical meshes.
     auto encodeCoord = [](int x, int y, int z) -> int64_t {
         return (int64_t(x) + (1<<20))
              | ((int64_t(y) + (1<<20)) << 21)
              | ((int64_t(z) + (1<<20)) << 42);
     };
 
-    // Single pass over our NanoVDB active voxels:
-    //   - build sorted coord list (for false-negative lookup)
-    //   - count false positives (active in ours, background in OpenVDB)
     auto ovdbAcc = refGrid->getConstAccessor();
-    uint64_t falsePositives = 0;
+    const float voxelSize = (float)refGrid->voxelSize()[0];
+
+    uint64_t falsePositives = 0, falseNegatives = 0;
+    float minMissedUDF = std::numeric_limits<float>::max();
+    uint64_t badUDF = 0;
+    float maxErrVoxels = 0.f;
+
     std::vector<int64_t> ourCoords;
     ourCoords.reserve(12000000);
 
@@ -68,212 +71,45 @@ void mainMeshToGrid(
         const auto &leaf = leaves[li];
         const auto origin = leaf.origin();
         for (uint32_t vi = 0; vi < 512; ++vi) {
-            if (leaf.isActive(vi)) {
-                const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
-                const int x = origin[0]+lx, y = origin[1]+ly, z = origin[2]+lz;
-                ourCoords.push_back(encodeCoord(x, y, z));
-                if (!ovdbAcc.isValueOn(openvdb::Coord(x, y, z)))
-                    ++falsePositives;
+            if (!leaf.isActive(vi)) continue;
+            const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
+            const int x = origin[0]+lx, y = origin[1]+ly, z = origin[2]+lz;
+            ourCoords.push_back(encodeCoord(x, y, z));
+
+            const openvdb::Coord coord(x, y, z);
+            if (!ovdbAcc.isValueOn(coord)) {
+                ++falsePositives;
+            } else {
+                const float err = std::abs(hostSidecar[leaf.getValue(vi)] - ovdbAcc.getValue(coord)) / voxelSize;
+                maxErrVoxels = std::max(maxErrVoxels, err);
+                if (err > 0.1f) ++badUDF;
             }
         }
     }
     std::sort(ourCoords.begin(), ourCoords.end());
 
-    // False negatives: active in OpenVDB UDF but absent from our sorted set.
-    uint64_t falseNegatives = 0;
-    float minMissedUDF = std::numeric_limits<float>::max();
     for (auto it = refGrid->tree().cbeginValueOn(); it; ++it) {
         const auto c = it.getCoord();
-        if (!std::binary_search(ourCoords.begin(), ourCoords.end(),
-                                encodeCoord(c[0], c[1], c[2]))) {
+        if (!std::binary_search(ourCoords.begin(), ourCoords.end(), encodeCoord(c[0], c[1], c[2]))) {
             ++falseNegatives;
             minMissedUDF = std::min(minMissedUDF, *it);
         }
     }
 
     const uint64_t ourActiveCount = ourCoords.size();
-    std::cout << "Our active voxels:     " << ourActiveCount << "\n";
-    std::cout << "OpenVDB active voxels: " << refGrid->tree().activeVoxelCount() << "\n";
-    if (falseNegatives == 0)
-        std::cout << "False negatives: 0 -- all OpenVDB active voxels present in our output\n";
-    else
-        std::cerr << "False negatives: " << falseNegatives
-                  << " (smallest missed UDF value: " << minMissedUDF << ")\n";
+    const uint64_t nTP = ourActiveCount - falsePositives;
+    std::cout << "\n--- Comparison against OpenVDB reference ---\n";
+    std::cout << "Active voxels: ours=" << ourActiveCount
+              << "  OpenVDB=" << refGrid->tree().activeVoxelCount() << "\n";
+    std::cout << "False negatives: " << falseNegatives;
+    if (falseNegatives > 0)
+        std::cout << "  (smallest missed UDF: " << minMissedUDF << ")";
+    std::cout << "\n";
     std::cout << "False positives: " << falsePositives
-              << " (" << (100.0 * falsePositives / ourActiveCount) << "% of our active voxels)\n";
-
-    // --- UDF sidecar value check ---
-    // Download sidecar and compare per-voxel UDF against OpenVDB reference.
-    std::cout << "\n--- UDF sidecar value check ---" << std::endl;
-
-    const uint64_t sidecarFloats = sidecar.size() / sizeof(float);
-    std::vector<float> hostSidecar(sidecarFloats);
-    cudaCheck(cudaMemcpy(hostSidecar.data(), sidecar.deviceData(),
-                         sidecar.size(), cudaMemcpyDeviceToHost));
-
-    // For each active voxel in our grid, compare our UDF against OpenVDB's.
-    // Both our sidecar and OpenVDB store world-space distances; error is reported in voxels.
-    const float voxelSize = (float)refGrid->voxelSize()[0];
-    // Split histogram between true positives (active in both) and false positives
-    // (active in ours only). For false positives, refUDF = background = mBandWidth,
-    // so error = |ourUDF - mBandWidth|; a large error there is a real concern.
-    const float thresholds[] = { 0.01f, 0.05f, 0.1f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f };
-    constexpr int nThresh = sizeof(thresholds) / sizeof(thresholds[0]);
-    uint64_t badTP[nThresh] = {}, badFP[nThresh] = {};
-    float maxErrTP = 0.f, maxErrFP = 0.f;
-
-    // Track worst voxels for CPU ground-truth verification.
-    // topNTP is maintained as a min-heap (smallest error at front) capped at N,
-    // so we always evict the least-bad entry when a worse one arrives.
-    struct WorstVoxel { int x, y, z; float ourUDF, refUDF, err; bool isFP; };
-    constexpr int N = 20;
-    auto minHeapCmp = [](const WorstVoxel& a, const WorstVoxel& b){ return a.err > b.err; };
-    std::vector<WorstVoxel> topNTP;
-    topNTP.reserve(N + 1);
-    WorstVoxel worstFP{};
-
-    for (uint32_t li = 0; li < nanoLeafCount; ++li) {
-        const auto &leaf = leaves[li];
-        const auto origin = leaf.origin();
-        for (uint32_t vi = 0; vi < 512; ++vi) {
-            if (!leaf.isActive(vi)) continue;
-            const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
-            const int x = origin[0]+lx, y = origin[1]+ly, z = origin[2]+lz;
-
-            const openvdb::Coord coord(x, y, z);
-            const uint64_t sidecarIdx = leaf.getValue(vi);
-            const float ourUDF_world = hostSidecar[sidecarIdx];
-            const float refUDF       = ovdbAcc.getValue(coord);
-            const float err = std::abs(ourUDF_world - refUDF) / voxelSize;
-
-            const WorstVoxel candidate{ x, y, z, ourUDF_world / voxelSize,
-                                        refUDF / voxelSize, err, !ovdbAcc.isValueOn(coord) };
-
-            if (ovdbAcc.isValueOn(coord)) {
-                maxErrTP = std::max(maxErrTP, err);
-                for (int t = 0; t < nThresh; ++t)
-                    if (err > thresholds[t]) ++badTP[t];
-                if ((int)topNTP.size() < N || err > topNTP.front().err) {
-                    topNTP.push_back(candidate);
-                    std::push_heap(topNTP.begin(), topNTP.end(), minHeapCmp);
-                    if ((int)topNTP.size() > N) {
-                        std::pop_heap(topNTP.begin(), topNTP.end(), minHeapCmp);
-                        topNTP.pop_back();
-                    }
-                }
-            } else {
-                if (err > worstFP.err) worstFP = candidate;
-                maxErrFP = std::max(maxErrFP, err);
-                for (int t = 0; t < nThresh; ++t)
-                    if (err > thresholds[t]) ++badFP[t];
-            }
-        }
-    }
-    // Sort top-N true positives from worst to best
-    std::sort(topNTP.begin(), topNTP.end(), [](const WorstVoxel& a, const WorstVoxel& b){
-        return a.err > b.err; });
-
-    const uint64_t nTP = ourCoords.size() - falsePositives;
-    std::cout << "True positives (" << nTP << " voxels), max error: " << maxErrTP << " voxels\n";
-    for (int t = 0; t < nThresh; ++t)
-        std::cout << "  > " << thresholds[t] << " voxels: " << badTP[t] << "\n";
-    std::cout << "False positives (" << falsePositives << " voxels), max error: " << maxErrFP << " voxels\n";
-    for (int t = 0; t < nThresh; ++t)
-        std::cout << "  > " << thresholds[t] << " voxels: " << badFP[t] << "\n";
-
-    // --- CPU ground-truth check: brute-force both NanoVDB and Ericson routines ---
-    struct CPUResult {
-        float nvdbUDF, ericsonUDF;   // voxel units
-        int   nearestTri;            // index into deviceTriangles
-        nanovdb::Vec3f voxelCenterWorld;
-    };
-    auto cpuBruteForce = [&](const WorstVoxel& wv) -> CPUResult {
-        const nanovdb::Vec3f wcNvdb = map.applyMap(
-            nanovdb::Vec3f(float(wv.x), float(wv.y), float(wv.z)));
-        const openvdb::Vec3s wcOvdb(wcNvdb[0], wcNvdb[1], wcNvdb[2]);
-
-        float nvdbMinDistSqr = std::numeric_limits<float>::max();
-        float refMinDistSqr  = std::numeric_limits<float>::max();
-        int   nearestTri = -1;
-        for (int t = 0; t < triangleCount; ++t) {
-            const nanovdb::Vec3f nv0 = devicePoints[deviceTriangles[t][0]];
-            const nanovdb::Vec3f nv1 = devicePoints[deviceTriangles[t][1]];
-            const nanovdb::Vec3f nv2 = devicePoints[deviceTriangles[t][2]];
-
-            const float d = nanovdb::math::pointToTriangleDistSqr(nv0, nv1, nv2, wcNvdb);
-            if (d < nvdbMinDistSqr) { nvdbMinDistSqr = d; nearestTri = t; }
-
-            // Reference: Ericson §5.1.5, openvdb::Vec3s arithmetic
-            const openvdb::Vec3s a(nv0[0], nv0[1], nv0[2]);
-            const openvdb::Vec3s b(nv1[0], nv1[1], nv1[2]);
-            const openvdb::Vec3s c(nv2[0], nv2[1], nv2[2]);
-            const openvdb::Vec3s p = wcOvdb;
-            const openvdb::Vec3s ab = b-a, ac = c-a, ap = p-a;
-            const float d1 = ab.dot(ap), d2 = ac.dot(ap);
-            if (d1 <= 0.f && d2 <= 0.f) { refMinDistSqr = std::min(refMinDistSqr, (p-a).lengthSqr()); continue; }
-            const openvdb::Vec3s bp = p-b;
-            const float d3 = ab.dot(bp), d4 = ac.dot(bp);
-            if (d3 >= 0.f && d4 <= d3)  { refMinDistSqr = std::min(refMinDistSqr, (p-b).lengthSqr()); continue; }
-            const openvdb::Vec3s cp = p-c;
-            const float d5 = ab.dot(cp), d6 = ac.dot(cp);
-            if (d6 >= 0.f && d5 <= d6)  { refMinDistSqr = std::min(refMinDistSqr, (p-c).lengthSqr()); continue; }
-            const float vc = d1*d4 - d3*d2;
-            if (vc <= 0.f && d1 >= 0.f && d3 <= 0.f) {
-                float v = d1/(d1-d3);
-                refMinDistSqr = std::min(refMinDistSqr, (p-(a+v*ab)).lengthSqr()); continue; }
-            const float vb = d5*d2 - d1*d6;
-            if (vb <= 0.f && d2 >= 0.f && d6 <= 0.f) {
-                float w = d2/(d2-d6);
-                refMinDistSqr = std::min(refMinDistSqr, (p-(a+w*ac)).lengthSqr()); continue; }
-            const float va = d3*d6 - d5*d4;
-            if (va <= 0.f && (d4-d3) >= 0.f && (d5-d6) >= 0.f) {
-                float w = (d4-d3)/((d4-d3)+(d5-d6));
-                refMinDistSqr = std::min(refMinDistSqr, (p-(b+w*(c-b))).lengthSqr()); continue; }
-            const float denom = 1.f/(va+vb+vc);
-            const float rv = vb*denom, rw = vc*denom;
-            refMinDistSqr = std::min(refMinDistSqr, (p-(a+rv*ab+rw*ac)).lengthSqr());
-        }
-        return { std::sqrt(nvdbMinDistSqr) / voxelSize,
-                 std::sqrt(refMinDistSqr)  / voxelSize,
-                 nearestTri, wcNvdb };
-    };
-
-    auto printVec3 = [](const char* label, float x, float y, float z) {
-        std::cout << "    " << label << ": (" << x << ", " << y << ", " << z << ")\n";
-    };
-
-    auto printWorst = [&](const char* label, const WorstVoxel& wv) {
-        std::cout << "\n--- " << label << " ---\n";
-        std::cout << "  Our UDF     : " << wv.ourUDF << " voxels\n";
-        std::cout << "  OpenVDB UDF : " << wv.refUDF << " voxels"
-                  << (wv.isFP ? " (background — not active in OpenVDB)" : "") << "\n";
-        std::cout << "  Error       : " << wv.err << " voxels\n";
-        auto res = cpuBruteForce(wv);
-        std::cout << "  CPU (NanoVDB routine):   " << res.nvdbUDF    << " voxels\n";
-        std::cout << "  CPU (Ericson reference): " << res.ericsonUDF << " voxels\n";
-        std::cout << "  Routine discrepancy: " << std::abs(res.nvdbUDF - res.ericsonUDF) << " voxels\n";
-        std::cout << "  Error vs CPU: our=" << std::abs(wv.ourUDF - res.nvdbUDF)
-                  << "  OpenVDB ref=" << std::abs(wv.refUDF - res.nvdbUDF) << " voxels\n";
-        // World-space geometry
-        std::cout << "  World-space geometry:\n";
-        printVec3("voxel center", res.voxelCenterWorld[0], res.voxelCenterWorld[1], res.voxelCenterWorld[2]);
-        if (res.nearestTri >= 0) {
-            const nanovdb::Vec3f v0 = devicePoints[deviceTriangles[res.nearestTri][0]];
-            const nanovdb::Vec3f v1 = devicePoints[deviceTriangles[res.nearestTri][1]];
-            const nanovdb::Vec3f v2 = devicePoints[deviceTriangles[res.nearestTri][2]];
-            std::cout << "    nearest tri #" << res.nearestTri << ":\n";
-            printVec3("  v0", v0[0], v0[1], v0[2]);
-            printVec3("  v1", v1[0], v1[1], v1[2]);
-            printVec3("  v2", v2[0], v2[1], v2[2]);
-        }
-    };
-
-    for (int i = 0; i < (int)topNTP.size(); ++i) {
-        std::string label = "True positive #" + std::to_string(i+1)
-                          + " (error " + std::to_string(topNTP[i].err) + " voxels)";
-        printWorst(label.c_str(), topNTP[i]);
-    }
-    printWorst("Worst false positive", worstFP);
+              << " (" << (100.0 * falsePositives / ourActiveCount) << "%)\n";
+    std::cout << "UDF vs OpenVDB (true positives=" << nTP << "): "
+              << "max error=" << maxErrVoxels << " voxels, "
+              << "exceeding 0.1 voxels: " << badUDF << "\n";
 
 }
 

--- a/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda_kernels.cu
+++ b/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda_kernels.cu
@@ -1,0 +1,279 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include <nanovdb/NanoVDB.h>
+
+#include <nanovdb/tools/cuda/MeshToGrid.cuh>
+
+#include <openvdb/openvdb.h>
+
+#include <algorithm>
+#include <limits>
+#include <array>
+#include <vector>
+
+
+template<typename BuildT>
+void mainMeshToGrid(
+    const nanovdb::Vec3f *devicePoints,
+    const int pointCount,
+    const nanovdb::Vec3i *deviceTriangles,
+    const int triangleCount,
+    const nanovdb::Map map,
+    const openvdb::FloatGrid::Ptr refGrid)
+{
+    // Initialize mesh-to-grid converter
+    nanovdb::tools::cuda::MeshToGrid<BuildT> converter( devicePoints, pointCount, deviceTriangles, triangleCount, map );
+    converter.setVerbose(1);
+    auto [handle, sidecar] = converter.getHandleAndUDF();
+
+
+
+    // --- Voxel-level UDF correctness check ---
+    // Download NanoVDB grid to host for CPU-side analysis
+    std::vector<char> hostBuf(handle.bufferSize());
+    cudaCheck(cudaMemcpy(hostBuf.data(), handle.deviceData(), handle.bufferSize(), cudaMemcpyDeviceToHost));
+    const auto *nanoGrid = reinterpret_cast<const nanovdb::NanoGrid<BuildT>*>(hostBuf.data());
+
+    std::cout << "\n--- Voxel-level UDF correctness check ---" << std::endl;
+
+    // Encode a voxel coord as a sortable int64_t key.
+    // Coords fit well within 20 bits per axis for typical meshes.
+    auto encodeCoord = [](int x, int y, int z) -> int64_t {
+        return (int64_t(x) + (1<<20))
+             | ((int64_t(y) + (1<<20)) << 21)
+             | ((int64_t(z) + (1<<20)) << 42);
+    };
+
+    // Single pass over our NanoVDB active voxels:
+    //   - build sorted coord list (for false-negative lookup)
+    //   - count false positives (active in ours, background in OpenVDB)
+    auto ovdbAcc = refGrid->getConstAccessor();
+    uint64_t falsePositives = 0;
+    std::vector<int64_t> ourCoords;
+    ourCoords.reserve(12000000);
+
+    const uint32_t nanoLeafCount = nanoGrid->tree().nodeCount(0);
+    const auto *leaves = nanoGrid->tree().getFirstLeaf();
+    for (uint32_t li = 0; li < nanoLeafCount; ++li) {
+        const auto &leaf = leaves[li];
+        const auto origin = leaf.origin();
+        for (uint32_t vi = 0; vi < 512; ++vi) {
+            if (leaf.isActive(vi)) {
+                const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
+                const int x = origin[0]+lx, y = origin[1]+ly, z = origin[2]+lz;
+                ourCoords.push_back(encodeCoord(x, y, z));
+                if (!ovdbAcc.isValueOn(openvdb::Coord(x, y, z)))
+                    ++falsePositives;
+            }
+        }
+    }
+    std::sort(ourCoords.begin(), ourCoords.end());
+
+    // False negatives: active in OpenVDB UDF but absent from our sorted set.
+    uint64_t falseNegatives = 0;
+    float minMissedUDF = std::numeric_limits<float>::max();
+    for (auto it = refGrid->tree().cbeginValueOn(); it; ++it) {
+        const auto c = it.getCoord();
+        if (!std::binary_search(ourCoords.begin(), ourCoords.end(),
+                                encodeCoord(c[0], c[1], c[2]))) {
+            ++falseNegatives;
+            minMissedUDF = std::min(minMissedUDF, *it);
+        }
+    }
+
+    const uint64_t ourActiveCount = ourCoords.size();
+    std::cout << "Our active voxels:     " << ourActiveCount << "\n";
+    std::cout << "OpenVDB active voxels: " << refGrid->tree().activeVoxelCount() << "\n";
+    if (falseNegatives == 0)
+        std::cout << "False negatives: 0 -- all OpenVDB active voxels present in our output\n";
+    else
+        std::cerr << "False negatives: " << falseNegatives
+                  << " (smallest missed UDF value: " << minMissedUDF << ")\n";
+    std::cout << "False positives: " << falsePositives
+              << " (" << (100.0 * falsePositives / ourActiveCount) << "% of our active voxels)\n";
+
+    // --- UDF sidecar value check ---
+    // Download sidecar and compare per-voxel UDF against OpenVDB reference.
+    std::cout << "\n--- UDF sidecar value check ---" << std::endl;
+
+    const uint64_t sidecarFloats = sidecar.size() / sizeof(float);
+    std::vector<float> hostSidecar(sidecarFloats);
+    cudaCheck(cudaMemcpy(hostSidecar.data(), sidecar.deviceData(),
+                         sidecar.size(), cudaMemcpyDeviceToHost));
+
+    // For each active voxel in our grid, compare our UDF against OpenVDB's.
+    // Both our sidecar and OpenVDB store world-space distances; error is reported in voxels.
+    const float voxelSize = (float)refGrid->voxelSize()[0];
+    // Split histogram between true positives (active in both) and false positives
+    // (active in ours only). For false positives, refUDF = background = mBandWidth,
+    // so error = |ourUDF - mBandWidth|; a large error there is a real concern.
+    const float thresholds[] = { 0.01f, 0.05f, 0.1f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f };
+    constexpr int nThresh = sizeof(thresholds) / sizeof(thresholds[0]);
+    uint64_t badTP[nThresh] = {}, badFP[nThresh] = {};
+    float maxErrTP = 0.f, maxErrFP = 0.f;
+
+    // Track worst voxels for CPU ground-truth verification.
+    // topNTP is maintained as a min-heap (smallest error at front) capped at N,
+    // so we always evict the least-bad entry when a worse one arrives.
+    struct WorstVoxel { int x, y, z; float ourUDF, refUDF, err; bool isFP; };
+    constexpr int N = 20;
+    auto minHeapCmp = [](const WorstVoxel& a, const WorstVoxel& b){ return a.err > b.err; };
+    std::vector<WorstVoxel> topNTP;
+    topNTP.reserve(N + 1);
+    WorstVoxel worstFP{};
+
+    for (uint32_t li = 0; li < nanoLeafCount; ++li) {
+        const auto &leaf = leaves[li];
+        const auto origin = leaf.origin();
+        for (uint32_t vi = 0; vi < 512; ++vi) {
+            if (!leaf.isActive(vi)) continue;
+            const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
+            const int x = origin[0]+lx, y = origin[1]+ly, z = origin[2]+lz;
+
+            const openvdb::Coord coord(x, y, z);
+            const uint64_t sidecarIdx = leaf.getValue(vi);
+            const float ourUDF_world = hostSidecar[sidecarIdx];
+            const float refUDF       = ovdbAcc.getValue(coord);
+            const float err = std::abs(ourUDF_world - refUDF) / voxelSize;
+
+            const WorstVoxel candidate{ x, y, z, ourUDF_world / voxelSize,
+                                        refUDF / voxelSize, err, !ovdbAcc.isValueOn(coord) };
+
+            if (ovdbAcc.isValueOn(coord)) {
+                maxErrTP = std::max(maxErrTP, err);
+                for (int t = 0; t < nThresh; ++t)
+                    if (err > thresholds[t]) ++badTP[t];
+                if ((int)topNTP.size() < N || err > topNTP.front().err) {
+                    topNTP.push_back(candidate);
+                    std::push_heap(topNTP.begin(), topNTP.end(), minHeapCmp);
+                    if ((int)topNTP.size() > N) {
+                        std::pop_heap(topNTP.begin(), topNTP.end(), minHeapCmp);
+                        topNTP.pop_back();
+                    }
+                }
+            } else {
+                if (err > worstFP.err) worstFP = candidate;
+                maxErrFP = std::max(maxErrFP, err);
+                for (int t = 0; t < nThresh; ++t)
+                    if (err > thresholds[t]) ++badFP[t];
+            }
+        }
+    }
+    // Sort top-N true positives from worst to best
+    std::sort(topNTP.begin(), topNTP.end(), [](const WorstVoxel& a, const WorstVoxel& b){
+        return a.err > b.err; });
+
+    const uint64_t nTP = ourCoords.size() - falsePositives;
+    std::cout << "True positives (" << nTP << " voxels), max error: " << maxErrTP << " voxels\n";
+    for (int t = 0; t < nThresh; ++t)
+        std::cout << "  > " << thresholds[t] << " voxels: " << badTP[t] << "\n";
+    std::cout << "False positives (" << falsePositives << " voxels), max error: " << maxErrFP << " voxels\n";
+    for (int t = 0; t < nThresh; ++t)
+        std::cout << "  > " << thresholds[t] << " voxels: " << badFP[t] << "\n";
+
+    // --- CPU ground-truth check: brute-force both NanoVDB and Ericson routines ---
+    struct CPUResult {
+        float nvdbUDF, ericsonUDF;   // voxel units
+        int   nearestTri;            // index into deviceTriangles
+        nanovdb::Vec3f voxelCenterWorld;
+    };
+    auto cpuBruteForce = [&](const WorstVoxel& wv) -> CPUResult {
+        const nanovdb::Vec3f wcNvdb = map.applyMap(
+            nanovdb::Vec3f(float(wv.x), float(wv.y), float(wv.z)));
+        const openvdb::Vec3s wcOvdb(wcNvdb[0], wcNvdb[1], wcNvdb[2]);
+
+        float nvdbMinDistSqr = std::numeric_limits<float>::max();
+        float refMinDistSqr  = std::numeric_limits<float>::max();
+        int   nearestTri = -1;
+        for (int t = 0; t < triangleCount; ++t) {
+            const nanovdb::Vec3f nv0 = devicePoints[deviceTriangles[t][0]];
+            const nanovdb::Vec3f nv1 = devicePoints[deviceTriangles[t][1]];
+            const nanovdb::Vec3f nv2 = devicePoints[deviceTriangles[t][2]];
+
+            const float d = nanovdb::math::pointToTriangleDistSqr(nv0, nv1, nv2, wcNvdb);
+            if (d < nvdbMinDistSqr) { nvdbMinDistSqr = d; nearestTri = t; }
+
+            // Reference: Ericson §5.1.5, openvdb::Vec3s arithmetic
+            const openvdb::Vec3s a(nv0[0], nv0[1], nv0[2]);
+            const openvdb::Vec3s b(nv1[0], nv1[1], nv1[2]);
+            const openvdb::Vec3s c(nv2[0], nv2[1], nv2[2]);
+            const openvdb::Vec3s p = wcOvdb;
+            const openvdb::Vec3s ab = b-a, ac = c-a, ap = p-a;
+            const float d1 = ab.dot(ap), d2 = ac.dot(ap);
+            if (d1 <= 0.f && d2 <= 0.f) { refMinDistSqr = std::min(refMinDistSqr, (p-a).lengthSqr()); continue; }
+            const openvdb::Vec3s bp = p-b;
+            const float d3 = ab.dot(bp), d4 = ac.dot(bp);
+            if (d3 >= 0.f && d4 <= d3)  { refMinDistSqr = std::min(refMinDistSqr, (p-b).lengthSqr()); continue; }
+            const openvdb::Vec3s cp = p-c;
+            const float d5 = ab.dot(cp), d6 = ac.dot(cp);
+            if (d6 >= 0.f && d5 <= d6)  { refMinDistSqr = std::min(refMinDistSqr, (p-c).lengthSqr()); continue; }
+            const float vc = d1*d4 - d3*d2;
+            if (vc <= 0.f && d1 >= 0.f && d3 <= 0.f) {
+                float v = d1/(d1-d3);
+                refMinDistSqr = std::min(refMinDistSqr, (p-(a+v*ab)).lengthSqr()); continue; }
+            const float vb = d5*d2 - d1*d6;
+            if (vb <= 0.f && d2 >= 0.f && d6 <= 0.f) {
+                float w = d2/(d2-d6);
+                refMinDistSqr = std::min(refMinDistSqr, (p-(a+w*ac)).lengthSqr()); continue; }
+            const float va = d3*d6 - d5*d4;
+            if (va <= 0.f && (d4-d3) >= 0.f && (d5-d6) >= 0.f) {
+                float w = (d4-d3)/((d4-d3)+(d5-d6));
+                refMinDistSqr = std::min(refMinDistSqr, (p-(b+w*(c-b))).lengthSqr()); continue; }
+            const float denom = 1.f/(va+vb+vc);
+            const float rv = vb*denom, rw = vc*denom;
+            refMinDistSqr = std::min(refMinDistSqr, (p-(a+rv*ab+rw*ac)).lengthSqr());
+        }
+        return { std::sqrt(nvdbMinDistSqr) / voxelSize,
+                 std::sqrt(refMinDistSqr)  / voxelSize,
+                 nearestTri, wcNvdb };
+    };
+
+    auto printVec3 = [](const char* label, float x, float y, float z) {
+        std::cout << "    " << label << ": (" << x << ", " << y << ", " << z << ")\n";
+    };
+
+    auto printWorst = [&](const char* label, const WorstVoxel& wv) {
+        std::cout << "\n--- " << label << " ---\n";
+        std::cout << "  Our UDF     : " << wv.ourUDF << " voxels\n";
+        std::cout << "  OpenVDB UDF : " << wv.refUDF << " voxels"
+                  << (wv.isFP ? " (background — not active in OpenVDB)" : "") << "\n";
+        std::cout << "  Error       : " << wv.err << " voxels\n";
+        auto res = cpuBruteForce(wv);
+        std::cout << "  CPU (NanoVDB routine):   " << res.nvdbUDF    << " voxels\n";
+        std::cout << "  CPU (Ericson reference): " << res.ericsonUDF << " voxels\n";
+        std::cout << "  Routine discrepancy: " << std::abs(res.nvdbUDF - res.ericsonUDF) << " voxels\n";
+        std::cout << "  Error vs CPU: our=" << std::abs(wv.ourUDF - res.nvdbUDF)
+                  << "  OpenVDB ref=" << std::abs(wv.refUDF - res.nvdbUDF) << " voxels\n";
+        // World-space geometry
+        std::cout << "  World-space geometry:\n";
+        printVec3("voxel center", res.voxelCenterWorld[0], res.voxelCenterWorld[1], res.voxelCenterWorld[2]);
+        if (res.nearestTri >= 0) {
+            const nanovdb::Vec3f v0 = devicePoints[deviceTriangles[res.nearestTri][0]];
+            const nanovdb::Vec3f v1 = devicePoints[deviceTriangles[res.nearestTri][1]];
+            const nanovdb::Vec3f v2 = devicePoints[deviceTriangles[res.nearestTri][2]];
+            std::cout << "    nearest tri #" << res.nearestTri << ":\n";
+            printVec3("  v0", v0[0], v0[1], v0[2]);
+            printVec3("  v1", v1[0], v1[1], v1[2]);
+            printVec3("  v2", v2[0], v2[1], v2[2]);
+        }
+    };
+
+    for (int i = 0; i < (int)topNTP.size(); ++i) {
+        std::string label = "True positive #" + std::to_string(i+1)
+                          + " (error " + std::to_string(topNTP[i].err) + " voxels)";
+        printWorst(label.c_str(), topNTP[i]);
+    }
+    printWorst("Worst false positive", worstFP);
+
+}
+
+template
+void mainMeshToGrid<nanovdb::ValueOnIndex>(
+    const nanovdb::Vec3f *devicePoints,
+    const int pointCount,
+    const nanovdb::Vec3i *deviceTriangles,
+    const int triangleCount,
+    const nanovdb::Map map,
+    const openvdb::FloatGrid::Ptr refGrid);

--- a/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda_kernels.cu
+++ b/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda_kernels.cu
@@ -23,6 +23,14 @@ void mainMeshToGrid(
     const nanovdb::Map map,
     const openvdb::FloatGrid::Ptr refGrid)
 {
+    // Test topology-only path (getHandle)
+    {
+        nanovdb::tools::cuda::MeshToGrid<BuildT> conv(devicePoints, pointCount, deviceTriangles, triangleCount, map);
+        conv.setVerbose(1);
+        auto handle = conv.getHandle();
+        std::cout << "[getHandle] completed, buffer size: " << handle.bufferSize() << " bytes\n";
+    }
+
     // Initialize mesh-to-grid converter
     nanovdb::tools::cuda::MeshToGrid<BuildT> converter( devicePoints, pointCount, deviceTriangles, triangleCount, map );
     converter.setVerbose(1);

--- a/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda_kernels.cu
+++ b/nanovdb/nanovdb/examples/ex_mesh_to_grid_cuda/mesh_to_grid_cuda_kernels.cu
@@ -72,8 +72,8 @@ void mainMeshToGrid(
         const auto origin = leaf.origin();
         for (uint32_t vi = 0; vi < 512; ++vi) {
             if (!leaf.isActive(vi)) continue;
-            const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
-            const int x = origin[0]+lx, y = origin[1]+ly, z = origin[2]+lz;
+            const auto local = nanovdb::NanoLeaf<BuildT>::OffsetToLocalCoord(vi);
+            const int x = origin[0]+local[0], y = origin[1]+local[1], z = origin[2]+local[2];
             ourCoords.push_back(encodeCoord(x, y, z));
 
             const openvdb::Coord coord(x, y, z);

--- a/nanovdb/nanovdb/math/Proximity.h
+++ b/nanovdb/nanovdb/math/Proximity.h
@@ -1,0 +1,150 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file   Proximity.h
+
+    \author Efty Sifakis
+
+    \brief  Closest-point queries on geometric primitives,
+            suitable for use in both host and device code.
+*/
+
+#ifndef NANOVDB_MATH_PROXIMITY_H_HAS_BEEN_INCLUDED
+#define NANOVDB_MATH_PROXIMITY_H_HAS_BEEN_INCLUDED
+
+#include <nanovdb/util/Util.h>  // for __hostdev__
+#include <nanovdb/math/Math.h>  // for nanovdb::math::Sqrt
+
+namespace nanovdb {
+
+namespace math {
+
+/// @brief Returns the closest point on the line segment [v0,v1] to @a p.
+///
+///        The result lies on the closed segment (t clamped to [0,1]).
+///
+/// @tparam Vec3T  Any Vec3 type supporting arithmetic and dot().
+template<typename Vec3T>
+__hostdev__ inline Vec3T
+closestPointOnSegmentToPoint(const Vec3T &v0, const Vec3T &v1, const Vec3T &p)
+{
+    const Vec3T seg = v1 - v0;
+    const Vec3T w   = p  - v0;
+
+    const auto c1 = seg.dot(w);
+    if (c1 <= 0) return v0;
+
+    const auto c2 = seg.dot(seg);
+    if (c2 <= c1) return v1;
+
+    return v0 + (c1 / c2) * seg;
+}
+
+/// @brief Returns the closest point on triangle [v0,v1,v2] to @a p,
+///        and (via @a t0, @a t1) the barycentric coordinates of that
+///        point: closest = v0 + t0*(v1-v0) + t1*(v2-v0).
+///
+///        Uses Voronoi-region decomposition (Ericson, "Real-Time Collision
+///        Detection", Sec. 5.1.5). Degenerate triangles (zero area, collinear or
+///        coincident vertices) are handled implicitly: the face-interior test
+///        naturally fails and the code falls through to the nearest edge or
+///        vertex result.
+///
+/// @tparam Vec3T  Any Vec3 type supporting arithmetic and dot().
+template<typename Vec3T>
+__hostdev__ inline Vec3T
+closestPointOnTriangleToPoint(
+    const Vec3T &v0,
+    const Vec3T &v1,
+    const Vec3T &v2,
+    const Vec3T &p,
+    typename Vec3T::ValueType &t0,
+    typename Vec3T::ValueType &t1)
+{
+    using RealT = typename Vec3T::ValueType;
+
+    const Vec3T ab = v1 - v0;
+    const Vec3T ac = v2 - v0;
+    const Vec3T ap = p  - v0;
+
+    // --- Region A (vertex v0) ---
+    const RealT d1 = ab.dot(ap);
+    const RealT d2 = ac.dot(ap);
+    if (d1 <= RealT(0) && d2 <= RealT(0)) {
+        t0 = RealT(0);
+        t1 = RealT(0);
+        return v0;
+    }
+
+    // --- Region B (vertex v1) ---
+    const Vec3T bp = p - v1;
+    const RealT d3 = ab.dot(bp);
+    const RealT d4 = ac.dot(bp);
+    if (d3 >= RealT(0) && d4 <= d3) {
+        t0 = RealT(1);
+        t1 = RealT(0);
+        return v1;
+    }
+
+    // --- Region AB (edge v0-v1) ---
+    const RealT vc = d1 * d4 - d3 * d2;
+    if (vc <= RealT(0) && d1 >= RealT(0) && d3 <= RealT(0)) {
+        t0 = d1 / (d1 - d3);
+        t1 = RealT(0);
+        return v0 + t0 * ab;
+    }
+
+    // --- Region C (vertex v2) ---
+    const Vec3T cp = p - v2;
+    const RealT d5 = ab.dot(cp);
+    const RealT d6 = ac.dot(cp);
+    if (d6 >= RealT(0) && d5 <= d6) {
+        t0 = RealT(0);
+        t1 = RealT(1);
+        return v2;
+    }
+
+    // --- Region AC (edge v0-v2) ---
+    const RealT vb = d5 * d2 - d1 * d6;
+    if (vb <= RealT(0) && d2 >= RealT(0) && d6 <= RealT(0)) {
+        t1 = d2 / (d2 - d6);
+        t0 = RealT(0);
+        return v0 + t1 * ac;
+    }
+
+    // --- Region BC (edge v1-v2) ---
+    const RealT va = d3 * d6 - d5 * d4;
+    if (va <= RealT(0) && (d4 - d3) >= RealT(0) && (d5 - d6) >= RealT(0)) {
+        t1 = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+        t0 = RealT(1) - t1;
+        return v1 + t1 * (v2 - v1);
+    }
+
+    // --- Interior of triangle ---
+    const RealT denom = RealT(1) / (va + vb + vc);
+    t0 = vb * denom;
+    t1 = vc * denom;
+    return v0 + t0 * ab + t1 * ac;
+}
+
+/// @brief Returns the squared distance from @a p to the closest point
+///        on triangle [v0,v1,v2].
+template<typename Vec3T>
+__hostdev__ inline typename Vec3T::ValueType
+pointToTriangleDistSqr(
+    const Vec3T &v0,
+    const Vec3T &v1,
+    const Vec3T &v2,
+    const Vec3T &p)
+{
+    typename Vec3T::ValueType t0, t1;
+    const Vec3T closest = closestPointOnTriangleToPoint(v0, v1, v2, p, t0, t1);
+    return (p - closest).lengthSqr();
+}
+
+} // namespace math
+
+} // namespace nanovdb
+
+#endif // NANOVDB_MATH_PROXIMITY_H_HAS_BEEN_INCLUDED

--- a/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
@@ -253,10 +253,6 @@ MeshToGrid<BuildT>::getHandle(const BufferT &pool)
     mBuilder.countNodes(mStream);
     cudaStreamSynchronize(mStream); // node counts written async; sync before reading or passing to getBuffer
     if (mVerbose==1) mTimer.stop();
-    if (mVerbose>=2) printf("Node counts - upper: %u  lower: %u  leaf: %u\n",
-           mBuilder.data()->nodeCount[2],
-           mBuilder.data()->nodeCount[1],
-           mBuilder.data()->nodeCount[0]);
 
     // Allocate output grid buffer
     if (mVerbose==1) mTimer.start("Allocating grid buffer");
@@ -302,11 +298,6 @@ MeshToGrid<BuildT>::getHandle(const BufferT &pool)
     mBuilder.postProcessGridTree(mStream);
     cudaStreamSynchronize(mStream);
     if (mVerbose==1) mTimer.stop();
-    if (mVerbose>=2) {
-        const auto voxelCount = util::cuda::DeviceGridTraits<BuildT>::getActiveVoxelCount(
-            &mBuilder.data()->getGrid());
-        printf("Active voxels: %llu\n", (unsigned long long)voxelCount);
-    }
 
     if (mVerbose==1) mTimer.start("Pruning empty leaves");
     int device = 0; cudaGetDevice(&device);
@@ -361,7 +352,6 @@ void MeshToGrid<BuildT>::transformTriangles()
     mXformedTriangles = nanovdb::cuda::DeviceBuffer::create(mTriangleCount*sizeof(TriangleT), nullptr, device, mStream);
     if (mXformedTriangles.deviceData() == nullptr) throw std::runtime_error("Failed to allocate transofmed upper mask buffer on device");
 
-    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::transformTriangles()] Launching TransformTrianglesFunctor");
     util::cuda::lambdaKernel<<<numBlocks(mTriangleCount), mNumThreads, 0, mStream>>>(
         mTriangleCount,
         topology::detail::TransformTrianglesFunctor<BuildT>{
@@ -497,8 +487,6 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
 
     // Pass 1: Count intersecting root boxes per triangle
 
-    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::processRootTrianglePairs()] Launching processRootTrianglePairs");
-
     nanovdb::cuda::DeviceBuffer
         rootBoxCounts = nanovdb::cuda::DeviceBuffer::create(mTriangleCount * sizeof(uint64_t), nullptr, device, mStream);
     if (rootBoxCounts.deviceData() == nullptr) throw std::runtime_error("Failed to allocate root box counts buffer");
@@ -515,8 +503,6 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
 
     // Pass 2: InclusiveSum Scan to compute offsets and total allocations
 
-    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::processRootTrianglePairs()] Prefix sum");
-
     nanovdb::cuda::DeviceBuffer rootBoxOffsets =
         nanovdb::cuda::DeviceBuffer::create((mTriangleCount+1)*sizeof(uint64_t), nullptr, device, mStream);
     if (rootBoxOffsets.deviceData() == nullptr) throw std::runtime_error("Failed to allocate root box offsets buffer");
@@ -529,11 +515,7 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
     cudaCheck(cudaMemcpyAsync(&mBoxTrianglePairCount, static_cast<uint64_t*>(rootBoxOffsets.deviceData())+mTriangleCount, sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
     cudaStreamSynchronize(mStream);
 
-    if (mVerbose >= 2) printf("Total Root/Triangle pairs to generate: %d\n", (int)mBoxTrianglePairCount);
-
     // Pass 3: Re-enumerate intersections of (padded) root boxes and triangles, and scatter to allocated list
-
-    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::processRootTrianglePairs()] Scatter pairs");
 
     mBoxTrianglePairsBuffer = nanovdb::cuda::DeviceBuffer::create(
         mBoxTrianglePairCount * sizeof(typename MeshToGrid<BuildT>::BoxTrianglePair), nullptr, device, mStream);
@@ -801,8 +783,6 @@ void MeshToGrid<BuildT>::enumerateRootTiles()
     cudaGetDevice(&device);
 
     // Step 1: Encode each pair's root origin as a sortable uint64_t key
-    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::enumerateRootTiles()] Encoding origins as keys");
-
     nanovdb::cuda::DeviceBuffer keysBuffer = nanovdb::cuda::DeviceBuffer::create(
         mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
     auto *dKeys = static_cast<uint64_t*>(keysBuffer.deviceData());
@@ -814,8 +794,6 @@ void MeshToGrid<BuildT>::enumerateRootTiles()
     cudaCheckError();
 
     // Step 2: Sort keys (SortKeys requires separate in/out buffers)
-    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::enumerateRootTiles()] Sorting keys");
-
     nanovdb::cuda::DeviceBuffer sortedKeysBuffer = nanovdb::cuda::DeviceBuffer::create(
         mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
     auto *dSortedKeys = static_cast<uint64_t*>(sortedKeysBuffer.deviceData());
@@ -823,8 +801,6 @@ void MeshToGrid<BuildT>::enumerateRootTiles()
     CALL_CUBS(DeviceRadixSort::SortKeys, dKeys, dSortedKeys, (int)mBoxTrianglePairCount, 0, 64);
 
     // Step 3: Select unique keys
-    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::enumerateRootTiles()] Selecting unique keys");
-
     nanovdb::cuda::DeviceBuffer uniqueKeysBuffer = nanovdb::cuda::DeviceBuffer::create(
         mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
     auto *dUniqueKeys = static_cast<uint64_t*>(uniqueKeysBuffer.deviceData());
@@ -840,11 +816,7 @@ void MeshToGrid<BuildT>::enumerateRootTiles()
     cudaStreamSynchronize(mStream);
     mUniqueRootTileCount = static_cast<uint64_t>(uniqueCount);
 
-    if (mVerbose >= 2) printf("Unique root tiles: %llu\n", (unsigned long long)mUniqueRootTileCount);
-
     // Step 4: Decode unique keys back to Coord origins
-    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::enumerateRootTiles()] Decoding keys to Coord origins");
-
     mUniqueRootOriginsBuffer = nanovdb::cuda::DeviceBuffer::create(
         mUniqueRootTileCount * sizeof(nanovdb::Coord), nullptr, device, mStream);
     auto *dOrigins = deviceUniqueRootOrigins();
@@ -962,11 +934,6 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
     int scale = 4096; // Start at Root node scale
 
     for (int pass = 0; pass < 3; ++pass) {
-        if (mVerbose >= 2) {
-            printf("\n--- Subdivision Pass %d (Scale: %d -> %d) ---\n",
-                   pass, scale, scale / 8);
-        }
-
         // Allocate Mask<3> buffer for the CTA hit results
         // Size: mBoxTrianglePairCount * sizeof(nanovdb::Mask<3>)
         nanovdb::cuda::DeviceBuffer maskBuffer = nanovdb::cuda::DeviceBuffer::create(
@@ -991,7 +958,6 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
         // extends 0.5 beyond outermost cell centers), but we add 0.5 extra for safety.
         int childScale = scale / 8;
         const float padding = mBandWidth;
-        if (mVerbose >= 2) mTimer.start("  Evaluate & Count");
         if (childScale >= mSATThreshold)
             topology::detail::evaluateAndCountSubBoxesKernel<BuildT, true>
                 <<<mBoxTrianglePairCount, 512, 0, mStream>>>(
@@ -1001,7 +967,6 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
                 <<<mBoxTrianglePairCount, 512, 0, mStream>>>(
                     deviceBoxTrianglePairs(), deviceXformedTriangles(), dMasks, dCounts, scale, padding);
         cudaCheckError();
-        if (mVerbose >= 2) mTimer.stop();
 
         // Prefix Sum: element [i+1] = exclusive write offset for parent i's children,
         // element [0] = 0, element [mBoxTrianglePairCount] = total child pair count.
@@ -1022,8 +987,6 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
             sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
         cudaStreamSynchronize(mStream);
 
-        if (mVerbose >= 2) printf("Total child pairs after subdivision: %llu\n", (unsigned long long)newPairCount);
-
         // Allocate new child pair buffer
         nanovdb::cuda::DeviceBuffer newPairsBuffer = nanovdb::cuda::DeviceBuffer::create(
             newPairCount * sizeof(BoxTrianglePair), nullptr, device, mStream);
@@ -1032,7 +995,6 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
         auto* dNewPairs = static_cast<BoxTrianglePair*>(newPairsBuffer.deviceData());
 
         // Scatter surviving child pairs into the new buffer
-        if (mVerbose >= 2) mTimer.start("  Scatter");
         util::cuda::lambdaKernel<<<numBlocks(mBoxTrianglePairCount), mNumThreads, 0, mStream>>>(
             mBoxTrianglePairCount,
             topology::detail::ScatterChildPairsFunctor<BuildT>{
@@ -1040,7 +1002,6 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
             }
         );
         cudaCheckError();
-        if (mVerbose >= 2) mTimer.stop();
 
         // Ping-pong: replace the parent pair buffer with the new child pair buffer
         mBoxTrianglePairsBuffer = std::move(newPairsBuffer);
@@ -1129,10 +1090,6 @@ MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBu
     mBuilder.countNodes(mStream);
     cudaStreamSynchronize(mStream);
     if (mVerbose==1) mTimer.stop();
-    if (mVerbose>=2) printf("Node counts - upper: %u  lower: %u  leaf: %u\n",
-           mBuilder.data()->nodeCount[2],
-           mBuilder.data()->nodeCount[1],
-           mBuilder.data()->nodeCount[0]);
 
     if (mVerbose==1) mTimer.start("Allocating grid buffer");
     auto buffer = mBuilder.getBuffer(gridPool, mStream);
@@ -1190,7 +1147,6 @@ MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBu
 
     const uint64_t activeVoxelCount = util::cuda::DeviceGridTraits<BuildT>::getActiveVoxelCount(
         handle.template deviceGrid<BuildT>());
-    if (mVerbose>=2) printf("Active voxels: %llu\n", (unsigned long long)activeVoxelCount);
 
     auto sidecarBuffer = nanovdb::cuda::DeviceBuffer::create(
         (activeVoxelCount + 1) * sizeof(float), nullptr, device, mStream);

--- a/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
@@ -6,7 +6,8 @@
 
     \authors Efty Sifakis
 
-    \brief Rasterization of triangle mesh into a sparse NanoVDB indexGrid on the device
+    \brief Rasterization of triangle mesh into a sparse NanoVDB indexGrid on the device.
+           Optionally an Unsigned Distance Field can be returned in a newly allocated sidecar.
 
     \warning The header file contains cuda device code so be sure
              to only include it in .cu files (or other .cuh files)
@@ -50,15 +51,15 @@ struct Triangle {
 template <typename BuildT>
 class MeshToGrid
 {
-    using PointT  = nanovdb::Vec3f;
+    using PointT = nanovdb::Vec3f;
     using TriangleIndexT = nanovdb::Vec3i;
     using TriangleT = Triangle;
-    using GridT   = NanoGrid<BuildT>;
-    using TreeT   = NanoTree<BuildT>;
-    using RootT   = NanoRoot<BuildT>;
-    using UpperT  = NanoUpper<BuildT>;
-    using LowerT  = NanoLower<BuildT>;
-    using LeafT   = NanoLeaf<BuildT>;
+    using GridT  = NanoGrid<BuildT>;
+    using TreeT  = NanoTree<BuildT>;
+    using RootT  = NanoRoot<BuildT>;
+    using UpperT = NanoUpper<BuildT>;
+    using LowerT = NanoLower<BuildT>;
+    using LeafT  = NanoLeaf<BuildT>;
 
 public:
     struct alignas(16) BoxTrianglePair { // sizeof(BoxTrianglePair) = 16B
@@ -259,7 +260,7 @@ MeshToGrid<BuildT>::getHandle(const BufferT &pool)
 
     // Allocate output grid buffer
     if (mVerbose==1) mTimer.start("Allocating grid buffer");
-    auto gridBuffer = mBuilder.getBuffer(pool, mStream);
+    auto buffer = mBuilder.getBuffer(pool, mStream);
     if (mVerbose==1) mTimer.stop();
 
     // Initialize grid/tree/root metadata
@@ -281,8 +282,10 @@ MeshToGrid<BuildT>::getHandle(const BufferT &pool)
     if (mVerbose==1) mTimer.start("Rasterizing leaf nodes");
     rasterizeLeafNodes();
     if (mVerbose==1) mTimer.stop();
-    mXformedTriangles.clear(mStream);
-    mBoxTrianglePairsBuffer.clear(mStream);
+    if (mBoxTrianglePairCount) {
+        mXformedTriangles.clear(mStream);
+        mBoxTrianglePairsBuffer.clear(mStream);
+    }
 
     // Update leaf value offsets (prefix sums of per-leaf active voxel counts)
     if (mVerbose==1) mTimer.start("Processing leaf offsets");
@@ -308,17 +311,20 @@ MeshToGrid<BuildT>::getHandle(const BufferT &pool)
     if (mVerbose==1) mTimer.start("Pruning empty leaves");
     int device = 0; cudaGetDevice(&device);
     const uint32_t leafCount = mBuilder.data()->nodeCount[0];
-    nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
-        uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
-    cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
-        uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
-    tools::cuda::PruneGrid<BuildT> pruner(
-        static_cast<const GridT*>(gridBuffer.deviceData()),
-        static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
-        mStream);
-    auto prunedHandle = pruner.template getHandle<BufferT>(pool);
+    auto handle = GridHandle<BufferT>(std::move(buffer));
+    if (leafCount) {
+        nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
+            uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
+        cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
+            uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
+        tools::cuda::PruneGrid<BuildT> pruner(
+            static_cast<const GridT*>(handle.deviceData()),
+            static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
+            mStream);
+        handle = pruner.template getHandle<BufferT>(pool);
+    }
     if (mVerbose==1) mTimer.stop();
-    return prunedHandle;
+    return handle;
 } // MeshToGrid<BuildT>::getHandle
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -347,9 +353,7 @@ struct TransformTrianglesFunctor
 template<typename BuildT>
 void MeshToGrid<BuildT>::transformTriangles()
 {
-    // TODO: Handle null input case
-    if (mTriangleCount == 0)
-        throw std::runtime_error("MeshToGrid currently requires mTriangleCount > 0 (Holistic zero-handling pending).");
+    if (mTriangleCount == 0) return;
 
     int device = 0;
     cudaGetDevice(&device);
@@ -486,9 +490,7 @@ struct ScatterRootTrianglePairsFunctor
 template<typename BuildT>
 void MeshToGrid<BuildT>::processRootTrianglePairs()
 {
-    // TODO: Handle null input case
-    if (mTriangleCount == 0)
-        throw std::runtime_error("MeshToGrid currently requires mTriangleCount > 0 (Holistic zero-handling pending).");
+    if (mTriangleCount == 0) { mBoxTrianglePairCount = 0; return; }
 
     int device = 0;
     cudaGetDevice(&device);
@@ -867,10 +869,6 @@ void MeshToGrid<BuildT>::buildRasterizedRoot()
     // Origins are already in coordToKey-sorted order from enumerateRootTiles(),
     // so no further sorting or deduplication is required here.
     uint32_t tileCount = static_cast<uint32_t>(mUniqueRootTileCount);
-    std::vector<nanovdb::Coord> hostOrigins(tileCount);
-    cudaCheck(cudaMemcpy(hostOrigins.data(),
-        deviceUniqueRootOrigins(),
-        tileCount * sizeof(nanovdb::Coord), cudaMemcpyDeviceToHost));
 
     // Build the root node on CPU: one tile per unique root origin.
     // Only the NanoVDB tile key is set here; child pointers and values are
@@ -880,12 +878,17 @@ void MeshToGrid<BuildT>::buildRasterizedRoot()
     auto *rootPtr = static_cast<RootT*>(mBuilder.mProcessedRoot.data());
     rootPtr->mTableSize = tileCount;
     rootPtr->mBackground = typename RootT::ValueType{};
-    for (uint32_t t = 0; t < tileCount; ++t)
-        *rootPtr->tile(t) = typename RootT::DataType::Tile{RootT::CoordToKey(hostOrigins[t])};
 
-    mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
-
-    mUniqueRootOriginsBuffer.clear(mStream);
+    if (tileCount) {
+        std::vector<nanovdb::Coord> hostOrigins(tileCount);
+        cudaCheck(cudaMemcpy(hostOrigins.data(),
+            deviceUniqueRootOrigins(),
+            tileCount * sizeof(nanovdb::Coord), cudaMemcpyDeviceToHost));
+        for (uint32_t t = 0; t < tileCount; ++t)
+            *rootPtr->tile(t) = typename RootT::DataType::Tile{RootT::CoordToKey(hostOrigins[t])};
+        mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
+        mUniqueRootOriginsBuffer.clear(mStream);
+    }
 } // MeshToGrid<BuildT>::buildRasterizedRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -893,6 +896,8 @@ void MeshToGrid<BuildT>::buildRasterizedRoot()
 template<typename BuildT>
 void MeshToGrid<BuildT>::rasterizeInternalNodes()
 {
+    if (mBoxTrianglePairCount == 0) return;
+
     using RasterizerT = util::rasterization::cuda::RasterizeInternalNodesFunctor<BuildT, BoxTrianglePair>;
 
     auto *dUpperMasks = static_cast<Mask<5>*>(mBuilder.deviceUpperMasks());
@@ -949,9 +954,7 @@ void MeshToGrid<BuildT>::rasterizeLeafNodes()
 template<typename BuildT>
 void MeshToGrid<BuildT>::processLeafTrianglePairs()
 {
-    // TODO: Handle null input case
-    if (mTriangleCount == 0)
-        throw std::runtime_error("MeshToGrid currently requires mTriangleCount > 0 (Holistic zero-handling pending).");
+    if (mBoxTrianglePairCount == 0) return;
 
     int device = 0;
     cudaGetDevice(&device);
@@ -1132,7 +1135,7 @@ MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBu
            mBuilder.data()->nodeCount[0]);
 
     if (mVerbose==1) mTimer.start("Allocating grid buffer");
-    auto gridBuffer = mBuilder.getBuffer(gridPool, mStream);
+    auto buffer = mBuilder.getBuffer(gridPool, mStream);
     if (mVerbose==1) mTimer.stop();
 
     if (mVerbose==1) mTimer.start("Processing grid/tree/root");
@@ -1167,15 +1170,18 @@ MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBu
     if (mVerbose==1) mTimer.start("Pruning empty leaves");
     int device = 0; cudaGetDevice(&device);
     const uint32_t leafCount = mBuilder.data()->nodeCount[0];
-    nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
-        uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
-    cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
-        uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
-    tools::cuda::PruneGrid<BuildT> pruner(
-        static_cast<const GridT*>(gridBuffer.deviceData()),
-        static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
-        mStream);
-    auto handle = pruner.template getHandle<GridBufferT>(gridPool);
+    auto handle = GridHandle<GridBufferT>(std::move(buffer));
+    if (leafCount) {
+        nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
+            uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
+        cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
+            uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
+        tools::cuda::PruneGrid<BuildT> pruner(
+            static_cast<const GridT*>(handle.deviceData()),
+            static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
+            mStream);
+        handle = pruner.template getHandle<GridBufferT>(gridPool);
+    }
     if (mVerbose==1) mTimer.stop();
 
     // ---- UDF sidecar ----
@@ -1198,16 +1204,18 @@ MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBu
     if (mVerbose==1) mTimer.stop();
 
     if (mVerbose==1) mTimer.start("Computing UDF via leaf/triangle pairs");
-    using UDFFunctorT = util::rasterization::cuda::ComputeUDFFunctor<BuildT, BoxTrianglePair, Triangle>;
-    util::cuda::operatorKernelInstance<UDFFunctorT>
-        <<<mBoxTrianglePairCount, UDFFunctorT::MaxThreadsPerBlock, 0, mStream>>>(
-            UDFFunctorT{ deviceBoxTrianglePairs(), deviceXformedTriangles(),
-                         handle.template deviceGrid<BuildT>(), dSidecar,
-                         mBandWidth * mBandWidth });
-    cudaCheckError();
+    if (mBoxTrianglePairCount) {
+        using UDFFunctorT = util::rasterization::cuda::ComputeUDFFunctor<BuildT, BoxTrianglePair, Triangle>;
+        util::cuda::operatorKernelInstance<UDFFunctorT>
+            <<<mBoxTrianglePairCount, UDFFunctorT::MaxThreadsPerBlock, 0, mStream>>>(
+                UDFFunctorT{ deviceBoxTrianglePairs(), deviceXformedTriangles(),
+                             handle.template deviceGrid<BuildT>(), dSidecar,
+                             mBandWidth * mBandWidth });
+        cudaCheckError();
+        mXformedTriangles.clear(mStream);
+        mBoxTrianglePairsBuffer.clear(mStream);
+    }
     if (mVerbose==1) mTimer.stop();
-    mXformedTriangles.clear(mStream);
-    mBoxTrianglePairsBuffer.clear(mStream);
 
     if (mVerbose==1) mTimer.start("Finalizing UDF sidecar (sqrt + clamp)");
     util::cuda::lambdaKernel<<<numBlocks(activeVoxelCount + 1), mNumThreads, 0, mStream>>>(

--- a/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
@@ -125,12 +125,14 @@ public:
     ///
     /// @tparam GridBufferT    Buffer type for the output grid handle
     /// @tparam SidecarBufferT Buffer type for the UDF sidecar (defaults to DeviceBuffer)
+    /// @param buffer          optional allocator for the grid handle (currently ignored)
+    /// @param sidecarBuffer   optional allocator for the UDF sidecar (currently ignored)
     /// @return std::pair of grid handle and UDF sidecar buffer
-    template<typename GridBufferT   = nanovdb::cuda::DeviceBuffer,
+    template<typename GridBufferT    = nanovdb::cuda::DeviceBuffer,
              typename SidecarBufferT = nanovdb::cuda::DeviceBuffer>
     std::pair<GridHandle<GridBufferT>, SidecarBufferT>
-    getHandleAndUDF(const GridBufferT&    gridPool    = GridBufferT(),
-                    const SidecarBufferT& sidecarPool = SidecarBufferT());
+    getHandleAndUDF(const GridBufferT&    buffer        = GridBufferT(),
+                    const SidecarBufferT& sidecarBuffer = SidecarBufferT());
 
 private:
     void transformTriangles();
@@ -177,14 +179,6 @@ private:
     auto deviceUniqueRootOrigins() const { return static_cast<nanovdb::Coord*>(mUniqueRootOriginsBuffer.deviceData()); }
 
     nanovdb::cuda::TempDevicePool mTempDevicePool;
-
-    // For diagnostic purposes
-public:
-    uint64_t getPairCount() const { return mBoxTrianglePairCount; }
-    const BoxTrianglePair *getDevicePairs() const { return static_cast<const BoxTrianglePair*>(mBoxTrianglePairsBuffer.deviceData()); }
-
-    uint64_t getRootTileCount() const { return mUniqueRootTileCount; }
-    const nanovdb::Coord *getDeviceRootOrigins() const { return deviceUniqueRootOrigins(); }
 }; // tools::cuda::MeshToGrid<BuildT>
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -209,7 +203,7 @@ public:
 template<typename BuildT>
 template<typename BufferT>
 GridHandle<BufferT>
-MeshToGrid<BuildT>::getHandle(const BufferT &pool)
+MeshToGrid<BuildT>::getHandle(const BufferT &buffer)
 {
     cudaStreamSynchronize(mStream);
 
@@ -256,7 +250,7 @@ MeshToGrid<BuildT>::getHandle(const BufferT &pool)
 
     // Allocate output grid buffer
     if (mVerbose==1) mTimer.start("Allocating grid buffer");
-    auto buffer = mBuilder.getBuffer(pool, mStream);
+    auto gridBuffer = mBuilder.getBuffer(buffer, mStream);
     if (mVerbose==1) mTimer.stop();
 
     // Initialize grid/tree/root metadata
@@ -302,7 +296,7 @@ MeshToGrid<BuildT>::getHandle(const BufferT &pool)
     if (mVerbose==1) mTimer.start("Pruning empty leaves");
     int device = 0; cudaGetDevice(&device);
     const uint32_t leafCount = mBuilder.data()->nodeCount[0];
-    auto handle = GridHandle<BufferT>(std::move(buffer));
+    auto handle = GridHandle<BufferT>(std::move(gridBuffer));
     if (leafCount) {
         nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
@@ -312,7 +306,7 @@ MeshToGrid<BuildT>::getHandle(const BufferT &pool)
             static_cast<const GridT*>(handle.deviceData()),
             static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
             mStream);
-        handle = pruner.template getHandle<BufferT>(pool);
+        handle = pruner.template getHandle<BufferT>(buffer);
     }
     if (mVerbose==1) mTimer.stop();
     return handle;
@@ -1052,7 +1046,7 @@ struct FinalizeSidecarFunctor
 template<typename BuildT>
 template<typename GridBufferT, typename SidecarBufferT>
 std::pair<GridHandle<GridBufferT>, SidecarBufferT>
-MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBufferT&)
+MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& buffer, const SidecarBufferT&)
 {
     cudaStreamSynchronize(mStream);
 
@@ -1092,7 +1086,7 @@ MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBu
     if (mVerbose==1) mTimer.stop();
 
     if (mVerbose==1) mTimer.start("Allocating grid buffer");
-    auto buffer = mBuilder.getBuffer(gridPool, mStream);
+    auto gridBuffer = mBuilder.getBuffer(buffer, mStream);
     if (mVerbose==1) mTimer.stop();
 
     if (mVerbose==1) mTimer.start("Processing grid/tree/root");
@@ -1127,7 +1121,7 @@ MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBu
     if (mVerbose==1) mTimer.start("Pruning empty leaves");
     int device = 0; cudaGetDevice(&device);
     const uint32_t leafCount = mBuilder.data()->nodeCount[0];
-    auto handle = GridHandle<GridBufferT>(std::move(buffer));
+    auto handle = GridHandle<GridBufferT>(std::move(gridBuffer));
     if (leafCount) {
         nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
@@ -1137,7 +1131,7 @@ MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBu
             static_cast<const GridT*>(handle.deviceData()),
             static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
             mStream);
-        handle = pruner.template getHandle<GridBufferT>(gridPool);
+        handle = pruner.template getHandle<GridBufferT>(buffer);
     }
     if (mVerbose==1) mTimer.stop();
 

--- a/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
@@ -1,0 +1,1230 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/cuda/MeshToGrid.cuh
+
+    \authors Efty Sifakis
+
+    \brief Rasterization of triangle mesh into a sparse NanoVDB indexGrid on the device
+
+    \warning The header file contains cuda device code so be sure
+             to only include it in .cu files (or other .cuh files)
+*/
+
+#ifndef NVIDIA_TOOLS_CUDA_MESHTOGRID_CUH_HAS_BEEN_INCLUDED
+#define NVIDIA_TOOLS_CUDA_MESHTOGRID_CUH_HAS_BEEN_INCLUDED
+
+#include <cub/cub.cuh>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/cuda/TempPool.h>
+#include <nanovdb/util/cuda/Timer.h>
+#include <nanovdb/tools/cuda/TopologyBuilder.cuh>
+#include <nanovdb/tools/cuda/PruneGrid.cuh>
+#include <nanovdb/util/cuda/Rasterization.cuh>
+#include <nanovdb/util/cuda/DeviceGridTraits.cuh>
+
+#include <utility>
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+/// @brief POD triangle type with __hostdev__ accessors, safe for use in both host and device code.
+///
+///        Used as the element type of the transformed-triangle device buffer throughout MeshToGrid.
+///        The only interface requirement imposed on this type by the rasterization functors in
+///        Rasterization.cuh is a __hostdev__ const Vec3f& operator[](int) const returning the
+///        i-th vertex (i = 0, 1, 2).
+///
+/// @todo  This type should ultimately migrate to a dedicated geometric-primitives header in
+///        nanovdb/math/ (e.g. nanovdb/math/Primitives.h) once such a header is introduced.
+struct Triangle {
+    nanovdb::Vec3f v[3];
+    __hostdev__ const nanovdb::Vec3f& operator[](int i) const { return v[i]; }
+    __hostdev__       nanovdb::Vec3f& operator[](int i)       { return v[i]; }
+};
+
+template <typename BuildT>
+class MeshToGrid
+{
+    using PointT  = nanovdb::Vec3f;
+    using TriangleIndexT = nanovdb::Vec3i;
+    using TriangleT = Triangle;
+    using GridT   = NanoGrid<BuildT>;
+    using TreeT   = NanoTree<BuildT>;
+    using RootT   = NanoRoot<BuildT>;
+    using UpperT  = NanoUpper<BuildT>;
+    using LowerT  = NanoLower<BuildT>;
+    using LeafT   = NanoLeaf<BuildT>;
+
+public:
+    struct alignas(16) BoxTrianglePair { // sizeof(BoxTrianglePair) = 16B
+        nanovdb::Coord origin; // 12B
+        uint32_t triangleID;   // 4B
+    };
+
+    /// @brief Constructor
+    /// @param devicePoints Vertex list for input triangle surface
+    /// @param pointCount Vertex count for input triangle surface
+    /// @param deviceTriangles Triangle index list
+    /// @param triangleCount Triangle count
+    /// @param map Affine map to be used in the conversion
+    MeshToGrid(
+        const nanovdb::Vec3f *devicePoints,
+        const uint32_t pointCount,
+        const nanovdb::Vec3i *deviceTriangles,
+        const uint32_t triangleCount,
+        const nanovdb::Map map = nanovdb::Map(),
+        cudaStream_t stream = 0
+    )
+        : mStream(stream), mTimer(stream), mBuilder(stream), mDevicePoints(devicePoints), mPointCount(pointCount),
+         mDeviceTriangles(deviceTriangles), mTriangleCount(triangleCount), mMap(map)
+    {}
+
+    /// @brief Toggle on and off verbose mode
+    /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
+    void setVerbose(int level = 1) { mVerbose = level; }
+
+    /// @brief Set desired width of narrow band
+    /// @param bandWidth Narrow band width in cell units
+    void setNarrowBandWidth(float bandWidth = 3.f) { mBandWidth = bandWidth; }
+
+    /// @brief Set the AABB scale threshold below which the intersection test switches
+    ///        from a conservative AABB-only test to a precise SAT test.
+    ///        Default is 128 (the size of a NanoVDB lower node).
+    /// @param threshold Index-space AABB scale threshold in voxel units
+    void setSATThreshold(int threshold = 128) { mSATThreshold = threshold; }
+
+    /// @brief Set the name of the output grid
+    /// @param name Grid name string
+    void setGridName(const std::string &name) { mGridName = name; }
+
+    /// @brief Set the mode for checksum computation, which is disabled by default
+    /// @param mode Mode of checksum computation
+    void setChecksum(CheckMode mode = CheckMode::Disable) { mBuilder.mChecksum = mode; }
+
+    /// @brief Creates a handle to the output grid
+    /// @tparam BufferT Buffer type used for allocation of the grid handle
+    /// @param buffer optional buffer (currently ignored)
+    /// @return returns a handle with a grid of type NanoGrid<BuildT>
+    template<typename BufferT = nanovdb::cuda::DeviceBuffer>
+    GridHandle<BufferT>
+    getHandle(const BufferT &buffer = BufferT());
+
+    /// @brief Creates a grid handle and a device sidecar buffer containing the
+    ///        per-active-voxel unsigned distance field values.
+    ///
+    ///        The sidecar buffer stores (activeVoxelCount+1) floats indexed by
+    ///        leaf->getValue(voxelID) for ValueOnIndex grids:
+    ///          - sidecar[0]   = mBandWidth (background slot)
+    ///          - sidecar[k>0] = UDF at the k-th active voxel (in voxel units)
+    ///
+    /// @tparam GridBufferT    Buffer type for the output grid handle
+    /// @tparam SidecarBufferT Buffer type for the UDF sidecar (defaults to DeviceBuffer)
+    /// @return std::pair of grid handle and UDF sidecar buffer
+    template<typename GridBufferT   = nanovdb::cuda::DeviceBuffer,
+             typename SidecarBufferT = nanovdb::cuda::DeviceBuffer>
+    std::pair<GridHandle<GridBufferT>, SidecarBufferT>
+    getHandleAndUDF(const GridBufferT&    gridPool    = GridBufferT(),
+                    const SidecarBufferT& sidecarPool = SidecarBufferT());
+
+private:
+    void transformTriangles();
+
+    void processRootTrianglePairs();
+
+    void enumerateRootTiles();
+
+    void processLeafTrianglePairs();
+
+    void buildRasterizedRoot();
+
+    void rasterizeInternalNodes();
+
+    void processGridTreeRoot();
+
+    void rasterizeLeafNodes();
+
+
+    static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
+    static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
+
+    TopologyBuilder<BuildT>      mBuilder;
+    cudaStream_t                 mStream{0};
+    std::string                  mGridName;
+    util::cuda::Timer            mTimer;
+    int                          mVerbose{0};
+    float                        mBandWidth{3.f};
+    int                          mSATThreshold{128};
+    const nanovdb::Vec3f         *mDevicePoints;
+    const uint32_t               mPointCount;
+    const nanovdb::Vec3i         *mDeviceTriangles;
+    const uint32_t               mTriangleCount;
+    const nanovdb::Map           mMap;
+
+    nanovdb::cuda::DeviceBuffer  mXformedTriangles;
+    nanovdb::cuda::DeviceBuffer  mBoxTrianglePairsBuffer;
+    uint64_t                     mBoxTrianglePairCount{0};
+    nanovdb::cuda::DeviceBuffer  mUniqueRootOriginsBuffer;
+    uint64_t                     mUniqueRootTileCount{0};
+
+    auto deviceXformedTriangles()  { return static_cast<TriangleT*>(mXformedTriangles.deviceData()); }
+    auto deviceBoxTrianglePairs()  { return static_cast<BoxTrianglePair*>(mBoxTrianglePairsBuffer.deviceData()); }
+    auto deviceUniqueRootOrigins() const { return static_cast<nanovdb::Coord*>(mUniqueRootOriginsBuffer.deviceData()); }
+
+    nanovdb::cuda::TempDevicePool mTempDevicePool;
+
+    // For diagnostic purposes
+public:
+    uint64_t getPairCount() const { return mBoxTrianglePairCount; }
+    const BoxTrianglePair *getDevicePairs() const { return static_cast<const BoxTrianglePair*>(mBoxTrianglePairsBuffer.deviceData()); }
+
+    uint64_t getRootTileCount() const { return mUniqueRootTileCount; }
+    const nanovdb::Coord *getDeviceRootOrigins() const { return deviceUniqueRootOrigins(); }
+}; // tools::cuda::MeshToGrid<BuildT>
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+// Define utility macro used to call cub functions that use dynamic temporary storage
+#ifndef CALL_CUBS
+#ifdef _WIN32
+#define CALL_CUBS(func, ...) \
+    cudaCheck(cub::func(nullptr, mTempDevicePool.requestedSize(), __VA_ARGS__, mStream)); \
+    mTempDevicePool.reallocate(mStream); \
+    cudaCheck(cub::func(mTempDevicePool.data(), mTempDevicePool.size(), __VA_ARGS__, mStream));
+#else// ndef _WIN32
+#define CALL_CUBS(func, args...) \
+    cudaCheck(cub::func(nullptr, mTempDevicePool.requestedSize(), args, mStream)); \
+    mTempDevicePool.reallocate(mStream); \
+    cudaCheck(cub::func(mTempDevicePool.data(), mTempDevicePool.size(), args, mStream));
+#endif// ifdef _WIN32
+#endif// ifndef CALL_CUBS
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+template<typename BufferT>
+GridHandle<BufferT>
+MeshToGrid<BuildT>::getHandle(const BufferT &pool)
+{
+    cudaStreamSynchronize(mStream);
+    
+    // Transform triangle data to (floating-point) index space
+    if (mVerbose==1) mTimer.start("Transforming triangles to grid index space");
+    transformTriangles();
+    if (mVerbose==1) mTimer.stop();
+
+    // Process Root-Triangle pairs
+    if (mVerbose==1) mTimer.start("Computing candidate RootTile-Triangle intersection pairs");
+    processRootTrianglePairs();
+    if (mVerbose==1) mTimer.stop();
+
+    // Extract unique root tile origins while root-level pairs are still available
+    if (mVerbose==1) mTimer.start("Enumerating unique root tiles");
+    enumerateRootTiles();
+    if (mVerbose==1) mTimer.stop();
+
+    // Process Leaf-Triangle pairs
+    if (mVerbose==1) mTimer.start("Computing candidate LeafNode-Triangle intersection pairs");
+    processLeafTrianglePairs();
+    if (mVerbose==1) mTimer.stop();
+
+    // Build rasterized root node (one tile per unique root origin)
+    if (mVerbose==1) mTimer.start("Building rasterized root node");
+    buildRasterizedRoot();
+    if (mVerbose==1) mTimer.stop();
+
+    // Allocate (zero-filled) upper/lower mask buffers sized from the root tile count
+    if (mVerbose==1) mTimer.start("Allocating internal mask buffers");
+    mBuilder.allocateInternalMaskBuffers(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    // Scatter leaf/triangle pair origins into upper/lower topology masks
+    if (mVerbose==1) mTimer.start("Rasterizing internal nodes");
+    rasterizeInternalNodes();
+    if (mVerbose==1) mTimer.stop();
+
+    // Count nodes at all levels from the filled masks
+    if (mVerbose==1) mTimer.start("Counting nodes");
+    mBuilder.countNodes(mStream);
+    cudaStreamSynchronize(mStream); // node counts written async; sync before reading or passing to getBuffer
+    if (mVerbose==1) mTimer.stop();
+    if (mVerbose>=2) printf("Node counts - upper: %u  lower: %u  leaf: %u\n",
+           mBuilder.data()->nodeCount[2],
+           mBuilder.data()->nodeCount[1],
+           mBuilder.data()->nodeCount[0]);
+
+    // Allocate output grid buffer
+    if (mVerbose==1) mTimer.start("Allocating grid buffer");
+    auto gridBuffer = mBuilder.getBuffer(pool, mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    // Initialize grid/tree/root metadata
+    if (mVerbose==1) mTimer.start("Processing grid/tree/root");
+    processGridTreeRoot();
+    if (mVerbose==1) mTimer.stop();
+
+    // Connect upper nodes to root tiles and fill upper node preambles
+    if (mVerbose==1) mTimer.start("Processing upper nodes");
+    mBuilder.processUpperNodes(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    // Fill lower node data and leaf node preambles; releases intermediate mask buffers
+    if (mVerbose==1) mTimer.start("Processing lower nodes");
+    mBuilder.processLowerNodes(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    // Fill leaf voxel value masks via exact point-to-triangle UDF
+    if (mVerbose==1) mTimer.start("Rasterizing leaf nodes");
+    rasterizeLeafNodes();
+    if (mVerbose==1) mTimer.stop();
+    mXformedTriangles.clear(mStream);
+    mBoxTrianglePairsBuffer.clear(mStream);
+
+    // Update leaf value offsets (prefix sums of per-leaf active voxel counts)
+    if (mVerbose==1) mTimer.start("Processing leaf offsets");
+    mBuilder.processLeafOffsets(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    // Compute world-space bounding boxes
+    if (mVerbose==1) mTimer.start("Processing bounding boxes");
+    mBuilder.processBBox(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    // Finalize tree statistics (total active voxel count, etc.)
+    if (mVerbose==1) mTimer.start("Post-processing grid/tree data");
+    mBuilder.postProcessGridTree(mStream);
+    cudaStreamSynchronize(mStream);
+    if (mVerbose==1) mTimer.stop();
+    if (mVerbose>=2) {
+        const auto voxelCount = util::cuda::DeviceGridTraits<BuildT>::getActiveVoxelCount(
+            &mBuilder.data()->getGrid());
+        printf("Active voxels: %llu\n", (unsigned long long)voxelCount);
+    }
+
+    if (mVerbose==1) mTimer.start("Pruning empty leaves");
+    int device = 0; cudaGetDevice(&device);
+    const uint32_t leafCount = mBuilder.data()->nodeCount[0];
+    nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
+        uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
+    cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
+        uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
+    tools::cuda::PruneGrid<BuildT> pruner(
+        static_cast<const GridT*>(gridBuffer.deviceData()),
+        static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
+        mStream);
+    auto prunedHandle = pruner.template getHandle<BufferT>(pool);
+    if (mVerbose==1) mTimer.stop();
+    return prunedHandle;
+} // MeshToGrid<BuildT>::getHandle
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
+template <typename BuildT>
+struct TransformTrianglesFunctor
+{
+    const nanovdb::Vec3f* dPoints;
+    const nanovdb::Vec3i* dTriangleIndices;
+    Triangle* dXformedTriangles;
+    nanovdb::Map map; 
+
+    __device__
+    void operator()(size_t triangleID) const
+    {
+        for (int v = 0; v < 3; ++v) {
+            dXformedTriangles[triangleID][v] = map.applyInverseMap(dPoints[dTriangleIndices[triangleID][v]]);
+        }
+    }
+};
+
+} // namespace topology::detail
+
+template<typename BuildT>
+void MeshToGrid<BuildT>::transformTriangles()
+{
+    // TODO: Handle null input case
+    if (mTriangleCount == 0)
+        throw std::runtime_error("MeshToGrid currently requires mTriangleCount > 0 (Holistic zero-handling pending).");
+
+    int device = 0;
+    cudaGetDevice(&device);
+
+    mXformedTriangles = nanovdb::cuda::DeviceBuffer::create(mTriangleCount*sizeof(TriangleT), nullptr, device, mStream);
+    if (mXformedTriangles.deviceData() == nullptr) throw std::runtime_error("Failed to allocate transofmed upper mask buffer on device");
+
+    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::transformTriangles()] Launching TransformTrianglesFunctor");
+    util::cuda::lambdaKernel<<<numBlocks(mTriangleCount), mNumThreads, 0, mStream>>>(
+        mTriangleCount,
+        topology::detail::TransformTrianglesFunctor<BuildT>{
+            mDevicePoints, mDeviceTriangles, deviceXformedTriangles(), mMap
+        }
+    );
+
+    cudaCheckError();
+
+} // MeshToGrid<BuildT>::transformTriangles
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
+template <typename BuildT>
+struct CountRootBoxesFunctor
+{
+    const Triangle* dXformedTriangles;
+    uint64_t* dCounts;
+    float mBandWidth; 
+
+    __device__
+    void operator()(size_t triangleID) const
+    {
+        const auto& tri = dXformedTriangles[triangleID];
+
+        // Compute the strict AABB of the triangle in (cell-centered) index space
+        float min_x = fminf(tri[0][0], fminf(tri[1][0], tri[2][0]));
+        float min_y = fminf(tri[0][1], fminf(tri[1][1], tri[2][1]));
+        float min_z = fminf(tri[0][2], fminf(tri[1][2], tri[2][2]));
+
+        float max_x = fmaxf(tri[0][0], fmaxf(tri[1][0], tri[2][0]));
+        float max_y = fmaxf(tri[0][1], fmaxf(tri[1][1], tri[2][1]));
+        float max_z = fmaxf(tri[0][2], fmaxf(tri[1][2], tri[2][2]));
+
+        // Find the exact integer Voxel/Cell indices we must cover
+        // ceilf() gets the lowest integer >= min_valid
+        // floorf() gets the highest integer <= max_valid
+        float voxel_min_x = ceilf(min_x - mBandWidth);
+        float voxel_min_y = ceilf(min_y - mBandWidth);
+        float voxel_min_z = ceilf(min_z - mBandWidth);
+
+        float voxel_max_x = floorf(max_x + mBandWidth);
+        float voxel_max_y = floorf(max_y + mBandWidth);
+        float voxel_max_z = floorf(max_z + mBandWidth);
+
+        // Map the required voxels to Root Node index space
+        const float invRootDim = 1.0f / 4096.0f;
+        int min_i = static_cast<int>(floorf(voxel_min_x * invRootDim));
+        int min_j = static_cast<int>(floorf(voxel_min_y * invRootDim));
+        int min_k = static_cast<int>(floorf(voxel_min_z * invRootDim));
+
+        int max_i = static_cast<int>(floorf(voxel_max_x * invRootDim));
+        int max_j = static_cast<int>(floorf(voxel_max_y * invRootDim));
+        int max_k = static_cast<int>(floorf(voxel_max_z * invRootDim));
+
+        // Compute the 3D grid dimensions of overlapping root boxes
+        uint64_t count_x = max_i - min_i + 1;
+        uint64_t count_y = max_j - min_j + 1;
+        uint64_t count_z = max_k - min_k + 1;
+
+        // Write the total count of root boxes this triangle touches
+        dCounts[triangleID] = count_x * count_y * count_z;
+    }
+};
+
+template <typename BuildT>
+struct ScatterRootTrianglePairsFunctor
+{
+    using PairT = typename MeshToGrid<BuildT>::BoxTrianglePair;
+
+    const Triangle* dXformedTriangles;
+    const uint64_t* dOffsets;
+    PairT* dPairs;
+    float mBandWidth;
+
+    __device__
+    void operator()(size_t triangleID) const
+    {
+        const auto& tri = dXformedTriangles[triangleID];
+
+        // Recompute the strict AABB
+        float min_x = fminf(tri[0][0], fminf(tri[1][0], tri[2][0]));
+        float min_y = fminf(tri[0][1], fminf(tri[1][1], tri[2][1]));
+        float min_z = fminf(tri[0][2], fminf(tri[1][2], tri[2][2]));
+
+        float max_x = fmaxf(tri[0][0], fmaxf(tri[1][0], tri[2][0]));
+        float max_y = fmaxf(tri[0][1], fmaxf(tri[1][1], tri[2][1]));
+        float max_z = fmaxf(tri[0][2], fmaxf(tri[1][2], tri[2][2]));
+
+        // Find the exact integer Voxel/Cell indices we must cover
+        float voxel_min_x = ceilf(min_x - mBandWidth);
+        float voxel_min_y = ceilf(min_y - mBandWidth);
+        float voxel_min_z = ceilf(min_z - mBandWidth);
+
+        float voxel_max_x = floorf(max_x + mBandWidth);
+        float voxel_max_y = floorf(max_y + mBandWidth);
+        float voxel_max_z = floorf(max_z + mBandWidth);
+
+        // 3. Map the required voxels to Root Node index space
+        const float invRootDim = 1.0f / 4096.0f;
+        int min_i = static_cast<int>(floorf(voxel_min_x * invRootDim));
+        int min_j = static_cast<int>(floorf(voxel_min_y * invRootDim));
+        int min_k = static_cast<int>(floorf(voxel_min_z * invRootDim));
+
+        int max_i = static_cast<int>(floorf(voxel_max_x * invRootDim));
+        int max_j = static_cast<int>(floorf(voxel_max_y * invRootDim));
+        int max_k = static_cast<int>(floorf(voxel_max_z * invRootDim));
+
+        // Scatter the pairs into the global array
+        uint64_t write_idx = dOffsets[triangleID];
+        for (int k = min_k; k <= max_k; ++k)
+        for (int j = min_j; j <= max_j; ++j)
+        for (int i = min_i; i <= max_i; ++i) {
+            // Multiply back by 4096 to get the true NanoVDB index-space origin
+            dPairs[write_idx].origin = nanovdb::Coord(i * 4096, j * 4096, k * 4096);
+            dPairs[write_idx].triangleID = static_cast<uint32_t>(triangleID);
+            write_idx++;
+        }
+    }
+};
+
+} // namespace topology::detail
+
+template<typename BuildT>
+void MeshToGrid<BuildT>::processRootTrianglePairs()
+{
+    // TODO: Handle null input case
+    if (mTriangleCount == 0)
+        throw std::runtime_error("MeshToGrid currently requires mTriangleCount > 0 (Holistic zero-handling pending).");
+
+    int device = 0;
+    cudaGetDevice(&device);
+
+    // Pass 1: Count intersecting root boxes per triangle
+    
+    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::processRootTrianglePairs()] Launching processRootTrianglePairs");
+
+    nanovdb::cuda::DeviceBuffer
+        rootBoxCounts = nanovdb::cuda::DeviceBuffer::create(mTriangleCount * sizeof(uint64_t), nullptr, device, mStream);
+    if (rootBoxCounts.deviceData() == nullptr) throw std::runtime_error("Failed to allocate root box counts buffer");
+
+    util::cuda::lambdaKernel<<<numBlocks(mTriangleCount), mNumThreads, 0, mStream>>>(
+        mTriangleCount, 
+        topology::detail::CountRootBoxesFunctor<BuildT>{
+            deviceXformedTriangles(),
+            static_cast<uint64_t*>(rootBoxCounts.deviceData()),
+            mBandWidth
+        }
+    );
+    cudaCheckError();
+
+    // Pass 2: InclusiveSum Scan to compute offsets and total allocations
+    
+    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::processRootTrianglePairs()] Prefix sum");
+    
+    nanovdb::cuda::DeviceBuffer rootBoxOffsets =
+        nanovdb::cuda::DeviceBuffer::create((mTriangleCount+1)*sizeof(uint64_t), nullptr, device, mStream);
+    if (rootBoxOffsets.deviceData() == nullptr) throw std::runtime_error("Failed to allocate root box offsets buffer");
+
+    cudaCheck(cudaMemsetAsync(rootBoxOffsets.deviceData(), 0, sizeof(uint64_t), mStream));
+    CALL_CUBS(DeviceScan::InclusiveSum,
+        static_cast<uint64_t*>(rootBoxCounts.deviceData()),
+        static_cast<uint64_t*>(rootBoxOffsets.deviceData())+1,
+        mTriangleCount);
+    cudaCheck(cudaMemcpyAsync(&mBoxTrianglePairCount, static_cast<uint64_t*>(rootBoxOffsets.deviceData())+mTriangleCount, sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
+    cudaStreamSynchronize(mStream);
+
+    if (mVerbose >= 2) printf("Total Root/Triangle pairs to generate: %d\n", (int)mBoxTrianglePairCount);
+
+    // Pass 3: Re-enumerate intersections of (padded) root boxes and triangles, and scatter to allocated list
+
+    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::processRootTrianglePairs()] Scatter pairs");
+
+    mBoxTrianglePairsBuffer = nanovdb::cuda::DeviceBuffer::create(
+        mBoxTrianglePairCount * sizeof(typename MeshToGrid<BuildT>::BoxTrianglePair), nullptr, device, mStream);
+    if (mBoxTrianglePairsBuffer.deviceData() == nullptr) throw std::runtime_error("Failed to allocate pairs buffer");
+
+    util::cuda::lambdaKernel<<<numBlocks(mTriangleCount), mNumThreads, 0, mStream>>>(
+        mTriangleCount, 
+        topology::detail::ScatterRootTrianglePairsFunctor<BuildT>{
+            deviceXformedTriangles(),
+            static_cast<uint64_t*>(rootBoxOffsets.deviceData()),
+            deviceBoxTrianglePairs(),
+            mBandWidth
+        }
+    );
+
+} // MeshToGrid<BuildT>::processRootTrianglePairs
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
+/// @brief Scatters surviving child BoxTrianglePairs from a subdivision pass.
+///        Launched with 1 thread per parent pair; each thread iterates over set bits
+///        in the parent's Mask<3> and writes a new BoxTrianglePair for each surviving
+///        child sub-box.
+///
+///        @note The 1-thread-per-parent approach is simple and efficient for sparse masks
+///        (typical after SAT culling at finer scales). It does incur warp divergence since
+///        different parents may have different child counts. An alternative would be a
+///        1-CTA-per-parent launch (512 threads, one per child sub-box) with a warp-level
+///        scan to compute local write offsets - better for dense masks but more complex.
+///        Profile before switching.
+template <typename BuildT>
+struct ScatterChildPairsFunctor
+{
+    using PairT = typename MeshToGrid<BuildT>::BoxTrianglePair;
+
+    const PairT*            dParents;
+    const nanovdb::Mask<3>* dMasks;
+    const uint64_t*         dOffsets;
+    PairT*                  dNewPairs;
+    int                     childScale;
+
+    __device__
+    void operator()(size_t parentID) const
+    {
+        const auto& parentPair = dParents[parentID];
+        const auto& mask       = dMasks[parentID];
+        uint64_t    writeIdx   = dOffsets[parentID];
+
+        for (uint32_t n = 0; n < 512; ++n) {
+            if (mask.isOn(n)) {
+                int i =  n       & 0x7;
+                int j = (n >> 3) & 0x7;
+                int k = (n >> 6) & 0x7;
+                dNewPairs[writeIdx].origin = nanovdb::Coord(
+                    parentPair.origin[0] + i * childScale,
+                    parentPair.origin[1] + j * childScale,
+                    parentPair.origin[2] + k * childScale);
+                dNewPairs[writeIdx].triangleID = parentPair.triangleID;
+                ++writeIdx;
+            }
+        }
+    }
+};
+
+/// @brief Tests if a Triangle intersects an Axis-Aligned Bounding Box.
+template <bool OnlyUseAABB>
+__device__ inline bool testTriangleAABB(
+    const nanovdb::Vec3f& boxCenter,
+    const nanovdb::Vec3f& boxHalfExtents,
+    const nanovdb::Vec3f& V0,
+    const nanovdb::Vec3f& V1,
+    const nanovdb::Vec3f& V2)
+{
+    // Translate the triangle as if the AABB is centered at the origin
+    nanovdb::Vec3f v0 = V0 - boxCenter;
+    nanovdb::Vec3f v1 = V1 - boxCenter;
+    nanovdb::Vec3f v2 = V2 - boxCenter;
+
+    // --- PHASE 1: AABB OVERLAP (3 Axes) ---
+    float minX = fminf(v0[0], fminf(v1[0], v2[0]));
+    float maxX = fmaxf(v0[0], fmaxf(v1[0], v2[0]));
+    if (minX > boxHalfExtents[0] || maxX < -boxHalfExtents[0]) return false;
+
+    float minY = fminf(v0[1], fminf(v1[1], v2[1]));
+    float maxY = fmaxf(v0[1], fmaxf(v1[1], v2[1]));
+    if (minY > boxHalfExtents[1] || maxY < -boxHalfExtents[1]) return false;
+
+    float minZ = fminf(v0[2], fminf(v1[2], v2[2]));
+    float maxZ = fmaxf(v0[2], fmaxf(v1[2], v2[2]));
+    if (minZ > boxHalfExtents[2] || maxZ < -boxHalfExtents[2]) return false;
+
+    if constexpr (OnlyUseAABB) return true; 
+
+    // --- PHASE 2: SEPARATING AXIS THEOREM (SAT) (10 additional axes) ---
+    nanovdb::Vec3f f0 = v1 - v0, f1 = v2 - v1, f2 = v0 - v2;
+    float r, p0, p1, p2;
+
+    // Axis 00, 01, 02 (X-axis cross products)
+    p0 = v0[2]*f0[1] - v0[1]*f0[2]; p2 = v2[2]*f0[1] - v2[1]*f0[2];
+    r = boxHalfExtents[1]*fabsf(f0[2]) + boxHalfExtents[2]*fabsf(f0[1]);
+    if (fminf(p0, p2) > r || fmaxf(p0, p2) < -r) return false;
+
+    p0 = v0[2]*f1[1] - v0[1]*f1[2]; p1 = v1[2]*f1[1] - v1[1]*f1[2];
+    r = boxHalfExtents[1]*fabsf(f1[2]) + boxHalfExtents[2]*fabsf(f1[1]);
+    if (fminf(p0, p1) > r || fmaxf(p0, p1) < -r) return false;
+
+    p0 = v0[2]*f2[1] - v0[1]*f2[2]; p1 = v1[2]*f2[1] - v1[1]*f2[2];
+    r = boxHalfExtents[1]*fabsf(f2[2]) + boxHalfExtents[2]*fabsf(f2[1]);
+    if (fminf(p0, p1) > r || fmaxf(p0, p1) < -r) return false;
+
+    // Axis 10, 11, 12 (Y-axis cross products)
+    p0 = v0[0]*f0[2] - v0[2]*f0[0]; p2 = v2[0]*f0[2] - v2[2]*f0[0];
+    r = boxHalfExtents[0]*fabsf(f0[2]) + boxHalfExtents[2]*fabsf(f0[0]);
+    if (fminf(p0, p2) > r || fmaxf(p0, p2) < -r) return false;
+
+    p0 = v0[0]*f1[2] - v0[2]*f1[0]; p1 = v1[0]*f1[2] - v1[2]*f1[0];
+    r = boxHalfExtents[0]*fabsf(f1[2]) + boxHalfExtents[2]*fabsf(f1[0]);
+    if (fminf(p0, p1) > r || fmaxf(p0, p1) < -r) return false;
+
+    p0 = v0[0]*f2[2] - v0[2]*f2[0]; p1 = v1[0]*f2[2] - v1[2]*f2[0];
+    r = boxHalfExtents[0]*fabsf(f2[2]) + boxHalfExtents[2]*fabsf(f2[0]);
+    if (fminf(p0, p1) > r || fmaxf(p0, p1) < -r) return false;
+
+    // Axis 20, 21, 22 (Z-axis cross products)
+    p0 = v0[1]*f0[0] - v0[0]*f0[1]; p2 = v2[1]*f0[0] - v2[0]*f0[1];
+    r = boxHalfExtents[0]*fabsf(f0[1]) + boxHalfExtents[1]*fabsf(f0[0]);
+    if (fminf(p0, p2) > r || fmaxf(p0, p2) < -r) return false;
+
+    p0 = v0[1]*f1[0] - v0[0]*f1[1]; p1 = v1[1]*f1[0] - v1[0]*f1[1];
+    r = boxHalfExtents[0]*fabsf(f1[1]) + boxHalfExtents[1]*fabsf(f1[0]);
+    if (fminf(p0, p1) > r || fmaxf(p0, p1) < -r) return false;
+
+    p0 = v0[1]*f2[0] - v0[0]*f2[1]; p1 = v1[1]*f2[0] - v1[0]*f2[1];
+    r = boxHalfExtents[0]*fabsf(f2[1]) + boxHalfExtents[1]*fabsf(f2[0]);
+    if (fminf(p0, p1) > r || fmaxf(p0, p1) < -r) return false;
+
+    // Face normal test
+    nanovdb::Vec3f n(f0[1]*f1[2] - f0[2]*f1[1], f0[2]*f1[0] - f0[0]*f1[2], f0[0]*f1[1] - f0[1]*f1[0]);
+    float d = n[0]*v0[0] + n[1]*v0[1] + n[2]*v0[2];
+    r = boxHalfExtents[0]*fabsf(n[0]) + boxHalfExtents[1]*fabsf(n[1]) + boxHalfExtents[2]*fabsf(n[2]);
+    if (fabsf(d) > r) return false;
+
+    return true;
+}
+
+template <typename BuildT, bool OnlyUseAABB>
+__global__ void evaluateAndCountSubBoxesKernel(
+    const typename MeshToGrid<BuildT>::BoxTrianglePair* dParents,
+    const Triangle* dXformedTriangles,
+    nanovdb::Mask<3>* dMasks,
+    uint64_t* dCounts,
+    int parentScale,
+    float padding)
+{
+    // 1 CTA exactly evaluates/refines 1 parent Pair
+    uint64_t parentID = blockIdx.x;
+    int threadID = threadIdx.x;
+
+    const auto& parentPair = dParents[parentID];
+    const auto& tri = dXformedTriangles[parentPair.triangleID];
+
+    int childScale = parentScale / 8;
+
+    // Thread to 3D sub-box index mapping
+    int i =  threadID       & 0x7;
+    int j = (threadID >> 3) & 0x7;
+    int k = (threadID >> 6) & 0x7;
+
+    // Compute voxel-encompassing bounding box for this subdomain
+    // Voxel bounds are [origin - 0.5, origin + childScale - 0.5]
+    float centerX = parentPair.origin[0] + i * childScale + (childScale * 0.5f) - 0.5f;
+    float centerY = parentPair.origin[1] + j * childScale + (childScale * 0.5f) - 0.5f;
+    float centerZ = parentPair.origin[2] + k * childScale + (childScale * 0.5f) - 0.5f;
+    
+    nanovdb::Vec3f boxCenter(centerX, centerY, centerZ);
+    float halfExt = (childScale * 0.5f) + padding;
+    nanovdb::Vec3f boxHalfExtents(halfExt, halfExt, halfExt);
+
+    // Evaluate intersection
+    bool hit = testTriangleAABB<OnlyUseAABB>(boxCenter, boxHalfExtents, tri[0], tri[1], tri[2]);
+
+    // Mask Building without using atomics, via Warp Voting
+    // threadID = i + j*8 + k*64 matches NanoVDB Mask<3> bit ordering exactly,
+    // so warp ballots map directly into the mask with no stitching required.
+    // We use reinterpret_cast rather than a union to avoid Mask<3>'s non-trivial
+    // constructor deleting the union's default constructor.
+    __shared__ alignas(nanovdb::Mask<3>) uint32_t s_words32[16]; // 16 warps * 32 bits = 512 bits total
+
+    unsigned int ballot = __ballot_sync(0xFFFFFFFF, hit);
+    if ((threadID & 31) == 0) {
+        // The first thread of each warp writes its ballot directly into the mask
+        s_words32[threadID >> 5] = ballot;
+    }
+
+    __syncthreads();
+
+    // Thread 0 flushes the mask and its popcount to global memory
+    if (threadID == 0) {
+        const auto& outMask = reinterpret_cast<const nanovdb::Mask<3>&>(s_words32);
+        dMasks[parentID] = outMask;
+        dCounts[parentID] = outMask.countOn();
+    }
+}
+
+} // namespace topology::detail
+
+namespace topology::detail {
+
+// coordToKey / keyToCoord: encode/decode a root-tile Coord origin as a
+// sortable uint64_t key, following the convention from PointsToGrid.cuh.
+//   key     = (field_x << 42) | (field_y << 21) | field_z
+//   field_i = uint32_t(int64_t(ijk[i]) + kOffset) >> 12
+// The >>12 groups all voxels sharing a 4096^3 root tile to the same key.
+// kOffset = 1<<31 ensures the full int32_t coordinate range maps to [0, 2^32-1]
+// before the uint32_t cast, making the encoding well-defined for all coordinates.
+
+static constexpr int64_t kRootTileKeyOffset = int64_t(1) << 31;
+
+__device__ inline uint64_t coordToKey(const nanovdb::Coord& ijk)
+{
+    return  (uint64_t(uint32_t(int64_t(ijk[0]) + kRootTileKeyOffset) >> 12) << 42) |
+            (uint64_t(uint32_t(int64_t(ijk[1]) + kRootTileKeyOffset) >> 12) << 21) |
+             uint64_t(uint32_t(int64_t(ijk[2]) + kRootTileKeyOffset) >> 12);
+}
+
+__device__ inline nanovdb::Coord keyToCoord(uint64_t key)
+{
+    const uint32_t field_x = uint32_t(key >> 42);
+    const uint32_t field_y = uint32_t((key >> 21) & 0x1FFFFF);
+    const uint32_t field_z = uint32_t(key & 0x1FFFFF);
+    return nanovdb::Coord(
+        int32_t(int64_t(uint64_t(field_x) << 12) - kRootTileKeyOffset),
+        int32_t(int64_t(uint64_t(field_y) << 12) - kRootTileKeyOffset),
+        int32_t(int64_t(uint64_t(field_z) << 12) - kRootTileKeyOffset));
+}
+
+template <typename BuildT>
+struct EncodeRootOriginsFunctor
+{
+    const typename MeshToGrid<BuildT>::BoxTrianglePair* dPairs;
+    uint64_t*                                           dKeys;
+
+    __device__ void operator()(size_t i) const { dKeys[i] = coordToKey(dPairs[i].origin); }
+};
+
+template <typename BuildT>
+struct DecodeRootOriginsFunctor
+{
+    const uint64_t*  dKeys;
+    nanovdb::Coord*  dOrigins;
+
+    __device__ void operator()(size_t i) const { dOrigins[i] = keyToCoord(dKeys[i]); }
+};
+
+} // namespace topology::detail
+
+template<typename BuildT>
+void MeshToGrid<BuildT>::enumerateRootTiles()
+{
+    if (mBoxTrianglePairCount == 0) return;
+
+    int device = 0;
+    cudaGetDevice(&device);
+
+    // Step 1: Encode each pair's root origin as a sortable uint64_t key
+    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::enumerateRootTiles()] Encoding origins as keys");
+
+    nanovdb::cuda::DeviceBuffer keysBuffer = nanovdb::cuda::DeviceBuffer::create(
+        mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
+    auto *dKeys = static_cast<uint64_t*>(keysBuffer.deviceData());
+
+    util::cuda::lambdaKernel<<<numBlocks(mBoxTrianglePairCount), mNumThreads, 0, mStream>>>(
+        mBoxTrianglePairCount,
+        topology::detail::EncodeRootOriginsFunctor<BuildT>{ deviceBoxTrianglePairs(), dKeys }
+    );
+    cudaCheckError();
+
+    // Step 2: Sort keys (SortKeys requires separate in/out buffers)
+    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::enumerateRootTiles()] Sorting keys");
+
+    nanovdb::cuda::DeviceBuffer sortedKeysBuffer = nanovdb::cuda::DeviceBuffer::create(
+        mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
+    auto *dSortedKeys = static_cast<uint64_t*>(sortedKeysBuffer.deviceData());
+
+    CALL_CUBS(DeviceRadixSort::SortKeys, dKeys, dSortedKeys, (int)mBoxTrianglePairCount, 0, 64);
+
+    // Step 3: Select unique keys
+    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::enumerateRootTiles()] Selecting unique keys");
+
+    nanovdb::cuda::DeviceBuffer uniqueKeysBuffer = nanovdb::cuda::DeviceBuffer::create(
+        mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
+    auto *dUniqueKeys = static_cast<uint64_t*>(uniqueKeysBuffer.deviceData());
+
+    nanovdb::cuda::DeviceBuffer numSelectedBuffer = nanovdb::cuda::DeviceBuffer::create(
+        sizeof(int32_t), nullptr, device, mStream);
+    auto *dNumSelected = static_cast<int32_t*>(numSelectedBuffer.deviceData());
+
+    CALL_CUBS(DeviceSelect::Unique, dSortedKeys, dUniqueKeys, dNumSelected, (int)mBoxTrianglePairCount);
+
+    int32_t uniqueCount = 0;
+    cudaCheck(cudaMemcpyAsync(&uniqueCount, dNumSelected, sizeof(int32_t), cudaMemcpyDeviceToHost, mStream));
+    cudaStreamSynchronize(mStream);
+    mUniqueRootTileCount = static_cast<uint64_t>(uniqueCount);
+
+    if (mVerbose >= 2) printf("Unique root tiles: %llu\n", (unsigned long long)mUniqueRootTileCount);
+
+    // Step 4: Decode unique keys back to Coord origins
+    if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::enumerateRootTiles()] Decoding keys to Coord origins");
+
+    mUniqueRootOriginsBuffer = nanovdb::cuda::DeviceBuffer::create(
+        mUniqueRootTileCount * sizeof(nanovdb::Coord), nullptr, device, mStream);
+    auto *dOrigins = deviceUniqueRootOrigins();
+
+    util::cuda::lambdaKernel<<<numBlocks(mUniqueRootTileCount), mNumThreads, 0, mStream>>>(
+        mUniqueRootTileCount,
+        topology::detail::DecodeRootOriginsFunctor<BuildT>{ dUniqueKeys, dOrigins }
+    );
+    cudaCheckError();
+
+} // MeshToGrid<BuildT>::enumerateRootTiles
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void MeshToGrid<BuildT>::buildRasterizedRoot()
+{
+    int device = 0;
+    cudaGetDevice(&device);
+
+    // Download unique root origins to host.
+    // Origins are already in coordToKey-sorted order from enumerateRootTiles(),
+    // so no further sorting or deduplication is required here.
+    uint32_t tileCount = static_cast<uint32_t>(mUniqueRootTileCount);
+    std::vector<nanovdb::Coord> hostOrigins(tileCount);
+    cudaCheck(cudaMemcpy(hostOrigins.data(),
+        deviceUniqueRootOrigins(),
+        tileCount * sizeof(nanovdb::Coord), cudaMemcpyDeviceToHost));
+
+    // Build the root node on CPU: one tile per unique root origin.
+    // Only the NanoVDB tile key is set here; child pointers and values are
+    // filled by TopologyBuilder's subsequent pipeline stages.
+    uint64_t rootSize = RootT::memUsage(tileCount);
+    mBuilder.mProcessedRoot = nanovdb::cuda::DeviceBuffer::create(rootSize);
+    auto *rootPtr = static_cast<RootT*>(mBuilder.mProcessedRoot.data());
+    rootPtr->mTableSize = tileCount;
+    rootPtr->mBackground = typename RootT::ValueType{};
+    for (uint32_t t = 0; t < tileCount; ++t)
+        *rootPtr->tile(t) = typename RootT::DataType::Tile{RootT::CoordToKey(hostOrigins[t])};
+
+    mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
+
+    mUniqueRootOriginsBuffer.clear(mStream);
+} // MeshToGrid<BuildT>::buildRasterizedRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void MeshToGrid<BuildT>::rasterizeInternalNodes()
+{
+    using RasterizerT = util::rasterization::cuda::RasterizeInternalNodesFunctor<BuildT, BoxTrianglePair>;
+
+    auto *dUpperMasks = static_cast<Mask<5>*>(mBuilder.deviceUpperMasks());
+    auto *dLowerMasks = static_cast<Mask<4>(*)[Mask<5>::SIZE]>(mBuilder.deviceLowerMasks());
+
+    util::cuda::lambdaKernel<<<numBlocks(mBoxTrianglePairCount), mNumThreads, 0, mStream>>>(
+        mBoxTrianglePairCount,
+        RasterizerT{ deviceBoxTrianglePairs(), mBuilder.deviceProcessedRoot(), dUpperMasks, dLowerMasks }
+    );
+    cudaCheckError();
+
+} // MeshToGrid<BuildT>::rasterizeInternalNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void MeshToGrid<BuildT>::processGridTreeRoot()
+{
+    // Initialize grid/tree/root metadata from scratch using the provided map.
+    // InitGridTreeRootFunctor sets all GridData fields explicitly (magic, version,
+    // flags, map, gridClass=IndexGrid, etc.) since there is no source grid to copy from.
+    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1,
+        topology::detail::InitGridTreeRootFunctor<BuildT>{mMap}, mBuilder.deviceData());
+    cudaCheckError();
+
+    // Copy grid name into the output grid's name field
+    char *dst = mBuilder.data()->getGrid().mGridName;
+    if (!mGridName.empty()) {
+        cudaCheck(cudaMemcpyAsync(dst, mGridName.data(), GridData::MaxNameSize, cudaMemcpyHostToDevice, mStream));
+    } else {
+        cudaCheck(cudaMemsetAsync(dst, 0, GridData::MaxNameSize, mStream));
+    }
+
+} // MeshToGrid<BuildT>::processGridTreeRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void MeshToGrid<BuildT>::rasterizeLeafNodes()
+{
+    if (mBoxTrianglePairCount == 0) return;
+
+    using FunctorT = util::rasterization::cuda::RasterizeLeafNodesFunctor<BuildT, BoxTrianglePair, Triangle>;
+    util::cuda::operatorKernelInstance<FunctorT>
+        <<<mBoxTrianglePairCount, FunctorT::MaxThreadsPerBlock, 0, mStream>>>(
+            FunctorT{ deviceBoxTrianglePairs(), deviceXformedTriangles(),
+                      &mBuilder.data()->getGrid(), mBandWidth * mBandWidth });
+    cudaCheckError();
+
+} // MeshToGrid<BuildT>::rasterizeLeafNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void MeshToGrid<BuildT>::processLeafTrianglePairs()
+{
+    // TODO: Handle null input case
+    if (mTriangleCount == 0)
+        throw std::runtime_error("MeshToGrid currently requires mTriangleCount > 0 (Holistic zero-handling pending).");
+
+    int device = 0;
+    cudaGetDevice(&device);
+
+    int scale = 4096; // Start at Root node scale
+
+    for (int pass = 0; pass < 3; ++pass) {
+        if (mVerbose >= 2) {
+            printf("\n--- Subdivision Pass %d (Scale: %d -> %d) ---\n", 
+                   pass, scale, scale / 8);
+        }
+
+        // Allocate Mask<3> buffer for the CTA hit results
+        // Size: mBoxTrianglePairCount * sizeof(nanovdb::Mask<3>)
+        nanovdb::cuda::DeviceBuffer maskBuffer = nanovdb::cuda::DeviceBuffer::create(
+            mBoxTrianglePairCount * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
+        if (maskBuffer.deviceData() == nullptr) {
+            throw std::runtime_error("Failed to allocate mask buffer for subdivision pass");
+        }
+        auto* dMasks = static_cast<nanovdb::Mask<3>*>(maskBuffer.deviceData());
+
+        // Allocate Counts buffer for Prefix Sum
+        // Size: mBoxTrianglePairCount * sizeof(uint64_t)
+        nanovdb::cuda::DeviceBuffer countsBuffer = nanovdb::cuda::DeviceBuffer::create(
+            mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
+        if (countsBuffer.deviceData() == nullptr) {
+            throw std::runtime_error("Failed to allocate counts buffer for subdivision pass");
+        }
+        auto* dCounts = static_cast<uint64_t*>(countsBuffer.deviceData());
+
+        // Evaluate & Count: 1 CTA per parent pair, 512 threads per CTA.
+        // Uses AABB-only test for large child scales (>= mSATThreshold), full SAT below.
+        // padding = mBandWidth: tight bound would be mBandWidth-0.5 (geometric box already
+        // extends 0.5 beyond outermost cell centers), but we add 0.5 extra for safety.
+        int childScale = scale / 8;
+        const float padding = mBandWidth;
+        if (mVerbose >= 2) mTimer.start("  Evaluate & Count");
+        if (childScale >= mSATThreshold)
+            topology::detail::evaluateAndCountSubBoxesKernel<BuildT, true>
+                <<<mBoxTrianglePairCount, 512, 0, mStream>>>(
+                    deviceBoxTrianglePairs(), deviceXformedTriangles(), dMasks, dCounts, scale, padding);
+        else
+            topology::detail::evaluateAndCountSubBoxesKernel<BuildT, false>
+                <<<mBoxTrianglePairCount, 512, 0, mStream>>>(
+                    deviceBoxTrianglePairs(), deviceXformedTriangles(), dMasks, dCounts, scale, padding);
+        cudaCheckError();
+        if (mVerbose >= 2) mTimer.stop();
+
+        // Prefix Sum: element [i+1] = exclusive write offset for parent i's children,
+        // element [0] = 0, element [mBoxTrianglePairCount] = total child pair count.
+        nanovdb::cuda::DeviceBuffer offsetsBuffer = nanovdb::cuda::DeviceBuffer::create(
+            (mBoxTrianglePairCount + 1) * sizeof(uint64_t), nullptr, device, mStream);
+        if (offsetsBuffer.deviceData() == nullptr)
+            throw std::runtime_error("Failed to allocate offsets buffer for subdivision pass");
+        auto* dOffsets = static_cast<uint64_t*>(offsetsBuffer.deviceData());
+
+        cudaCheck(cudaMemsetAsync(dOffsets, 0, sizeof(uint64_t), mStream));
+        CALL_CUBS(DeviceScan::InclusiveSum,
+            dCounts,
+            dOffsets + 1,
+            mBoxTrianglePairCount);
+
+        uint64_t newPairCount = 0;
+        cudaCheck(cudaMemcpyAsync(&newPairCount, dOffsets + mBoxTrianglePairCount,
+            sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
+        cudaStreamSynchronize(mStream);
+
+        if (mVerbose >= 2) printf("Total child pairs after subdivision: %llu\n", (unsigned long long)newPairCount);
+
+        // Allocate new child pair buffer
+        nanovdb::cuda::DeviceBuffer newPairsBuffer = nanovdb::cuda::DeviceBuffer::create(
+            newPairCount * sizeof(BoxTrianglePair), nullptr, device, mStream);
+        if (newPairsBuffer.deviceData() == nullptr)
+            throw std::runtime_error("Failed to allocate child pairs buffer for subdivision pass");
+        auto* dNewPairs = static_cast<BoxTrianglePair*>(newPairsBuffer.deviceData());
+
+        // Scatter surviving child pairs into the new buffer
+        if (mVerbose >= 2) mTimer.start("  Scatter");
+        util::cuda::lambdaKernel<<<numBlocks(mBoxTrianglePairCount), mNumThreads, 0, mStream>>>(
+            mBoxTrianglePairCount,
+            topology::detail::ScatterChildPairsFunctor<BuildT>{
+                deviceBoxTrianglePairs(), dMasks, dOffsets, dNewPairs, childScale
+            }
+        );
+        cudaCheckError();
+        if (mVerbose >= 2) mTimer.stop();
+
+        // Ping-pong: replace the parent pair buffer with the new child pair buffer
+        mBoxTrianglePairsBuffer = std::move(newPairsBuffer);
+        mBoxTrianglePairCount   = newPairCount;
+
+        scale /= 8;
+    }
+
+} // MeshToGrid<BuildT>::processLeafTrianglePairs
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
+/// @brief Fills each sidecar slot with the FLT_MAX bit pattern (0x7F7FFFFFu),
+///        serving as a "not yet written" sentinel for the UDF atomic-min pass.
+struct InitSidecarFunctor
+{
+    uint32_t *dSidecar;
+    __device__ void operator()(size_t i) const { dSidecar[i] = 0x7F7FFFFFu; }
+};
+
+/// @brief Finalizes the sidecar after the atomic-min UDF pass, emitting world-space distances:
+///          - slot 0 (background) <- mBandWidth * voxelSize
+///          - slot k (active)     <- sqrtf(distSqr) * voxelSize  if a triangle contributed
+///                                <- mBandWidth * voxelSize       otherwise (false-positive voxels)
+struct FinalizeSidecarFunctor
+{
+    float *dSidecar;
+    float  bandWidth; // world-space = mBandWidth * voxelSize
+    float  voxelSize;
+
+    __device__ void operator()(size_t i) const
+    {
+        if (i == 0) { dSidecar[0] = bandWidth; return; }
+        const uint32_t bits = __float_as_uint(dSidecar[i]);
+        dSidecar[i] = (bits == 0x7F7FFFFFu) ? bandWidth : sqrtf(dSidecar[i]) * voxelSize;
+    }
+};
+
+} // namespace topology::detail
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+template<typename GridBufferT, typename SidecarBufferT>
+std::pair<GridHandle<GridBufferT>, SidecarBufferT>
+MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& gridPool, const SidecarBufferT&)
+{
+    cudaStreamSynchronize(mStream);
+
+    // ---- Topology pipeline (mirrors getHandle) ----
+
+    if (mVerbose==1) mTimer.start("Transforming triangles to grid index space");
+    transformTriangles();
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Computing candidate RootTile-Triangle intersection pairs");
+    processRootTrianglePairs();
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Enumerating unique root tiles");
+    enumerateRootTiles();
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Computing candidate LeafNode-Triangle intersection pairs");
+    processLeafTrianglePairs();
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Building rasterized root node");
+    buildRasterizedRoot();
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Allocating internal mask buffers");
+    mBuilder.allocateInternalMaskBuffers(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Rasterizing internal nodes");
+    rasterizeInternalNodes();
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Counting nodes");
+    mBuilder.countNodes(mStream);
+    cudaStreamSynchronize(mStream);
+    if (mVerbose==1) mTimer.stop();
+    if (mVerbose>=2) printf("Node counts - upper: %u  lower: %u  leaf: %u\n",
+           mBuilder.data()->nodeCount[2],
+           mBuilder.data()->nodeCount[1],
+           mBuilder.data()->nodeCount[0]);
+
+    if (mVerbose==1) mTimer.start("Allocating grid buffer");
+    auto gridBuffer = mBuilder.getBuffer(gridPool, mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Processing grid/tree/root");
+    processGridTreeRoot();
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Processing upper nodes");
+    mBuilder.processUpperNodes(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Processing lower nodes");
+    mBuilder.processLowerNodes(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Rasterizing leaf nodes");
+    rasterizeLeafNodes();
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Processing leaf offsets");
+    mBuilder.processLeafOffsets(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Processing bounding boxes");
+    mBuilder.processBBox(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Post-processing grid/tree data");
+    mBuilder.postProcessGridTree(mStream);
+    cudaStreamSynchronize(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Pruning empty leaves");
+    int device = 0; cudaGetDevice(&device);
+    const uint32_t leafCount = mBuilder.data()->nodeCount[0];
+    nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
+        uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
+    cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
+        uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
+    tools::cuda::PruneGrid<BuildT> pruner(
+        static_cast<const GridT*>(gridBuffer.deviceData()),
+        static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
+        mStream);
+    auto handle = pruner.template getHandle<GridBufferT>(gridPool);
+    if (mVerbose==1) mTimer.stop();
+
+    // ---- UDF sidecar ----
+
+    const float voxelSize = (float)mMap.getVoxelSize()[0];
+
+    const uint64_t activeVoxelCount = util::cuda::DeviceGridTraits<BuildT>::getActiveVoxelCount(
+        handle.template deviceGrid<BuildT>());
+    if (mVerbose>=2) printf("Active voxels: %llu\n", (unsigned long long)activeVoxelCount);
+
+    auto sidecarBuffer = nanovdb::cuda::DeviceBuffer::create(
+        (activeVoxelCount + 1) * sizeof(float), nullptr, device, mStream);
+    auto *dSidecar = static_cast<float*>(sidecarBuffer.deviceData());
+
+    if (mVerbose==1) mTimer.start("Initializing UDF sidecar");
+    util::cuda::lambdaKernel<<<numBlocks(activeVoxelCount + 1), mNumThreads, 0, mStream>>>(
+        activeVoxelCount + 1,
+        topology::detail::InitSidecarFunctor{ reinterpret_cast<uint32_t*>(dSidecar) });
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+
+    if (mVerbose==1) mTimer.start("Computing UDF via leaf/triangle pairs");
+    using UDFFunctorT = util::rasterization::cuda::ComputeUDFFunctor<BuildT, BoxTrianglePair, Triangle>;
+    util::cuda::operatorKernelInstance<UDFFunctorT>
+        <<<mBoxTrianglePairCount, UDFFunctorT::MaxThreadsPerBlock, 0, mStream>>>(
+            UDFFunctorT{ deviceBoxTrianglePairs(), deviceXformedTriangles(),
+                         handle.template deviceGrid<BuildT>(), dSidecar,
+                         mBandWidth * mBandWidth });
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+    mXformedTriangles.clear(mStream);
+    mBoxTrianglePairsBuffer.clear(mStream);
+
+    if (mVerbose==1) mTimer.start("Finalizing UDF sidecar (sqrt + clamp)");
+    util::cuda::lambdaKernel<<<numBlocks(activeVoxelCount + 1), mNumThreads, 0, mStream>>>(
+        activeVoxelCount + 1,
+        topology::detail::FinalizeSidecarFunctor{ dSidecar, mBandWidth * voxelSize, voxelSize });
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+
+    cudaStreamSynchronize(mStream);
+
+    return { std::move(handle), std::move(sidecarBuffer) };
+} // MeshToGrid<BuildT>::getHandleAndUDF
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+} // namespace tools::cuda
+
+} // namespace nanovdb
+
+#endif // NVIDIA_TOOLS_CUDA_MESHTOGRID_CUH_HAS_BEEN_INCLUDED

--- a/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
@@ -211,7 +211,7 @@ GridHandle<BufferT>
 MeshToGrid<BuildT>::getHandle(const BufferT &pool)
 {
     cudaStreamSynchronize(mStream);
-    
+
     // Transform triangle data to (floating-point) index space
     if (mVerbose==1) mTimer.start("Transforming triangles to grid index space");
     transformTriangles();
@@ -331,7 +331,7 @@ struct TransformTrianglesFunctor
     const nanovdb::Vec3f* dPoints;
     const nanovdb::Vec3i* dTriangleIndices;
     Triangle* dXformedTriangles;
-    nanovdb::Map map; 
+    nanovdb::Map map;
 
     __device__
     void operator()(size_t triangleID) const
@@ -378,7 +378,7 @@ struct CountRootBoxesFunctor
 {
     const Triangle* dXformedTriangles;
     uint64_t* dCounts;
-    float mBandWidth; 
+    float mBandWidth;
 
     __device__
     void operator()(size_t triangleID) const
@@ -494,7 +494,7 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
     cudaGetDevice(&device);
 
     // Pass 1: Count intersecting root boxes per triangle
-    
+
     if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::processRootTrianglePairs()] Launching processRootTrianglePairs");
 
     nanovdb::cuda::DeviceBuffer
@@ -502,7 +502,7 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
     if (rootBoxCounts.deviceData() == nullptr) throw std::runtime_error("Failed to allocate root box counts buffer");
 
     util::cuda::lambdaKernel<<<numBlocks(mTriangleCount), mNumThreads, 0, mStream>>>(
-        mTriangleCount, 
+        mTriangleCount,
         topology::detail::CountRootBoxesFunctor<BuildT>{
             deviceXformedTriangles(),
             static_cast<uint64_t*>(rootBoxCounts.deviceData()),
@@ -512,9 +512,9 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
     cudaCheckError();
 
     // Pass 2: InclusiveSum Scan to compute offsets and total allocations
-    
+
     if (mVerbose >= 2) mTimer.restart("[In MeshToGrid::processRootTrianglePairs()] Prefix sum");
-    
+
     nanovdb::cuda::DeviceBuffer rootBoxOffsets =
         nanovdb::cuda::DeviceBuffer::create((mTriangleCount+1)*sizeof(uint64_t), nullptr, device, mStream);
     if (rootBoxOffsets.deviceData() == nullptr) throw std::runtime_error("Failed to allocate root box offsets buffer");
@@ -538,7 +538,7 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
     if (mBoxTrianglePairsBuffer.deviceData() == nullptr) throw std::runtime_error("Failed to allocate pairs buffer");
 
     util::cuda::lambdaKernel<<<numBlocks(mTriangleCount), mNumThreads, 0, mStream>>>(
-        mTriangleCount, 
+        mTriangleCount,
         topology::detail::ScatterRootTrianglePairsFunctor<BuildT>{
             deviceXformedTriangles(),
             static_cast<uint64_t*>(rootBoxOffsets.deviceData()),
@@ -625,7 +625,7 @@ __device__ inline bool testTriangleAABB(
     float maxZ = fmaxf(v0[2], fmaxf(v1[2], v2[2]));
     if (minZ > boxHalfExtents[2] || maxZ < -boxHalfExtents[2]) return false;
 
-    if constexpr (OnlyUseAABB) return true; 
+    if constexpr (OnlyUseAABB) return true;
 
     // --- PHASE 2: SEPARATING AXIS THEOREM (SAT) (10 additional axes) ---
     nanovdb::Vec3f f0 = v1 - v0, f1 = v2 - v1, f2 = v0 - v2;
@@ -707,7 +707,7 @@ __global__ void evaluateAndCountSubBoxesKernel(
     float centerX = parentPair.origin[0] + i * childScale + (childScale * 0.5f) - 0.5f;
     float centerY = parentPair.origin[1] + j * childScale + (childScale * 0.5f) - 0.5f;
     float centerZ = parentPair.origin[2] + k * childScale + (childScale * 0.5f) - 0.5f;
-    
+
     nanovdb::Vec3f boxCenter(centerX, centerY, centerZ);
     float halfExt = (childScale * 0.5f) + padding;
     nanovdb::Vec3f boxHalfExtents(halfExt, halfExt, halfExt);
@@ -960,7 +960,7 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
 
     for (int pass = 0; pass < 3; ++pass) {
         if (mVerbose >= 2) {
-            printf("\n--- Subdivision Pass %d (Scale: %d -> %d) ---\n", 
+            printf("\n--- Subdivision Pass %d (Scale: %d -> %d) ---\n",
                    pass, scale, scale / 8);
         }
 

--- a/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
@@ -562,13 +562,11 @@ struct ScatterChildPairsFunctor
 
         for (uint32_t n = 0; n < 512; ++n) {
             if (mask.isOn(n)) {
-                int i =  n       & 0x7;
-                int j = (n >> 3) & 0x7;
-                int k = (n >> 6) & 0x7;
+                const nanovdb::Coord local = nanovdb::NanoLeaf<BuildT>::OffsetToLocalCoord(n);
                 dNewPairs[writeIdx].origin = nanovdb::Coord(
-                    parentPair.origin[0] + i * childScale,
-                    parentPair.origin[1] + j * childScale,
-                    parentPair.origin[2] + k * childScale);
+                    parentPair.origin[0] + local[0] * childScale,
+                    parentPair.origin[1] + local[1] * childScale,
+                    parentPair.origin[2] + local[2] * childScale);
                 dNewPairs[writeIdx].triangleID = parentPair.triangleID;
                 ++writeIdx;
             }
@@ -675,16 +673,13 @@ __global__ void evaluateAndCountSubBoxesKernel(
 
     int childScale = parentScale / 8;
 
-    // Thread to 3D sub-box index mapping
-    int i =  threadID       & 0x7;
-    int j = (threadID >> 3) & 0x7;
-    int k = (threadID >> 6) & 0x7;
+    const nanovdb::Coord local = nanovdb::NanoLeaf<BuildT>::OffsetToLocalCoord(threadID);
 
     // Compute voxel-encompassing bounding box for this subdomain
     // Voxel bounds are [origin - 0.5, origin + childScale - 0.5]
-    float centerX = parentPair.origin[0] + i * childScale + (childScale * 0.5f) - 0.5f;
-    float centerY = parentPair.origin[1] + j * childScale + (childScale * 0.5f) - 0.5f;
-    float centerZ = parentPair.origin[2] + k * childScale + (childScale * 0.5f) - 0.5f;
+    float centerX = parentPair.origin[0] + local[0] * childScale + (childScale * 0.5f) - 0.5f;
+    float centerY = parentPair.origin[1] + local[1] * childScale + (childScale * 0.5f) - 0.5f;
+    float centerZ = parentPair.origin[2] + local[2] * childScale + (childScale * 0.5f) - 0.5f;
 
     nanovdb::Vec3f boxCenter(centerX, centerY, centerZ);
     float halfExt = (childScale * 0.5f) + padding;
@@ -694,7 +689,7 @@ __global__ void evaluateAndCountSubBoxesKernel(
     bool hit = testTriangleAABB<OnlyUseAABB>(boxCenter, boxHalfExtents, tri[0], tri[1], tri[2]);
 
     // Mask Building without using atomics, via Warp Voting
-    // threadID = i + j*8 + k*64 matches NanoVDB Mask<3> bit ordering exactly,
+    // threadID uses NanoVDB's Mask<3> bit ordering,
     // so warp ballots map directly into the mask with no stitching required.
     // We use reinterpret_cast rather than a union to avoid Mask<3>'s non-trivial
     // constructor deleting the union's default constructor.

--- a/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
+++ b/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
@@ -311,6 +311,80 @@ struct BuildGridTreeRootFunctor
 
 namespace topology::detail {
 
+/// @brief Variant of BuildGridTreeRootFunctor for grids constructed from scratch
+///        (i.e. with no source grid to copy metadata from). Sets all GridData fields
+///        explicitly rather than asserting they were pre-initialized.
+template <typename BuildT>
+struct InitGridTreeRootFunctor
+{
+    Map map; // transform to embed in the output grid
+
+    __device__
+    void operator()(size_t, typename TopologyBuilder<BuildT>::Data *d_data) {
+
+        // process Root (identical to BuildGridTreeRootFunctor)
+        auto &root = d_data->getRoot();
+        root.mTableSize = d_data->nodeCount[2];
+        root.mBackground = NanoRoot<BuildT>::ValueType(0);
+        root.mMinimum = root.mMaximum = NanoRoot<BuildT>::ValueType(0);
+        root.mAverage = root.mStdDevi = NanoRoot<BuildT>::FloatType(0);
+        root.mBBox = CoordBBox();
+
+        // process Tree (identical to BuildGridTreeRootFunctor)
+        auto &tree = d_data->getTree();
+        tree.setRoot(&root);
+        if (d_data->nodeCount[2]) {
+            tree.setFirstNode(&d_data->getUpper(0));
+            tree.setFirstNode(&d_data->getLower(0));
+            tree.setFirstNode(&d_data->getLeaf(0));
+        } else {
+            tree.template setFirstNode<NanoUpper<BuildT>>(nullptr);
+            tree.template setFirstNode<NanoLower<BuildT>>(nullptr);
+            tree.template setFirstNode<NanoLeaf<BuildT>>(nullptr);
+        }
+        tree.mNodeCount[2] = d_data->nodeCount[2];
+        tree.mNodeCount[1] = d_data->nodeCount[1];
+        tree.mNodeCount[0] = d_data->nodeCount[0];
+        tree.mVoxelCount = 0;
+        tree.mTileCount[2] = tree.mTileCount[1] = tree.mTileCount[0] = 0;
+
+        // process Grid — set all fields explicitly (no source grid to copy from)
+        auto &grid = d_data->getGrid();
+#ifdef NANOVDB_USE_NEW_MAGIC_NUMBERS
+        grid.mMagic = NANOVDB_MAGIC_GRID;
+#else
+        grid.mMagic = NANOVDB_MAGIC_NUMB;
+#endif
+        grid.mChecksum.disable();
+        grid.mVersion = Version();
+        grid.mFlags.initMask({GridFlags::IsBreadthFirst});
+        grid.mGridIndex = 0u;
+        grid.mGridCount = 1u;
+        grid.mGridSize = d_data->size;
+        // grid.mGridName is left zeroed; caller copies name via cudaMemcpyAsync
+        grid.mMap = map;
+        grid.mWorldBBox = Vec3dBBox();
+        grid.mVoxelSize = map.getVoxelSize();
+        grid.mGridClass = GridClass::IndexGrid;
+        grid.mGridType = toGridType<BuildT>();
+        grid.mBlindMetadataOffset = d_data->size;
+        grid.mBlindMetadataCount = 0u;
+        grid.mData0 = 0u;
+        grid.mData1 = 1u;
+#ifdef NANOVDB_USE_NEW_MAGIC_NUMBERS
+        grid.mData2 = 0u;
+#else
+        grid.mData2 = NANOVDB_MAGIC_GRID;
+#endif
+    }
+};
+
+}// namespace topology::detail
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
 template <typename BuildT>
 struct BuildUpperNodesFunctor
 {

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -23,6 +23,8 @@
 #include <nanovdb/tools/cuda/CoarsenGrid.cuh>
 #include <nanovdb/tools/cuda/RefineGrid.cuh>
 #include <nanovdb/util/cuda/Injection.cuh>
+#include <nanovdb/tools/cuda/MeshToGrid.cuh>
+#include <nanovdb/math/Proximity.h>
 #include <nanovdb/util/cuda/Timer.h>
 #include <nanovdb/util/Timer.h>
 #include <nanovdb/io/IO.h>
@@ -34,6 +36,7 @@
 #include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 #include <algorithm>// for std::sort
+#include <unordered_set>
 #include <iomanip> // for std::setw, std::setfill
 #include <thread> // for std::thread
 
@@ -3746,3 +3749,178 @@ TEST(TestNanoVDBCUDA, GridHandle_from_HostBuffer)
     }
 }
 
+TEST(TestNanoVDBCUDA, MeshToGrid_EmptyMesh)
+{
+    using BuildT = nanovdb::ValueOnIndex;
+
+    nanovdb::Map map;
+    map.set(0.1, nanovdb::Vec3d(0.0));
+
+    nanovdb::tools::cuda::MeshToGrid<BuildT> converter(nullptr, 0u, nullptr, 0u, map);
+    converter.setVerbose(0);
+    auto handle = converter.getHandle();
+    handle.deviceDownload();
+    const auto* grid = handle.grid<BuildT>();
+    ASSERT_NE(grid, nullptr);
+    EXPECT_EQ(grid->tree().activeVoxelCount(), 0);
+}// MeshToGrid_EmptyMesh
+
+TEST(TestNanoVDBCUDA, MeshToGrid_UnitTetrahedron)
+{
+    using BuildT = nanovdb::ValueOnIndex;
+
+    // Unit tetrahedron: four vertices, four triangular faces.
+    // Vertex coordinates are in world space.
+    const std::vector<nanovdb::Vec3f> hostPoints = {
+        {0.f, 0.f, 0.f},  // p0
+        {1.f, 0.f, 0.f},  // p1
+        {0.f, 1.f, 0.f},  // p2
+        {0.f, 0.f, 1.f},  // p3
+    };
+    // t0: z=0 face, t1: x=0 face, t2: y=0 face, t3: diagonal face (x+y+z=1)
+    const std::vector<nanovdb::Vec3i> hostTriangles = {
+        {0, 1, 2},
+        {0, 2, 3},
+        {0, 3, 1},
+        {1, 2, 3},
+    };
+
+    auto nPoints = hostPoints.size();
+    auto nTriangles = hostTriangles.size();
+
+    // Upload points and triangles to device
+    auto pointsBuf = nanovdb::cuda::DeviceBuffer::create(nPoints * sizeof(nanovdb::Vec3f), nullptr, false);
+    ASSERT_TRUE(pointsBuf.deviceData());
+    cudaCheck(cudaMemcpy(pointsBuf.deviceData(), hostPoints.data(),
+                         nPoints * sizeof(nanovdb::Vec3f), cudaMemcpyHostToDevice));
+
+    auto trisBuf = nanovdb::cuda::DeviceBuffer::create(nTriangles * sizeof(nanovdb::Vec3i), nullptr, false);
+    ASSERT_TRUE(trisBuf.deviceData());
+    cudaCheck(cudaMemcpy(trisBuf.deviceData(), hostTriangles.data(),
+                         nTriangles * sizeof(nanovdb::Vec3i), cudaMemcpyHostToDevice));
+
+    auto dPoints = static_cast<const nanovdb::Vec3f*>(pointsBuf.deviceData());
+    auto dTriangles = static_cast<const nanovdb::Vec3i*>(trisBuf.deviceData());
+
+    // Uniform-scale map: world = dx * index
+    const double dx = 0.1;
+    nanovdb::Map map;
+    map.set(dx, nanovdb::Vec3d(0.0));
+
+    const float bandWidth = 3.0f;  // default, in voxels
+    const float bandWidthWorld = bandWidth * float(dx);
+
+    // CPU brute-force UDF in index space (matches GPU arithmetic exactly):
+    // transform world-space verts to index space, compute pointToTriangleDistSqr
+    // with integer voxel centers, scale result to world space.
+    std::array<nanovdb::Vec3f, 4> idxVerts;
+    for (uint32_t i = 0; i < nPoints; ++i)
+        idxVerts[i] = map.applyInverseMap(hostPoints[i]);
+
+    auto cpuUDF = [&](int ix, int iy, int iz) -> float {
+        const nanovdb::Vec3f p{float(ix), float(iy), float(iz)};
+        float minDistSqr = std::numeric_limits<float>::max();
+        for (const auto& tri : hostTriangles) {
+            const float d = nanovdb::math::pointToTriangleDistSqr<nanovdb::Vec3f>(
+                idxVerts[tri[0]], idxVerts[tri[1]], idxVerts[tri[2]], p);
+            minDistSqr = std::min(minDistSqr, d);
+        }
+        return std::sqrt(minDistSqr) * float(dx);  // world-space distance
+    };
+
+    // --- Topology-only path ---
+    uint64_t topoChecksum = 0;
+    {
+        nanovdb::tools::cuda::MeshToGrid<BuildT> conv(dPoints, nPoints, dTriangles, nTriangles, map);
+        conv.setVerbose(0);
+        conv.setChecksum(nanovdb::CheckMode::Full);
+        auto handle = conv.getHandle();
+        handle.deviceDownload();
+        const auto* topoGrid = handle.grid<BuildT>();
+        ASSERT_NE(topoGrid, nullptr);
+        topoChecksum = topoGrid->mChecksum.full();
+        EXPECT_GT(topoGrid->tree().activeVoxelCount(), uint64_t(0));
+    }
+
+    // --- UDF path ---
+    nanovdb::tools::cuda::MeshToGrid<BuildT> converter(dPoints, nPoints, dTriangles, nTriangles, map);
+    converter.setVerbose(0);
+    converter.setChecksum(nanovdb::CheckMode::Full);
+    auto [handle, sidecarBuf] = converter.getHandleAndUDF();
+
+    handle.deviceDownload();
+    const auto* grid = handle.grid<BuildT>();
+    ASSERT_NE(grid, nullptr);
+
+    const uint64_t sidecarCount = sidecarBuf.size() / sizeof(float);
+    std::vector<float> hostSidecar(sidecarCount);
+    cudaCheck(cudaMemcpy(hostSidecar.data(), sidecarBuf.deviceData(),
+                         sidecarBuf.size(), cudaMemcpyDeviceToHost));
+
+    // Per-voxel UDF correctness: every active voxel must lie inside the narrow band
+    // and its sidecar distance must match the CPU brute-force value within 1e-3 voxels.
+    const uint32_t nLeaves = grid->tree().nodeCount(0);
+    const auto* leaves  = grid->tree().getFirstLeaf();
+    uint64_t activeCount = 0;
+
+    for (uint32_t li = 0; li < nLeaves; ++li) {
+        const auto& leaf = leaves[li];
+        const auto  org  = leaf.origin();
+        for (int vi = 0; vi < 512; ++vi) {
+            if (!leaf.isActive(vi)) continue;
+            ++activeCount;
+
+            const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
+            const int ix = org[0]+lx, iy = org[1]+ly, iz = org[2]+lz;
+
+            const float exactUDF = cpuUDF(ix, iy, iz);
+            ASSERT_LE(exactUDF, bandWidthWorld * (1.f + 1e-5f))
+                << "Active voxel at (" << ix << "," << iy << "," << iz
+                << ") is outside the narrow band (distance=" << exactUDF/float(dx) << " voxels)";
+
+            const uint64_t sIdx = leaf.getValue(vi);
+            ASSERT_LT(sIdx, sidecarCount) << "Sidecar index out of range";
+
+            const float ourUDF    = hostSidecar[sIdx];
+            const float errVoxels = std::abs(ourUDF - exactUDF) / float(dx);
+            EXPECT_LT(errVoxels, 1e-3f)
+                << "UDF error at (" << ix << "," << iy << "," << iz
+                << "): ours=" << ourUDF/float(dx) << " exact=" << exactUDF/float(dx) << " voxels";
+        }
+    }
+    EXPECT_GT(activeCount, uint64_t(0));
+
+    // Build a flat set of active coord keys from the leaf iteration
+    // Encode each (ix,iy,iz) as a uint64_t with 21 bits per axis, offset by 2^20.
+    auto encodeCoord = [](int x, int y, int z) -> uint64_t {
+        return (uint64_t(x + (1<<20)))
+             | (uint64_t(y + (1<<20)) << 21)
+             | (uint64_t(z + (1<<20)) << 42);
+    };
+    std::unordered_set<uint64_t> activeSet;
+    activeSet.reserve(activeCount);
+    for (uint32_t li = 0; li < nLeaves; ++li) {
+        const auto& leaf = leaves[li];
+        const auto  org  = leaf.origin();
+        for (int vi = 0; vi < 512; ++vi) {
+            if (!leaf.isActive(vi)) continue;
+            const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
+            activeSet.insert(encodeCoord(org[0]+lx, org[1]+ly, org[2]+lz));
+        }
+    }
+
+    // No false negatives: every voxel with CPU UDF strictly inside the band must be active.
+    const int ilo = (int)std::floor(-bandWidth) - 1;
+    const int ihi = (int)std::ceil(1.0 / dx + bandWidth) + 1;
+    uint64_t missedCount = 0;
+    for (int ix = ilo; ix <= ihi; ++ix)
+        for (int iy = ilo; iy <= ihi; ++iy)
+            for (int iz = ilo; iz <= ihi; ++iz)
+                if (cpuUDF(ix, iy, iz) < bandWidthWorld)
+                    if (activeSet.count(encodeCoord(ix, iy, iz)) == 0)
+                        ++missedCount;
+    EXPECT_EQ(missedCount, uint64_t(0));
+
+    // getHandle() and getHandleAndUDF() must produce identical grids.
+    EXPECT_EQ(grid->mChecksum.full(), topoChecksum);
+}// MeshToGrid_UnitTetrahedron

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -3870,8 +3870,8 @@ TEST(TestNanoVDBCUDA, MeshToGrid_UnitTetrahedron)
             if (!leaf.isActive(vi)) continue;
             ++activeCount;
 
-            const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
-            const int ix = org[0]+lx, iy = org[1]+ly, iz = org[2]+lz;
+            const auto local = nanovdb::NanoLeaf<BuildT>::OffsetToLocalCoord(vi);
+            const int ix = org[0]+local[0], iy = org[1]+local[1], iz = org[2]+local[2];
 
             const float exactUDF = cpuUDF(ix, iy, iz);
             ASSERT_LE(exactUDF, bandWidthWorld * (1.f + 1e-5f))
@@ -3904,8 +3904,8 @@ TEST(TestNanoVDBCUDA, MeshToGrid_UnitTetrahedron)
         const auto  org  = leaf.origin();
         for (int vi = 0; vi < 512; ++vi) {
             if (!leaf.isActive(vi)) continue;
-            const int lx = vi & 7, ly = (vi >> 3) & 7, lz = (vi >> 6) & 7;
-            activeSet.insert(encodeCoord(org[0]+lx, org[1]+ly, org[2]+lz));
+            const auto local = nanovdb::NanoLeaf<BuildT>::OffsetToLocalCoord(vi);
+            activeSet.insert(encodeCoord(org[0]+local[0], org[1]+local[1], org[2]+local[2]));
         }
     }
 

--- a/nanovdb/nanovdb/util/cuda/Rasterization.cuh
+++ b/nanovdb/nanovdb/util/cuda/Rasterization.cuh
@@ -94,7 +94,7 @@ struct RasterizeLeafNodesFunctor
     const PairT      *dPairs;
     const TriangleT  *dTriangles;
     NanoGrid<BuildT> *dGrid;
-    float             bandWidthSqr;
+    float            bandWidthSqr;
 
     __device__ void operator()() const
     {
@@ -170,7 +170,7 @@ struct ComputeUDFFunctor
     const TriangleT        *dTriangles;
     const NanoGrid<BuildT> *dGrid;
     float                  *dSidecar;
-    float                   bandWidthSqr;
+    float                  bandWidthSqr;
 
     __device__ void operator()() const
     {

--- a/nanovdb/nanovdb/util/cuda/Rasterization.cuh
+++ b/nanovdb/nanovdb/util/cuda/Rasterization.cuh
@@ -44,8 +44,8 @@ struct RasterizeInternalNodesFunctor
 
     const PairT *dPairs;
     const RootT *dRoot;
-    Mask<5>     *dUpperMasks;
-    Mask<4>     (*dLowerMasks)[Mask<5>::SIZE];
+    Mask<5> *dUpperMasks;
+    Mask<4> (*dLowerMasks)[Mask<5>::SIZE];
 
     __device__ void operator()(size_t pairID) const
     {
@@ -53,8 +53,7 @@ struct RasterizeInternalNodesFunctor
 
         // Locate the root tile containing this leaf origin
         const auto *tile = dRoot->probeTile(pair.origin);
-        uint64_t tileIdx = util::PtrDiff(tile, dRoot->tile(0))
-                           / sizeof(typename RootT::Tile);
+        uint64_t tileIdx = util::PtrDiff(tile, dRoot->tile(0)) / sizeof(typename RootT::Tile);
 
         // Offsets of the enclosing upper and lower nodes
         const uint32_t upperBit = UpperT::CoordToOffset(pair.origin);
@@ -65,20 +64,18 @@ struct RasterizeInternalNodesFunctor
     }
 };
 
-/// @brief Fills leaf voxel value masks via exact point-to-triangle UDF.
+/// @brief Fills leaf voxel value masks via exact point-to-triangle distance calculation.
 ///
 ///        Intended to be called via nanovdb::util::cuda::operatorKernelInstance.
 ///        Launched as <<<pairCount, MaxThreadsPerBlock>>> - 1 CTA per leaf/triangle
-///        pair, 512 threads (one per voxel in the 8^3 leaf). Each CTA:
-///          1. Each thread decodes its voxel local coords (lx, ly, lz) and
-///             computes closestPointOnTriangleToPoint from the voxel center
-///             to the pair's triangle.
-///          2. Warp ballot builds a local 16-word mask without atomics (same
-///             pattern as evaluateAndCountSubBoxesKernel).
+///        pair, 512 threads (one per voxel in the 8^3 leaf). For each CTA:
+///          1. Each thread computes closestPointOnTriangleToPoint from the voxel
+///             center (lx,ly,lz) to the triangle.
+///          2. Warp ballot builds a local 16-word mask without atomics
 ///          3. Thread 0 locates the destination leaf via probeLeaf().
 ///          4. Threads 0..7 each pack two 32-bit ballots into one uint64_t and
 ///             atomicOr into the corresponding mask word, allowing multiple CTAs
-///             writing to the same leaf to coexist.
+///             to work concurrently on the same leaf.
 ///
 /// @note  Degenerate triangles (zero area) are handled implicitly: the face
 ///        interior test naturally fails and the code falls through to the
@@ -91,18 +88,18 @@ struct RasterizeLeafNodesFunctor
     static constexpr int MaxThreadsPerBlock = 512;
     static constexpr int MinBlocksPerMultiprocessor = 1;
 
-    const PairT      *dPairs;
-    const TriangleT  *dTriangles;
+    const PairT *dPairs;
+    const TriangleT *dTriangles;
     NanoGrid<BuildT> *dGrid;
-    float            bandWidthSqr;
+    float bandWidthSqr;
 
     __device__ void operator()() const
     {
         const uint64_t pairID   = blockIdx.x;
-        const int      threadID = threadIdx.x; // 0..511 = voxel index within leaf
+        const int threadID = threadIdx.x; // 0..511 = voxel index within leaf
 
         const auto &pair = dPairs[pairID];
-        const auto &tri  = dTriangles[pair.triangleID];
+        const auto &tri = dTriangles[pair.triangleID];
 
         // Decode voxel local coords within the 8^3 leaf
         // Bit ordering: threadID = lx + ly*8 + lz*64 matches NanoVDB Mask<3> layout
@@ -110,13 +107,8 @@ struct RasterizeLeafNodesFunctor
         const int ly = (threadID >> 3) & 0x7;
         const int lz = (threadID >> 6) & 0x7;
 
-        const nanovdb::Vec3f voxelCenter(
-            float(pair.origin[0] + lx),
-            float(pair.origin[1] + ly),
-            float(pair.origin[2] + lz));
-
-        const bool hit = nanovdb::math::pointToTriangleDistSqr(
-            tri[0], tri[1], tri[2], voxelCenter) <= bandWidthSqr;
+        const nanovdb::Vec3f voxelCenter(float(pair.origin[0] + lx), float(pair.origin[1] + ly), float(pair.origin[2] + lz));
+        const bool hit = nanovdb::math::pointToTriangleDistSqr(tri[0], tri[1], tri[2], voxelCenter) <= bandWidthSqr;
 
         // Build a per-block local mask via warp ballot (avoids per-voxel atomics).
         // 512 threads -> 16 warps -> 16 x 32-bit ballot words.
@@ -128,8 +120,7 @@ struct RasterizeLeafNodesFunctor
 
         // Threads 0..7 each pack two ballots into one uint64_t and atomicOr into the
         // corresponding mask word.
-        auto *leaf = const_cast<nanovdb::NanoLeaf<BuildT>*>(
-            dGrid->tree().root().probeLeaf(pair.origin));
+        auto *leaf = const_cast<nanovdb::NanoLeaf<BuildT>*>(dGrid->tree().root().probeLeaf(pair.origin));
 
         if (threadID < int(nanovdb::Mask<3>::WORD_COUNT)) {
             const uint64_t word = uint64_t(s_ballots[2*threadID])
@@ -147,7 +138,7 @@ struct RasterizeLeafNodesFunctor
 ///
 ///        Intended to be called via nanovdb::util::cuda::operatorKernelInstance.
 ///        Launched as <<<pairCount, MaxThreadsPerBlock>>> - 1 CTA per leaf/triangle
-///        pair, 512 threads (one per voxel in the 8^3 leaf). Each CTA:
+///        pair, 512 threads (one per voxel in the 8^3 leaf). For each CTA:
 ///          1. Probes the leaf pointer from the grid using the pair's origin.
 ///          2. Each thread skips its voxel if inactive in the leaf mask.
 ///          3. Active threads compute pointToTriangleDistSqr from the voxel center
@@ -163,19 +154,19 @@ struct RasterizeLeafNodesFunctor
 template<typename BuildT, typename PairT, typename TriangleT>
 struct ComputeUDFFunctor
 {
-    static constexpr int MaxThreadsPerBlock         = 512;
+    static constexpr int MaxThreadsPerBlock = 512;
     static constexpr int MinBlocksPerMultiprocessor = 1;
 
-    const PairT            *dPairs;
-    const TriangleT        *dTriangles;
+    const PairT *dPairs;
+    const TriangleT *dTriangles;
     const NanoGrid<BuildT> *dGrid;
-    float                  *dSidecar;
-    float                  bandWidthSqr;
+    float *dSidecar;
+    float bandWidthSqr;
 
     __device__ void operator()() const
     {
         const uint64_t pairID   = blockIdx.x;
-        const int      threadID = threadIdx.x;
+        const int threadID = threadIdx.x;
 
         const auto &pair = dPairs[pairID];
         const auto *leaf = dGrid->tree().root().probeLeaf(pair.origin);
@@ -186,14 +177,10 @@ struct ComputeUDFFunctor
         const int ly = (threadID >> 3) & 0x7;
         const int lz = (threadID >> 6) & 0x7;
 
-        const nanovdb::Vec3f voxelCenter(
-            float(pair.origin[0] + lx),
-            float(pair.origin[1] + ly),
-            float(pair.origin[2] + lz));
+        const nanovdb::Vec3f voxelCenter(float(pair.origin[0] + lx), float(pair.origin[1] + ly), float(pair.origin[2] + lz));
 
         const auto &tri = dTriangles[pair.triangleID];
-        const float distSqr = nanovdb::math::pointToTriangleDistSqr(
-            tri[0], tri[1], tri[2], voxelCenter);
+        const float distSqr = nanovdb::math::pointToTriangleDistSqr(tri[0], tri[1], tri[2], voxelCenter);
 
         if (distSqr >= bandWidthSqr) return;
 

--- a/nanovdb/nanovdb/util/cuda/Rasterization.cuh
+++ b/nanovdb/nanovdb/util/cuda/Rasterization.cuh
@@ -1,0 +1,212 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file Rasterization.cuh
+
+    \author Efty Sifakis
+
+    \brief Implements GPU kernels for rasterizing triangle mesh geometry into
+           NanoVDB sparse tree topology (upper/lower internal node masks and
+           leaf voxel value masks).
+*/
+
+#ifndef NANOVDB_UTIL_CUDA_RASTERIZATION_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_UTIL_CUDA_RASTERIZATION_CUH_HAS_BEEN_INCLUDED
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/math/Proximity.h>
+
+namespace nanovdb::util {
+
+namespace rasterization {
+
+namespace cuda {
+
+/// @brief Scatters leaf/triangle pair origins into the upper and lower internal
+///        node topology masks of a rasterized NanoVDB tree.
+///
+///        Intended to be called via nanovdb::util::cuda::lambdaKernel.
+///        Launched with 1 thread per leaf/triangle pair. Each thread:
+///          1. Locates its root tile via probeTile() + pointer-difference index
+///          2. Computes upper and lower child offsets via CoordToOffset()
+///          3. Atomically sets the corresponding bits in mUpperMasks and mLowerMasks
+///
+///        Both setOnAtomic() calls are required since multiple pairs can share
+///        the same upper node (competing for the upper mask) or the same lower
+///        node (competing for the lower mask).
+template<typename BuildT, typename PairT>
+struct RasterizeInternalNodesFunctor
+{
+    using RootT  = NanoRoot<BuildT>;
+    using UpperT = NanoUpper<BuildT>;
+    using LowerT = NanoLower<BuildT>;
+
+    const PairT *dPairs;
+    const RootT *dRoot;
+    Mask<5>     *dUpperMasks;
+    Mask<4>     (*dLowerMasks)[Mask<5>::SIZE];
+
+    __device__ void operator()(size_t pairID) const
+    {
+        const auto &pair = dPairs[pairID];
+
+        // Locate the root tile containing this leaf origin
+        const auto *tile = dRoot->probeTile(pair.origin);
+        uint64_t tileIdx = util::PtrDiff(tile, dRoot->tile(0))
+                           / sizeof(typename RootT::Tile);
+
+        // Offsets of the enclosing upper and lower nodes
+        const uint32_t upperBit = UpperT::CoordToOffset(pair.origin);
+        const uint32_t lowerBit = LowerT::CoordToOffset(pair.origin);
+
+        dUpperMasks[tileIdx].setOnAtomic(upperBit);
+        dLowerMasks[tileIdx][upperBit].setOnAtomic(lowerBit);
+    }
+};
+
+/// @brief Fills leaf voxel value masks via exact point-to-triangle UDF.
+///
+///        Intended to be called via nanovdb::util::cuda::operatorKernelInstance.
+///        Launched as <<<pairCount, MaxThreadsPerBlock>>> - 1 CTA per leaf/triangle
+///        pair, 512 threads (one per voxel in the 8^3 leaf). Each CTA:
+///          1. Each thread decodes its voxel local coords (lx, ly, lz) and
+///             computes closestPointOnTriangleToPoint from the voxel center
+///             to the pair's triangle.
+///          2. Warp ballot builds a local 16-word mask without atomics (same
+///             pattern as evaluateAndCountSubBoxesKernel).
+///          3. Thread 0 locates the destination leaf via probeLeaf().
+///          4. Threads 0..7 each pack two 32-bit ballots into one uint64_t and
+///             atomicOr into the corresponding mask word, allowing multiple CTAs
+///             writing to the same leaf to coexist.
+///
+/// @note  Degenerate triangles (zero area) are handled implicitly: the face
+///        interior test naturally fails and the code falls through to the
+///        nearest edge/vertex result, which is correct.
+/// @tparam TriangleT  Any type with a __hostdev__ const Vec3f& operator[](int) const
+///                    returning the i-th vertex (i = 0, 1, 2).
+template<typename BuildT, typename PairT, typename TriangleT>
+struct RasterizeLeafNodesFunctor
+{
+    static constexpr int MaxThreadsPerBlock = 512;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    const PairT      *dPairs;
+    const TriangleT  *dTriangles;
+    NanoGrid<BuildT> *dGrid;
+    float             bandWidthSqr;
+
+    __device__ void operator()() const
+    {
+        const uint64_t pairID   = blockIdx.x;
+        const int      threadID = threadIdx.x; // 0..511 = voxel index within leaf
+
+        const auto &pair = dPairs[pairID];
+        const auto &tri  = dTriangles[pair.triangleID];
+
+        // Decode voxel local coords within the 8^3 leaf
+        // Bit ordering: threadID = lx + ly*8 + lz*64 matches NanoVDB Mask<3> layout
+        const int lx =  threadID       & 0x7;
+        const int ly = (threadID >> 3) & 0x7;
+        const int lz = (threadID >> 6) & 0x7;
+
+        const nanovdb::Vec3f voxelCenter(
+            float(pair.origin[0] + lx),
+            float(pair.origin[1] + ly),
+            float(pair.origin[2] + lz));
+
+        const bool hit = nanovdb::math::pointToTriangleDistSqr(
+            tri[0], tri[1], tri[2], voxelCenter) <= bandWidthSqr;
+
+        // Build a per-block local mask via warp ballot (avoids per-voxel atomics).
+        // 512 threads -> 16 warps -> 16 x 32-bit ballot words.
+        // Mask<3> stores 512 bits as 8 x uint64_t words, so we pack pairs of ballots.
+        __shared__ uint32_t s_ballots[16]; // one 32-bit ballot per warp
+        const unsigned int ballot = __ballot_sync(0xFFFFFFFF, hit);
+        if ((threadID & 31) == 0) s_ballots[threadID >> 5] = ballot;
+        __syncthreads();
+
+        // Threads 0..7 each pack two ballots into one uint64_t and atomicOr into the
+        // corresponding mask word.
+        auto *leaf = const_cast<nanovdb::NanoLeaf<BuildT>*>(
+            dGrid->tree().root().probeLeaf(pair.origin));
+
+        if (threadID < int(nanovdb::Mask<3>::WORD_COUNT)) {
+            const uint64_t word = uint64_t(s_ballots[2*threadID])
+                                | (uint64_t(s_ballots[2*threadID + 1]) << 32);
+            auto &maskWord = const_cast<nanovdb::Mask<3>&>(leaf->valueMask()).words()[threadID];
+            atomicOr(reinterpret_cast<unsigned long long*>(&maskWord),
+                     static_cast<unsigned long long>(word));
+        }
+    }
+};
+
+/// @brief Computes unsigned distance field (UDF) values for all active voxels
+///        by iterating over (leaf, triangle) pairs and accumulating the minimum
+///        squared distance to each voxel's sidecar entry via an atomic min.
+///
+///        Intended to be called via nanovdb::util::cuda::operatorKernelInstance.
+///        Launched as <<<pairCount, MaxThreadsPerBlock>>> - 1 CTA per leaf/triangle
+///        pair, 512 threads (one per voxel in the 8^3 leaf). Each CTA:
+///          1. Probes the leaf pointer from the grid using the pair's origin.
+///          2. Each thread skips its voxel if inactive in the leaf mask.
+///          3. Active threads compute pointToTriangleDistSqr from the voxel center
+///             to the pair's triangle.
+///          4. If distSqr < bandWidthSqr, an atomicMin via uint32 reinterpret
+///             updates dSidecar[sidecarIdx] with the new minimum squared distance.
+///
+/// @note atomicMin via uint32 reinterpret is valid for all IEEE-754 non-negative
+///       floats (including subnormals and +0.0) because their uint32 bit patterns
+///       are ordered identically to the corresponding floating-point values.
+/// @tparam TriangleT  Any type with a __hostdev__ const Vec3f& operator[](int) const
+///                    returning the i-th vertex (i = 0, 1, 2).
+template<typename BuildT, typename PairT, typename TriangleT>
+struct ComputeUDFFunctor
+{
+    static constexpr int MaxThreadsPerBlock         = 512;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    const PairT            *dPairs;
+    const TriangleT        *dTriangles;
+    const NanoGrid<BuildT> *dGrid;
+    float                  *dSidecar;
+    float                   bandWidthSqr;
+
+    __device__ void operator()() const
+    {
+        const uint64_t pairID   = blockIdx.x;
+        const int      threadID = threadIdx.x;
+
+        const auto &pair = dPairs[pairID];
+        const auto *leaf = dGrid->tree().root().probeLeaf(pair.origin);
+        if (!leaf) return;
+        if (!leaf->isActive(threadID)) return;
+
+        const int lx =  threadID       & 0x7;
+        const int ly = (threadID >> 3) & 0x7;
+        const int lz = (threadID >> 6) & 0x7;
+
+        const nanovdb::Vec3f voxelCenter(
+            float(pair.origin[0] + lx),
+            float(pair.origin[1] + ly),
+            float(pair.origin[2] + lz));
+
+        const auto &tri = dTriangles[pair.triangleID];
+        const float distSqr = nanovdb::math::pointToTriangleDistSqr(
+            tri[0], tri[1], tri[2], voxelCenter);
+
+        if (distSqr >= bandWidthSqr) return;
+
+        const uint64_t sidecarIdx = leaf->getValue(threadID);
+        atomicMin(reinterpret_cast<uint32_t*>(&dSidecar[sidecarIdx]),
+                  __float_as_uint(distSqr));
+    }
+};
+
+} // namespace cuda
+
+} // namespace rasterization
+
+} // namespace nanovdb::util
+
+#endif // NANOVDB_UTIL_CUDA_RASTERIZATION_CUH_HAS_BEEN_INCLUDED

--- a/nanovdb/nanovdb/util/cuda/Rasterization.cuh
+++ b/nanovdb/nanovdb/util/cuda/Rasterization.cuh
@@ -120,11 +120,11 @@ struct RasterizeLeafNodesFunctor
         auto *leaf = const_cast<nanovdb::NanoLeaf<BuildT>*>(dGrid->tree().root().probeLeaf(pair.origin));
 
         if (threadID < int(nanovdb::Mask<3>::WORD_COUNT)) {
-            const uint64_t word = uint64_t(s_ballots[2*threadID])
-                                | (uint64_t(s_ballots[2*threadID + 1]) << 32);
-            auto &maskWord = const_cast<nanovdb::Mask<3>&>(leaf->valueMask()).words()[threadID];
-            atomicOr(reinterpret_cast<unsigned long long*>(&maskWord),
-                     static_cast<unsigned long long>(word));
+            const unsigned long long word = (unsigned long long)(s_ballots[2*threadID])
+                                          | ((unsigned long long)(s_ballots[2*threadID + 1]) << 32);
+            unsigned long long *maskWord = reinterpret_cast<unsigned long long*>(
+                const_cast<uint64_t*>(&leaf->valueMask().words()[threadID]));
+            ::atomicOr(maskWord, word);
         }
     }
 };

--- a/nanovdb/nanovdb/util/cuda/Rasterization.cuh
+++ b/nanovdb/nanovdb/util/cuda/Rasterization.cuh
@@ -101,13 +101,10 @@ struct RasterizeLeafNodesFunctor
         const auto &pair = dPairs[pairID];
         const auto &tri = dTriangles[pair.triangleID];
 
-        // Decode voxel local coords within the 8^3 leaf
-        // Bit ordering: threadID = lx + ly*8 + lz*64 matches NanoVDB Mask<3> layout
-        const int lx =  threadID       & 0x7;
-        const int ly = (threadID >> 3) & 0x7;
-        const int lz = (threadID >> 6) & 0x7;
-
-        const nanovdb::Vec3f voxelCenter(float(pair.origin[0] + lx), float(pair.origin[1] + ly), float(pair.origin[2] + lz));
+        const nanovdb::Coord local = nanovdb::NanoLeaf<BuildT>::OffsetToLocalCoord(threadID);
+        const nanovdb::Vec3f voxelCenter(float(pair.origin[0] + local[0]),
+                                         float(pair.origin[1] + local[1]),
+                                         float(pair.origin[2] + local[2]));
         const bool hit = nanovdb::math::pointToTriangleDistSqr(tri[0], tri[1], tri[2], voxelCenter) <= bandWidthSqr;
 
         // Build a per-block local mask via warp ballot (avoids per-voxel atomics).
@@ -173,11 +170,10 @@ struct ComputeUDFFunctor
         if (!leaf) return;
         if (!leaf->isActive(threadID)) return;
 
-        const int lx =  threadID       & 0x7;
-        const int ly = (threadID >> 3) & 0x7;
-        const int lz = (threadID >> 6) & 0x7;
-
-        const nanovdb::Vec3f voxelCenter(float(pair.origin[0] + lx), float(pair.origin[1] + ly), float(pair.origin[2] + lz));
+        const nanovdb::Coord local = nanovdb::NanoLeaf<BuildT>::OffsetToLocalCoord(threadID);
+        const nanovdb::Vec3f voxelCenter(float(pair.origin[0] + local[0]),
+                                         float(pair.origin[1] + local[1]),
+                                         float(pair.origin[2] + local[2]));
 
         const auto &tri = dTriangles[pair.triangleID];
         const float distSqr = nanovdb::math::pointToTriangleDistSqr(tri[0], tri[1], tri[2], voxelCenter);

--- a/nanovdb/nanovdb/util/cuda/Util.h
+++ b/nanovdb/nanovdb/util/cuda/Util.h
@@ -271,6 +271,17 @@ void operatorKernel(
     op( args... );
 }
 
+/// @brief Cuda kernel that launches a pre-constructed device operator functor with arbitrary arguments.
+///        Unlike operatorKernel, the operator is passed by value (copied at launch) rather than
+///        default-constructed on the device, allowing functors with data members.
+template<class Operator, typename... Args>
+__global__
+__launch_bounds__(Operator::MaxThreadsPerBlock, Operator::MinBlocksPerMultiprocessor)
+void operatorKernelInstance(Operator op, Args... args)
+{
+    op( args... );
+}
+
 /// @brief Cuda kernel that launches device operator functors with arbitrary arguments, using dynamic shared memory
 template<class Operator, typename... Args>
 __global__


### PR DESCRIPTION
## Summary                                                                                                                        
                                                                                                                                    
  Introduces `nanovdb::tools::cuda::MeshToGrid<BuildT>`, a GPU-accelerated rasterizer that converts a triangle soup (vertex list + index list) into a sparse NanoVDB grid on the device. Two output modes are implemented:                                           
                                                                                                                                    
  - `getHandle()` — produces a `ValueOnIndex` (topology-only) IndexGrid                                                             
  - `getHandleAndUDF()` — produces the same grid plus a device sidecar buffer of per-active-voxel unsigned distances (world-space UDF, ordered by active voxel index)                                                                                               
                  
  SDF (signed distance field) output is planned future work.                                                                        
                  
  ## Pipeline

  1. **`transformTriangles()`** — vertices transformed to NanoVDB index space
  2. **`processRootTrianglePairs()`** — enumerates `(root tile, triangle)` pairs whose padded AABBs overlap, via CUB prefix-sum + scatter (no atomics)                                                                                                              
  3. **`processLeafTrianglePairs()`** — 3-level 8× subdivision (4096→512→64→8), refining the pair list at each level using triangle-AABB / SAT intersection tests (1 CTA per pair, 512 threads, warp ballot + CUB block reduce)                              
  4. **Topology assembly** — unique leaf origins extracted, NanoVDB `ValueOnIndex` tree built via `TopologyBuilder`, empty leaves pruned via `PruneGrid`                                                                                                            
  5. **UDF computation** (`getHandleAndUDF` only) — `ComputeUDFFunctor` computes per-voxel point-to-triangle distances via atomic-min, finalized to world-space in a second pass                                                                             
  
  ## Files                                                                                                                          
                  
  **New:**
  - `nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh` — main converter
  - `nanovdb/nanovdb/math/Proximity.h` — point/triangle proximity utilities                                                         
  - `nanovdb/nanovdb/util/cuda/Rasterization.cuh` — `ComputeUDFFunctor` and helpers                                                 
                                                                                                                                    
  **Modified:**                                                                                                                     
  - `nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh` — adds `InitGridTreeRootFunctor` for constructing grids from scratch (no source grid to copy metadata from)                                                                                                      
  - `nanovdb/nanovdb/util/cuda/Util.h` — adds `operatorKernelInstance` for launching pre-constructed device functors carrying data members                                                                                                                           
  - `nanovdb/nanovdb/examples/CMakeLists.txt` — registers `ex_mesh_to_grid_cuda`
                                                                                                                                    
  ## Tests        
                                                                                                                                    
  Two unit tests added to `TestNanoVDB.cu`:                                                                                         
  - `MeshToGrid_EmptyMesh` — verifies an empty triangle list produces a valid zero-active-voxel grid
  - `MeshToGrid_UnitTetrahedron` — verifies topology and UDF accuracy against a CPU brute-force reference on a unit tetrahedron     
                                                                                                                                    
  ## Known TODOs
                                                                                                                                    
  - The `Triangle` POD struct (currently in `MeshToGrid.cuh`) is a candidate for migration to a dedicated geometric-primitives header in `nanovdb/math/` once such a header is introduced.
