### PR TITLE
Add Tree I/O Option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,9 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cxx: clang++, image: '2026',           abi: '13', build: 'Release', cmake: '-DOPENVDB_USE_FUTURE_ABI_13=ON -DOPENVDB_ENABLE_ASSERTS=ON' }
-          - { cxx: g++,     image: '2026',           abi: '13', build: 'Release', cmake: '-DOPENVDB_USE_FUTURE_ABI_13=ON' }
-          - { cxx: clang++, image: '2026',           abi: '13', build: 'Debug',   cmake: '-DOPENVDB_USE_FUTURE_ABI_13=ON' }
+          - { cxx: clang++, image: '2026',           abi: '13', build: 'Release', cmake: '-DOPENVDB_ENABLE_ASSERTS=ON -DOPENVDB_ENABLE_TREE_IO=ON' }
+          - { cxx: g++,     image: '2026',           abi: '13', build: 'Release', cmake: '' }
+          - { cxx: clang++, image: '2026',           abi: '13', build: 'Debug',   cmake: '' }
           - { cxx: clang++, image: '2025-clang19.1', abi: '12', build: 'Release', cmake: '' }
           - { cxx: clang++, image: '2024-clang17.2', abi: '11', build: 'Release', cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON' }
       fail-fast: false

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -154,6 +154,7 @@ jobs:
           - { name: 'asan',   image: '2026',           build: 'asan',    components: 'core,test',                        cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON -DNANOVDB_USE_OPENVDB=ON -DOPENVDB_AX_STATIC=OFF -DOPENVDB_CORE_STATIC=OFF -DUSE_BLOSC=OFF' } # We never called blosc_destroy(), so disable blosc to silence these errors
           - { name: 'ubsan',  image: '2026',           build: 'ubsan',   components: 'core,test',                        cmake: '-DDISABLE_DEPENDENCY_VERSION_CHECKS=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" ' }
           - { name: 'c++20',  image: '2026',           build: 'Release', components: 'core,test',                        cmake: '-DCMAKE_CXX_STANDARD=20' }
+          - { name: 'io',     image: '2026',           build: 'Release', components: 'core,test',                        cmake: '-DOPENVDB_ENABLE_TREE_IO=ON -DOPENVDB_ENABLE_ASSERTS=ON' }
           - { name: 'abi14',  image: '2026',           build: 'Release', components: 'core,test',                        cmake: '-DOPENVDB_USE_FUTURE_ABI_14=ON -DOPENVDB_ENABLE_ASSERTS=ON' }
           - { name: 'conf',   image: '2026',           build: 'Release', components: 'core,python,bin,view,render,test', cmake: '-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON' }
       fail-fast: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ option(OPENVDB_BUILD_NANOVDB "Build the NanoVDB library. Turns ON if USE_NANOVDB
 # Global options
 option(OPENVDB_ENABLE_RPATH "Build with RPATH information" ON)
 option(OPENVDB_ENABLE_ASSERTS "Build with asserts in OpenVDB code enabled" OFF)
+option(OPENVDB_ENABLE_TREE_IO "Build with Tree I/O functionality enabled" ON)
 option(OPENVDB_CXX_STRICT "Enable or disable pre-defined compiler warnings" OFF)
 cmake_dependent_option(OPENVDB_INSTALL_CMAKE_MODULES
   "Install the provided OpenVDB CMake modules when building the core library"

--- a/openvdb/openvdb/Grid.h
+++ b/openvdb/openvdb/Grid.h
@@ -448,15 +448,15 @@ public:
 
     /// @brief Read the grid topology from a stream.
     /// This will read only the grid structure, not the actual data buffers.
-    virtual void readTopology(std::istream&) = 0;
+    virtual void readTopology(std::istream&) = OPENVDB_TREE_IO_VIRTUAL;
     /// @brief Write the grid topology to a stream.
     /// This will write only the grid structure, not the actual data buffers.
-    virtual void writeTopology(std::ostream&) const = 0;
+    virtual void writeTopology(std::ostream&) const = OPENVDB_TREE_IO_VIRTUAL;
 
     /// Read all data buffers for this grid.
-    virtual void readBuffers(std::istream&) = 0;
+    virtual void readBuffers(std::istream&) = OPENVDB_TREE_IO_VIRTUAL;
     /// Read all of this grid's data buffers that intersect the given index-space bounding box.
-    virtual void readBuffers(std::istream&, const CoordBBox&) = 0;
+    virtual void readBuffers(std::istream&, const CoordBBox&) = OPENVDB_TREE_IO_VIRTUAL;
 
 #if OPENVDB_ABI_VERSION_NUMBER < 14
     OPENVDB_DEPRECATED_MESSAGE("This method is deprecated and will be removed. Delayed loading is no longer supported.")
@@ -464,7 +464,7 @@ public:
 #endif
 
     /// Write out all data buffers for this grid.
-    virtual void writeBuffers(std::ostream&) const = 0;
+    virtual void writeBuffers(std::ostream&) const = OPENVDB_TREE_IO_VIRTUAL;
 
     /// Read in the transform for this grid.
     void readTransform(std::istream& is) { transform().read(is); }
@@ -928,6 +928,7 @@ public:
     /// @name I/O
     /// @{
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     /// @brief Read the grid topology from a stream.
     /// This will read only the grid structure, not the actual data buffers.
     void readTopology(std::istream&) override;
@@ -939,14 +940,17 @@ public:
     void readBuffers(std::istream&) override;
     /// Read all of this grid's data buffers that intersect the given index-space bounding box.
     void readBuffers(std::istream&, const CoordBBox&) override;
+#endif // OPENVDB_ENABLE_TREE_IO
 
 #if OPENVDB_ABI_VERSION_NUMBER < 14
     OPENVDB_DEPRECATED_MESSAGE("This method is deprecated and will be removed. Delayed loading is no longer supported.")
     void readNonresidentBuffers() const override { }
 #endif
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     /// Write out all data buffers for this grid.
     void writeBuffers(std::ostream&) const override;
+#endif // OPENVDB_ENABLE_TREE_IO
 
     /// Output a human-readable description of this grid.
     void print(std::ostream& = std::cout, int verboseLevel = 1) const override;
@@ -1625,6 +1629,8 @@ Grid<TreeT>::evalActiveVoxelDim() const
 /// @internal Consider using the stream tagging mechanism (see io::Archive)
 /// to specify the float precision, but note that the setting is per-grid.
 
+#ifdef OPENVDB_ENABLE_TREE_IO
+
 template<typename TreeT>
 inline void
 Grid<TreeT>::readTopology(std::istream& is)
@@ -1716,6 +1722,8 @@ Grid<TreeT>::writeBuffers(std::ostream& os) const
         }
     }
 }
+
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 //static

--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -1005,12 +1005,17 @@ Archive::readGrid(const GridDescriptor& gd, std::istream& is, const io::ReadOpti
         if (codec) {
             codec->readTopology(is, *codecData, readOptions, diagnostics);
         } else {
+#ifdef OPENVDB_ENABLE_TREE_IO
             grid->readTopology(is);
+#else
+            OPENVDB_THROW(IoError, "Tree I/O functionality is not enabled");
+#endif
         }
         // read buffers
         if (codec) {
             codec->readBuffers(is, *codecData, readOptions, diagnostics);
         } else {
+#ifdef OPENVDB_ENABLE_TREE_IO
             const auto& worldBBox = readOptions.clipBBox;
             const bool clip = worldBBox.isSorted();
             if (clip) {
@@ -1019,6 +1024,9 @@ Archive::readGrid(const GridDescriptor& gd, std::istream& is, const io::ReadOpti
             } else {
                 grid->readBuffers(is);
             }
+#else
+            OPENVDB_THROW(IoError, "Tree I/O functionality is not enabled");
+#endif
         }
     }
 
@@ -1204,7 +1212,11 @@ Archive::writeGrid(GridDescriptor& gd, GridBase::ConstPtr grid,
     if (codec) {
         codec->writeTopology(os, *grid, writeOptions);
     } else {
+#ifdef OPENVDB_ENABLE_TREE_IO
         grid->writeTopology(os);
+#else
+        OPENVDB_THROW(IoError, "Tree I/O functionality is not enabled");
+#endif
     }
 
     // Now we know the grid block storage position.
@@ -1214,7 +1226,11 @@ Archive::writeGrid(GridDescriptor& gd, GridBase::ConstPtr grid,
     if (codec) {
         codec->writeBuffers(os, *grid, writeOptions);
     } else {
+#ifdef OPENVDB_ENABLE_TREE_IO
         grid->writeBuffers(os);
+#else
+        OPENVDB_THROW(IoError, "Tree I/O functionality is not enabled");
+#endif
     }
 
     // Now we know the end position of this grid.

--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -973,6 +973,17 @@ Archive::readGrid(const GridDescriptor& gd, std::istream& is, const io::ReadOpti
     }
     grid->setSaveFloatAsHalf(gd.saveFloatAsHalf());
 
+#ifndef OPENVDB_ENABLE_TREE_IO
+    if (!codec) {
+        OPENVDB_THROW(IoError,
+            "No I/O codec found for " << gd.gridType() << ", "
+            << "register the codec for this grid type "
+            << "(either explicitly or via openvdb::initialize()). "
+            << "Note: Tree I/O is deprecated, "
+            << "but can be re-enabled by recompiling with CMake OPENVDB_ENABLE_TREE_IO=ON.");
+    }
+#endif
+
     // Stream metadata varies per grid, and it needs to persist
     // in case delayed load is in effect.
     io::StreamMetadata::Ptr streamMetadata;
@@ -1007,8 +1018,6 @@ Archive::readGrid(const GridDescriptor& gd, std::istream& is, const io::ReadOpti
         } else {
 #ifdef OPENVDB_ENABLE_TREE_IO
             grid->readTopology(is);
-#else
-            OPENVDB_THROW(IoError, "Tree I/O functionality is not enabled");
 #endif
         }
         // read buffers
@@ -1024,8 +1033,6 @@ Archive::readGrid(const GridDescriptor& gd, std::istream& is, const io::ReadOpti
             } else {
                 grid->readBuffers(is);
             }
-#else
-            OPENVDB_THROW(IoError, "Tree I/O functionality is not enabled");
 #endif
         }
     }
@@ -1166,6 +1173,17 @@ Archive::writeGrid(GridDescriptor& gd, GridBase::ConstPtr grid,
     // Find the codec for the grid type and options.
     io::Codec* codec = findCodec(gd.gridType());
 
+#ifndef OPENVDB_ENABLE_TREE_IO
+    if (!codec) {
+        OPENVDB_THROW(IoError,
+            "No I/O codec found for " << gd.gridType() << ", "
+            << "register the codec for this grid type "
+            << "(either explicitly or via openvdb::initialize()). "
+            << "Note: Tree I/O is deprecated, "
+            << "but can be re-enabled by recompiling with CMake OPENVDB_ENABLE_TREE_IO=ON.");
+    }
+#endif
+
     // Stream metadata varies per grid, so make a copy of the file-level stream metadata.
     io::StreamMetadata::Ptr streamMetadata;
     if (io::StreamMetadata::Ptr meta = io::getStreamMetadataPtr(os)) {
@@ -1214,8 +1232,6 @@ Archive::writeGrid(GridDescriptor& gd, GridBase::ConstPtr grid,
     } else {
 #ifdef OPENVDB_ENABLE_TREE_IO
         grid->writeTopology(os);
-#else
-        OPENVDB_THROW(IoError, "Tree I/O functionality is not enabled");
 #endif
     }
 
@@ -1228,8 +1244,6 @@ Archive::writeGrid(GridDescriptor& gd, GridBase::ConstPtr grid,
     } else {
 #ifdef OPENVDB_ENABLE_TREE_IO
         grid->writeBuffers(os);
-#else
-        OPENVDB_THROW(IoError, "Tree I/O functionality is not enabled");
 #endif
     }
 

--- a/openvdb/openvdb/points/PointDataGrid.h
+++ b/openvdb/openvdb/points/PointDataGrid.h
@@ -362,16 +362,18 @@ public:
     //@}
 
     // I/O methods
-
+#ifdef OPENVDB_ENABLE_TREE_IO
     void readTopology(std::istream& is, bool fromHalf = false);
     void writeTopology(std::ostream& os, bool toHalf = false) const;
+#endif // OPENVDB_ENABLE_TREE_IO
 
     Index buffers() const;
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     void readBuffers(std::istream& is, bool fromHalf = false);
     void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
     void writeBuffers(std::ostream& os, bool toHalf = false) const;
-
+#endif // OPENVDB_ENABLE_TREE_IO
 
     Index64 memUsage() const;
     OPENVDB_DEPRECATED_MESSAGE("Use memUsage() instead. This method is deprecated and will be removed. Delayed loading is no longer supported.")
@@ -987,6 +989,7 @@ PointDataLeafNode<T, Log2Dim>::setOffsetOnly(Index offset, const ValueType& val)
     this->buffer().setValue(offset, val);
 }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 template<typename T, Index Log2Dim>
 inline void
 PointDataLeafNode<T, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
@@ -1000,6 +1003,7 @@ PointDataLeafNode<T, Log2Dim>::writeTopology(std::ostream& os, bool toHalf) cons
 {
     BaseLeaf::writeTopology(os, toHalf);
 }
+#endif // OPENVDB_ENABLE_TREE_IO
 
 template<typename T, Index Log2Dim>
 inline Index
@@ -1013,6 +1017,7 @@ PointDataLeafNode<T, Log2Dim>::buffers() const
                     /*cleanup*/                     1);
 }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 template<typename T, Index Log2Dim>
 inline void
 PointDataLeafNode<T, Log2Dim>::readBuffers(std::istream& is, bool fromHalf)
@@ -1385,6 +1390,7 @@ PointDataLeafNode<T, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
         Local::destroyPagedStream(meta->auxData(), attributeIndex);
     }
 }
+#endif // OPENVDB_ENABLE_TREE_IO
 
 template<typename T, Index Log2Dim>
 inline Index64

--- a/openvdb/openvdb/tools/PointIndexGrid.h
+++ b/openvdb/openvdb/tools/PointIndexGrid.h
@@ -1485,9 +1485,11 @@ public:
 
     // I/O methods
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     void readBuffers(std::istream& is, bool fromHalf = false);
     void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
     void writeBuffers(std::ostream& os, bool toHalf = false) const;
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
     Index64 memUsage() const;
@@ -1718,6 +1720,8 @@ PointIndexLeafNode<T, Log2Dim>::isEmpty(const CoordBBox& bbox) const
 }
 
 
+#ifdef OPENVDB_ENABLE_TREE_IO
+
 template<typename T, Index Log2Dim>
 inline void
 PointIndexLeafNode<T, Log2Dim>::readBuffers(std::istream& is, bool fromHalf)
@@ -1790,6 +1794,8 @@ PointIndexLeafNode<T, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) cons
     const Index64 auxDataBytes = Index64(0);
     os.write(reinterpret_cast<const char*>(&auxDataBytes), sizeof(Index64));
 }
+
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 template<typename T, Index Log2Dim>

--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -454,6 +454,7 @@ public:
     /// Mark all values (both tiles and voxels) as active.
     void setValuesOn();
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     //
     // I/O
     //
@@ -463,6 +464,7 @@ public:
     void readBuffers(std::istream&, bool fromHalf = false);
     void readBuffers(std::istream&, const CoordBBox&, bool fromHalf = false);
 
+#endif // OPENVDB_ENABLE_TREE_IO
 
     //
     // Unsafe methods
@@ -2388,6 +2390,7 @@ InternalNode<ChildT, Log2Dim>::copyToDense(const CoordBBox& bbox, DenseT& dense)
 
 ////////////////////////////////////////
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 
 template<typename ChildT, Index Log2Dim>
 inline void
@@ -2458,6 +2461,7 @@ InternalNode<ChildT, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
     }
 }
 
+#endif // OPENVDB_ENABLE_TREE_IO
 
 ////////////////////////////////////////
 
@@ -3213,6 +3217,8 @@ InternalNode<ChildT, Log2Dim>::combine2(const InternalNode& other, const OtherVa
 ////////////////////////////////////////
 
 
+#ifdef OPENVDB_ENABLE_TREE_IO
+
 template<typename ChildT, Index Log2Dim>
 inline void
 InternalNode<ChildT, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
@@ -3253,6 +3259,8 @@ InternalNode<ChildT, Log2Dim>::readBuffers(std::istream& is,
     }
     this->clip(clipBBox, background);
 }
+
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -378,6 +378,7 @@ public:
     const Buffer& buffer() const { return mBuffer; }
     Buffer& buffer() { return mBuffer; }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     //
     // I/O methods
     //
@@ -403,6 +404,7 @@ public:
     /// @param os      the stream to which to write
     /// @param toHalf  if true, output floating-point values as 16-bit half floats
     void writeBuffers(std::ostream& os, bool toHalf = false) const;
+#endif // OPENVDB_ENABLE_TREE_IO
 
     size_t streamingSize(bool toHalf = false) const;
 
@@ -921,7 +923,9 @@ protected:
     void setValueMaskOn(Index n)  { mValueMask.setOn(n); }
     void setValueMaskOff(Index n) { mValueMask.setOff(n); }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     inline void skipCompressedValues(bool seekable, std::istream&, bool fromHalf);
+#endif // OPENVDB_ENABLE_TREE_IO
 
     /// Compute the origin of the leaf node that contains the voxel with the given coordinates.
     static void evalNodeOrigin(Coord& xyz) { xyz &= ~(DIM - 1); }
@@ -1319,6 +1323,8 @@ LeafNode<T, Log2Dim>::copyFromDense(const CoordBBox& bbox, const DenseT& dense,
 ////////////////////////////////////////
 
 
+#ifdef OPENVDB_ENABLE_TREE_IO
+
 template<typename T, Index Log2Dim>
 inline void
 LeafNode<T, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
@@ -1432,6 +1438,8 @@ LeafNode<T, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
     io::writeCompressedValues(os, mBuffer.mData, SIZE,
         mValueMask, /*childMask=*/NodeMaskType(), toHalf);
 }
+
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/openvdb/tree/LeafNodeBool.h
@@ -200,6 +200,7 @@ public:
     const Buffer& buffer() const { return mBuffer; }
     Buffer& buffer() { return mBuffer; }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     //
     // I/O methods
     //
@@ -213,6 +214,7 @@ public:
     void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
     /// Write out the topology and the origin.
     void writeBuffers(std::ostream&, bool toHalf = false) const;
+#endif // OPENVDB_ENABLE_TREE_IO
 
     //
     // Accessor methods
@@ -976,6 +978,8 @@ LeafNode<bool, Log2Dim>::offsetToGlobalCoord(Index n) const
 ////////////////////////////////////////
 
 
+#ifdef OPENVDB_ENABLE_TREE_IO
+
 template<Index Log2Dim>
 inline void
 LeafNode<bool, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
@@ -1038,6 +1042,7 @@ LeafNode<bool, Log2Dim>::writeBuffers(std::ostream& os, bool /*toHalf*/) const
     mBuffer.mData.save(os);
 }
 
+#endif // OPENVDB_ENABLE_TREE_IO
 
 ////////////////////////////////////////
 

--- a/openvdb/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/openvdb/tree/LeafNodeMask.h
@@ -199,6 +199,7 @@ public:
     const Buffer& buffer() const { return mBuffer; }
     Buffer& buffer() { return mBuffer; }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     //
     // I/O methods
     //
@@ -212,6 +213,7 @@ public:
     void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
     /// Write out the topology and the origin.
     void writeBuffers(std::ostream&, bool toHalf = false) const;
+#endif // OPENVDB_ENABLE_TREE_IO
 
     //
     // Accessor methods
@@ -962,6 +964,8 @@ LeafNode<ValueMask, Log2Dim>::offsetToGlobalCoord(Index n) const
 ////////////////////////////////////////
 
 
+#ifdef OPENVDB_ENABLE_TREE_IO
+
 template<Index Log2Dim>
 inline void
 LeafNode<ValueMask, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
@@ -1016,6 +1020,8 @@ LeafNode<ValueMask, Log2Dim>::writeBuffers(std::ostream& os, bool /*toHalf*/) co
     // Write out the origin.
     os.write(reinterpret_cast<const char*>(&mOrigin), sizeof(Coord::ValueType) * 3);
 }
+
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tree/RootNode.h
+++ b/openvdb/openvdb/tree/RootNode.h
@@ -575,6 +575,7 @@ public:
     void copyToDense(const CoordBBox& bbox, DenseT& dense) const;
 
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     //
     // I/O
     //
@@ -584,6 +585,7 @@ public:
     void writeBuffers(std::ostream&, bool toHalf = false) const;
     void readBuffers(std::istream&, bool fromHalf = false);
     void readBuffers(std::istream&, const CoordBBox&, bool fromHalf = false);
+#endif
 
 
     //
@@ -2342,6 +2344,7 @@ RootNode<ChildT>::copyToDense(const CoordBBox& bbox, DenseT& dense) const
 
 ////////////////////////////////////////
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 
 template<typename ChildT>
 inline bool
@@ -2463,6 +2466,8 @@ RootNode<ChildT>::readBuffers(std::istream& is, const CoordBBox& clipBBox, bool 
     // Clip root-level tiles and prune children that were clipped.
     this->clip(clipBBox);
 }
+
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tree/Tree.h
+++ b/openvdb/openvdb/tree/Tree.h
@@ -144,30 +144,29 @@ public:
     /// Return the total amount of memory in bytes occupied by this tree.
     virtual Index64 memUsage() const { return 0; }
 
-
     //
     // I/O methods
     //
     /// @brief Read the tree topology from a stream.
     ///
     /// This will read the tree structure and tile values, but not voxel data.
-    virtual void readTopology(std::istream&, bool saveFloatAsHalf = false) = 0;
+    virtual void readTopology(std::istream&, bool saveFloatAsHalf = false) = OPENVDB_TREE_IO_VIRTUAL;
     /// @brief Write the tree topology to a stream.
     ///
     /// This will write the tree structure and tile values, but not voxel data.
-    virtual void writeTopology(std::ostream&, bool saveFloatAsHalf = false) const = 0;
-
+    virtual void writeTopology(std::ostream&, bool saveFloatAsHalf = false) const = OPENVDB_TREE_IO_VIRTUAL;
     /// Read all data buffers for this tree.
-    virtual void readBuffers(std::istream&, bool saveFloatAsHalf = false) = 0;
+    virtual void readBuffers(std::istream&, bool saveFloatAsHalf = false) = OPENVDB_TREE_IO_VIRTUAL;
     /// Read all of this tree's data buffers that intersect the given bounding box.
-    virtual void readBuffers(std::istream&, const CoordBBox&, bool saveFloatAsHalf = false) = 0;
+    virtual void readBuffers(std::istream&, const CoordBBox&, bool saveFloatAsHalf = false) = OPENVDB_TREE_IO_VIRTUAL;
 
 #if OPENVDB_ABI_VERSION_NUMBER < 14
     OPENVDB_DEPRECATED_MESSAGE("This method is deprecated and will be removed. Delayed loading is no longer supported.")
-    virtual void readNonresidentBuffers() const = 0;
+    virtual void readNonresidentBuffers() const = OPENVDB_TREE_IO_VIRTUAL;
 #endif
+
     /// Write out all the data buffers for this tree.
-    virtual void writeBuffers(std::ostream&, bool saveFloatAsHalf = false) const = 0;
+    virtual void writeBuffers(std::ostream&, bool saveFloatAsHalf = false) const = OPENVDB_TREE_IO_VIRTUAL;
 
     /// @brief Print statistics, memory usage and other information about this tree.
     /// @param os            a stream to which to write textual information
@@ -320,6 +319,7 @@ public:
     //
     // I/O methods
     //
+#ifdef OPENVDB_ENABLE_TREE_IO
     /// @brief Read the tree topology from a stream.
     ///
     /// This will read the tree structure and tile values, but not voxel data.
@@ -340,6 +340,7 @@ public:
 
     /// Write out all data buffers for this tree.
     void writeBuffers(std::ostream&, bool saveFloatAsHalf = false) const override;
+#endif // OPENVDB_ENABLE_TREE_IO
 
     void print(std::ostream& os = std::cout, int verboseLevel = 1) const override;
 
@@ -1250,6 +1251,7 @@ Tree<RootNodeType>::cbegin() const
 
 ////////////////////////////////////////
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 
 template<typename RootNodeType>
 void
@@ -1298,6 +1300,7 @@ Tree<RootNodeType>::writeBuffers(std::ostream &os, bool saveFloatAsHalf) const
     mRoot.writeBuffers(os, saveFloatAsHalf);
 }
 
+#endif // OPENVDB_ENABLE_TREE_IO
 
 template<typename RootNodeType>
 template<typename ArrayT>

--- a/openvdb/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/openvdb/unittest/TestAttributeArray.cc
@@ -795,6 +795,7 @@ TEST_F(TestAttributeArray, testAttributeArray)
         EXPECT_NEAR(double(vec3.z()), unitVec.get(2).z(), /*tolerance=*/double(0.0001));
     }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     { // IO
         const Index count = 50;
         AttributeArrayI attrA(count);
@@ -830,6 +831,7 @@ TEST_F(TestAttributeArray, testAttributeArray)
 
         EXPECT_TRUE(!ostrD.str().empty());
     }
+#endif // OPENVDB_ENABLE_TREE_IO
 
     // Registry
     AttributeArrayI::registerType();
@@ -1354,6 +1356,7 @@ TEST_F(TestAttributeArray, testStrided)
         EXPECT_EQ(array->dataSize(), handle.size());
     }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     { // IO
         const Index count = 50, total = 100;
         AttributeArrayI attrA(count, total, /*constantStride=*/false);
@@ -1372,6 +1375,7 @@ TEST_F(TestAttributeArray, testStrided)
 
         EXPECT_TRUE(attrA == attrB);
     }
+#endif // OPENVDB_ENABLE_TREE_IO
 }
 
 

--- a/openvdb/openvdb/unittest/TestAttributeArrayString.cc
+++ b/openvdb/openvdb/unittest/TestAttributeArrayString.cc
@@ -279,6 +279,7 @@ TEST_F(TestAttributeArrayString, testStringAttribute)
         EXPECT_TRUE(!baseAttr.valueTypeIsFloatingPoint());
     }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     { // IO
         const Index count = 50;
         StringAttributeArray attrA(count);
@@ -309,6 +310,7 @@ TEST_F(TestAttributeArrayString, testStringAttribute)
             EXPECT_EQ(attrA.get(i), attrB.get(i));
         }
     }
+#endif // OPENVDB_ENABLE_TREE_IO
 }
 
 

--- a/openvdb/openvdb/unittest/TestAttributeGroup.cc
+++ b/openvdb/openvdb/unittest/TestAttributeGroup.cc
@@ -105,6 +105,7 @@ TEST_F(TestAttributeGroup, testAttributeGroup)
         EXPECT_NO_THROW(GroupAttributeArray::cast(constGroupArray));
     }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     { // IO
         const size_t count = 50;
         GroupAttributeArray attrA(count);
@@ -135,6 +136,7 @@ TEST_F(TestAttributeGroup, testAttributeGroup)
             EXPECT_EQ(attrA.get(i), attrB.get(i));
         }
     }
+#endif // OPENVDB_ENABLE_TREE_IO
 }
 
 

--- a/openvdb/openvdb/unittest/TestAttributeSet.cc
+++ b/openvdb/openvdb/unittest/TestAttributeSet.cc
@@ -1004,6 +1004,7 @@ TestAttributeSet::testAttributeSet()
     openvdb::MetaMap& meta = attrSetA.descriptor().getMetadata();
     meta.insertMeta("exampleMeta", openvdb::FloatMetadata(2.0));
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     { // I/O test
         std::ostringstream ostr(std::ios_base::binary);
         attrSetA.write(ostr);
@@ -1039,6 +1040,7 @@ TestAttributeSet::testAttributeSet()
 
         EXPECT_EQ(attrSetC.size(), size_t(2));
     }
+#endif // OPENVDB_ENABLE_TREE_IO
 }
 TEST_F(TestAttributeSet, testAttributeSet) { testAttributeSet(); }
 

--- a/openvdb/openvdb/unittest/TestCodec.cc
+++ b/openvdb/openvdb/unittest/TestCodec.cc
@@ -240,12 +240,14 @@ void testCodecIOImpl(
     ASSERT_TRUE(openvdb::io::CodecRegistry::isRegistered(GridT::gridType()));
     // test the io implementation (codec)
     testIOImpl<GridT>(gridName, bgValue, fillValue);
+#ifdef OPENVDB_ENABLE_TREE_IO
     // clear the codec registry (now read/write falls back to Tree I/O)
     openvdb::io::CodecRegistry::clear();
     // ensure the codec is not registered
     ASSERT_FALSE(openvdb::io::CodecRegistry::isRegistered(GridT::gridType()));
     // test the io implementation (tree I/O)
     testIOImpl<GridT>(gridName, bgValue, fillValue);
+#endif
 }
 
 TEST_F(TestCodec, testFloatCodecIO) { testCodecIOImpl<openvdb::FloatGrid>("float_grid", 0.0f, 1.0f); }

--- a/openvdb/openvdb/unittest/TestGrid.cc
+++ b/openvdb/openvdb/unittest/TestGrid.cc
@@ -60,17 +60,21 @@ public:
 
     TreeBasePtr copy() const override { return TreeBasePtr(new ProxyTree(*this)); }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     void readTopology(std::istream& is, bool = false) override { is.seekg(0, std::ios::beg); }
     void writeTopology(std::ostream& os, bool = false) const override { os.seekp(0); }
 
     void readBuffers(std::istream& is,
         const openvdb::CoordBBox&, bool /*saveFloatAsHalf*/=false) override { is.seekg(0); }
+
 #if OPENVDB_ABI_VERSION_NUMBER < 14
     void readNonresidentBuffers() const override {}
 #endif
+
     void readBuffers(std::istream& is, bool /*saveFloatAsHalf*/=false) override { is.seekg(0); }
     void writeBuffers(std::ostream& os, bool /*saveFloatAsHalf*/=false) const override
         { os.seekp(0, std::ios::beg); }
+#endif // OPENVDB_ENABLE_TREE_IO
 
     bool empty() const { return true; }
     void clear() {}

--- a/openvdb/openvdb/unittest/TestLeafBool.cc
+++ b/openvdb/openvdb/unittest/TestLeafBool.cc
@@ -339,6 +339,7 @@ TEST_F(TestLeafBool, testIO)
     }
 }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 
 TEST_F(TestLeafBool, testTreeIO)
 {
@@ -367,6 +368,7 @@ TEST_F(TestLeafBool, testTreeIO)
 
     EXPECT_TRUE(leaf.onVoxelCount() == 2);
 }
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 TEST_F(TestLeafBool, testConstructors)

--- a/openvdb/openvdb/unittest/TestLeafIO.cc
+++ b/openvdb/openvdb/unittest/TestLeafIO.cc
@@ -17,7 +17,9 @@ class TestLeafIO
 {
 public:
     static void testBuffer();
+#ifdef OPENVDB_ENABLE_TREE_IO
     static void testTreeIO();
+#endif // OPENVDB_ENABLE_TREE_IO
 };
 
 template<typename T>
@@ -78,6 +80,7 @@ TestLeafIO<T>::testBuffer()
 }
 
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 template<typename T>
 void
 TestLeafIO<T>::testTreeIO()
@@ -105,6 +108,7 @@ TestLeafIO<T>::testTreeIO()
 
     EXPECT_TRUE(leaf.onVoxelCount() == 2);
 }
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 class TestLeafIOTest: public ::testing::Test
@@ -119,7 +123,9 @@ TEST_F(TestLeafIOTest, testBufferInt) { TestLeafIO<int>::testBuffer(); }
 TEST_F(TestLeafIOTest, testBufferFloat) { TestLeafIO<float>::testBuffer(); }
 TEST_F(TestLeafIOTest, testBufferDouble) { TestLeafIO<double>::testBuffer(); }
 TEST_F(TestLeafIOTest, testBufferBool) { TestLeafIO<bool>::testBuffer(); }
+#ifdef OPENVDB_ENABLE_TREE_IO
 TEST_F(TestLeafIOTest, testBufferByte) { TestLeafIO<openvdb::Byte>::testBuffer(); }
+#endif
 
 
 TEST_F(TestLeafIOTest, testBufferVec3R)
@@ -175,6 +181,7 @@ TEST_F(TestLeafIOTest, testBufferVec3R)
     }
 }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 TEST_F(TestLeafIOTest, testTreeIOInt) { TestLeafIO<int>::testTreeIO(); }
 TEST_F(TestLeafIOTest, testTreeIOFloat) { TestLeafIO<float>::testTreeIO(); }
 TEST_F(TestLeafIOTest, testTreeIODouble) { TestLeafIO<double>::testTreeIO(); }
@@ -207,3 +214,4 @@ TEST_F(TestLeafIOTest, testTreeIOVec3R)
 
     EXPECT_TRUE(leaf.onVoxelCount() == 2);
 }
+#endif // OPENVDB_ENABLE_TREE_IO

--- a/openvdb/openvdb/unittest/TestLeafMask.cc
+++ b/openvdb/openvdb/unittest/TestLeafMask.cc
@@ -336,6 +336,7 @@ TEST_F(TestLeafMask, testIO)
     }
 }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 
 TEST_F(TestLeafMask, testTreeIO)
 {
@@ -364,6 +365,7 @@ TEST_F(TestLeafMask, testTreeIO)
 
     EXPECT_TRUE(leaf.onVoxelCount() == 2);
 }
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 TEST_F(TestLeafMask, testTopologyCopy)

--- a/openvdb/openvdb/unittest/TestPointCodec.cc
+++ b/openvdb/openvdb/unittest/TestPointCodec.cc
@@ -48,6 +48,7 @@ TEST_F(TestPointCodec, testPointIndexCodecIO)
         tools::createPointIndexGrid<PointIndexGrid>(pointList, *transform);
     srcGrid->setName("point_index_grid");
 
+#ifdef OPENVDB_ENABLE_TREE_IO
     const std::string rawPath = "testPointIndexCodec_raw.vdb";
 
     // Phase 1: write/read without codec
@@ -79,6 +80,7 @@ TEST_F(TestPointCodec, testPointIndexCodecIO)
     EXPECT_EQ(rawTopo->getName(), std::string("point_index_grid"));
 
     std::remove(rawPath.c_str());
+#endif
 
     const std::string codecPath = "testPointIndexCodec_codec.vdb";
 
@@ -194,6 +196,7 @@ TEST_F(TestPointCodec, testPointDataCodecIO)
             createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
         srcGrid->setName("pdg_positions");
 
+#ifdef OPENVDB_ENABLE_TREE_IO
         const std::string rawPath = "testPDG_A_raw.vdb";
 
         // Phase 1: write/read without codec
@@ -225,6 +228,7 @@ TEST_F(TestPointCodec, testPointDataCodecIO)
         EXPECT_EQ(rawTopo->activeVoxelCount(), Index64(4));
 
         std::remove(rawPath.c_str());
+#endif
 
         const std::string codecPath = "testPDG_A_codec.vdb";
 
@@ -325,6 +329,7 @@ TEST_F(TestPointCodec, testPointDataCodecIO)
 
         CodecRegistry::clear();
 
+#ifdef OPENVDB_ENABLE_TREE_IO
         const std::string rawPath = "testPDG_B_raw.vdb";
 
         // Phase 1: write/read without codec
@@ -343,6 +348,7 @@ TEST_F(TestPointCodec, testPointDataCodecIO)
         ASSERT_TRUE(rawGrid);
 
         std::remove(rawPath.c_str());
+#endif
 
         const std::string codecPath = "testPDG_B_codec.vdb";
 

--- a/openvdb/openvdb/unittest/TestPointDataLeaf.cc
+++ b/openvdb/openvdb/unittest/TestPointDataLeaf.cc
@@ -1276,6 +1276,7 @@ TEST_F(TestPointDataLeaf, testIO)
 }
 
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 TEST_F(TestPointDataLeaf, testTreeIO)
 {
     using AttributeVec3s    = TypedAttributeArray<openvdb::Vec3s>;
@@ -1365,6 +1366,7 @@ TEST_F(TestPointDataLeaf, testTreeIO)
         EXPECT_EQ(leaf2.attributeSet().size(), size_t(2));
     }
 }
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 TEST_F(TestPointDataLeaf, testSwap)

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -830,6 +830,7 @@ TEST_F(TestTree, testIO)
     }
 }
 
+#ifdef OPENVDB_ENABLE_TREE_IO
 
 TEST_F(TestTree, testTreeIO)
 {
@@ -881,6 +882,7 @@ TEST_F(TestTree, testTreeIO)
         ASSERT_DOUBLES_EXACTLY_EQUAL(sum, (0.234f + 4.5678f));
     }
 }
+#endif // OPENVDB_ENABLE_TREE_IO
 
 
 TEST_F(TestTree, testNegativeIndexing)

--- a/openvdb/openvdb/version.h.in
+++ b/openvdb/openvdb/version.h.in
@@ -148,6 +148,21 @@
 #cmakedefine OPENVDB_USE_EXPLICIT_INSTANTIATION
 #endif
 
+/* Denotes whether VDB was built with Tree I/O support */
+#ifndef OPENVDB_ENABLE_TREE_IO
+#cmakedefine OPENVDB_ENABLE_TREE_IO
+#endif
+
+/* Macro for virtual functions that are pure (=0) or deleted based on Tree I/O and ABI.
+ * On Itanium C++ ABI platforms (Linux, macOS), virtual functions are marked deleted when
+ * Tree I/O is disabled. On Windows, all Tree I/O methods are disabled, but Grid virtual
+ * methods are left as pure virtual to avoid ABI issues. */
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(OPENVDB_ENABLE_TREE_IO)
+#define OPENVDB_TREE_IO_VIRTUAL delete
+#else
+#define OPENVDB_TREE_IO_VIRTUAL 0
+#endif
+
 /* Defines the macros for explicit template declarations. */
 #define OPENVDB_INSTANTIATE extern template OPENVDB_TEMPLATE_IMPORT
 #define OPENVDB_INSTANTIATE_CLASS extern template class OPENVDB_TEMPLATE_IMPORT


### PR DESCRIPTION
This adds a CMake option which defaults to ON (`OPENVDB_ENABLE_TREE_IO=ON`) that enables the Tree I/O methods. By switching this off, it is possible to remove all the code paths that provide Tree I/O and thus rely solely on the new I/O codecs.

Note that Itanium C++ ABI rules allow us to delete the virtual methods on the Grid and the Tree without changing the vtable layout.

In the future, we will disable Tree I/O by default and then ultimately remove it.