### PR TITLE
Add support for reading file version 221 (FLOAT_FRUSTUM_BBOX)

### DIFF
--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -630,9 +630,9 @@ getFormatVersion(std::ios_base& is)
 void
 checkFormatVersion(std::ios_base& is)
 {
-    if (getFormatVersion(is) < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION ) {
+    if (getFormatVersion(is) < OPENVDB_FILE_VERSION_FLOAT_FRUSTUM_BBOX ) {
         OPENVDB_THROW(IoError,
-            "VDB file version < 222 (NODE_MASK_COMPRESSION) is no longer supported. "
+            "VDB file version < 221 (FLOAT_FRUSTUM_BBOX) is no longer supported. "
             "To read older VDB files, please use VDB 12.x or older and then write "
             "them out again to produce files that are compatible with 13.0 and above.");
     }

--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -630,9 +630,9 @@ getFormatVersion(std::ios_base& is)
 void
 checkFormatVersion(std::ios_base& is)
 {
-    if (getFormatVersion(is) < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION ) {
+    if (getFormatVersion(is) < OPENVDB_FILE_VERSION_FLOAT_FRUSTUM_BBOX ) {
         OPENVDB_THROW(IoError,
-            "VDB file version < 222 (NODE_MASK_COMPRESSION) is no longer supported. "
+            "VDB file version < 221 (FLOAT_FRUSTUM_BBOX) is no longer supported. "
             "To read older VDB files, please use VDB 12.x or older and then write "
             "them out again to produce files that are compatible with 13.0 and above.");
     }
@@ -951,9 +951,9 @@ Archive::readHeader(std::istream& is)
     if (mFileVersion > OPENVDB_FILE_VERSION) {
         OPENVDB_LOG_WARN("unsupported VDB file format (expected version "
             << OPENVDB_FILE_VERSION << " or earlier, got version " << mFileVersion << ")");
-    } else if (mFileVersion < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION) {
+    } else if (mFileVersion < OPENVDB_FILE_VERSION_FLOAT_FRUSTUM_BBOX) {
         OPENVDB_THROW(IoError,
-            "VDB file version < 222 (NODE_MASK_COMPRESSION) is no longer supported.");
+            "VDB file version < 221 (FLOAT_FRUSTUM_BBOX) is no longer supported.");
     }
 
     // 3) Read the library version numbers (not stored prior to file format version 211).

--- a/openvdb/openvdb/io/Compression.h
+++ b/openvdb/openvdb/io/Compression.h
@@ -488,15 +488,17 @@ readCompressedValues(std::istream& is, ValueT* destBuf, Index destCount,
 
     int8_t metadata = NO_MASK_AND_ALL_VALS;
 
-    // Read the flag that specifies what, if any, additional metadata
-    // (selection mask and/or inactive value(s)) is saved.
-    if (seek && !maskCompressed) {
-        is.seekg(/*bytes=*/1, std::ios_base::cur);
-    } else if (seek && delayLoadMeta) {
-        metadata = delayLoadMeta->getMask(leafIndex);
-        is.seekg(/*bytes=*/1, std::ios_base::cur);
-    } else {
-        is.read(reinterpret_cast<char*>(&metadata), /*bytes=*/1);
+    if (getFormatVersion(is) >= OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION) {
+        // Read the flag that specifies what, if any, additional metadata
+        // (selection mask and/or inactive value(s)) is saved.
+        if (seek && !maskCompressed) {
+            is.seekg(/*bytes=*/1, std::ios_base::cur);
+        } else if (seek && delayLoadMeta) {
+            metadata = delayLoadMeta->getMask(leafIndex);
+            is.seekg(/*bytes=*/1, std::ios_base::cur);
+        } else {
+            is.read(reinterpret_cast<char*>(&metadata), /*bytes=*/1);
+        }
     }
 
     ValueT background = zeroVal<ValueT>();

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -523,9 +523,9 @@ File::readAllGridMetadata()
         OPENVDB_THROW(IoError, filename() << " is not open for reading");
     }
 
-    if (fileVersion() < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION) {
+    if (fileVersion() < OPENVDB_FILE_VERSION_FLOAT_FRUSTUM_BBOX) {
         OPENVDB_THROW(IoError,
-            "VDB file version < 222 (NODE_MASK_COMPRESSION) is no longer supported.");
+            "VDB file version < 221 (FLOAT_FRUSTUM_BBOX) is no longer supported.");
     }
 
     GridPtrVecPtr ret(new GridPtrVec);
@@ -560,9 +560,9 @@ File::readGridMetadata(const Name& name)
         OPENVDB_THROW(IoError, filename() << " is not open for reading.");
     }
 
-    if (fileVersion() < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION) {
+    if (fileVersion() < OPENVDB_FILE_VERSION_FLOAT_FRUSTUM_BBOX) {
         OPENVDB_THROW(IoError,
-            "VDB file version < 222 (NODE_MASK_COMPRESSION) is no longer supported.");
+            "VDB file version < 221 (FLOAT_FRUSTUM_BBOX) is no longer supported.");
     }
 
     GridBase::ConstPtr ret;

--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -2426,7 +2426,9 @@ InternalNode<ChildT, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
     mChildMask.load(is);
     mValueMask.load(is);
 
-    const Index numValues = NUM_VALUES;
+    const bool oldVersion =
+        (io::getFormatVersion(is) < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION);
+    const Index numValues = (oldVersion ? mChildMask.countOff() : NUM_VALUES);
     {
         // Read in (and uncompress, if necessary) all of this node's values
         // into a contiguous array.
@@ -2435,8 +2437,16 @@ InternalNode<ChildT, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
         io::readCompressedValues(is, values, numValues, mValueMask, fromHalf);
 
         // Copy values from the array into this node's table.
-        for (ValueAllIter iter = this->beginValueAll(); iter; ++iter) {
-            mNodes[iter.pos()].setValue(values[iter.pos()]);
+        if (oldVersion) {
+            Index n = 0;
+            for (ValueAllIter iter = this->beginValueAll(); iter; ++iter) {
+                mNodes[iter.pos()].setValue(values[n++]);
+            }
+            OPENVDB_ASSERT(n == numValues);
+        } else {
+            for (ValueAllIter iter = this->beginValueAll(); iter; ++iter) {
+                mNodes[iter.pos()].setValue(values[iter.pos()]);
+            }
         }
     }
 

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -1388,6 +1388,13 @@ LeafNode<T,Log2Dim>::readBuffers(std::istream& is, const CoordBBox& clipBBox, bo
     }
 
     int8_t numBuffers = 1;
+    if (io::getFormatVersion(is) < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION) {
+        // Read in the origin.
+        is.read(reinterpret_cast<char*>(&mOrigin), sizeof(Coord::ValueType) * 3);
+
+        // Read in the number of buffers, which should now always be one.
+        is.read(reinterpret_cast<char*>(&numBuffers), sizeof(int8_t));
+    }
 
     CoordBBox nodeBBox = this->getNodeBoundingBox();
     if (!clipBBox.hasOverlap(nodeBBox)) {


### PR DESCRIPTION
Add back in support for reading file format 221 (FLOAT_FRUSTUM_BBOX). This was the last I/O file format _before_ VDB 3.0 which was the intention behind https://github.com/AcademySoftwareFoundation/openvdb/pull/2087. File format 222 is the first release of VDB 3.0. This allows reading files written in that window (2013 - 2014).