### PR TITLE
Refactor I/O

### DIFF
--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -886,9 +886,8 @@ Archive::connectInstance(const GridDescriptor& gd, const NamedGridMap& grids) co
 ////////////////////////////////////////
 
 
-void
-Archive::readGrid(GridBase::Ptr grid, const GridDescriptor& gd,
-    std::istream& is, const BBoxd& worldBBox)
+GridBase::Ptr
+Archive::readGrid(const GridDescriptor& gd, std::istream& is, const BBoxd& worldBBox, bool partial/* = false*/)
 {
     // Read the compression settings for this grid and tag the stream with them
     // so that downstream functions can reference them.
@@ -902,6 +901,16 @@ Archive::readGrid(GridBase::Ptr grid, const GridDescriptor& gd,
         void* ptr;
     };
     OnExit restore(is);
+
+    // Create the grid.
+    if (!GridBase::isRegistered(gd.gridType())) {
+        OPENVDB_THROW(KeyError, "Cannot read grid "
+            << GridDescriptor::nameAsString(gd.uniqueName())
+            << ": grid type " << gd.gridType() << " is not registered");
+    }
+
+    GridBase::Ptr grid = GridBase::createGrid(gd.gridType());
+    if (grid) grid->setSaveFloatAsHalf(gd.saveFloatAsHalf());
 
     // Stream metadata varies per grid, and it needs to persist
     // in case delayed load is in effect.
@@ -930,7 +939,7 @@ Archive::readGrid(GridBase::Ptr grid, const GridDescriptor& gd,
     io::setGridClass(is, gridClass);
 
     grid->readTransform(is);
-    if (!gd.isInstance()) {
+    if (!partial && !gd.isInstance()) {
         grid->readTopology(is);
         const bool clip = worldBBox.isSorted();
         if (clip) {
@@ -940,6 +949,8 @@ Archive::readGrid(GridBase::Ptr grid, const GridDescriptor& gd,
             grid->readBuffers(is);
         }
     }
+
+    return grid;
 }
 
 

--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -886,23 +886,13 @@ Archive::connectInstance(const GridDescriptor& gd, const NamedGridMap& grids) co
 ////////////////////////////////////////
 
 
-namespace {
-
-struct NoBBox {};
-
-template<typename BoxType>
 void
-doReadGrid(GridBase::Ptr grid, const GridDescriptor& gd, std::istream& is, const BoxType& bbox)
+Archive::readGrid(GridBase::Ptr grid, const GridDescriptor& gd,
+    std::istream& is, const BBoxd& worldBBox)
 {
-    struct Local {
-        static void readBuffers(GridBase& g, std::istream& istrm, NoBBox) { g.readBuffers(istrm); }
-        static void readBuffers(GridBase& g, std::istream& istrm, const CoordBBox& indexBBox) {
-            g.readBuffers(istrm, indexBBox);
-        }
-        static void readBuffers(GridBase& g, std::istream& istrm, const BBoxd& worldBBox) {
-            g.readBuffers(istrm, g.constTransform().worldToIndexNodeCentered(worldBBox));
-        }
-    };
+    // Read the compression settings for this grid and tag the stream with them
+    // so that downstream functions can reference them.
+    readGridCompression(is);
 
     // Restore the file-level stream metadata on exit.
     struct OnExit {
@@ -942,37 +932,14 @@ doReadGrid(GridBase::Ptr grid, const GridDescriptor& gd, std::istream& is, const
     grid->readTransform(is);
     if (!gd.isInstance()) {
         grid->readTopology(is);
-        Local::readBuffers(*grid, is, bbox);
+        const bool clip = worldBBox.isSorted();
+        if (clip) {
+            const auto indexBBox = grid->constTransform().worldToIndexNodeCentered(worldBBox);
+            grid->readBuffers(is, indexBBox);
+        } else {
+            grid->readBuffers(is);
+        }
     }
-}
-
-} // unnamed namespace
-
-
-void
-Archive::readGrid(GridBase::Ptr grid, const GridDescriptor& gd, std::istream& is)
-{
-    // Read the compression settings for this grid and tag the stream with them
-    // so that downstream functions can reference them.
-    readGridCompression(is);
-
-    doReadGrid(grid, gd, is, NoBBox());
-}
-
-void
-Archive::readGrid(GridBase::Ptr grid, const GridDescriptor& gd,
-    std::istream& is, const BBoxd& worldBBox)
-{
-    readGridCompression(is);
-    doReadGrid(grid, gd, is, worldBBox);
-}
-
-void
-Archive::readGrid(GridBase::Ptr grid, const GridDescriptor& gd,
-    std::istream& is, const CoordBBox& indexBBox)
-{
-    readGridCompression(is);
-    doReadGrid(grid, gd, is, indexBBox);
 }
 
 

--- a/openvdb/openvdb/io/Archive.h
+++ b/openvdb/openvdb/io/Archive.h
@@ -127,14 +127,9 @@ protected:
     /// Read in and return the number of grids on the input stream.
     static int32_t readGridCount(std::istream&);
 
-    /// Populate the given grid from the input stream.
-    static void readGrid(GridBase::Ptr, const GridDescriptor&, std::istream&);
     /// @brief Populate the given grid from the input stream, but only where it
     /// intersects the given world-space bounding box.
     static void readGrid(GridBase::Ptr, const GridDescriptor&, std::istream&, const BBoxd&);
-    /// @brief Populate the given grid from the input stream, but only where it
-    /// intersects the given index-space bounding box.
-    static void readGrid(GridBase::Ptr, const GridDescriptor&, std::istream&, const CoordBBox&);
 
     using NamedGridMap = std::map<Name /*uniqueName*/, GridBase::Ptr>;
 

--- a/openvdb/openvdb/io/Archive.h
+++ b/openvdb/openvdb/io/Archive.h
@@ -127,9 +127,10 @@ protected:
     /// Read in and return the number of grids on the input stream.
     static int32_t readGridCount(std::istream&);
 
-    /// @brief Populate the given grid from the input stream, but only where it
-    /// intersects the given world-space bounding box.
-    static void readGrid(GridBase::Ptr, const GridDescriptor&, std::istream&, const BBoxd&);
+    /// @brief Read in and create the grid represented by the given grid descriptor using the
+    /// given input stream, but only where it intersects the given world-space bounding box.
+    /// @param partial If true, only read the metadata and transform of the grid.
+    static GridBase::Ptr readGrid(const GridDescriptor&, std::istream&, const BBoxd&, bool partial = false);
 
     using NamedGridMap = std::map<Name /*uniqueName*/, GridBase::Ptr>;
 

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -442,7 +442,7 @@ File::readAllGridMetadata()
         // Read just the metadata and transforms for all grids.
         for (NameMapCIter i = gridDescriptors().begin(), e = gridDescriptors().end(); i != e; ++i) {
             const GridDescriptor& gd = i->second;
-            GridBase::ConstPtr grid = readGridPartial(gd, /*readTopology=*/false);
+            GridBase::ConstPtr grid = readGridPartial(gd);
             // Return copies of the grids, but with empty trees.
             // (As of 0.98.0, at least, it would suffice to just const cast
             // the grid pointers returned by readGridPartial(), but shallow
@@ -479,7 +479,7 @@ File::readGridMetadata(const Name& name)
 
         // Seek to and read in the grid from the file.
         const GridDescriptor& gd = it->second;
-        ret = readGridPartial(gd, /*readTopology=*/false);
+        ret = readGridPartial(gd);
     }
     return ret->copyGridWithNewTree();
 }
@@ -644,18 +644,30 @@ File::createGrid(const GridDescriptor& gd) const
 
 
 GridBase::ConstPtr
-File::readGridPartial(const GridDescriptor& gd, bool readTopology) const
+File::readGridPartial(const GridDescriptor& gd) const
 {
     // This method should not be called for files that don't contain grid offsets.
     OPENVDB_ASSERT(inputHasGridOffsets());
 
+    std::istream& is = inputStream();
+
     GridBase::Ptr grid = createGrid(gd);
 
     // Seek to grid.
-    gd.seekToGrid(inputStream());
+    gd.seekToGrid(is);
 
-    // Read the grid partially.
-    readGridPartial(grid, inputStream(), gd.isInstance(), readTopology);
+    // This code needs to stay in sync with io::Archive::readGrid(), in terms of
+    // the order of operations.
+    readGridCompression(is);
+    grid->readMeta(is);
+
+    // Delayed loading is no longer supported - always remove metadata related to delayed loading if it exists
+    if ((*grid)[GridBase::META_FILE_DELAYED_LOAD]) {
+        grid->removeMeta(GridBase::META_FILE_DELAYED_LOAD);
+    }
+
+    // Read the transform.
+    grid->readTransform(is);
 
     // Promote to a const grid.
     GridBase::ConstPtr constGrid = grid;
@@ -682,30 +694,6 @@ GridBase::Ptr
 File::readGrid(const GridDescriptor& gd, const CoordBBox& bbox) const
 {
     return Impl::readGrid(*this, gd, bbox);
-}
-
-
-void
-File::readGridPartial(GridBase::Ptr grid, std::istream& is,
-    bool isInstance, bool readTopology) const
-{
-    // This method should not be called for files that don't contain grid offsets.
-    OPENVDB_ASSERT(inputHasGridOffsets());
-
-    // This code needs to stay in sync with io::Archive::readGrid(), in terms of
-    // the order of operations.
-    readGridCompression(is);
-    grid->readMeta(is);
-
-    // Delayed loading is no longer supported - always remove metadata related to delayed loading if it exists
-    if ((*grid)[GridBase::META_FILE_DELAYED_LOAD]) {
-        grid->removeMeta(GridBase::META_FILE_DELAYED_LOAD);
-    }
-
-    grid->readTransform(is);
-    if (!isInstance && readTopology) {
-        grid->readTopology(is);
-    }
 }
 
 

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -224,8 +224,7 @@ File::open()
             gd.readHeader(inputStream());
             gd.readStreamPos(inputStream());
 
-            GridBase::Ptr grid = createGrid(gd);
-            Archive::readGrid(grid, gd, inputStream(), BBoxd());
+            GridBase::Ptr grid = Archive::readGrid(gd, inputStream(), BBoxd());
 
             mGridDescriptors.insert(std::make_pair(gd.gridName(), gd));
             mGrids->push_back(grid);
@@ -318,7 +317,9 @@ File::getGrids() const
         // Read all grids represented by the GridDescriptors.
         for (NameMapCIter i = mGridDescriptors.begin(), e = mGridDescriptors.end(); i != e; ++i) {
             const GridDescriptor& gd = i->second;
-            GridBase::Ptr grid = readGrid(gd, BBoxd());
+            // Seek to the grid in the file.
+            gd.seekToGrid(inputStream());
+            GridBase::Ptr grid = Archive::readGrid(gd, inputStream(), BBoxd());
             ret->push_back(grid);
             namedGrids[gd.uniqueName()] = grid;
         }
@@ -382,10 +383,12 @@ File::readAllGridMetadata()
         // Read just the metadata and transforms for all grids.
         for (NameMapCIter i = mGridDescriptors.begin(), e = mGridDescriptors.end(); i != e; ++i) {
             const GridDescriptor& gd = i->second;
-            GridBase::ConstPtr grid = readGridPartial(gd);
+            // Seek to the grid in the file.
+            gd.seekToGrid(inputStream());
+            GridBase::ConstPtr grid = Archive::readGrid(gd, inputStream(), BBoxd(), /*partial=*/true);
             // Return copies of the grids, but with empty trees.
             // (As of 0.98.0, at least, it would suffice to just const cast
-            // the grid pointers returned by readGridPartial(), but shallow
+            // the grid pointers returned by readGrid(partial=true), but shallow
             // copying the grids helps to ensure future compatibility.)
             ret->push_back(grid->copyGridWithNewTree());
         }
@@ -419,7 +422,8 @@ File::readGridMetadata(const Name& name)
 
         // Seek to and read in the grid from the file.
         const GridDescriptor& gd = it->second;
-        ret = readGridPartial(gd);
+        gd.seekToGrid(inputStream());
+        ret = Archive::readGrid(gd, inputStream(), BBoxd(), /*partial=*/true);
     }
     return ret->copyGridWithNewTree();
 }
@@ -463,7 +467,11 @@ File::readGrid(const Name& name, const BBoxd& bbox)
 
     // Seek to and read in the grid from the file.
     const GridDescriptor& gd = it->second;
-    grid = readGrid(gd, bbox);
+    // This method should not be called for files that don't contain grid offsets.
+    OPENVDB_ASSERT(inputHasGridOffsets());
+    // Seek to the grid in the file.
+    gd.seekToGrid(inputStream());
+    grid = Archive::readGrid(gd, inputStream(), bbox);
 
     if (gd.isInstance()) {
         /// @todo Refactor to share code with Archive::connectInstance()?
@@ -477,7 +485,9 @@ File::readGrid(const Name& name, const BBoxd& bbox)
         }
 
         GridBase::Ptr parent;
-        parent = readGrid(parentIt->second, bbox);
+        OPENVDB_ASSERT(inputHasGridOffsets());
+        parentIt->second.seekToGrid(inputStream());
+        parent = Archive::readGrid(parentIt->second, inputStream(), bbox);
         if (parent) grid->setTree(parent->baseTreePtr());
     }
     return grid;
@@ -554,73 +564,6 @@ File::findDescriptor(const Name& name) const
         }
     }
     return ret;
-}
-
-
-////////////////////////////////////////
-
-
-GridBase::Ptr
-File::createGrid(const GridDescriptor& gd) const
-{
-    // Create the grid.
-    if (!GridBase::isRegistered(gd.gridType())) {
-        OPENVDB_THROW(KeyError, "Cannot read grid "
-            << GridDescriptor::nameAsString(gd.uniqueName())
-            << " from " << mFilename << ": grid type "
-            << gd.gridType() << " is not registered");
-    }
-
-    GridBase::Ptr grid = GridBase::createGrid(gd.gridType());
-    if (grid) grid->setSaveFloatAsHalf(gd.saveFloatAsHalf());
-
-    return grid;
-}
-
-
-GridBase::ConstPtr
-File::readGridPartial(const GridDescriptor& gd) const
-{
-    // This method should not be called for files that don't contain grid offsets.
-    OPENVDB_ASSERT(inputHasGridOffsets());
-
-    std::istream& is = inputStream();
-
-    GridBase::Ptr grid = createGrid(gd);
-
-    // Seek to grid.
-    gd.seekToGrid(is);
-
-    // This code needs to stay in sync with io::Archive::readGrid(), in terms of
-    // the order of operations.
-    readGridCompression(is);
-    grid->readMeta(is);
-
-    // Delayed loading is no longer supported - always remove metadata related to delayed loading if it exists
-    if ((*grid)[GridBase::META_FILE_DELAYED_LOAD]) {
-        grid->removeMeta(GridBase::META_FILE_DELAYED_LOAD);
-    }
-
-    // Read the transform.
-    grid->readTransform(is);
-
-    // Promote to a const grid.
-    GridBase::ConstPtr constGrid = grid;
-
-    return constGrid;
-}
-
-
-GridBase::Ptr
-File::readGrid(const GridDescriptor& gd, const BBoxd& bbox) const
-{
-    // This method should not be called for files that don't contain grid offsets.
-    OPENVDB_ASSERT(inputHasGridOffsets());
-
-    GridBase::Ptr grid = createGrid(gd);
-    gd.seekToGrid(inputStream());
-    Archive::readGrid(grid, gd, inputStream(), bbox);
-    return grid;
 }
 
 

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -296,8 +296,20 @@ File::open()
             Archive::connectInstance(it->second, mImpl->mNamedGrids);
         }
     } else {
-        // Read in just the grid descriptors.
-        readGridDescriptors(inputStream());
+        gridDescriptors().clear();
+
+        for (int32_t i = 0, N = readGridCount(inputStream()); i < N; ++i) {
+            // Read the grid descriptor.
+            GridDescriptor gd;
+            gd.readHeader(inputStream());
+            gd.readStreamPos(inputStream());
+
+            // Add the descriptor to the dictionary.
+            gridDescriptors().insert(std::make_pair(gd.gridName(), gd));
+
+            // Skip forward to the next descriptor.
+            gd.seekToEnd(inputStream());
+        }
     }
 
     mImpl->mIsOpen = true;
@@ -570,31 +582,6 @@ File::writeGrids(const GridCPtrVec& grids, const MetaMap& meta) const
     file.close();
 }
 
-
-////////////////////////////////////////
-
-
-void
-File::readGridDescriptors(std::istream& is)
-{
-    // This method should not be called for files that don't contain grid offsets.
-    OPENVDB_ASSERT(inputHasGridOffsets());
-
-    gridDescriptors().clear();
-
-    for (int32_t i = 0, N = readGridCount(is); i < N; ++i) {
-        // Read the grid descriptor.
-        GridDescriptor gd;
-        gd.readHeader(is);
-        gd.readStreamPos(is);
-
-        // Add the descriptor to the dictionary.
-        gridDescriptors().insert(std::make_pair(gd.gridName(), gd));
-
-        // Skip forward to the next descriptor.
-        gd.seekToEnd(is);
-    }
-}
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -225,7 +225,7 @@ File::open()
             gd.readStreamPos(inputStream());
 
             GridBase::Ptr grid = createGrid(gd);
-            Archive::readGrid(grid, gd, inputStream());
+            Archive::readGrid(grid, gd, inputStream(), BBoxd());
 
             mGridDescriptors.insert(std::make_pair(gd.gridName(), gd));
             mGrids->push_back(grid);
@@ -318,7 +318,7 @@ File::getGrids() const
         // Read all grids represented by the GridDescriptors.
         for (NameMapCIter i = mGridDescriptors.begin(), e = mGridDescriptors.end(); i != e; ++i) {
             const GridDescriptor& gd = i->second;
-            GridBase::Ptr grid = readGrid(gd);
+            GridBase::Ptr grid = readGrid(gd, BBoxd());
             ret->push_back(grid);
             namedGrids[gd.uniqueName()] = grid;
         }
@@ -463,7 +463,7 @@ File::readGrid(const Name& name, const BBoxd& bbox)
 
     // Seek to and read in the grid from the file.
     const GridDescriptor& gd = it->second;
-    grid = (clip ? readGrid(gd, bbox) : readGrid(gd));
+    grid = readGrid(gd, bbox);
 
     if (gd.isInstance()) {
         /// @todo Refactor to share code with Archive::connectInstance()?
@@ -477,12 +477,7 @@ File::readGrid(const Name& name, const BBoxd& bbox)
         }
 
         GridBase::Ptr parent;
-        if (clip) {
-            const CoordBBox indexBBox = grid->constTransform().worldToIndexNodeCentered(bbox);
-            parent = readGrid(parentIt->second, indexBBox);
-        } else {
-            parent = readGrid(parentIt->second);
-        }
+        parent = readGrid(parentIt->second, bbox);
         if (parent) grid->setTree(parent->baseTreePtr());
     }
     return grid;
@@ -617,33 +612,7 @@ File::readGridPartial(const GridDescriptor& gd) const
 
 
 GridBase::Ptr
-File::readGrid(const GridDescriptor& gd) const
-{
-    // This method should not be called for files that don't contain grid offsets.
-    OPENVDB_ASSERT(inputHasGridOffsets());
-
-    GridBase::Ptr grid = createGrid(gd);
-    gd.seekToGrid(inputStream());
-    Archive::readGrid(grid, gd, inputStream());
-    return grid;
-}
-
-
-GridBase::Ptr
 File::readGrid(const GridDescriptor& gd, const BBoxd& bbox) const
-{
-    // This method should not be called for files that don't contain grid offsets.
-    OPENVDB_ASSERT(inputHasGridOffsets());
-
-    GridBase::Ptr grid = createGrid(gd);
-    gd.seekToGrid(inputStream());
-    Archive::readGrid(grid, gd, inputStream(), bbox);
-    return grid;
-}
-
-
-GridBase::Ptr
-File::readGrid(const GridDescriptor& gd, const CoordBBox& bbox) const
 {
     // This method should not be called for files that don't contain grid offsets.
     OPENVDB_ASSERT(inputHasGridOffsets());

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -25,83 +25,24 @@ OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
 namespace io {
 
-// Implementation details of the File class
-struct File::Impl
+
+File::File(const std::string& filename)
+    : Archive()
+    , mFilename(filename)
 {
-    struct NoBBox {};
-
-    // Common implementation of the various File::readGrid() overloads,
-    // with and without bounding box clipping
-    template<typename BoxType>
-    static GridBase::Ptr readGrid(const File& file, const GridDescriptor& gd, const BoxType& bbox)
-    {
-        // This method should not be called for files that don't contain grid offsets.
-        OPENVDB_ASSERT(file.inputHasGridOffsets());
-
-        GridBase::Ptr grid = file.createGrid(gd);
-        gd.seekToGrid(file.inputStream());
-        unarchive(file, grid, gd, bbox);
-        return grid;
-    }
-
-    static void unarchive(const File& file, GridBase::Ptr& grid,
-        const GridDescriptor& gd, NoBBox)
-    {
-        file.Archive::readGrid(grid, gd, file.inputStream());
-    }
-
-    static void unarchive(const File& file, GridBase::Ptr& grid,
-        const GridDescriptor& gd, const CoordBBox& indexBBox)
-    {
-        file.Archive::readGrid(grid, gd, file.inputStream(), indexBBox);
-    }
-
-    static void unarchive(const File& file, GridBase::Ptr& grid,
-        const GridDescriptor& gd, const BBoxd& worldBBox)
-    {
-        file.Archive::readGrid(grid, gd, file.inputStream(), worldBBox);
-    }
-
-    std::string mFilename;
-    // The file-level metadata
-    MetaMap::Ptr mMeta;
-    // The file stream that is open for reading
-    std::unique_ptr<std::istream> mInStream;
-    // File-level stream metadata (file format, compression, etc.)
-    StreamMetadata::Ptr mStreamMetadata;
-    // Flag indicating if we have read in the global information (header,
-    // metadata, and grid descriptors) for this VDB file
-    bool mIsOpen;
-    // Grid descriptors for all grids stored in the file, indexed by grid name
-    NameMap mGridDescriptors;
-    // All grids, indexed by unique name (used only when mHasGridOffsets is false)
-    Archive::NamedGridMap mNamedGrids;
-    // All grids stored in the file (used only when mHasGridOffsets is false)
-    GridPtrVecPtr mGrids;
-}; // class File::Impl
-
-
-////////////////////////////////////////
-
-
-File::File(const std::string& filename): mImpl(new Impl)
-{
-    mImpl->mFilename = filename;
-    mImpl->mIsOpen = false;
     setInputHasGridOffsets(true);
-}
-
-
-File::~File()
-{
 }
 
 
 File::File(const File& other)
     : Archive(other)
-    , mImpl(new Impl)
+    , mFilename(other.mFilename)
+    , mMeta(other.mMeta)
+    , mIsOpen(false)
+    , mGridDescriptors(other.mGridDescriptors)
+    , mNamedGrids(other.mNamedGrids)
+    , mGrids(other.mGrids)
 {
-    *this = other;
 }
 
 
@@ -110,13 +51,12 @@ File::operator=(const File& other)
 {
     if (&other != this) {
         Archive::operator=(other);
-        const Impl& otherImpl = *other.mImpl;
-        mImpl->mFilename = otherImpl.mFilename;
-        mImpl->mMeta = otherImpl.mMeta;
-        mImpl->mIsOpen = false; // don't want two file objects reading from the same stream
-        mImpl->mGridDescriptors = otherImpl.mGridDescriptors;
-        mImpl->mNamedGrids = otherImpl.mNamedGrids;
-        mImpl->mGrids = otherImpl.mGrids;
+        mFilename = other.mFilename;
+        mMeta = other.mMeta;
+        mIsOpen = false; // don't want two file objects reading from the same stream
+        mGridDescriptors = other.mGridDescriptors;
+        mNamedGrids = other.mNamedGrids;
+        mGrids = other.mGrids;
     }
     return *this;
 }
@@ -135,43 +75,43 @@ File::copy() const
 const std::string&
 File::filename() const
 {
-    return mImpl->mFilename;
+    return mFilename;
 }
 
 
 MetaMap::Ptr
 File::fileMetadata()
 {
-    return mImpl->mMeta;
+    return mMeta;
 }
 
 MetaMap::ConstPtr
 File::fileMetadata() const
 {
-    return mImpl->mMeta;
+    return mMeta;
 }
 
 
 const File::NameMap&
 File::gridDescriptors() const
 {
-    return mImpl->mGridDescriptors;
+    return mGridDescriptors;
 }
 
 File::NameMap&
 File::gridDescriptors()
 {
-    return mImpl->mGridDescriptors;
+    return mGridDescriptors;
 }
 
 
 std::istream&
 File::inputStream() const
 {
-    if (!mImpl->mInStream) {
-        OPENVDB_THROW(IoError, filename() << " is not open for reading");
+    if (!mInStream) {
+        OPENVDB_THROW(IoError, mFilename << " is not open for reading");
     }
-    return *mImpl->mInStream;
+    return *mInStream;
 }
 
 
@@ -187,11 +127,11 @@ File::getSize() const
 
     Index64 result = std::numeric_limits<Index64>::max();
 
-    std::string mesg = "could not get size of file " + filename();
+    std::string mesg = "could not get size of file " + mFilename;
 
 #ifdef _WIN32
     // Get the file size by seeking to the end of the file.
-    std::ifstream fstrm(filename());
+    std::ifstream fstrm(mFilename);
     if (fstrm) {
         fstrm.seekg(0, fstrm.end);
         result = static_cast<Index64>(fstrm.tellg());
@@ -201,7 +141,7 @@ File::getSize() const
 #else
     // Get the file size using the stat() system call.
     struct stat info;
-    if (0 != ::stat(filename().c_str(), &info)) {
+    if (0 != ::stat(mFilename.c_str(), &info)) {
         std::string s = getErrorString();
         if (!s.empty()) mesg += " (" + s + ")";
         OPENVDB_THROW(IoError, mesg);
@@ -223,25 +163,25 @@ File::getSize() const
 bool
 File::isOpen() const
 {
-    return mImpl->mIsOpen;
+    return mIsOpen;
 }
 
 
 bool
 File::open()
 {
-    if (isOpen()) {
-        OPENVDB_THROW(IoError, filename() << " is already open");
+    if (mIsOpen) {
+        OPENVDB_THROW(IoError, mFilename << " is already open");
     }
-    mImpl->mInStream.reset();
+    mInStream.reset();
 
     // Open the file using standard I/O (delayed loading has been removed)
     std::unique_ptr<std::istream> newStream;
     newStream.reset(new std::ifstream(
-        filename().c_str(), std::ios_base::in | std::ios_base::binary));
+        mFilename.c_str(), std::ios_base::in | std::ios_base::binary));
 
     if (newStream->fail()) {
-        OPENVDB_THROW(IoError, "could not open file " << filename());
+        OPENVDB_THROW(IoError, "could not open file " << mFilename);
     }
 
     // Read in the file header.
@@ -251,31 +191,31 @@ File::open()
     } catch (IoError& e) {
         if (e.what() && std::string("not a VDB file") == e.what()) {
             // Rethrow, adding the filename.
-            OPENVDB_THROW(IoError, filename() << " is not a VDB file");
+            OPENVDB_THROW(IoError, mFilename << " is not a VDB file");
         }
         throw;
     }
 
-    mImpl->mInStream.swap(newStream);
+    mInStream.swap(newStream);
 
     // Tag the input stream with the file format and library version numbers
     // and other metadata.
-    mImpl->mStreamMetadata.reset(new StreamMetadata);
-    mImpl->mStreamMetadata->setSeekable(true);
-    io::setStreamMetadataPtr(inputStream(), mImpl->mStreamMetadata, /*transfer=*/false);
+    mStreamMetadata.reset(new StreamMetadata);
+    mStreamMetadata->setSeekable(true);
+    io::setStreamMetadataPtr(inputStream(), mStreamMetadata, /*transfer=*/false);
     Archive::setFormatVersion(inputStream());
     Archive::setLibraryVersion(inputStream());
     Archive::setDataCompression(inputStream());
 
     // Read in the VDB metadata.
-    mImpl->mMeta = MetaMap::Ptr(new MetaMap);
-    mImpl->mMeta->readMeta(inputStream());
+    mMeta = MetaMap::Ptr(new MetaMap);
+    mMeta->readMeta(inputStream());
 
     if (!inputHasGridOffsets()) {
-        OPENVDB_LOG_DEBUG_RUNTIME("file " << filename() << " does not support partial reading");
+        OPENVDB_LOG_DEBUG_RUNTIME("file " << mFilename << " does not support partial reading");
 
-        mImpl->mGrids.reset(new GridPtrVec);
-        mImpl->mNamedGrids.clear();
+        mGrids.reset(new GridPtrVec);
+        mNamedGrids.clear();
 
         // Stream in the entire contents of the file and append all grids to mGrids.
         const int32_t gridCount = readGridCount(inputStream());
@@ -287,16 +227,16 @@ File::open()
             GridBase::Ptr grid = createGrid(gd);
             Archive::readGrid(grid, gd, inputStream());
 
-            gridDescriptors().insert(std::make_pair(gd.gridName(), gd));
-            mImpl->mGrids->push_back(grid);
-            mImpl->mNamedGrids[gd.uniqueName()] = grid;
+            mGridDescriptors.insert(std::make_pair(gd.gridName(), gd));
+            mGrids->push_back(grid);
+            mNamedGrids[gd.uniqueName()] = grid;
         }
         // Connect instances (grids that share trees with other grids).
-        for (NameMapCIter it = gridDescriptors().begin(); it != gridDescriptors().end(); ++it) {
-            Archive::connectInstance(it->second, mImpl->mNamedGrids);
+        for (NameMapCIter it = mGridDescriptors.begin(); it != mGridDescriptors.end(); ++it) {
+            Archive::connectInstance(it->second, mNamedGrids);
         }
     } else {
-        gridDescriptors().clear();
+        mGridDescriptors.clear();
 
         for (int32_t i = 0, N = readGridCount(inputStream()); i < N; ++i) {
             // Read the grid descriptor.
@@ -305,14 +245,14 @@ File::open()
             gd.readStreamPos(inputStream());
 
             // Add the descriptor to the dictionary.
-            gridDescriptors().insert(std::make_pair(gd.gridName(), gd));
+            mGridDescriptors.insert(std::make_pair(gd.gridName(), gd));
 
             // Skip forward to the next descriptor.
             gd.seekToEnd(inputStream());
         }
     }
 
-    mImpl->mIsOpen = true;
+    mIsOpen = true;
     return newFile; // true if file is not identical to opened file
 }
 
@@ -321,14 +261,14 @@ void
 File::close()
 {
     // Reset all data.
-    mImpl->mMeta.reset();
-    mImpl->mGridDescriptors.clear();
-    mImpl->mGrids.reset();
-    mImpl->mNamedGrids.clear();
-    mImpl->mInStream.reset();
-    mImpl->mStreamMetadata.reset();
+    mMeta.reset();
+    mGridDescriptors.clear();
+    mGrids.reset();
+    mNamedGrids.clear();
+    mInStream.reset();
+    mStreamMetadata.reset();
 
-    mImpl->mIsOpen = false;
+    mIsOpen = false;
     setInputHasGridOffsets(true);
 }
 
@@ -339,44 +279,44 @@ File::close()
 bool
 File::hasGrid(const Name& name) const
 {
-    if (!isOpen()) {
-        OPENVDB_THROW(IoError, filename() << " is not open for reading");
+    if (!mIsOpen) {
+        OPENVDB_THROW(IoError, mFilename << " is not open for reading");
     }
-    return (findDescriptor(name) != gridDescriptors().end());
+    return (findDescriptor(name) != mGridDescriptors.end());
 }
 
 
 MetaMap::Ptr
 File::getMetadata() const
 {
-    if (!isOpen()) {
-        OPENVDB_THROW(IoError, filename() << " is not open for reading");
+    if (!mIsOpen) {
+        OPENVDB_THROW(IoError, mFilename << " is not open for reading");
     }
     // Return a deep copy of the file-level metadata, which was read
     // when the file was opened.
-    return MetaMap::Ptr(new MetaMap(*mImpl->mMeta));
+    return MetaMap::Ptr(new MetaMap(*mMeta));
 }
 
 
 GridPtrVecPtr
 File::getGrids() const
 {
-    if (!isOpen()) {
-        OPENVDB_THROW(IoError, filename() << " is not open for reading");
+    if (!mIsOpen) {
+        OPENVDB_THROW(IoError, mFilename << " is not open for reading");
     }
 
     GridPtrVecPtr ret;
     if (!inputHasGridOffsets()) {
         // If the input file doesn't have grid offsets, then all of the grids
         // have already been streamed in and stored in mGrids.
-        ret = mImpl->mGrids;
+        ret = mGrids;
     } else {
         ret.reset(new GridPtrVec);
 
         Archive::NamedGridMap namedGrids;
 
         // Read all grids represented by the GridDescriptors.
-        for (NameMapCIter i = gridDescriptors().begin(), e = gridDescriptors().end(); i != e; ++i) {
+        for (NameMapCIter i = mGridDescriptors.begin(), e = mGridDescriptors.end(); i != e; ++i) {
             const GridDescriptor& gd = i->second;
             GridBase::Ptr grid = readGrid(gd);
             ret->push_back(grid);
@@ -384,7 +324,7 @@ File::getGrids() const
         }
 
         // Connect instances (grids that share trees with other grids).
-        for (NameMapCIter i = gridDescriptors().begin(), e = gridDescriptors().end(); i != e; ++i) {
+        for (NameMapCIter i = mGridDescriptors.begin(), e = mGridDescriptors.end(); i != e; ++i) {
             Archive::connectInstance(i->second, namedGrids);
         }
     }
@@ -404,11 +344,11 @@ File::retrieveCachedGrid(const Name& name) const
 
     // Search by unique name.
     Archive::NamedGridMap::const_iterator it =
-        mImpl->mNamedGrids.find(GridDescriptor::stringAsUniqueName(name));
+        mNamedGrids.find(GridDescriptor::stringAsUniqueName(name));
     // If not found, search by grid name.
-    if (it == mImpl->mNamedGrids.end()) it = mImpl->mNamedGrids.find(name);
-    if (it == mImpl->mNamedGrids.end()) {
-        OPENVDB_THROW(KeyError, filename() << " has no grid named \"" << name << "\"");
+    if (it == mNamedGrids.end()) it = mNamedGrids.find(name);
+    if (it == mNamedGrids.end()) {
+        OPENVDB_THROW(KeyError, mFilename << " has no grid named \"" << name << "\"");
     }
     return it->second;
 }
@@ -420,8 +360,8 @@ File::retrieveCachedGrid(const Name& name) const
 GridPtrVecPtr
 File::readAllGridMetadata()
 {
-    if (!isOpen()) {
-        OPENVDB_THROW(IoError, filename() << " is not open for reading");
+    if (!mIsOpen) {
+        OPENVDB_THROW(IoError, mFilename << " is not open for reading");
     }
 
     if (fileVersion() < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION) {
@@ -434,13 +374,13 @@ File::readAllGridMetadata()
     if (!inputHasGridOffsets()) {
         // If the input file doesn't have grid offsets, then all of the grids
         // have already been streamed in and stored in mGrids.
-        for (size_t i = 0, N = mImpl->mGrids->size(); i < N; ++i) {
+        for (size_t i = 0, N = mGrids->size(); i < N; ++i) {
             // Return copies of the grids, but with empty trees.
-            ret->push_back((*mImpl->mGrids)[i]->copyGridWithNewTree());
+            ret->push_back((*mGrids)[i]->copyGridWithNewTree());
         }
     } else {
         // Read just the metadata and transforms for all grids.
-        for (NameMapCIter i = gridDescriptors().begin(), e = gridDescriptors().end(); i != e; ++i) {
+        for (NameMapCIter i = mGridDescriptors.begin(), e = mGridDescriptors.end(); i != e; ++i) {
             const GridDescriptor& gd = i->second;
             GridBase::ConstPtr grid = readGridPartial(gd);
             // Return copies of the grids, but with empty trees.
@@ -457,8 +397,8 @@ File::readAllGridMetadata()
 GridBase::Ptr
 File::readGridMetadata(const Name& name)
 {
-    if (!isOpen()) {
-        OPENVDB_THROW(IoError, filename() << " is not open for reading.");
+    if (!mIsOpen) {
+        OPENVDB_THROW(IoError, mFilename << " is not open for reading.");
     }
 
     if (fileVersion() < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION) {
@@ -473,8 +413,8 @@ File::readGridMetadata(const Name& name)
         ret = readGrid(name);
     } else {
         NameMapCIter it = findDescriptor(name);
-        if (it == gridDescriptors().end()) {
-            OPENVDB_THROW(KeyError, filename() << " has no grid named \"" << name << "\"");
+        if (it == mGridDescriptors.end()) {
+            OPENVDB_THROW(KeyError, mFilename << " has no grid named \"" << name << "\"");
         }
 
         // Seek to and read in the grid from the file.
@@ -498,8 +438,8 @@ File::readGrid(const Name& name)
 GridBase::Ptr
 File::readGrid(const Name& name, const BBoxd& bbox)
 {
-    if (!isOpen()) {
-        OPENVDB_THROW(IoError, filename() << " is not open for reading.");
+    if (!mIsOpen) {
+        OPENVDB_THROW(IoError, mFilename << " is not open for reading.");
     }
 
     const bool clip = bbox.isSorted();
@@ -517,8 +457,8 @@ File::readGrid(const Name& name, const BBoxd& bbox)
     }
 
     NameMapCIter it = findDescriptor(name);
-    if (it == gridDescriptors().end()) {
-        OPENVDB_THROW(KeyError, filename() << " has no grid named \"" << name << "\"");
+    if (it == mGridDescriptors.end()) {
+        OPENVDB_THROW(KeyError, mFilename << " has no grid named \"" << name << "\"");
     }
 
     // Seek to and read in the grid from the file.
@@ -529,11 +469,11 @@ File::readGrid(const Name& name, const BBoxd& bbox)
         /// @todo Refactor to share code with Archive::connectInstance()?
         NameMapCIter parentIt =
             findDescriptor(GridDescriptor::nameAsString(gd.instanceParentName()));
-        if (parentIt == gridDescriptors().end()) {
+        if (parentIt == mGridDescriptors.end()) {
             OPENVDB_THROW(KeyError, "missing instance parent \""
                 << GridDescriptor::nameAsString(gd.instanceParentName())
                 << "\" for grid " << GridDescriptor::nameAsString(gd.uniqueName())
-                << " in file " << filename());
+                << " in file " << mFilename);
         }
 
         GridBase::Ptr parent;
@@ -555,18 +495,18 @@ File::readGrid(const Name& name, const BBoxd& bbox)
 void
 File::writeGrids(const GridCPtrVec& grids, const MetaMap& meta) const
 {
-    if (isOpen()) {
+    if (mIsOpen) {
         OPENVDB_THROW(IoError,
-            filename() << " cannot be written because it is open for reading");
+            mFilename << " cannot be written because it is open for reading");
     }
 
     // Create a file stream and write it out.
     std::ofstream file;
-    file.open(filename().c_str(),
+    file.open(mFilename.c_str(),
         std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
 
     if (file.fail()) {
-        OPENVDB_THROW(IoError, "could not open " << filename() << " for writing");
+        OPENVDB_THROW(IoError, "could not open " << mFilename << " for writing");
     }
 
     // Write out the vdb.
@@ -586,20 +526,20 @@ File::findDescriptor(const Name& name) const
     const Name uniqueName = GridDescriptor::stringAsUniqueName(name);
 
     // Find all descriptors with the given grid name.
-    std::pair<NameMapCIter, NameMapCIter> range = gridDescriptors().equal_range(name);
+    std::pair<NameMapCIter, NameMapCIter> range = mGridDescriptors.equal_range(name);
 
     if (range.first == range.second) {
         // If no descriptors were found with the given grid name, the name might have
         // a suffix ("name[N]").  In that case, remove the "[N]" suffix and search again.
-        range = gridDescriptors().equal_range(GridDescriptor::stripSuffix(uniqueName));
+        range = mGridDescriptors.equal_range(GridDescriptor::stripSuffix(uniqueName));
     }
 
     const size_t count = size_t(std::distance(range.first, range.second));
     if (count > 1 && name == uniqueName) {
-        OPENVDB_LOG_WARN(filename() << " has more than one grid named \"" << name << "\"");
+        OPENVDB_LOG_WARN(mFilename << " has more than one grid named \"" << name << "\"");
     }
 
-    NameMapCIter ret = gridDescriptors().end();
+    NameMapCIter ret = mGridDescriptors.end();
 
     if (count > 0) {
         if (name == uniqueName) {
@@ -632,7 +572,7 @@ File::createGrid(const GridDescriptor& gd) const
     if (!GridBase::isRegistered(gd.gridType())) {
         OPENVDB_THROW(KeyError, "Cannot read grid "
             << GridDescriptor::nameAsString(gd.uniqueName())
-            << " from " << filename() << ": grid type "
+            << " from " << mFilename << ": grid type "
             << gd.gridType() << " is not registered");
     }
 
@@ -679,21 +619,39 @@ File::readGridPartial(const GridDescriptor& gd) const
 GridBase::Ptr
 File::readGrid(const GridDescriptor& gd) const
 {
-    return Impl::readGrid(*this, gd, Impl::NoBBox());
+    // This method should not be called for files that don't contain grid offsets.
+    OPENVDB_ASSERT(inputHasGridOffsets());
+
+    GridBase::Ptr grid = createGrid(gd);
+    gd.seekToGrid(inputStream());
+    Archive::readGrid(grid, gd, inputStream());
+    return grid;
 }
 
 
 GridBase::Ptr
 File::readGrid(const GridDescriptor& gd, const BBoxd& bbox) const
 {
-    return Impl::readGrid(*this, gd, bbox);
+    // This method should not be called for files that don't contain grid offsets.
+    OPENVDB_ASSERT(inputHasGridOffsets());
+
+    GridBase::Ptr grid = createGrid(gd);
+    gd.seekToGrid(inputStream());
+    Archive::readGrid(grid, gd, inputStream(), bbox);
+    return grid;
 }
 
 
 GridBase::Ptr
 File::readGrid(const GridDescriptor& gd, const CoordBBox& bbox) const
 {
-    return Impl::readGrid(*this, gd, bbox);
+    // This method should not be called for files that don't contain grid offsets.
+    OPENVDB_ASSERT(inputHasGridOffsets());
+
+    GridBase::Ptr grid = createGrid(gd);
+    gd.seekToGrid(inputStream());
+    Archive::readGrid(grid, gd, inputStream(), bbox);
+    return grid;
 }
 
 
@@ -703,17 +661,17 @@ File::readGrid(const GridDescriptor& gd, const CoordBBox& bbox) const
 File::NameIterator
 File::beginName() const
 {
-    if (!isOpen()) {
-        OPENVDB_THROW(IoError, filename() << " is not open for reading");
+    if (!mIsOpen) {
+        OPENVDB_THROW(IoError, mFilename << " is not open for reading");
     }
-    return File::NameIterator(gridDescriptors().begin());
+    return File::NameIterator(mGridDescriptors.begin());
 }
 
 
 File::NameIterator
 File::endName() const
 {
-    return File::NameIterator(gridDescriptors().end());
+    return File::NameIterator(mGridDescriptors.end());
 }
 
 } // namespace io

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -281,7 +281,8 @@ File::open()
         const int32_t gridCount = readGridCount(inputStream());
         for (int32_t i = 0; i < gridCount; ++i) {
             GridDescriptor gd;
-            gd.read(inputStream());
+            gd.readHeader(inputStream());
+            gd.readStreamPos(inputStream());
 
             GridBase::Ptr grid = createGrid(gd);
             Archive::readGrid(grid, gd, inputStream());
@@ -584,7 +585,8 @@ File::readGridDescriptors(std::istream& is)
     for (int32_t i = 0, N = readGridCount(is); i < N; ++i) {
         // Read the grid descriptor.
         GridDescriptor gd;
-        gd.read(is);
+        gd.readHeader(is);
+        gd.readStreamPos(is);
 
         // Add the descriptor to the dictionary.
         gridDescriptors().insert(std::make_pair(gd.gridName(), gd));

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -491,19 +491,12 @@ File::readGridMetadata(const Name& name)
 GridBase::Ptr
 File::readGrid(const Name& name)
 {
-    return readGridByName(name, BBoxd());
+    return readGrid(name, BBoxd());
 }
 
 
 GridBase::Ptr
 File::readGrid(const Name& name, const BBoxd& bbox)
-{
-    return readGridByName(name, bbox);
-}
-
-
-GridBase::Ptr
-File::readGridByName(const Name& name, const BBoxd& bbox)
 {
     if (!isOpen()) {
         OPENVDB_THROW(IoError, filename() << " is not open for reading.");

--- a/openvdb/openvdb/io/File.h
+++ b/openvdb/openvdb/io/File.h
@@ -146,9 +146,6 @@ public:
     NameIterator endName() const;
 
 private:
-    /// Read in all grid descriptors that are stored in the given stream.
-    void readGridDescriptors(std::istream&);
-
     /// @brief Return an iterator to the descriptor for the grid with the given name.
     /// If the name is non-unique, return an iterator to the first matching descriptor.
     NameMapCIter findDescriptor(const Name&) const;

--- a/openvdb/openvdb/io/File.h
+++ b/openvdb/openvdb/io/File.h
@@ -34,7 +34,7 @@ public:
     using NameMapCIter = NameMap::const_iterator;
 
     explicit File(const std::string& filename);
-    ~File() override;
+    ~File() override { }
 
     /// @brief Copy constructor
     /// @details The copy will be closed and will not reference the same
@@ -183,8 +183,22 @@ private:
     friend class ::TestFile;
     friend class ::TestStream;
 
-    struct Impl;
-    std::unique_ptr<Impl> mImpl;
+    std::string mFilename;
+    // The file-level metadata
+    MetaMap::Ptr mMeta;
+    // The file stream that is open for reading
+    std::unique_ptr<std::istream> mInStream;
+    // File-level stream metadata (file format, compression, etc.)
+    StreamMetadata::Ptr mStreamMetadata;
+    // Flag indicating if we have read in the global information (header,
+    // metadata, and grid descriptors) for this VDB file
+    bool mIsOpen = false;
+    // Grid descriptors for all grids stored in the file, indexed by grid name
+    NameMap mGridDescriptors;
+    // All grids, indexed by unique name (used only when mHasGridOffsets is false)
+    Archive::NamedGridMap mNamedGrids;
+    // All grids stored in the file (used only when mHasGridOffsets is false)
+    GridPtrVecPtr mGrids;
 };
 
 

--- a/openvdb/openvdb/io/File.h
+++ b/openvdb/openvdb/io/File.h
@@ -153,10 +153,6 @@ private:
     /// Return a newly created, empty grid of the type specified by the given grid descriptor.
     GridBase::Ptr createGrid(const GridDescriptor&) const;
 
-    /// @brief Read a grid, including its data blocks, but only where it
-    /// intersects the given world-space bounding box.
-    GridBase::Ptr readGridByName(const Name&, const BBoxd&);
-
     /// Read in and return the partially-populated grid specified by the given grid descriptor.
     GridBase::ConstPtr readGridPartial(const GridDescriptor&, bool readTopology) const;
 

--- a/openvdb/openvdb/io/File.h
+++ b/openvdb/openvdb/io/File.h
@@ -156,14 +156,9 @@ private:
     /// Read in and return the partially-populated grid specified by the given grid descriptor.
     GridBase::ConstPtr readGridPartial(const GridDescriptor&) const;
 
-    /// Read in and return the grid specified by the given grid descriptor.
-    GridBase::Ptr readGrid(const GridDescriptor&) const;
     /// Read in and return the region of the grid specified by the given grid descriptor
     /// that intersects the given world-space bounding box.
     GridBase::Ptr readGrid(const GridDescriptor&, const BBoxd&) const;
-    /// Read in and return the region of the grid specified by the given grid descriptor
-    /// that intersects the given index-space bounding box.
-    GridBase::Ptr readGrid(const GridDescriptor&, const CoordBBox&) const;
 
     /// @brief Retrieve a grid from @c mNamedGrids.  Return a null pointer
     /// if @c mNamedGrids was not populated (because this file is random-access).

--- a/openvdb/openvdb/io/File.h
+++ b/openvdb/openvdb/io/File.h
@@ -150,16 +150,6 @@ private:
     /// If the name is non-unique, return an iterator to the first matching descriptor.
     NameMapCIter findDescriptor(const Name&) const;
 
-    /// Return a newly created, empty grid of the type specified by the given grid descriptor.
-    GridBase::Ptr createGrid(const GridDescriptor&) const;
-
-    /// Read in and return the partially-populated grid specified by the given grid descriptor.
-    GridBase::ConstPtr readGridPartial(const GridDescriptor&) const;
-
-    /// Read in and return the region of the grid specified by the given grid descriptor
-    /// that intersects the given world-space bounding box.
-    GridBase::Ptr readGrid(const GridDescriptor&, const BBoxd&) const;
-
     /// @brief Retrieve a grid from @c mNamedGrids.  Return a null pointer
     /// if @c mNamedGrids was not populated (because this file is random-access).
     /// @throw KeyError if no grid with the given name exists in this file.

--- a/openvdb/openvdb/io/File.h
+++ b/openvdb/openvdb/io/File.h
@@ -154,7 +154,7 @@ private:
     GridBase::Ptr createGrid(const GridDescriptor&) const;
 
     /// Read in and return the partially-populated grid specified by the given grid descriptor.
-    GridBase::ConstPtr readGridPartial(const GridDescriptor&, bool readTopology) const;
+    GridBase::ConstPtr readGridPartial(const GridDescriptor&) const;
 
     /// Read in and return the grid specified by the given grid descriptor.
     GridBase::Ptr readGrid(const GridDescriptor&) const;
@@ -164,10 +164,6 @@ private:
     /// Read in and return the region of the grid specified by the given grid descriptor
     /// that intersects the given index-space bounding box.
     GridBase::Ptr readGrid(const GridDescriptor&, const CoordBBox&) const;
-
-    /// @brief Partially populate the given grid by reading its metadata and transform and,
-    /// if the grid is not an instance, its tree structure, but not the tree's leaf nodes.
-    void readGridPartial(GridBase::Ptr, std::istream&, bool isInstance, bool readTopology) const;
 
     /// @brief Retrieve a grid from @c mNamedGrids.  Return a null pointer
     /// if @c mNamedGrids was not populated (because this file is random-access).

--- a/openvdb/openvdb/io/GridDescriptor.cc
+++ b/openvdb/openvdb/io/GridDescriptor.cc
@@ -69,8 +69,8 @@ GridDescriptor::writeStreamPos(std::ostream &os) const
     os.write(reinterpret_cast<const char*>(&mEndPos), sizeof(int64_t));
 }
 
-GridBase::Ptr
-GridDescriptor::read(std::istream &is)
+void
+GridDescriptor::readHeader(std::istream &is)
 {
     checkFormatVersion(is);
 
@@ -86,21 +86,28 @@ GridDescriptor::read(std::istream &is)
     }
 
     mInstanceParentName = readString(is);
+}
 
-    // Create the grid of the type if it has been registered.
+void
+GridDescriptor::readStreamPos(std::istream &is)
+{
+    is.read(reinterpret_cast<char*>(&mGridPos), sizeof(int64_t));
+    is.read(reinterpret_cast<char*>(&mBlockPos), sizeof(int64_t));
+    is.read(reinterpret_cast<char*>(&mEndPos), sizeof(int64_t));
+}
+
+GridBase::Ptr
+GridDescriptor::read(std::istream &is)
+{
+    readHeader(is);
+    readStreamPos(is);
+
     if (!GridBase::isRegistered(mGridType)) {
         OPENVDB_THROW(LookupError, "Cannot read grid." <<
             " Grid type " << mGridType << " is not registered.");
     }
-    // else
     GridBase::Ptr grid = GridBase::createGrid(mGridType);
     if (grid) grid->setSaveFloatAsHalf(mSaveFloatAsHalf);
-
-    // Read in the offsets.
-    is.read(reinterpret_cast<char*>(&mGridPos), sizeof(int64_t));
-    is.read(reinterpret_cast<char*>(&mBlockPos), sizeof(int64_t));
-    is.read(reinterpret_cast<char*>(&mEndPos), sizeof(int64_t));
-
     return grid;
 }
 

--- a/openvdb/openvdb/io/GridDescriptor.h
+++ b/openvdb/openvdb/io/GridDescriptor.h
@@ -61,8 +61,18 @@ public:
     /// written out separately.
     void writeStreamPos(std::ostream&) const;
 
+    /// @brief Read this descriptor's header information (all data except for
+    /// stream offsets) from the given stream.
+    void readHeader(std::istream&);
+
+    /// @brief Read stream positions (grid, block, and end offsets) from the
+    /// given stream.
+    void readStreamPos(std::istream&);
+
     /// @brief Read a grid descriptor from the given stream.
     /// @return an empty grid of the type specified by the grid descriptor.
+    /// @deprecated Use readHeader() followed by readStreamPos() instead.
+    OPENVDB_DEPRECATED_MESSAGE("Use readHeader() followed by readStreamPos() instead.")
     GridBase::Ptr read(std::istream&);
 
     /// @brief Append the number @a n to the given name (separated by an ASCII

--- a/openvdb/openvdb/io/Stream.cc
+++ b/openvdb/openvdb/io/Stream.cc
@@ -114,7 +114,7 @@ Stream::readGrid(const GridDescriptor& gd, std::istream& is) const
         grid = GridBase::createGrid(gd.gridType());
         if (grid) grid->setSaveFloatAsHalf(gd.saveFloatAsHalf());
 
-        Archive::readGrid(grid, gd, is);
+        Archive::readGrid(grid, gd, is, BBoxd());
     }
     return grid;
 }

--- a/openvdb/openvdb/io/Stream.cc
+++ b/openvdb/openvdb/io/Stream.cc
@@ -51,7 +51,7 @@ Stream::Stream(std::istream& is)
         gd.readHeader(is);
         gd.readStreamPos(is);
         descriptors.push_back(gd);
-        GridBase::Ptr grid = readGrid(gd, is);
+        GridBase::Ptr grid = Archive::readGrid(gd, is, BBoxd());
         mGrids->push_back(grid);
         namedGrids[gd.uniqueName()] = grid;
     }
@@ -99,25 +99,6 @@ Stream::copy() const
 
 
 ////////////////////////////////////////
-
-
-GridBase::Ptr
-Stream::readGrid(const GridDescriptor& gd, std::istream& is) const
-{
-    GridBase::Ptr grid;
-
-    if (!GridBase::isRegistered(gd.gridType())) {
-        OPENVDB_THROW(TypeError, "can't read grid \""
-            << GridDescriptor::nameAsString(gd.uniqueName()) <<
-            "\" from input stream because grid type " << gd.gridType() << " is unknown");
-    } else {
-        grid = GridBase::createGrid(gd.gridType());
-        if (grid) grid->setSaveFloatAsHalf(gd.saveFloatAsHalf());
-
-        Archive::readGrid(grid, gd, is, BBoxd());
-    }
-    return grid;
-}
 
 
 void

--- a/openvdb/openvdb/io/Stream.cc
+++ b/openvdb/openvdb/io/Stream.cc
@@ -19,32 +19,8 @@ OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
 namespace io {
 
-struct Stream::Impl
-{
-    Impl(): mOutputStream{nullptr} {}
-    Impl(const Impl& other) { *this = other; }
-    Impl& operator=(const Impl& other)
-    {
-        if (&other != this) {
-            mMeta = other.mMeta; ///< @todo deep copy?
-            mGrids = other.mGrids; ///< @todo deep copy?
-            mOutputStream = other.mOutputStream;
-            mFile.reset();
-        }
-        return *this;
-    }
 
-    MetaMap::Ptr mMeta;
-    GridPtrVecPtr mGrids;
-    std::ostream* mOutputStream;
-    std::unique_ptr<File> mFile;
-};
-
-
-////////////////////////////////////////
-
-
-Stream::Stream(std::istream& is): mImpl(new Impl)
+Stream::Stream(std::istream& is)
 {
     if (!is) return;
 
@@ -59,14 +35,14 @@ Stream::Stream(std::istream& is): mImpl(new Impl)
     io::setDataCompression(is, compression());
 
     // Read in the VDB metadata.
-    mImpl->mMeta.reset(new MetaMap);
-    mImpl->mMeta->readMeta(is);
+    mMeta.reset(new MetaMap);
+    mMeta->readMeta(is);
 
     // Read in the number of grids.
     const int32_t gridCount = readGridCount(is);
 
     // Read in all grids and insert them into mGrids.
-    mImpl->mGrids.reset(new GridPtrVec);
+    mGrids.reset(new GridPtrVec);
     std::vector<GridDescriptor> descriptors;
     descriptors.reserve(gridCount);
     Archive::NamedGridMap namedGrids;
@@ -76,7 +52,7 @@ Stream::Stream(std::istream& is): mImpl(new Impl)
         gd.readStreamPos(is);
         descriptors.push_back(gd);
         GridBase::Ptr grid = readGrid(gd, is);
-        mImpl->mGrids->push_back(grid);
+        mGrids->push_back(grid);
         namedGrids[gd.uniqueName()] = grid;
     }
 
@@ -87,23 +63,18 @@ Stream::Stream(std::istream& is): mImpl(new Impl)
 }
 
 
-Stream::Stream(): mImpl(new Impl)
+Stream::Stream(std::ostream& os)
+    : Archive()
+    , mOutputStream(&os)
 {
 }
 
 
-Stream::Stream(std::ostream& os): mImpl(new Impl)
-{
-    mImpl->mOutputStream = &os;
-}
-
-
-Stream::~Stream()
-{
-}
-
-
-Stream::Stream(const Stream& other): Archive(other), mImpl(new Impl(*other.mImpl))
+Stream::Stream(const Stream& other)
+    : Archive(other)
+    , mMeta(other.mMeta)
+    , mGrids(other.mGrids)
+    , mOutputStream(other.mOutputStream)
 {
 }
 
@@ -112,7 +83,9 @@ Stream&
 Stream::operator=(const Stream& other)
 {
     if (&other != this) {
-        mImpl.reset(new Impl(*other.mImpl));
+        mMeta = other.mMeta;
+        mGrids = other.mGrids;
+        mOutputStream = other.mOutputStream;
     }
     return *this;
 }
@@ -150,10 +123,10 @@ Stream::readGrid(const GridDescriptor& gd, std::istream& is) const
 void
 Stream::write(const GridCPtrVec& grids, const MetaMap& metadata) const
 {
-    if (mImpl->mOutputStream == nullptr) {
+    if (mOutputStream == nullptr) {
         OPENVDB_THROW(ValueError, "no output stream was specified");
     }
-    this->writeGrids(*mImpl->mOutputStream, grids, metadata);
+    this->writeGrids(*mOutputStream, grids, metadata);
 }
 
 
@@ -171,10 +144,10 @@ MetaMap::Ptr
 Stream::getMetadata() const
 {
     MetaMap::Ptr result;
-    if (mImpl->mMeta) {
+    if (mMeta) {
         // Return a deep copy of the file-level metadata
         // that was read when this object was constructed.
-        result.reset(new MetaMap(*mImpl->mMeta));
+        result.reset(new MetaMap(*mMeta));
     }
     return result;
 }
@@ -183,7 +156,7 @@ Stream::getMetadata() const
 GridPtrVecPtr
 Stream::getGrids()
 {
-    return mImpl->mGrids;
+    return mGrids;
 }
 
 } // namespace io

--- a/openvdb/openvdb/io/Stream.cc
+++ b/openvdb/openvdb/io/Stream.cc
@@ -72,7 +72,8 @@ Stream::Stream(std::istream& is): mImpl(new Impl)
     Archive::NamedGridMap namedGrids;
     for (int32_t i = 0; i < gridCount; ++i) {
         GridDescriptor gd;
-        gd.read(is);
+        gd.readHeader(is);
+        gd.readStreamPos(is);
         descriptors.push_back(gd);
         GridBase::Ptr grid = readGrid(gd, is);
         mImpl->mGrids->push_back(grid);

--- a/openvdb/openvdb/io/Stream.h
+++ b/openvdb/openvdb/io/Stream.h
@@ -29,14 +29,14 @@ public:
     Stream(std::istream& is, bool /*delayLoad*/) : Stream(is) { }
 
     /// Construct an archive for stream output.
-    Stream();
+    Stream() = default;
     /// Construct an archive for output to the given stream.
     explicit Stream(std::ostream&);
 
     Stream(const Stream&);
     Stream& operator=(const Stream&);
 
-    ~Stream() override;
+    ~Stream() override { }
 
     /// @brief Return a copy of this archive.
     Archive::Ptr copy() const override;
@@ -64,9 +64,9 @@ private:
 
     void writeGrids(std::ostream&, const GridCPtrVec&, const MetaMap&) const;
 
-
-    struct Impl;
-    std::unique_ptr<Impl> mImpl;
+    MetaMap::Ptr mMeta;
+    GridPtrVecPtr mGrids;
+    std::ostream* mOutputStream = nullptr;
 };
 
 

--- a/openvdb/openvdb/io/Stream.h
+++ b/openvdb/openvdb/io/Stream.h
@@ -57,11 +57,6 @@ public:
     void write(const GridPtrContainerT&, const MetaMap& = MetaMap()) const;
 
 private:
-    /// Create a new grid of the type specified by the given descriptor,
-    /// then populate the grid from the given input stream.
-    /// @return the newly created grid.
-    GridBase::Ptr readGrid(const GridDescriptor&, std::istream&) const;
-
     void writeGrids(std::ostream&, const GridCPtrVec&, const MetaMap&) const;
 
     MetaMap::Ptr mMeta;

--- a/openvdb/openvdb/unittest/TestFile.cc
+++ b/openvdb/openvdb/unittest/TestFile.cc
@@ -158,21 +158,7 @@ TestFile::testWriteGrid()
     gd2.readHeader(istr);
     gd2.readStreamPos(istr);
 
-    // manually create the grid
-    GridBase::Ptr gd2_grid = GridBase::createGrid(gd2.gridType());
-
-    EXPECT_EQ(gd.gridName(), gd2.gridName());
-    EXPECT_EQ(GridType::gridType(), gd2_grid->type());
-    EXPECT_EQ(gd.getGridPos(), gd2.getGridPos());
-    EXPECT_EQ(gd.getBlockPos(), gd2.getBlockPos());
-    EXPECT_EQ(gd.getEndPos(), gd2.getEndPos());
-
-    // Position the stream to beginning of the grid storage and read the grid.
-    gd2.seekToGrid(istr);
-    Archive::readGridCompression(istr);
-    gd2_grid->readMeta(istr);
-    gd2_grid->readTransform(istr);
-    gd2_grid->readTopology(istr);
+    GridBase::Ptr gd2_grid = Archive::readGrid(gd2, istr, BBoxd());
 
     // Delay load metadata should not exist.
     ASSERT_FALSE(bool((*gd2_grid)["file_delayed_load"]));
@@ -192,9 +178,6 @@ TestFile::testWriteGrid()
     EXPECT_EQ(
         grid->baseTree().treeDepth(), gd2_grid->baseTree().treeDepth());
 
-    // Read in the data blocks.
-    gd2.seekToBlocks(istr);
-    gd2_grid->readBuffers(istr);
     TreeType::Ptr tree2 = DynamicPtrCast<TreeType>(gd2_grid->baseTreePtr());
     EXPECT_TRUE(tree2.get() != nullptr);
     EXPECT_EQ(10, tree2->getValue(Coord(10, 1, 2)));
@@ -260,7 +243,8 @@ TestFile::testWriteMultipleGrids()
 
     gd_in.readHeader(istr);
     gd_in.readStreamPos(istr);
-    GridBase::Ptr gd_in_grid = GridBase::createGrid(gd_in.gridType());
+
+    GridBase::Ptr gd_in_grid = Archive::readGrid(gd_in, istr, BBoxd());
 
     // Ensure read in the right values.
     EXPECT_EQ(gd.gridName(), gd_in.gridName());
@@ -268,13 +252,6 @@ TestFile::testWriteMultipleGrids()
     EXPECT_EQ(gd.getGridPos(), gd_in.getGridPos());
     EXPECT_EQ(gd.getBlockPos(), gd_in.getBlockPos());
     EXPECT_EQ(gd.getEndPos(), gd_in.getEndPos());
-
-    // Position the stream to beginning of the grid storage and read the grid.
-    gd_in.seekToGrid(istr);
-    Archive::readGridCompression(istr);
-    gd_in_grid->readMeta(istr);
-    gd_in_grid->readTransform(istr);
-    gd_in_grid->readTopology(istr);
 
     // Ensure that we have the same topology and transform.
     EXPECT_EQ(
@@ -289,8 +266,6 @@ TestFile::testWriteMultipleGrids()
     // EXPECT_EQ(0.1, gd_in_grid->getTransform()->getVoxelSizeZ());
 
     // Read in the data blocks.
-    gd_in.seekToBlocks(istr);
-    gd_in_grid->readBuffers(istr);
     TreeType::Ptr grid_in = DynamicPtrCast<TreeType>(gd_in_grid->baseTreePtr());
     EXPECT_TRUE(grid_in.get() != nullptr);
     EXPECT_EQ(10, grid_in->getValue(Coord(10, 1, 2)));
@@ -306,7 +281,7 @@ TestFile::testWriteMultipleGrids()
     GridDescriptor gd2_in;
     gd2_in.readHeader(istr);
     gd2_in.readStreamPos(istr);
-    GridBase::Ptr gd2_in_grid = GridBase::createGrid(gd2_in.gridType());
+    GridBase::Ptr gd2_in_grid = Archive::readGrid(gd2_in, istr, BBoxd());
 
     // Ensure that we read in the right values.
     EXPECT_EQ(gd2.gridName(), gd2_in.gridName());
@@ -314,13 +289,6 @@ TestFile::testWriteMultipleGrids()
     EXPECT_EQ(gd2.getGridPos(), gd2_in.getGridPos());
     EXPECT_EQ(gd2.getBlockPos(), gd2_in.getBlockPos());
     EXPECT_EQ(gd2.getEndPos(), gd2_in.getEndPos());
-
-    // Position the stream to beginning of the grid storage and read the grid.
-    gd2_in.seekToGrid(istr);
-    Archive::readGridCompression(istr);
-    gd2_in_grid->readMeta(istr);
-    gd2_in_grid->readTransform(istr);
-    gd2_in_grid->readTopology(istr);
 
     // Ensure that we have the same topology and transform.
     EXPECT_EQ(
@@ -333,9 +301,6 @@ TestFile::testWriteMultipleGrids()
     // EXPECT_EQ(0.2, gd2_in_grid->getTransform()->getVoxelSizeY());
     // EXPECT_EQ(0.2, gd2_in_grid->getTransform()->getVoxelSizeZ());
 
-    // Read in the data blocks.
-    gd2_in.seekToBlocks(istr);
-    gd2_in_grid->readBuffers(istr);
     TreeType::Ptr grid2_in = DynamicPtrCast<TreeType>(gd2_in_grid->baseTreePtr());
     EXPECT_TRUE(grid2_in.get() != nullptr);
     EXPECT_EQ(50, grid2_in->getValue(Coord(1000, 1000, 1000)));
@@ -922,11 +887,7 @@ TestFile::testEmptyGridIO()
     EXPECT_TRUE(it != file2.mGridDescriptors.end());
     GridDescriptor file2gd = it->second;
     file2gd.seekToGrid(istr);
-    GridBase::Ptr gd_grid = GridBase::createGrid(file2gd.gridType());
-    Archive::readGridCompression(istr);
-    gd_grid->readMeta(istr);
-    gd_grid->readTransform(istr);
-    gd_grid->readTopology(istr);
+    GridBase::Ptr gd_grid = Archive::readGrid(file2gd, istr, BBoxd());
     EXPECT_EQ(gd.gridName(), file2gd.gridName());
     EXPECT_TRUE(gd_grid.get() != nullptr);
     EXPECT_EQ(0, int(gd_grid->baseTree().leafCount()));
@@ -940,11 +901,7 @@ TestFile::testEmptyGridIO()
     EXPECT_TRUE(it != file2.mGridDescriptors.end());
     file2gd = it->second;
     file2gd.seekToGrid(istr);
-    gd_grid = GridBase::createGrid(file2gd.gridType());
-    Archive::readGridCompression(istr);
-    gd_grid->readMeta(istr);
-    gd_grid->readTransform(istr);
-    gd_grid->readTopology(istr);
+    gd_grid = Archive::readGrid(file2gd, istr, BBoxd());
     EXPECT_EQ(gd2.gridName(), file2gd.gridName());
     EXPECT_TRUE(gd_grid.get() != nullptr);
     EXPECT_EQ(0, int(gd_grid->baseTree().leafCount()));

--- a/openvdb/openvdb/unittest/TestFile.cc
+++ b/openvdb/openvdb/unittest/TestFile.cc
@@ -636,11 +636,27 @@ TestFile::testReadGridDescriptors()
     File file2("something.vdb2");
     std::istringstream istr(ostr.str(), std::ios_base::binary);
     io::setCurrentVersion(istr);
-    file2.readGridDescriptors(istr);
+    // file2.readGridDescriptors(istr);
+    ////////////////////////////
+    file2.mGridDescriptors.clear();
+
+    for (int32_t i = 0, N = file2.readGridCount(istr); i < N; ++i) {
+        // Read the grid descriptor.
+        GridDescriptor gd;
+        gd.readHeader(istr);
+        gd.readStreamPos(istr);
+
+        // Add the descriptor to the dictionary.
+        file2.mGridDescriptors.insert(std::make_pair(gd.gridName(), gd));
+
+        // Skip forward to the next descriptor.
+        gd.seekToEnd(istr);
+    }
+    ////////////////////////////
 
     // Compare with the initial grid descriptors.
     File::NameMapCIter it = file2.findDescriptor("temperature");
-    EXPECT_TRUE(it != file2.gridDescriptors().end());
+    EXPECT_TRUE(it != file2.mGridDescriptors.end());
     GridDescriptor file2gd = it->second;
     EXPECT_EQ(gd.gridName(), file2gd.gridName());
     EXPECT_EQ(gd.getGridPos(), file2gd.getGridPos());
@@ -648,7 +664,7 @@ TestFile::testReadGridDescriptors()
     EXPECT_EQ(gd.getEndPos(), file2gd.getEndPos());
 
     it = file2.findDescriptor("density");
-    EXPECT_TRUE(it != file2.gridDescriptors().end());
+    EXPECT_TRUE(it != file2.mGridDescriptors.end());
     file2gd = it->second;
     EXPECT_EQ(gd2.gridName(), file2gd.gridName());
     EXPECT_EQ(gd2.getGridPos(), file2gd.getGridPos());
@@ -883,11 +899,27 @@ TestFile::testEmptyGridIO()
     File file2(filename);
     std::istringstream istr(ostr.str(), std::ios_base::binary);
     io::setCurrentVersion(istr);
-    file2.readGridDescriptors(istr);
+    // file2.readGridDescriptors(istr);
+    ////////////////////////////
+    file2.mGridDescriptors.clear();
+
+    for (int32_t i = 0, N = file2.readGridCount(istr); i < N; ++i) {
+        // Read the grid descriptor.
+        GridDescriptor gd;
+        gd.readHeader(istr);
+        gd.readStreamPos(istr);
+
+        // Add the descriptor to the dictionary.
+        file2.mGridDescriptors.insert(std::make_pair(gd.gridName(), gd));
+
+        // Skip forward to the next descriptor.
+        gd.seekToEnd(istr);
+    }
+    ////////////////////////////
 
     // Compare with the initial grid descriptors.
     File::NameMapCIter it = file2.findDescriptor("temperature");
-    EXPECT_TRUE(it != file2.gridDescriptors().end());
+    EXPECT_TRUE(it != file2.mGridDescriptors.end());
     GridDescriptor file2gd = it->second;
     file2gd.seekToGrid(istr);
     GridBase::Ptr gd_grid = GridBase::createGrid(file2gd.gridType());
@@ -905,7 +937,7 @@ TestFile::testEmptyGridIO()
     EXPECT_EQ(gd.getEndPos(), file2gd.getEndPos());
 
     it = file2.findDescriptor("density");
-    EXPECT_TRUE(it != file2.gridDescriptors().end());
+    EXPECT_TRUE(it != file2.mGridDescriptors.end());
     file2gd = it->second;
     file2gd.seekToGrid(istr);
     gd_grid = GridBase::createGrid(file2gd.gridType());
@@ -1000,16 +1032,16 @@ void TestFile::testOpen()
     EXPECT_EQ(2009, vdbfile.getMetadata()->metaValue<int32_t>("year"));
 
     // Ensure we got the grid descriptors.
-    EXPECT_EQ(1, int(vdbfile.gridDescriptors().count("density")));
-    EXPECT_EQ(1, int(vdbfile.gridDescriptors().count("temperature")));
+    EXPECT_EQ(1, int(vdbfile.mGridDescriptors.count("density")));
+    EXPECT_EQ(1, int(vdbfile.mGridDescriptors.count("temperature")));
 
     io::File::NameMapCIter it = vdbfile.findDescriptor("density");
-    EXPECT_TRUE(it != vdbfile.gridDescriptors().end());
+    EXPECT_TRUE(it != vdbfile.mGridDescriptors.end());
     io::GridDescriptor gd = it->second;
     EXPECT_EQ(IntTree::treeType(), gd.gridType());
 
     it = vdbfile.findDescriptor("temperature");
-    EXPECT_TRUE(it != vdbfile.gridDescriptors().end());
+    EXPECT_TRUE(it != vdbfile.mGridDescriptors.end());
     gd = it->second;
     EXPECT_EQ(FloatTree::treeType(), gd.gridType());
 
@@ -1021,8 +1053,8 @@ void TestFile::testOpen()
     // Test closing the file.
     vdbfile.close();
     EXPECT_TRUE(vdbfile.isOpen() == false);
-    EXPECT_TRUE(vdbfile.fileMetadata().get() == nullptr);
-    EXPECT_EQ(0, int(vdbfile.gridDescriptors().size()));
+    EXPECT_TRUE(vdbfile.mMeta.get() == nullptr);
+    EXPECT_EQ(0, int(vdbfile.mGridDescriptors.size()));
     EXPECT_THROW(vdbfile.inputStream(), openvdb::IoError);
 
     remove("something.vdb2");

--- a/openvdb/openvdb/unittest/TestFile.cc
+++ b/openvdb/openvdb/unittest/TestFile.cc
@@ -154,9 +154,12 @@ TestFile::testWriteGrid()
     // it doesn't have a header), set the file format version number explicitly.
     io::setCurrentVersion(istr);
 
-    GridBase::Ptr gd2_grid;
     istr.seekg(0, std::ios_base::beg);
-    EXPECT_NO_THROW(gd2_grid = gd2.read(istr));
+    gd2.readHeader(istr);
+    gd2.readStreamPos(istr);
+
+    // manually create the grid
+    GridBase::Ptr gd2_grid = GridBase::createGrid(gd2.gridType());
 
     EXPECT_EQ(gd.gridName(), gd2.gridName());
     EXPECT_EQ(GridType::gridType(), gd2_grid->type());
@@ -255,8 +258,9 @@ TestFile::testWriteMultipleGrids()
     std::istringstream istr(ostr.str(), std::ios_base::binary);
     io::setCurrentVersion(istr);
 
-    GridBase::Ptr gd_in_grid;
-    EXPECT_NO_THROW(gd_in_grid = gd_in.read(istr));
+    gd_in.readHeader(istr);
+    gd_in.readStreamPos(istr);
+    GridBase::Ptr gd_in_grid = GridBase::createGrid(gd_in.gridType());
 
     // Ensure read in the right values.
     EXPECT_EQ(gd.gridName(), gd_in.gridName());
@@ -300,8 +304,9 @@ TestFile::testWriteMultipleGrids()
     gd_in.seekToEnd(istr);
 
     GridDescriptor gd2_in;
-    GridBase::Ptr gd2_in_grid;
-    EXPECT_NO_THROW(gd2_in_grid = gd2_in.read(istr));
+    gd2_in.readHeader(istr);
+    gd2_in.readStreamPos(istr);
+    GridBase::Ptr gd2_in_grid = GridBase::createGrid(gd2_in.gridType());
 
     // Ensure that we read in the right values.
     EXPECT_EQ(gd2.gridName(), gd2_in.gridName());

--- a/openvdb/openvdb/unittest/TestGridDescriptor.cc
+++ b/openvdb/openvdb/unittest/TestGridDescriptor.cc
@@ -42,16 +42,15 @@ TEST_F(TestGridDescriptor, testIO)
 
     GridDescriptor gd2;
 
-    EXPECT_THROW(gd2.read(istr), openvdb::LookupError);
-
     // Register the grid.
     GridBase::clearRegistry();
     GridType::registerGrid();
 
     // seek back and read again.
     istr.seekg(0, std::ios_base::beg);
-    GridBase::Ptr grid;
-    EXPECT_NO_THROW(grid = gd2.read(istr));
+    gd2.readHeader(istr);
+    gd2.readStreamPos(istr);
+    GridBase::Ptr grid = GridBase::createGrid(gd2.gridType());
 
     EXPECT_EQ(gd.gridName(), gd2.gridName());
     EXPECT_EQ(gd.uniqueName(), gd2.uniqueName());

--- a/pendingchanges/iorefactor.txt
+++ b/pendingchanges/iorefactor.txt
@@ -1,0 +1,8 @@
+OpenVDB:
+  API changes:
+  - GridDescriptor::read() has been deprecated, use GridDescriptor::readHeader()
+    followed by GridDescriptor::readStreamPos() instead.
+
+  Improvements:
+  - Large refactor of I/O classes, many private and protected member functions have
+    been modified. No change in behavior for io::File and io::Stream.


### PR DESCRIPTION
This PR is a no-op change - no behavior changes and no breakages to the public I/O API. All unit tests pass and this portion of the codebase is reduced by ~250 lines.

The primary goals for this PR are:

* To consolidate _all_ the grid reading behind `Archive::readGrid()` and _all_ the grid writing behind `Archive::writeGrid()`
* To move _all_ grid creation into `Archive::readGrid()`
* To eliminate as much of the complexity in the I/O codebase now that delayed-loading is no longer supported, including:
    * Removing the pImpl pattern in File and Stream classes
    * Removing and consolidating lots of private and protected member functions

The changes are broken out into commits so as to make this easier to review:

1) GridDescriptor reading

This is the only public API change - `GridDescriptor::read()` creates a Grid from a GridDescriptor, however the Grid return type was never used in the OpenVDB codebase, so this function has been deprecated and all the places where this was previously used now calls `GridDescriptor.readHeader()` followed by `GridDescriptor::readStreamPos()` instead which does not create the Grid and mirrors the write implementation. Finally, `File::readGridDescriptors()` was only ever used in one place in the codebase, so this logic has been hoisted into the calling code instead.

https://github.com/AcademySoftwareFoundation/openvdb/pull/2179/commits/db9b6cf42569606fc376e6e7306135d3228c6a3a
https://github.com/AcademySoftwareFoundation/openvdb/pull/2179/commits/787ff90eb8c42626bd760b990d9e6fd9f211e869

2) Small refactor to remove private `File::readGridByName()` method

https://github.com/AcademySoftwareFoundation/openvdb/pull/2179/commits/b3471b020a680521b136e153a553dcc66c6a8ab2

3) Remove unused topology reading option to private `File::readPartialGrid()` method

This also removes one of the `File::readPartialGrid()` variants and hoists the logic into the calling code instead.

https://github.com/AcademySoftwareFoundation/openvdb/pull/2179/commits/e990a1589e66b327cfd3e45e6eded976d62c977e

4) Remove pImpl pattern

There was no longer a good reason to use this pattern. It didn't serve a practical purpose at reducing compile times or improving binary compatibility. We support reinterpret casting a Grid pointer across ABI boundaries, but not a File or Stream object. This greatly simplifies the code.

https://github.com/AcademySoftwareFoundation/openvdb/pull/2179/commits/7fe00363f4e19911e33cdd8597412d2ce148a80f
https://github.com/AcademySoftwareFoundation/openvdb/pull/2179/commits/5672d77db7cc9d890113d63e9a263f5cd40d120d

5) Always pass BBox through read methods

Some of the complexity in the I/O is due to handling different bounding box clipping options (no bounding box, index-space bounding box, world-space bounding box). Previously this code was checking `bbox.isSorted()` to know whether to clip or not and doing an world-space -> index-space conversion early, this mainly delays that until `Archive::read()` so as to reduce the number of variants. The public API remains the same after this change - it still has bbox clipping and non-bbox clipping methods, but the non-bbox clipping method now simply creates a default BBox and passes that down. In theory this introduces a tiny slowdown in checking this bbox is valid or not on every grid read (as opposed to once at the start), but the reduction in complexity vastly outweighs any performance concerns here IMO.

https://github.com/AcademySoftwareFoundation/openvdb/pull/2179/commits/864670ccd716a9d82e36f910f1b445e4474eb600

6) Move grid creation into `Archive::readGrid()`

This change adds a new `partial = false` argument to the private `Archive::readGrid()` method so that `File::readGridPartial()` can be removed entirely. Previously there was a loose agreement to keep the order of operations in both methods the same. The big change here is to move grid creation down into `Archive::readGrid()` instead of doing this in the calling functions. In practical terms, the only real difference is that the exception thrown does not distinguish if it is a filename or stream if the grid type has not been registered.

https://github.com/AcademySoftwareFoundation/openvdb/pull/2179/commits/eb8dead856405de12067769f8474ba7270e68990
