### PR TITLE
Minor AX unit test fix

### DIFF
--- a/openvdb_ax/openvdb_ax/codegen/FunctionTypes.cc
+++ b/openvdb_ax/openvdb_ax/codegen/FunctionTypes.cc
@@ -21,6 +21,8 @@
 #endif
 
 #include <limits>
+#include <vector>
+#include <set>
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
@@ -707,6 +709,16 @@ Value IRFunctionBase::call(const Arguments& args,
 
 ///////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////
+
+bool
+FunctionGroup::HasUniqueFunctionSymbols() const
+{
+    std::set<std::string> symset;
+    for (const auto& function : mFunctionList) {
+        if (!symset.insert(function->symbol()).second) return false;
+    }
+    return true;
+}
 
 bool
 FunctionGroup::HasUniqueTypeSignatures(llvm::LLVMContext& C) const

--- a/openvdb_ax/openvdb_ax/codegen/FunctionTypes.cc
+++ b/openvdb_ax/openvdb_ax/codegen/FunctionTypes.cc
@@ -20,6 +20,8 @@
 #include <llvm/Support/ModRef.h> // MemoryEffects
 #endif
 
+#include <limits>
+
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
@@ -100,7 +102,8 @@ inline ArgInfo llvmTypeToArgInfo(llvm::Type* in)
         in = in->getContainedType(0);
         ++nptrs;
     }
-    return ArgInfo(in, nptrs);
+    OPENVDB_ASSERT(nptrs < size_t(std::numeric_limits<uint8_t>::max()));
+    return ArgInfo(in, uint8_t(nptrs));
 }
 
 inline ArgInfoVector llvmTypeToArgInfo(const std::vector<llvm::Type*>& in)

--- a/openvdb_ax/openvdb_ax/codegen/FunctionTypes.h
+++ b/openvdb_ax/openvdb_ax/codegen/FunctionTypes.h
@@ -1404,10 +1404,16 @@ struct OPENVDB_AX_API FunctionGroup
             const FunctionList& list)
         : mName(name)
         , mDoc(doc)
-        , mFunctionList(list) {}
+        , mFunctionList(list) {
+            // Can't verify signatures yet without an LLVM context, asserted on demand
+            OPENVDB_ASSERT(this->HasUniqueFunctionSymbols());
+        }
     ~FunctionGroup() = default;
 
-    /// @brief  Verify the function signatures in this group.
+    /// @brief  Verify the function symbol names in this group (must be unique).
+    bool HasUniqueFunctionSymbols() const;
+
+    /// @brief  Verify the function signatures in this group (must be unique).
     bool HasUniqueTypeSignatures(llvm::LLVMContext& C) const;
 
     /// @brief  Given a vector of args, automatically returns the best

--- a/openvdb_ax/openvdb_ax/codegen/FunctionTypes.h
+++ b/openvdb_ax/openvdb_ax/codegen/FunctionTypes.h
@@ -1293,6 +1293,7 @@ protected:
             if (result->getType()->isPointerTy())
             {
 #if LLVM_VERSION_MAJOR <= 15
+                (void)this;
                 return Value(result, result->getType()->getPointerElementType());
 #else
                 ArgInfoVector unused;

--- a/openvdb_ax/openvdb_ax/test/backend/TestFunctionGroup.cc
+++ b/openvdb_ax/openvdb_ax/test/backend/TestFunctionGroup.cc
@@ -90,7 +90,7 @@ axtestmulti(llvm::LLVMContext& C)
             }, voidty, "ax.i32x2")),
             Function::Ptr(new unittest_util::TestFunction({
                 ArgInfo(llvm::ArrayType::get(llvm::Type::getInt32Ty(C), 3), 1)
-            }, voidty, "ax.i32x2")),
+            }, voidty, "ax.i32x3")),
          }));
     return group;
 }


### PR DESCRIPTION
ASWF docker containers seem to have changed and LLVM builds now build with asserts - caught a small issue in a unit test, no impact to core lib