### PR TITLE
Fix bug in value mask iterator 

### DIFF
--- a/openvdb/openvdb/tree/Iterator.h
+++ b/openvdb/openvdb/tree/Iterator.h
@@ -83,7 +83,7 @@ public:
     /// @details If this iterator is pointing to a child node, then the current item
     /// in the parent node's table is required to be inactive.  In that case,
     /// this method has no effect.
-    void setValueOff() const { parent().mValueMask.setOff(this->pos()); }
+    void setValueOff() const { parent().setValueMask(this->pos(), false); }
 
     /// Return the coordinates of the item to which this iterator is pointing.
     Coord getCoord() const { return parent().offsetToGlobalCoord(this->pos()); }

--- a/openvdb/openvdb/unittest/TestLeafMask.cc
+++ b/openvdb/openvdb/unittest/TestLeafMask.cc
@@ -4,6 +4,7 @@
 #include <openvdb/openvdb.h>
 #include <openvdb/Types.h>
 #include <openvdb/tools/Filter.h>
+#include <openvdb/tools/Prune.h>
 #include <openvdb/tree/LeafNode.h>
 #include <openvdb/util/logging.h>
 #include "util.h" // for unittest_util::makeSphere()
@@ -613,3 +614,16 @@ TEST_F(TestLeafMask, testUnsafe)
     EXPECT_EQ(leaf.getValueUnsafe(33), false);
 }
 
+TEST_F(TestLeafMask, testIterator)
+{
+    using namespace openvdb;
+
+    auto mask = MaskGrid::create(false);
+    mask->tree().setValue(Coord(0, 1, 2), true);
+
+    mask->tree().beginValueOn().setValueOff();
+
+    tools::pruneInactive(mask->tree());
+
+    EXPECT_TRUE(mask->tree().empty());
+}

--- a/pendingchanges/fixmaskleafiterator.txt
+++ b/pendingchanges/fixmaskleafiterator.txt
@@ -1,0 +1,3 @@
+OpenVDB:
+  Bug Fixes:
+    - Fix a bug to deactivate mask leaf node values through a tree iterator.


### PR DESCRIPTION
This fixes an issue in the tree iterator when trying to deactivate leaf node values so that it can work with MaskGrids.

(@Idclip)