### PR TITLE
NanoVDB Math: refactor onto `MatBase`/`VecBase`, fix correctness bugs, add tests

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -1406,7 +1406,7 @@ struct Map
     double mTaperD; // 8B, placeholder for taper value
 
     /// @brief Default constructor for the identity map
-    __hostdev__ Map()
+    __hostdev__ constexpr Map()
         : mMatF{   1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f}
         , mInvMatF{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f}
         , mVecF{0.0f, 0.0f, 0.0f}
@@ -1417,7 +1417,7 @@ struct Map
         , mTaperD{1.0}
     {
     }
-    __hostdev__ Map(double s, const Vec3d& t = Vec3d(0.0, 0.0, 0.0))
+    __hostdev__ constexpr Map(double s, const Vec3d& t = Vec3d(0.0, 0.0, 0.0))
         : mMatF{float(s), 0.0f, 0.0f, 0.0f, float(s), 0.0f, 0.0f, 0.0f, float(s)}
         , mInvMatF{1.0f / float(s), 0.0f, 0.0f, 0.0f, 1.0f / float(s), 0.0f, 0.0f, 0.0f, 1.0f / float(s)}
         , mVecF{float(t[0]), float(t[1]), float(t[2])}
@@ -1449,7 +1449,7 @@ struct Map
     /// @param ijk 3D vector to be mapped - typically floating point index coordinates
     /// @return Forward mapping for affine transformation, i.e. (mat x ijk) + translation
     template<typename Vec3T>
-    __hostdev__ Vec3T applyMap(const Vec3T& ijk) const { return math::matMult(mMatD, mVecD, ijk); }
+    __hostdev__ constexpr Vec3T applyMap(const Vec3T& ijk) const { return math::matMult(mMatD, mVecD, ijk); }
 
     /// @brief Apply the forward affine transformation to a vector using 32bit floating point arithmetics.
     /// @note Typically this operation is used for the scale, rotation and translation of index -> world mapping
@@ -1457,7 +1457,7 @@ struct Map
     /// @param ijk 3D vector to be mapped - typically floating point index coordinates
     /// @return Forward mapping for affine transformation, i.e. (mat x ijk) + translation
     template<typename Vec3T>
-    __hostdev__ Vec3T applyMapF(const Vec3T& ijk) const { return math::matMult(mMatF, mVecF, ijk); }
+    __hostdev__ constexpr Vec3T applyMapF(const Vec3T& ijk) const { return math::matMult(mMatF, mVecF, ijk); }
 
     /// @brief Apply the linear forward 3x3 transformation to an input 3d vector using 64bit floating point arithmetics,
     ///        e.g. scale and rotation WITHOUT translation.
@@ -1466,7 +1466,7 @@ struct Map
     /// @param ijk 3D vector to be mapped - typically floating point index coordinates
     /// @return linear forward 3x3 mapping of the input vector
     template<typename Vec3T>
-    __hostdev__ Vec3T applyJacobian(const Vec3T& ijk) const { return math::matMult(mMatD, ijk); }
+    __hostdev__ constexpr Vec3T applyJacobian(const Vec3T& ijk) const { return math::matMult(mMatD, ijk); }
 
     /// @brief Apply the linear forward 3x3 transformation to an input 3d vector using 32bit floating point arithmetics,
     ///        e.g. scale and rotation WITHOUT translation.
@@ -1475,7 +1475,7 @@ struct Map
     /// @param ijk 3D vector to be mapped - typically floating point index coordinates
     /// @return linear forward 3x3 mapping of the input vector
     template<typename Vec3T>
-    __hostdev__ Vec3T applyJacobianF(const Vec3T& ijk) const { return math::matMult(mMatF, ijk); }
+    __hostdev__ constexpr Vec3T applyJacobianF(const Vec3T& ijk) const { return math::matMult(mMatF, ijk); }
 
     /// @brief Apply the inverse affine mapping to a vector using 64bit floating point arithmetics.
     /// @note Typically this operation is used for the world -> index mapping
@@ -1483,7 +1483,7 @@ struct Map
     /// @param xyz 3D vector to be mapped - typically floating point world coordinates
     /// @return Inverse affine mapping of the input @c xyz i.e. (xyz - translation) x mat^-1
     template<typename Vec3T>
-    __hostdev__ Vec3T applyInverseMap(const Vec3T& xyz) const
+    __hostdev__ constexpr Vec3T applyInverseMap(const Vec3T& xyz) const
     {
         return math::matMult(mInvMatD, Vec3T(xyz[0] - mVecD[0], xyz[1] - mVecD[1], xyz[2] - mVecD[2]));
     }
@@ -1494,7 +1494,7 @@ struct Map
     /// @param xyz 3D vector to be mapped - typically floating point world coordinates
     /// @return Inverse affine mapping of the input @c xyz i.e. (xyz - translation) x mat^-1
     template<typename Vec3T>
-    __hostdev__ Vec3T applyInverseMapF(const Vec3T& xyz) const
+    __hostdev__ constexpr Vec3T applyInverseMapF(const Vec3T& xyz) const
     {
         return math::matMult(mInvMatF, Vec3T(xyz[0] - mVecF[0], xyz[1] - mVecF[1], xyz[2] - mVecF[2]));
     }
@@ -1506,7 +1506,7 @@ struct Map
     /// @param ijk 3D vector to be mapped - typically floating point index coordinates
     /// @return linear inverse 3x3 mapping of the input vector i.e. xyz x mat^-1
     template<typename Vec3T>
-    __hostdev__ Vec3T applyInverseJacobian(const Vec3T& xyz) const { return math::matMult(mInvMatD, xyz); }
+    __hostdev__ constexpr Vec3T applyInverseJacobian(const Vec3T& xyz) const { return math::matMult(mInvMatD, xyz); }
 
     /// @brief Apply the linear inverse 3x3 transformation to an input 3d vector using 32bit floating point arithmetics,
     ///        e.g. inverse scale and inverse rotation WITHOUT translation.
@@ -1515,7 +1515,7 @@ struct Map
     /// @param ijk 3D vector to be mapped - typically floating point index coordinates
     /// @return linear inverse 3x3 mapping of the input vector i.e. xyz x mat^-1
     template<typename Vec3T>
-    __hostdev__ Vec3T applyInverseJacobianF(const Vec3T& xyz) const { return math::matMult(mInvMatF, xyz); }
+    __hostdev__ constexpr Vec3T applyInverseJacobianF(const Vec3T& xyz) const { return math::matMult(mInvMatF, xyz); }
 
     /// @brief Apply the transposed inverse 3x3 transformation to an input 3d vector using 64bit floating point arithmetics,
     ///        e.g. inverse scale and inverse rotation WITHOUT translation.
@@ -1524,12 +1524,12 @@ struct Map
     /// @param ijk 3D vector to be mapped - typically floating point index coordinates
     /// @return linear inverse 3x3 mapping of the input vector i.e. xyz x mat^-1
     template<typename Vec3T>
-    __hostdev__ Vec3T applyIJT(const Vec3T& xyz) const { return math::matMultT(mInvMatD, xyz); }
+    __hostdev__ constexpr Vec3T applyIJT(const Vec3T& xyz) const { return math::matMultT(mInvMatD, xyz); }
     template<typename Vec3T>
-    __hostdev__ Vec3T applyIJTF(const Vec3T& xyz) const { return math::matMultT(mInvMatF, xyz); }
+    __hostdev__ constexpr Vec3T applyIJTF(const Vec3T& xyz) const { return math::matMultT(mInvMatF, xyz); }
 
     /// @brief Return a voxels size in each coordinate direction, measured at the origin
-    __hostdev__ Vec3d getVoxelSize() const { return this->applyMap(Vec3d(1)) - this->applyMap(Vec3d(0)); }
+    __hostdev__ constexpr Vec3d getVoxelSize() const { return this->applyMap(Vec3d(1)) - this->applyMap(Vec3d(0)); }
 }; // Map
 
 template<typename MatT, typename Vec3T>

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -1039,8 +1039,13 @@ public:
 // ----------------------------> Vec2 <--------------------------------------
 
 /// @brief A simple vector class with two components, similar to openvdb::math::Vec2
+///
+/// Aligned to 2*alignof(T) so the whole class fits in one SIMD-friendly
+/// chunk (e.g. 8 bytes for Vec2<float>, 16 bytes for Vec2<double>),
+/// without any tail padding because the byte size is already a power-of-2
+/// multiple of alignof(T).
 template<typename T>
-class Vec2 : public VecBase<T, 2>
+class alignas(alignof(T) * 2) Vec2 : public VecBase<T, 2>
 {
     using Base = VecBase<T, 2>;
 
@@ -1321,8 +1326,11 @@ template<typename T> class Vec4;
 
 
 
+// Aligned to 4*alignof(T) — Mat2 stores 4 elements (2x2), which is already
+// a power-of-2 multiple of alignof(T), so this is free in size and gives
+// SIMD-friendly placement (16 bytes for Mat2<float>, 32 bytes for double).
 template <typename T>
-class Mat2 : public MatBase<T, 2, 2> {
+class alignas(alignof(T) * 4) Mat2 : public MatBase<T, 2, 2> {
     using Base = MatBase<T, 2, 2>;
 public:
     Mat2() = default;
@@ -1376,6 +1384,10 @@ public:
     }
 };
 
+// Mat2x3 is intentionally NOT alignas-elevated: its byte size
+// (6*sizeof(T)) is not a power-of-2 multiple of alignof(T), so any
+// alignas(N > alignof(T)) would force tail padding and break
+// packed-array layout plus on-disk format compatibility.
 template <typename T>
 class Mat2x3 : public MatBase<T, 2, 3> {
     using Base = MatBase<T, 2, 3>;
@@ -1420,6 +1432,10 @@ public:
     __hostdev__ constexpr Mat3x2<T> transpose() const { return this->template transposeAs<Mat3x2<T>>(); }
 };
 
+// Mat3x2 is intentionally NOT alignas-elevated: its byte size
+// (6*sizeof(T)) is not a power-of-2 multiple of alignof(T), so any
+// alignas(N > alignof(T)) would force tail padding and break
+// packed-array layout plus on-disk format compatibility.
 template <typename T>
 class Mat3x2: public MatBase<T, 3, 2> {
     using Base = MatBase<T, 3, 2>;
@@ -1468,6 +1484,10 @@ public:
 
 };
 
+// Mat3 is intentionally NOT alignas-elevated: its byte size
+// (9*sizeof(T)) is not a power-of-2 multiple of alignof(T), so any
+// alignas(N > alignof(T)) would force tail padding and break
+// packed-array layout plus on-disk format compatibility.
 template <typename T>
 class Mat3 : public MatBase<T, 3, 3> {
     using Base = MatBase<T, 3, 3>;
@@ -1519,8 +1539,16 @@ public:
     __hostdev__ constexpr Mat3 transpose() const { return this->template transposeAs<Mat3>(); }
 };
 
+// Aligned to 16*alignof(T) — Mat4 stores 16 elements (4x4), which is
+// already a power-of-2 multiple of alignof(T), so the alignment is free
+// in size. Whole-matrix alignment (64 bytes for Mat4<float>, 128 bytes
+// for Mat4<double>) is heavy compared to row-alignment (4*alignof(T))
+// but matches the per-class "align to full size" rule used for Vec2 /
+// Vec4 / Mat2 above and lets a Mat4<float> load with a single AVX-512
+// instruction. Drop to alignas(alignof(T) * 4) here if the over-aligned
+// constraint causes friction with downstream allocators.
 template <typename T>
-class Mat4 : public MatBase<T, 4, 4> {
+class alignas(alignof(T) * 16) Mat4 : public MatBase<T, 4, 4> {
     using Base = MatBase<T, 4, 4>;
 public:
     Mat4() = default;
@@ -1621,6 +1649,13 @@ __hostdev__ constexpr Mat3x2<T> operator*(const Mat3<T>& lhs, const Mat3x2<T>& r
 // ----------------------------> Vec3 <--------------------------------------
 
 /// @brief A simple vector class with three components, similar to openvdb::math::Vec3
+///
+/// Vec3 is intentionally NOT alignas-elevated: its byte size
+/// (3*sizeof(T)) is not a power-of-2 multiple of alignof(T), so any
+/// alignas(N > alignof(T)) would force tail padding and break
+/// packed-array layout plus on-disk format compatibility. An opt-in
+/// over-aligned Vec3 wrapper (e.g. for CUDA-coalesced loads) is best
+/// added as a separate type rather than changing Vec3 itself.
 template<typename T>
 class Vec3 : public VecBase<T, 3>
 {
@@ -1754,8 +1789,13 @@ __hostdev__ inline constexpr Vec3<double> Coord::asVec3d() const
 // ----------------------------> Vec4 <--------------------------------------
 
 /// @brief A simple vector class with four components, similar to openvdb::math::Vec4
+///
+/// Aligned to 4*alignof(T) so the whole class fits in one SIMD register
+/// (16 bytes for Vec4<float>, 32 bytes for Vec4<double>), without any
+/// tail padding because the byte size is already a power-of-2 multiple
+/// of alignof(T).
 template<typename T>
-class Vec4 : public VecBase<T, 4>
+class alignas(alignof(T) * 4) Vec4 : public VecBase<T, 4>
 {
     using Base = VecBase<T, 4>;
 

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -136,11 +136,11 @@ __hostdev__ inline Type Min(Type a, Type b)
 }
 __hostdev__ inline int32_t Min(int32_t a, int32_t b)
 {
-    return int32_t(fminf(float(a), float(b)));
+    return a < b ? a : b;
 }
 __hostdev__ inline uint32_t Min(uint32_t a, uint32_t b)
 {
-    return uint32_t(fminf(float(a), float(b)));
+    return a < b ? a : b;
 }
 __hostdev__ inline float Min(float a, float b)
 {
@@ -158,11 +158,11 @@ __hostdev__ inline Type Max(Type a, Type b)
 
 __hostdev__ inline int32_t Max(int32_t a, int32_t b)
 {
-    return int32_t(fmaxf(float(a), float(b)));
+    return a > b ? a : b;
 }
 __hostdev__ inline uint32_t Max(uint32_t a, uint32_t b)
 {
-    return uint32_t(fmaxf(float(a), float(b)));
+    return a > b ? a : b;
 }
 __hostdev__ inline float Max(float a, float b)
 {
@@ -252,18 +252,23 @@ __hostdev__ inline int Abs(int x)
 template<typename CoordT, typename RealT, template<typename> class Vec3T>
 __hostdev__ inline CoordT Round(const Vec3T<RealT>& xyz);
 
+/// @brief Round each component to its closest integer (round-half-toward-+inf)
+/// using @c floor(x+0.5). Same rule is applied to both single and double
+/// precision so float and double inputs yield the same integer coords.
 template<typename CoordT, template<typename> class Vec3T>
 __hostdev__ inline CoordT Round(const Vec3T<float>& xyz)
 {
-    return CoordT(int32_t(rintf(xyz[0])), int32_t(rintf(xyz[1])), int32_t(rintf(xyz[2])));
-    //return CoordT(int32_t(roundf(xyz[0])), int32_t(roundf(xyz[1])), int32_t(roundf(xyz[2])) );
-    //return CoordT(int32_t(floorf(xyz[0] + 0.5f)), int32_t(floorf(xyz[1] + 0.5f)), int32_t(floorf(xyz[2] + 0.5f)));
+    return CoordT(int32_t(floorf(xyz[0] + 0.5f)),
+                  int32_t(floorf(xyz[1] + 0.5f)),
+                  int32_t(floorf(xyz[2] + 0.5f)));
 }
 
 template<typename CoordT, template<typename> class Vec3T>
 __hostdev__ inline CoordT Round(const Vec3T<double>& xyz)
 {
-    return CoordT(int32_t(floor(xyz[0] + 0.5)), int32_t(floor(xyz[1] + 0.5)), int32_t(floor(xyz[2] + 0.5)));
+    return CoordT(int32_t(floor(xyz[0] + 0.5)),
+                  int32_t(floor(xyz[1] + 0.5)),
+                  int32_t(floor(xyz[2] + 0.5)));
 }
 
 template<typename CoordT, typename RealT, template<typename> class Vec3T>
@@ -802,154 +807,279 @@ public:
     __hostdev__ inline Coord2 round() const { return *this; }
 }; // Coord2 class
 
-// ----------------------------> Vec2 <--------------------------------------
+// ----------------------------> VecBase <-----------------------------------
 
-/// @brief A simple vector class with three components, similar to openvdb::math::Vec3
-template<typename T>
-class Vec2
+/// @brief Base class for fixed-size vectors. Provides shared element-wise
+/// arithmetic, scalar arithmetic, equality, length/dot reductions,
+/// component min/max, and integer-coord rounding. Derived classes provide
+/// constructors and any dimension-specific extras (e.g. cross/outer on Vec3).
+template<typename T, int N>
+class VecBase
 {
-    T mVec[2];
+protected:
+    T mVec[N];
 
 public:
-    static const int SIZE = 2;
-    static const int size = 2; // in openvdb::math::Tuple
     using ValueType = T;
+    static constexpr int SIZE = N;
+
+    VecBase() = default;
+
+    /// @brief Indexed element access (no bounds check; assumes 0 <= i < N)
+    __hostdev__ const T& operator[](int i) const { return mVec[i]; }
+    __hostdev__ T&       operator[](int i)       { return mVec[i]; }
+
+    /// @brief raw pointer to the underlying N-element storage
+    __hostdev__ T*       asPointer()       { return mVec; }
+    __hostdev__ const T* asPointer() const { return mVec; }
+
+    // ---- generic element-wise helpers (taking/returning Derived) ----
+
+    template<typename Derived>
+    __hostdev__ Derived plus(const Derived& rhs) const {
+        Derived out;
+        for (int i = 0; i < N; ++i) out[i] = mVec[i] + rhs[i];
+        return out;
+    }
+    template<typename Derived>
+    __hostdev__ Derived minus(const Derived& rhs) const {
+        Derived out;
+        for (int i = 0; i < N; ++i) out[i] = mVec[i] - rhs[i];
+        return out;
+    }
+    template<typename Derived>
+    __hostdev__ Derived mul(const Derived& rhs) const {
+        Derived out;
+        for (int i = 0; i < N; ++i) out[i] = mVec[i] * rhs[i];
+        return out;
+    }
+    template<typename Derived>
+    __hostdev__ Derived div(const Derived& rhs) const {
+        Derived out;
+        for (int i = 0; i < N; ++i) out[i] = mVec[i] / rhs[i];
+        return out;
+    }
+    template<typename Derived>
+    __hostdev__ Derived negate() const {
+        Derived out;
+        for (int i = 0; i < N; ++i) out[i] = -mVec[i];
+        return out;
+    }
+    template<typename Derived>
+    __hostdev__ Derived scale(const T& s) const {
+        Derived out;
+        for (int i = 0; i < N; ++i) out[i] = mVec[i] * s;
+        return out;
+    }
+    /// @brief return (*this) / @a s element-wise as a @c Derived. Uses per-element
+    /// division (correct for integer @c T, unlike multiplying by 1/s).
+    template<typename Derived>
+    __hostdev__ Derived divideBy(const T& s) const {
+        Derived out;
+        for (int i = 0; i < N; ++i) out[i] = mVec[i] / s;
+        return out;
+    }
+
+    // ---- in-place compound assignment helpers ----
+
+    __hostdev__ VecBase& addAssign(const VecBase& rhs) {
+        for (int i = 0; i < N; ++i) mVec[i] += rhs.mVec[i];
+        return *this;
+    }
+    __hostdev__ VecBase& subAssign(const VecBase& rhs) {
+        for (int i = 0; i < N; ++i) mVec[i] -= rhs.mVec[i];
+        return *this;
+    }
+    __hostdev__ VecBase& mulAssign(const VecBase& rhs) {
+        for (int i = 0; i < N; ++i) mVec[i] *= rhs.mVec[i];
+        return *this;
+    }
+    __hostdev__ VecBase& divAssign(const VecBase& rhs) {
+        for (int i = 0; i < N; ++i) mVec[i] /= rhs.mVec[i];
+        return *this;
+    }
+    __hostdev__ VecBase& scaleAssign(const T& s) {
+        for (int i = 0; i < N; ++i) mVec[i] *= s;
+        return *this;
+    }
+    __hostdev__ VecBase& divideAssignScalar(const T& s) {
+        for (int i = 0; i < N; ++i) mVec[i] /= s;
+        return *this;
+    }
+
+    __hostdev__ bool equals(const VecBase& rhs) const {
+        for (int i = 0; i < N; ++i) if (mVec[i] != rhs.mVec[i]) return false;
+        return true;
+    }
+
+    // ---- reductions ----
+
+    /// @brief dot product. @a V must have @c operator[] valid for 0..N-1.
+    template<typename V>
+    __hostdev__ T dot(const V& v) const {
+        T s = T(0);
+        for (int i = 0; i < N; ++i) s += mVec[i] * v[i];
+        return s;
+    }
+    __hostdev__ T lengthSqr() const {
+        T s = T(0);
+        for (int i = 0; i < N; ++i) s += mVec[i] * mVec[i];
+        return s;
+    }
+    __hostdev__ T length() const { return Sqrt(this->lengthSqr()); }
+
+    /// @brief return the smallest of the N components
+    __hostdev__ T smallestComponent() const {
+        T m = mVec[0];
+        for (int i = 1; i < N; ++i) if (mVec[i] < m) m = mVec[i];
+        return m;
+    }
+    /// @brief return the largest of the N components
+    __hostdev__ T largestComponent() const {
+        T m = mVec[0];
+        for (int i = 1; i < N; ++i) if (mVec[i] > m) m = mVec[i];
+        return m;
+    }
+
+    // ---- component-wise (mutating) min/max ----
+
+    template<typename V>
+    __hostdev__ VecBase& mergeMin(const V& other) {
+        for (int i = 0; i < N; ++i) if (other[i] < mVec[i]) mVec[i] = other[i];
+        return *this;
+    }
+    template<typename V>
+    __hostdev__ VecBase& mergeMax(const V& other) {
+        for (int i = 0; i < N; ++i) if (other[i] > mVec[i]) mVec[i] = other[i];
+        return *this;
+    }
+
+    // ---- integer rounding (toward -inf / +inf / nearest) ----
+
+    /// @brief floor-rounded components into the @c Result type (whose @c [i]
+    /// must accept int32_t). For integer @c T the value is passed through.
+    template<typename Result>
+    __hostdev__ Result floorAs() const {
+        Result r;
+        if constexpr (util::is_floating_point<T>::value) {
+            for (int i = 0; i < N; ++i) r[i] = math::Floor(mVec[i]);
+        } else {
+            for (int i = 0; i < N; ++i) r[i] = static_cast<int32_t>(mVec[i]);
+        }
+        return r;
+    }
+    template<typename Result>
+    __hostdev__ Result ceilAs() const {
+        Result r;
+        if constexpr (util::is_floating_point<T>::value) {
+            for (int i = 0; i < N; ++i) r[i] = math::Ceil(mVec[i]);
+        } else {
+            for (int i = 0; i < N; ++i) r[i] = static_cast<int32_t>(mVec[i]);
+        }
+        return r;
+    }
+    /// @brief nearest-integer rounding using floor(x + 0.5) for floating @c T
+    /// (round-half-toward-positive-infinity). Unifies behaviour between float
+    /// and double; pass-through for integer @c T.
+    template<typename Result>
+    __hostdev__ Result roundAs() const {
+        Result r;
+        if constexpr (util::is_floating_point<T>::value) {
+            const T half = T(0.5);
+            for (int i = 0; i < N; ++i) r[i] = math::Floor(mVec[i] + half);
+        } else {
+            for (int i = 0; i < N; ++i) r[i] = static_cast<int32_t>(mVec[i]);
+        }
+        return r;
+    }
+}; // VecBase<T, N>
+
+// ----------------------------> Vec2 <--------------------------------------
+
+/// @brief A simple vector class with two components, similar to openvdb::math::Vec2
+template<typename T>
+class Vec2 : public VecBase<T, 2>
+{
+    using Base = VecBase<T, 2>;
+
+public:
+    using ValueType = T;
+    static const int size = 2; // openvdb::math::Tuple-compat alias of SIZE
+
     Vec2() = default;
-    __hostdev__ explicit Vec2(T x)
-        : mVec{x, x}
-    {
-    }
-    __hostdev__ Vec2(T x, T y)
-        : mVec{x, y}
-    {
-    }
+    __hostdev__ explicit Vec2(T x)            { this->mVec[0] = x;    this->mVec[1] = x;    }
+    __hostdev__ Vec2(T x, T y)                { this->mVec[0] = x;    this->mVec[1] = y;    }
+
     template<template<class> class Vec2T, class T2>
-    __hostdev__ Vec2(const Vec2T<T2>& v)
-        : mVec{T(v[0]), T(v[1])}
-    {
-        static_assert(Vec2T<T2>::size == size, "expected Vec2T::size==2!");
+    __hostdev__ Vec2(const Vec2T<T2>& v) {
+        static_assert(Vec2T<T2>::SIZE == 2, "expected Vec2T::SIZE==2!");
+        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]);
     }
     template<typename T2>
-    __hostdev__ explicit Vec2(const Vec2<T2>& v)
-        : mVec{T(v[0]), T(v[1])}
-    {
+    __hostdev__ explicit Vec2(const Vec2<T2>& v) {
+        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]);
     }
-    __hostdev__ explicit Vec2(const Coord2& ijk)
-        : mVec{T(ijk[0]), T(ijk[1])}
-    {
+    __hostdev__ explicit Vec2(const Coord2& ijk) {
+        this->mVec[0] = T(ijk[0]); this->mVec[1] = T(ijk[1]);
     }
-    __hostdev__ bool operator==(const Vec2& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
-    __hostdev__ bool operator!=(const Vec2& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
+
     template<template<class> class Vec2T, class T2>
-    __hostdev__ Vec2& operator=(const Vec2T<T2>& rhs)
-    {
-        static_assert(Vec2T<T2>::size == size, "expected Vec2T::size==2!");
-        mVec[0] = rhs[0];
-        mVec[1] = rhs[1];
-        return *this;
-    }
-    __hostdev__ const T& operator[](int i) const { return mVec[i]; }
-    __hostdev__ T&       operator[](int i) { return mVec[i]; }
-    template<typename Vec2T>
-    __hostdev__ T dot(const Vec2T& v) const { return mVec[0] * v[0] + mVec[1] * v[1]; }
-    __hostdev__ T lengthSqr() const
-    {
-        return mVec[0] * mVec[0] + mVec[1] * mVec[1]; // 3 flops
-    }
-    __hostdev__ T     length() const { return Sqrt(this->lengthSqr()); }
-    __hostdev__ Vec2  operator-() const { return Vec2(-mVec[0], -mVec[1]); }
-    __hostdev__ Vec2  operator*(const Vec2& v) const { return Vec2(mVec[0] * v[0], mVec[1] * v[1]); }
-    __hostdev__ Vec2  operator/(const Vec2& v) const { return Vec2(mVec[0] / v[0], mVec[1] / v[1]); }
-    __hostdev__ Vec2  operator+(const Vec2& v) const { return Vec2(mVec[0] + v[0], mVec[1] + v[1]); }
-    __hostdev__ Vec2  operator-(const Vec2& v) const { return Vec2(mVec[0] - v[0], mVec[1] - v[1]); }
-    __hostdev__ Vec2  operator+(const Coord& ijk) const { return Vec2(mVec[0] + ijk[0], mVec[1] + ijk[1]); }
-    __hostdev__ Vec2  operator-(const Coord& ijk) const { return Vec2(mVec[0] - ijk[0], mVec[1] - ijk[1]); }
-    __hostdev__ Vec2  operator*(const T& s) const { return Vec2(s * mVec[0], s * mVec[1]); }
-    __hostdev__ Vec2  operator/(const T& s) const { return (T(1) / s) * (*this); }
-    __hostdev__ Vec2& operator+=(const Vec2& v)
-    {
-        mVec[0] += v[0];
-        mVec[1] += v[1];
-        return *this;
-    }
-    __hostdev__ Vec2& operator+=(const Coord& ijk)
-    {
-        mVec[0] += T(ijk[0]);
-        mVec[1] += T(ijk[1]);
-        return *this;
-    }
-    __hostdev__ Vec2& operator-=(const Vec2& v)
-    {
-        mVec[0] -= v[0];
-        mVec[1] -= v[1];
-        return *this;
-    }
-    __hostdev__ Vec2& operator-=(const Coord& ijk)
-    {
-        mVec[0] -= T(ijk[0]);
-        mVec[1] -= T(ijk[1]);
-        return *this;
-    }
-    __hostdev__ Vec2& operator*=(const T& s)
-    {
-        mVec[0] *= s;
-        mVec[1] *= s;
-        return *this;
-    }
-    __hostdev__ Vec2& operator/=(const T& s) { return (*this) *= T(1) / s; }
-    __hostdev__ Vec2& normalize() { return (*this) /= this->length(); }
-    /// @brief Perform a component-wise minimum with the other Coord.
-    __hostdev__ Vec2& minComponent(const Vec2& other)
-    {
-        if (other[0] < mVec[0])
-            mVec[0] = other[0];
-        if (other[1] < mVec[1])
-            mVec[1] = other[1];
+    __hostdev__ Vec2& operator=(const Vec2T<T2>& rhs) {
+        static_assert(Vec2T<T2>::SIZE == 2, "expected Vec2T::SIZE==2!");
+        this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1];
         return *this;
     }
 
-    /// @brief Perform a component-wise maximum with the other Coord.
-    __hostdev__ Vec2& maxComponent(const Vec2& other)
-    {
-        if (other[0] > mVec[0])
-            mVec[0] = other[0];
-        if (other[1] > mVec[1])
-            mVec[1] = other[1];
+    // ---- element-wise (Vec & Vec) ----
+    __hostdev__ Vec2  operator-() const            { return Base::template negate<Vec2>(); }
+    __hostdev__ Vec2  operator+(const Vec2& v) const { return Base::template plus<Vec2>(v); }
+    __hostdev__ Vec2  operator-(const Vec2& v) const { return Base::template minus<Vec2>(v); }
+    __hostdev__ Vec2  operator*(const Vec2& v) const { return Base::template mul<Vec2>(v); }
+    __hostdev__ Vec2  operator/(const Vec2& v) const { return Base::template div<Vec2>(v); }
+    __hostdev__ Vec2& operator+=(const Vec2& v)    { Base::addAssign(v); return *this; }
+    __hostdev__ Vec2& operator-=(const Vec2& v)    { Base::subAssign(v); return *this; }
+
+    // ---- mixed Vec2 / Coord2 ----
+    __hostdev__ Vec2  operator+(const Coord2& ijk) const { return Vec2(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1]); }
+    __hostdev__ Vec2  operator-(const Coord2& ijk) const { return Vec2(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1]); }
+    __hostdev__ Vec2& operator+=(const Coord2& ijk) {
+        this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]);
         return *this;
     }
+    __hostdev__ Vec2& operator-=(const Coord2& ijk) {
+        this->mVec[0] -= T(ijk[0]); this->mVec[1] -= T(ijk[1]);
+        return *this;
+    }
+
+    // ---- scalar ----
+    __hostdev__ Vec2  operator*(const T& s) const  { return Base::template scale<Vec2>(s); }
+    __hostdev__ Vec2  operator/(const T& s) const  { return Base::template divideBy<Vec2>(s); }
+    __hostdev__ Vec2& operator*=(const T& s)       { Base::scaleAssign(s); return *this; }
+    __hostdev__ Vec2& operator/=(const T& s)       { Base::divideAssignScalar(s); return *this; }
+    __hostdev__ Vec2& normalize()                  { return (*this) /= this->length(); }
+
+    // ---- equality ----
+    __hostdev__ bool operator==(const Vec2& rhs) const { return Base::equals(rhs); }
+    __hostdev__ bool operator!=(const Vec2& rhs) const { return !Base::equals(rhs); }
+
+    // ---- component-wise min/max ----
+    __hostdev__ Vec2& minComponent(const Vec2& other) { Base::mergeMin(other); return *this; }
+    __hostdev__ Vec2& maxComponent(const Vec2& other) { Base::mergeMax(other); return *this; }
+
     /// @brief Return the smallest vector component
-    __hostdev__ ValueType min() const
-    {
-        return mVec[0] < mVec[1] ? mVec[0] : mVec[1];
-    }
+    __hostdev__ ValueType min() const { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ ValueType max() const
-    {
-        return mVec[0] > mVec[1] ? mVec[0] : mVec[1];
-    }
-    /// @brief Round each component if this Vec<T> up to its integer value
-    /// @return Return an integer Coord
-    __hostdev__ Coord2 floor() const { return Coord2(Floor(mVec[0]), Floor(mVec[1])); }
-    /// @brief Round each component if this Vec<T> down to its integer value
-    /// @return Return an integer Coord
-    __hostdev__ Coord2 ceil() const { return Coord2(Ceil(mVec[0]), Ceil(mVec[1])); }
-    /// @brief Round each component if this Vec<T> to its closest integer value
-    /// @return Return an integer Coord
-    __hostdev__ Coord2 round() const
-    {
-        if constexpr(util::is_same<T, float>::value) {
-            return Coord2(Floor(mVec[0] + 0.5f), Floor(mVec[1] + 0.5f));
-        } else if constexpr(util::is_same<T, int>::value) {
-            return Coord2(mVec[0], mVec[1]);
-        } else {
-            return Coord2(Floor(mVec[0] + 0.5), Floor(mVec[1] + 0.5));
-        }
-    }
+    __hostdev__ ValueType max() const { return Base::largestComponent(); }
 
-    /// @brief return a non-const raw constant pointer to array of three vector components
-    __hostdev__ T* asPointer() { return mVec; }
-    /// @brief return a const raw constant pointer to array of three vector components
-    __hostdev__ const T* asPointer() const { return mVec; }
+    /// @brief Round each component down (toward negative infinity)
+    /// @return integer Coord2
+    __hostdev__ Coord2 floor() const { return Base::template floorAs<Coord2>(); }
+    /// @brief Round each component up (toward positive infinity)
+    /// @return integer Coord2
+    __hostdev__ Coord2 ceil()  const { return Base::template ceilAs<Coord2>(); }
+    /// @brief Round each component to its closest integer value
+    /// @return integer Coord2
+    __hostdev__ Coord2 round() const { return Base::template roundAs<Coord2>(); }
 }; // Vec2<T>
 
 template<typename T1, typename T2>
@@ -982,16 +1112,18 @@ class MatBase {
 protected:
     T mData[ROWS * COLS];  // 1D array storage
 
+public:
+    using ValueType = T;
+
     static constexpr int rows() { return ROWS; }
     static constexpr int cols() { return COLS; }
     static constexpr int size() { return ROWS * COLS; }
 
-public:
     MatBase() = default;
 
     template<typename S>
     __hostdev__ MatBase(S* array) {
-        for (int i = 0; i < ROWS * COLS; ++i) {
+        for (int i = 0; i < size(); ++i) {
             mData[i] = static_cast<T>(array[i]);
         }
     }
@@ -1003,6 +1135,131 @@ public:
     __hostdev__ const T* operator[](int row) const {
         return &mData[row * COLS];
     }
+
+    /// @brief return a raw pointer to the underlying 1D storage (row-major)
+    __hostdev__ T*       data()       { return mData; }
+    /// @brief return a const raw pointer to the underlying 1D storage (row-major)
+    __hostdev__ const T* data() const { return mData; }
+
+    // ---- generic element-wise helpers ----
+
+    /// @brief return @c *this + @a rhs as a @c Derived
+    template<typename Derived>
+    __hostdev__ Derived plus(const Derived& rhs) const {
+        Derived out;
+        for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] + rhs.data()[i];
+        return out;
+    }
+
+    /// @brief return @c *this - @a rhs as a @c Derived
+    template<typename Derived>
+    __hostdev__ Derived minus(const Derived& rhs) const {
+        Derived out;
+        for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] - rhs.data()[i];
+        return out;
+    }
+
+    /// @brief return -(*this) as a @c Derived
+    template<typename Derived>
+    __hostdev__ Derived negate() const {
+        Derived out;
+        for (int i = 0; i < size(); ++i) out.data()[i] = -mData[i];
+        return out;
+    }
+
+    /// @brief return @a s * (*this) as a @c Derived
+    template<typename Derived>
+    __hostdev__ Derived scale(const T& s) const {
+        Derived out;
+        for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] * s;
+        return out;
+    }
+
+    __hostdev__ MatBase& addAssign(const MatBase& rhs) {
+        for (int i = 0; i < size(); ++i) mData[i] += rhs.mData[i];
+        return *this;
+    }
+    __hostdev__ MatBase& subAssign(const MatBase& rhs) {
+        for (int i = 0; i < size(); ++i) mData[i] -= rhs.mData[i];
+        return *this;
+    }
+    __hostdev__ MatBase& scaleAssign(const T& s) {
+        for (int i = 0; i < size(); ++i) mData[i] *= s;
+        return *this;
+    }
+
+    /// @brief return (*this) / @a s element-wise as a @c Derived. Uses
+    /// per-element division (correct for integer @c T, unlike multiplying by 1/s).
+    template<typename Derived>
+    __hostdev__ Derived divideBy(const T& s) const {
+        Derived out;
+        for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] / s;
+        return out;
+    }
+    __hostdev__ MatBase& divideAssign(const T& s) {
+        for (int i = 0; i < size(); ++i) mData[i] /= s;
+        return *this;
+    }
+
+    __hostdev__ bool equals(const MatBase& rhs) const {
+        for (int i = 0; i < size(); ++i) if (mData[i] != rhs.mData[i]) return false;
+        return true;
+    }
+
+    // ---- generic transpose ----
+
+    /// @brief return the transpose of @c *this as the @c Result type.
+    /// @tparam Result a matrix type whose dimensions are (COLS, ROWS)
+    template<typename Result>
+    __hostdev__ Result transposeAs() const {
+        static_assert(Result::rows() == COLS && Result::cols() == ROWS,
+                      "transposeAs: result dims must be (COLS, ROWS)");
+        Result r;
+        for (int i = 0; i < ROWS; ++i)
+            for (int j = 0; j < COLS; ++j)
+                r[j][i] = mData[i * COLS + j];
+        return r;
+    }
+
+    // ---- generic matrix * matrix ----
+
+    /// @brief return (*this) * @a rhs as the @c Result type.
+    /// @tparam Result a matrix type whose dimensions are (ROWS, Rhs::cols())
+    /// @tparam Rhs    a matrix type whose row count equals @c COLS
+    template<typename Result, typename Rhs>
+    __hostdev__ Result multiply(const Rhs& rhs) const {
+        static_assert(COLS == Rhs::rows(), "multiply: lhs.cols must equal rhs.rows");
+        static_assert(Result::rows() == ROWS && Result::cols() == Rhs::cols(),
+                      "multiply: result dims mismatch");
+        Result r;
+        for (int i = 0; i < ROWS; ++i) {
+            for (int j = 0; j < Rhs::cols(); ++j) {
+                T sum = T(0);
+                for (int k = 0; k < COLS; ++k)
+                    sum += mData[i * COLS + k] * rhs[k][j];
+                r[i][j] = sum;
+            }
+        }
+        return r;
+    }
+
+    // ---- generic matrix * vector ----
+
+    /// @brief return (*this) * @a v as the @c VecResult type.
+    /// @tparam VecResult a vector type whose @c SIZE equals @c ROWS
+    /// @tparam VecRhs    a vector type whose @c SIZE equals @c COLS
+    template<typename VecResult, typename VecRhs>
+    __hostdev__ VecResult multiplyVec(const VecRhs& v) const {
+        static_assert(VecRhs::SIZE == COLS && VecResult::SIZE == ROWS,
+                      "multiplyVec: dim mismatch");
+        VecResult r;
+        for (int i = 0; i < ROWS; ++i) {
+            T sum = T(0);
+            for (int k = 0; k < COLS; ++k) sum += mData[i * COLS + k] * v[k];
+            r[i] = sum;
+        }
+        return r;
+    }
 };
 
 // Forward declarations
@@ -1011,6 +1268,7 @@ template<typename T> class Mat2x3;
 template<typename T> class Mat3x2;
 template<typename T> class Mat3;
 template<typename T> class Mat4;
+template<typename T> class Vec4;
 
 
 
@@ -1033,40 +1291,39 @@ public:
     template<typename Source>
     __hostdev__ Mat2(Source* array) : Base(array) {}
 
-    __hostdev__ Mat2  operator-() const { return Mat2(-(*this)[0][0], -(*this)[0][1], -(*this)[1][0], -(*this)[1][1]); }
+    // ---- element-wise ----
+    __hostdev__ Mat2  operator-() const                  { return this->template negate<Mat2>(); }
+    __hostdev__ Mat2  operator+(const Mat2& m) const     { return this->template plus<Mat2>(m); }
+    __hostdev__ Mat2  operator-(const Mat2& m) const     { return this->template minus<Mat2>(m); }
+    __hostdev__ Mat2& operator+=(const Mat2& m)          { Base::addAssign(m); return *this; }
+    __hostdev__ Mat2& operator-=(const Mat2& m)          { Base::subAssign(m); return *this; }
 
-    /// @brief Multiply by 2x2 matrix @a m and return the resulting matrix.
-    __hostdev__ Mat2<T> operator*(const Mat2<T>& m) const {
-        return Mat2<T>(
-            (*this)[0][0] * m[0][0] + (*this)[0][1] * m[1][0],
-            (*this)[0][0] * m[0][1] + (*this)[0][1] * m[1][1],
-            (*this)[1][0] * m[0][0] + (*this)[1][1] * m[1][0],
-            (*this)[1][0] * m[0][1] + (*this)[1][1] * m[1][1]
-        );
-    }
+    // ---- matrix * matrix / matrix * vector ----
+    __hostdev__ Mat2     operator*(const Mat2& m) const     { return this->template multiply<Mat2, Mat2>(m); }
+    __hostdev__ Vec2<T>  operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec2<T>>(v); }
 
-    /// @brief Add each element of the given matrix to the corresponding element of this matrix.
-    __hostdev__ Mat2<T>& operator+=(const Mat2<T>& m) {
-        (*this)[0][0] += m[0][0];
-        (*this)[0][1] += m[0][1];
-        (*this)[1][0] += m[1][0];
-        (*this)[1][1] += m[1][1];
-        return *this;
-    }
+    // ---- scalar ----
+    __hostdev__ Mat2  operator*(const T& s) const        { return this->template scale<Mat2>(s); }
+    __hostdev__ Mat2  operator/(const T& s) const        { return this->template divideBy<Mat2>(s); }
+    __hostdev__ Mat2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ Mat2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+
+    // ---- equality ----
+    __hostdev__ bool operator==(const Mat2& m) const     { return Base::equals(m); }
+    __hostdev__ bool operator!=(const Mat2& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ Mat2<T> transpose() const {
-        return Mat2<T>((*this)[0][0], (*this)[1][0], (*this)[0][1], (*this)[1][1]);
-    }
+    __hostdev__ Mat2 transpose() const { return this->template transposeAs<Mat2>(); }
 
     /// @brief returns inverse of this
     __hostdev__ Mat2<T> inverse() const {
         T det = (*this)[0][0] * (*this)[1][1] - (*this)[0][1] * (*this)[1][0];
         if (isApproxZero(det)) {
-            return Mat2<T>();
+            return Mat2<T>(T(0), T(0), T(0), T(0));
         }
-        T invDet   = 1.f / det;
-        return Mat2<T>((*this)[1][1] * invDet, -(*this)[0][1] * invDet, -(*this)[1][0] * invDet, (*this)[0][0] * invDet);
+        T invDet = T(1) / det;
+        return Mat2<T>((*this)[1][1] * invDet, -(*this)[0][1] * invDet,
+                      -(*this)[1][0] * invDet,  (*this)[0][0] * invDet);
     }
 };
 
@@ -1090,29 +1347,28 @@ public:
     __hostdev__ Mat2x3(Source* array) : Base(array) {}
 
 
-    /// @brief Add two matrices and return the resulting matrix.
-    __hostdev__ Mat2x3<T> operator+(const Mat2x3<T>& m) const {
-        return Mat2x3<T>(
-            (*this)[0][0] + m[0][0], (*this)[0][1] + m[0][1], (*this)[0][2] + m[0][2],
-            (*this)[1][0] + m[1][0], (*this)[1][1] + m[1][1], (*this)[1][2] + m[1][2]
-        );
-    }
+    // ---- element-wise ----
+    __hostdev__ Mat2x3  operator-() const                  { return this->template negate<Mat2x3>(); }
+    __hostdev__ Mat2x3  operator+(const Mat2x3& m) const   { return this->template plus<Mat2x3>(m); }
+    __hostdev__ Mat2x3  operator-(const Mat2x3& m) const   { return this->template minus<Mat2x3>(m); }
+    __hostdev__ Mat2x3& operator+=(const Mat2x3& m)        { Base::addAssign(m); return *this; }
+    __hostdev__ Mat2x3& operator-=(const Mat2x3& m)        { Base::subAssign(m); return *this; }
 
-    /// @brief Add a 2x3 matrix to this matrix.
-    __hostdev__ Mat2x3<T>& operator+=(const Mat2x3<T>& m) {
-        (*this)[0][0] += m[0][0]; (*this)[0][1] += m[0][1]; (*this)[0][2] += m[0][2];
-        (*this)[1][0] += m[1][0]; (*this)[1][1] += m[1][1]; (*this)[1][2] += m[1][2];
-        return *this;
-    }
+    // ---- matrix * vector ----
+    __hostdev__ Vec2<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec3<T>>(v); }
+
+    // ---- scalar ----
+    __hostdev__ Mat2x3  operator*(const T& s) const        { return this->template scale<Mat2x3>(s); }
+    __hostdev__ Mat2x3  operator/(const T& s) const        { return this->template divideBy<Mat2x3>(s); }
+    __hostdev__ Mat2x3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ Mat2x3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+
+    // ---- equality ----
+    __hostdev__ bool operator==(const Mat2x3& m) const     { return Base::equals(m); }
+    __hostdev__ bool operator!=(const Mat2x3& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ Mat3x2<T> transpose() const {
-        return Mat3x2<T>(
-            (*this)[0][0], (*this)[1][0],  // First row
-            (*this)[0][1], (*this)[1][1],  // Second row
-            (*this)[0][2], (*this)[1][2]   // Third row
-        );
-    }
+    __hostdev__ Mat3x2<T> transpose() const { return this->template transposeAs<Mat3x2<T>>(); }
 };
 
 template <typename T>
@@ -1127,8 +1383,7 @@ public:
         c d
         e f
         @endverbatim */
-    template<typename Source>
-    __hostdev__ Mat3x2(Source a, Source b, Source c, Source d, Source e, Source f)
+    __hostdev__ Mat3x2(T a, T b, T c, T d, T e, T f)
     {
         this->mData[0] = a; this->mData[1] = b;
         this->mData[2] = c; this->mData[3] = d;
@@ -1139,11 +1394,28 @@ public:
     template<typename Source>
     __hostdev__ Mat3x2(Source *a): Base(a) {}
 
+    // ---- element-wise ----
+    __hostdev__ Mat3x2  operator-() const                  { return this->template negate<Mat3x2>(); }
+    __hostdev__ Mat3x2  operator+(const Mat3x2& m) const   { return this->template plus<Mat3x2>(m); }
+    __hostdev__ Mat3x2  operator-(const Mat3x2& m) const   { return this->template minus<Mat3x2>(m); }
+    __hostdev__ Mat3x2& operator+=(const Mat3x2& m)        { Base::addAssign(m); return *this; }
+    __hostdev__ Mat3x2& operator-=(const Mat3x2& m)        { Base::subAssign(m); return *this; }
+
+    // ---- matrix * vector ----
+    __hostdev__ Vec3<T> operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec2<T>>(v); }
+
+    // ---- scalar ----
+    __hostdev__ Mat3x2  operator*(const T& s) const        { return this->template scale<Mat3x2>(s); }
+    __hostdev__ Mat3x2  operator/(const T& s) const        { return this->template divideBy<Mat3x2>(s); }
+    __hostdev__ Mat3x2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ Mat3x2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+
+    // ---- equality ----
+    __hostdev__ bool operator==(const Mat3x2& m) const     { return Base::equals(m); }
+    __hostdev__ bool operator!=(const Mat3x2& m) const     { return !Base::equals(m); }
+
     /// @brief returns transpose of this
-    __hostdev__ Mat2x3<T> transpose() const {
-        return Mat2x3<T>((*this)[0][0], (*this)[1][0], (*this)[2][0], // First row
-                   (*this)[0][1], (*this)[1][1], (*this)[2][1]); // Second row
-    }
+    __hostdev__ Mat2x3<T> transpose() const { return this->template transposeAs<Mat2x3<T>>(); }
 
 };
 
@@ -1159,10 +1431,9 @@ public:
         d e f
         g h i
         @endverbatim */
-    template<typename Source>
-    __hostdev__ Mat3(Source a, Source b, Source c,
-         Source d, Source e, Source f,
-         Source g, Source h, Source i)
+    __hostdev__ Mat3(T a, T b, T c,
+                     T d, T e, T f,
+                     T g, T h, T i)
     {
         this->mData[0] = a; this->mData[1] = b; this->mData[2] = c;
         this->mData[3] = d; this->mData[4] = e; this->mData[5] = f;
@@ -1174,53 +1445,29 @@ public:
     __hostdev__ Mat3(Source *a): Base(a) {}
 
 
-    /// @brief Add two matrices and return the resulting matrix.
-    __hostdev__ Mat3<T> operator+(const Mat3<T>& m) const {
-        return Mat3<T>(
-            (*this)[0][0] + m[0][0], (*this)[0][1] + m[0][1], (*this)[0][2] + m[0][2],
-            (*this)[1][0] + m[1][0], (*this)[1][1] + m[1][1], (*this)[1][2] + m[1][2],
-            (*this)[2][0] + m[2][0], (*this)[2][1] + m[2][1], (*this)[2][2] + m[2][2]
-        );
-    }
+    // ---- element-wise ----
+    __hostdev__ Mat3  operator-() const                  { return this->template negate<Mat3>(); }
+    __hostdev__ Mat3  operator+(const Mat3& m) const     { return this->template plus<Mat3>(m); }
+    __hostdev__ Mat3  operator-(const Mat3& m) const     { return this->template minus<Mat3>(m); }
+    __hostdev__ Mat3& operator+=(const Mat3& m)          { Base::addAssign(m); return *this; }
+    __hostdev__ Mat3& operator-=(const Mat3& m)          { Base::subAssign(m); return *this; }
 
-    /// @brief Multiply by @a v and return the resulting vector.
-    __hostdev__ Vec3<T> operator*(const Vec3<T>& v) const {
-        return Vec3<T>(
-            (*this)[0][0] * v[0] + (*this)[0][1] * v[1] + (*this)[0][2] * v[2],
-            (*this)[1][0] * v[0] + (*this)[1][1] * v[1] + (*this)[1][2] * v[2],
-            (*this)[2][0] * v[0] + (*this)[2][1] * v[1] + (*this)[2][2] * v[2]
-        );
-    }
+    // ---- matrix * matrix / matrix * vector ----
+    __hostdev__ Mat3    operator*(const Mat3& m) const     { return this->template multiply<Mat3, Mat3>(m); }
+    __hostdev__ Vec3<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec3<T>>(v); }
 
-    /// @brief Multiply by 3x3 matrix @a m and return the resulting matrix.
-    __hostdev__ Mat3<T> operator*(const Mat3<T>& m) const {
-        return Mat3<T>(
-            (*this)[0][0] * m[0][0] + (*this)[0][1] * m[1][0] + (*this)[0][2] * m[2][0],
-            (*this)[0][0] * m[0][1] + (*this)[0][1] * m[1][1] + (*this)[0][2] * m[2][1],
-            (*this)[0][0] * m[0][2] + (*this)[0][1] * m[1][2] + (*this)[0][2] * m[2][2],
-            (*this)[1][0] * m[0][0] + (*this)[1][1] * m[1][0] + (*this)[1][2] * m[2][0],
-            (*this)[1][0] * m[0][1] + (*this)[1][1] * m[1][1] + (*this)[1][2] * m[2][1],
-            (*this)[1][0] * m[0][2] + (*this)[1][1] * m[1][2] + (*this)[1][2] * m[2][2],
-            (*this)[2][0] * m[0][0] + (*this)[2][1] * m[1][0] + (*this)[2][2] * m[2][0],
-            (*this)[2][0] * m[0][1] + (*this)[2][1] * m[1][1] + (*this)[2][2] * m[2][1],
-            (*this)[2][0] * m[0][2] + (*this)[2][1] * m[1][2] + (*this)[2][2] * m[2][2]
-        );
-    }
+    // ---- scalar ----
+    __hostdev__ Mat3  operator*(const T& s) const        { return this->template scale<Mat3>(s); }
+    __hostdev__ Mat3  operator/(const T& s) const        { return this->template divideBy<Mat3>(s); }
+    __hostdev__ Mat3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ Mat3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
-    /// @brief Add each element of the given matrix to the corresponding element of this matrix.
-    __hostdev__ Mat3<T>& operator+=(const Mat3<T>& m) {
-        (*this)[0][0] += m[0][0]; (*this)[0][1] += m[0][1]; (*this)[0][2] += m[0][2];
-        (*this)[1][0] += m[1][0]; (*this)[1][1] += m[1][1]; (*this)[1][2] += m[1][2];
-        (*this)[2][0] += m[2][0]; (*this)[2][1] += m[2][1]; (*this)[2][2] += m[2][2];
-        return *this;
-    }
+    // ---- equality ----
+    __hostdev__ bool operator==(const Mat3& m) const     { return Base::equals(m); }
+    __hostdev__ bool operator!=(const Mat3& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ Mat3 transpose() const {
-        return Mat3((*this)[0][0], (*this)[1][0], (*this)[2][0],
-                   (*this)[0][1], (*this)[1][1], (*this)[2][1],
-                   (*this)[0][2], (*this)[1][2], (*this)[2][2]);
-    }
+    __hostdev__ Mat3 transpose() const { return this->template transposeAs<Mat3>(); }
 };
 
 template <typename T>
@@ -1236,11 +1483,10 @@ public:
         i j k l
         m n o p
         @endverbatim */
-    template<typename Source>
-    __hostdev__ Mat4(Source a, Source b, Source c, Source d,
-         Source e, Source f, Source g, Source h,
-         Source i, Source j, Source k, Source l,
-         Source m, Source n, Source o, Source p)
+    __hostdev__ Mat4(T a, T b, T c, T d,
+                     T e, T f, T g, T h,
+                     T i, T j, T k, T l,
+                     T m, T n, T o, T p)
     {
         this->mData[0] = a; this->mData[1] = b; this->mData[2] = c; this->mData[3] = d;
         this->mData[4] = e; this->mData[5] = f; this->mData[6] = g; this->mData[7] = h;
@@ -1252,281 +1498,181 @@ public:
     template<typename Source>
     __hostdev__ Mat4(Source *a): Base(a) {}
 
+    // ---- element-wise ----
+    __hostdev__ Mat4  operator-() const                  { return this->template negate<Mat4>(); }
+    __hostdev__ Mat4  operator+(const Mat4& m) const     { return this->template plus<Mat4>(m); }
+    __hostdev__ Mat4  operator-(const Mat4& m) const     { return this->template minus<Mat4>(m); }
+    __hostdev__ Mat4& operator+=(const Mat4& m)          { Base::addAssign(m); return *this; }
+    __hostdev__ Mat4& operator-=(const Mat4& m)          { Base::subAssign(m); return *this; }
+
+    // ---- matrix * matrix / matrix * vector ----
+    __hostdev__ Mat4    operator*(const Mat4& m) const     { return this->template multiply<Mat4, Mat4>(m); }
+    __hostdev__ Vec4<T> operator*(const Vec4<T>& v) const  { return this->template multiplyVec<Vec4<T>, Vec4<T>>(v); }
+
+    // ---- scalar ----
+    __hostdev__ Mat4  operator*(const T& s) const        { return this->template scale<Mat4>(s); }
+    __hostdev__ Mat4  operator/(const T& s) const        { return this->template divideBy<Mat4>(s); }
+    __hostdev__ Mat4& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ Mat4& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+
+    // ---- equality ----
+    __hostdev__ bool operator==(const Mat4& m) const     { return Base::equals(m); }
+    __hostdev__ bool operator!=(const Mat4& m) const     { return !Base::equals(m); }
+
     /// @brief returns transpose of this
-    __hostdev__ Mat4 transpose() const {
-        return Mat4((*this)[0][0], (*this)[1][0], (*this)[2][0], (*this)[3][0],
-                   (*this)[0][1], (*this)[1][1], (*this)[2][1], (*this)[3][1],
-                   (*this)[0][2], (*this)[1][2], (*this)[2][2], (*this)[3][2],
-                   (*this)[0][3], (*this)[1][3], (*this)[2][3], (*this)[3][3]);
-    }
+    __hostdev__ Mat4 transpose() const { return this->template transposeAs<Mat4>(); }
 };
 
 /// @brief Multiply a scalar by a 2x2 matrix, result is a 2x2 matrix
 template<typename T>
-__hostdev__ Mat2<T> operator*(const T& s, const Mat2<T>& m) {
-    return Mat2<T>(m[0][0] * s, m[0][1] * s, m[1][0] * s, m[1][1] * s);
-}
+__hostdev__ Mat2<T> operator*(const T& s, const Mat2<T>& m) { return m.template scale<Mat2<T>>(s); }
+/// @brief Multiply a scalar by a 2x3 matrix, result is a 2x3 matrix
+template<typename T>
+__hostdev__ Mat2x3<T> operator*(const T& s, const Mat2x3<T>& m) { return m.template scale<Mat2x3<T>>(s); }
+/// @brief Multiply a scalar by a 3x2 matrix, result is a 3x2 matrix
+template<typename T>
+__hostdev__ Mat3x2<T> operator*(const T& s, const Mat3x2<T>& m) { return m.template scale<Mat3x2<T>>(s); }
+/// @brief Multiply a scalar by a 3x3 matrix, result is a 3x3 matrix
+template<typename T>
+__hostdev__ Mat3<T> operator*(const T& s, const Mat3<T>& m) { return m.template scale<Mat3<T>>(s); }
+/// @brief Multiply a scalar by a 4x4 matrix, result is a 4x4 matrix
+template<typename T>
+__hostdev__ Mat4<T> operator*(const T& s, const Mat4<T>& m) { return m.template scale<Mat4<T>>(s); }
 
 /// @brief Multiply a 2x3 matrix by a 3x2 matrix, result is a 2x2 matrix
 template<typename T>
 __hostdev__ Mat2<T> operator*(const Mat2x3<T>& lhs, const Mat3x2<T>& rhs) {
-    return Mat2<T>(
-        // First row
-        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0],    // [0][0]
-        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1] + lhs[0][2] * rhs[2][1],    // [0][1]
-
-        // Second row
-        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0] + lhs[1][2] * rhs[2][0],    // [1][0]
-        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1] + lhs[1][2] * rhs[2][1]     // [1][1]
-    );
-}
-/// @brief Multiply a 3x3 matrix by a 2x3 matrix, result is a 2x3 matrix
-template<typename T>
-__hostdev__ Mat2x3<T> operator*(const Mat3<T>& lhs, const Mat2x3<T>& rhs) {
-    return Mat2x3<T>(
-        // First row
-        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0],
-        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1],
-        lhs[0][0] * rhs[0][2] + lhs[0][1] * rhs[1][2],
-
-        // Second row
-        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0],
-        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1],
-        lhs[1][0] * rhs[0][2] + lhs[1][1] * rhs[1][2]
-    );
+    return lhs.template multiply<Mat2<T>, Mat3x2<T>>(rhs);
 }
 /// @brief Multiply a 2x3 matrix by a 3x3 matrix, result is a 2x3 matrix
 template<typename T>
 __hostdev__ Mat2x3<T> operator*(const Mat2x3<T>& lhs, const Mat3<T>& rhs) {
-    return Mat2x3<T>(
-        // First row (3 elements)
-        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0],
-        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1] + lhs[0][2] * rhs[2][1],
-        lhs[0][0] * rhs[0][2] + lhs[0][1] * rhs[1][2] + lhs[0][2] * rhs[2][2],
-
-        // Second row (3 elements)
-        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0] + lhs[1][2] * rhs[2][0],
-        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1] + lhs[1][2] * rhs[2][1],
-        lhs[1][0] * rhs[0][2] + lhs[1][1] * rhs[1][2] + lhs[1][2] * rhs[2][2]
-    );
+    return lhs.template multiply<Mat2x3<T>, Mat3<T>>(rhs);
 }
 /// @brief Multiply a 3x2 matrix by a 2x2 matrix, result is a 3x2 matrix
 template<typename T>
 __hostdev__ Mat3x2<T> operator*(const Mat3x2<T>& lhs, const Mat2<T>& rhs) {
-    return Mat3x2<T>(
-        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0],
-        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1],
-        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0],
-        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1],
-        lhs[2][0] * rhs[0][0] + lhs[2][1] * rhs[1][0],
-        lhs[2][0] * rhs[0][1] + lhs[2][1] * rhs[1][1]
-    );
+    return lhs.template multiply<Mat3x2<T>, Mat2<T>>(rhs);
 }
 /// @brief Multiply a 2x2 matrix by a 2x3 matrix, result is a 2x3 matrix
 template<typename T>
 __hostdev__ Mat2x3<T> operator*(const Mat2<T>& lhs, const Mat2x3<T>& rhs) {
-    return Mat2x3<T>(
-        // First row (3 elements)
-        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0],
-        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1],
-        lhs[0][0] * rhs[0][2] + lhs[0][1] * rhs[1][2],
-
-        // Second row (3 elements)
-        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0],
-        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1],
-        lhs[1][0] * rhs[0][2] + lhs[1][1] * rhs[1][2]
-    );
+    return lhs.template multiply<Mat2x3<T>, Mat2x3<T>>(rhs);
 }
 /// @brief Multiply a 3x2 matrix by a 2x3 matrix, result is a 3x3 matrix
 template<typename T>
 __hostdev__ Mat3<T> operator*(const Mat3x2<T>& lhs, const Mat2x3<T>& rhs) {
-    return Mat3<T>(
-        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0],
-        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1],
-        lhs[0][0] * rhs[0][2] + lhs[0][1] * rhs[1][2],
-
-        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0],
-        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1],
-        lhs[1][0] * rhs[0][2] + lhs[1][1] * rhs[1][2],
-
-        lhs[2][0] * rhs[0][0] + lhs[2][1] * rhs[1][0],
-        lhs[2][0] * rhs[0][1] + lhs[2][1] * rhs[1][1],
-        lhs[2][0] * rhs[0][2] + lhs[2][1] * rhs[1][2]
-    );
+    return lhs.template multiply<Mat3<T>, Mat2x3<T>>(rhs);
+}
+/// @brief Multiply a 3x3 matrix by a 3x2 matrix, result is a 3x2 matrix
+template<typename T>
+__hostdev__ Mat3x2<T> operator*(const Mat3<T>& lhs, const Mat3x2<T>& rhs) {
+    return lhs.template multiply<Mat3x2<T>, Mat3x2<T>>(rhs);
 }
 // ----------------------------> Vec3 <--------------------------------------
 
 /// @brief A simple vector class with three components, similar to openvdb::math::Vec3
 template<typename T>
-class Vec3
+class Vec3 : public VecBase<T, 3>
 {
-    T mVec[3];
+    using Base = VecBase<T, 3>;
 
 public:
-    static const int SIZE = 3;
-    static const int size = 3; // in openvdb::math::Tuple
     using ValueType = T;
+    static const int size = 3; // openvdb::math::Tuple-compat alias of SIZE
+
     Vec3() = default;
-    __hostdev__ explicit Vec3(T x)
-        : mVec{x, x, x}
-    {
-    }
-    __hostdev__ Vec3(T x, T y, T z)
-        : mVec{x, y, z}
-    {
-    }
+    __hostdev__ explicit Vec3(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; }
+    __hostdev__ Vec3(T x, T y, T z)           { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; }
+
     template<template<class> class Vec3T, class T2>
-    __hostdev__ Vec3(const Vec3T<T2>& v)
-        : mVec{T(v[0]), T(v[1]), T(v[2])}
-    {
-        static_assert(Vec3T<T2>::size == size, "expected Vec3T::size==3!");
+    __hostdev__ Vec3(const Vec3T<T2>& v) {
+        static_assert(Vec3T<T2>::SIZE == 3, "expected Vec3T::SIZE==3!");
+        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]);
     }
     template<typename T2>
-    __hostdev__ explicit Vec3(const Vec3<T2>& v)
-        : mVec{T(v[0]), T(v[1]), T(v[2])}
-    {
+    __hostdev__ explicit Vec3(const Vec3<T2>& v) {
+        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]);
     }
-    __hostdev__ explicit Vec3(const Coord& ijk)
-        : mVec{T(ijk[0]), T(ijk[1]), T(ijk[2])}
-    {
+    __hostdev__ explicit Vec3(const Coord& ijk) {
+        this->mVec[0] = T(ijk[0]); this->mVec[1] = T(ijk[1]); this->mVec[2] = T(ijk[2]);
     }
-    __hostdev__ bool operator==(const Vec3& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1] && mVec[2] == rhs[2]; }
-    __hostdev__ bool operator!=(const Vec3& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1] || mVec[2] != rhs[2]; }
+
     template<template<class> class Vec3T, class T2>
-    __hostdev__ Vec3& operator=(const Vec3T<T2>& rhs)
-    {
-        static_assert(Vec3T<T2>::size == size, "expected Vec3T::size==3!");
-        mVec[0] = rhs[0];
-        mVec[1] = rhs[1];
-        mVec[2] = rhs[2];
+    __hostdev__ Vec3& operator=(const Vec3T<T2>& rhs) {
+        static_assert(Vec3T<T2>::SIZE == 3, "expected Vec3T::SIZE==3!");
+        this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1]; this->mVec[2] = rhs[2];
         return *this;
     }
-    __hostdev__ const T& operator[](int i) const { return mVec[i]; }
-    __hostdev__ T&       operator[](int i) { return mVec[i]; }
-    template<typename Vec3T>
-    __hostdev__ T dot(const Vec3T& v) const { return mVec[0] * v[0] + mVec[1] * v[1] + mVec[2] * v[2]; }
-    template<typename Vec3T>
-    __hostdev__ Vec3 cross(const Vec3T& v) const
-    {
-        return Vec3(mVec[1] * v[2] - mVec[2] * v[1],
-                    mVec[2] * v[0] - mVec[0] * v[2],
-                    mVec[0] * v[1] - mVec[1] * v[0]);
+
+    // ---- element-wise (Vec & Vec) ----
+    __hostdev__ Vec3  operator-() const             { return Base::template negate<Vec3>(); }
+    __hostdev__ Vec3  operator+(const Vec3& v) const { return Base::template plus<Vec3>(v); }
+    __hostdev__ Vec3  operator-(const Vec3& v) const { return Base::template minus<Vec3>(v); }
+    __hostdev__ Vec3  operator*(const Vec3& v) const { return Base::template mul<Vec3>(v); }
+    __hostdev__ Vec3  operator/(const Vec3& v) const { return Base::template div<Vec3>(v); }
+    __hostdev__ Vec3& operator+=(const Vec3& v)     { Base::addAssign(v); return *this; }
+    __hostdev__ Vec3& operator-=(const Vec3& v)     { Base::subAssign(v); return *this; }
+
+    // ---- mixed Vec3 / Coord (3D) ----
+    __hostdev__ Vec3  operator+(const Coord& ijk) const { return Vec3(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1], this->mVec[2] + ijk[2]); }
+    __hostdev__ Vec3  operator-(const Coord& ijk) const { return Vec3(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1], this->mVec[2] - ijk[2]); }
+    __hostdev__ Vec3& operator+=(const Coord& ijk) {
+        this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]); this->mVec[2] += T(ijk[2]);
+        return *this;
     }
+    __hostdev__ Vec3& operator-=(const Coord& ijk) {
+        this->mVec[0] -= T(ijk[0]); this->mVec[1] -= T(ijk[1]); this->mVec[2] -= T(ijk[2]);
+        return *this;
+    }
+
+    // ---- scalar ----
+    __hostdev__ Vec3  operator*(const T& s) const   { return Base::template scale<Vec3>(s); }
+    __hostdev__ Vec3  operator/(const T& s) const   { return Base::template divideBy<Vec3>(s); }
+    __hostdev__ Vec3& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
+    __hostdev__ Vec3& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
+    __hostdev__ Vec3& normalize()                   { return (*this) /= this->length(); }
+
+    // ---- equality ----
+    __hostdev__ bool operator==(const Vec3& rhs) const { return Base::equals(rhs); }
+    __hostdev__ bool operator!=(const Vec3& rhs) const { return !Base::equals(rhs); }
+
+    // ---- component-wise min/max ----
+    __hostdev__ Vec3& minComponent(const Vec3& other) { Base::mergeMin(other); return *this; }
+    __hostdev__ Vec3& maxComponent(const Vec3& other) { Base::mergeMax(other); return *this; }
+
+    /// @brief Return the smallest vector component
+    __hostdev__ ValueType min() const { return Base::smallestComponent(); }
+    /// @brief Return the largest vector component
+    __hostdev__ ValueType max() const { return Base::largestComponent(); }
+
+    /// @brief Round each component down (toward negative infinity)
+    /// @return integer Coord
+    __hostdev__ Coord floor() const { return Base::template floorAs<Coord>(); }
+    /// @brief Round each component up (toward positive infinity)
+    /// @return integer Coord
+    __hostdev__ Coord ceil()  const { return Base::template ceilAs<Coord>(); }
+    /// @brief Round each component to its closest integer value
+    /// @return integer Coord
+    __hostdev__ Coord round() const { return Base::template roundAs<Coord>(); }
+
+    // ---- 3D-specific ----
+
+    /// @brief cross product with another 3-vector
+    template<typename Vec3T>
+    __hostdev__ Vec3 cross(const Vec3T& v) const {
+        return Vec3(this->mVec[1] * v[2] - this->mVec[2] * v[1],
+                    this->mVec[2] * v[0] - this->mVec[0] * v[2],
+                    this->mVec[0] * v[1] - this->mVec[1] * v[0]);
+    }
+
     /// @brief Outer product of a 3x1 vector and a 1x3 vector, result is a 3x3 matrix
     template<typename Vec3T>
-    __hostdev__ Mat3<ValueType> outer(const Vec3T& v) const
-    {
-        return Mat3<ValueType>(mVec[0] * v[0], mVec[0] * v[1], mVec[0] * v[2],
-                    mVec[1] * v[0], mVec[1] * v[1], mVec[1] * v[2],
-                    mVec[2] * v[0], mVec[2] * v[1], mVec[2] * v[2]);
+    __hostdev__ Mat3<ValueType> outer(const Vec3T& v) const {
+        return Mat3<ValueType>(this->mVec[0] * v[0], this->mVec[0] * v[1], this->mVec[0] * v[2],
+                               this->mVec[1] * v[0], this->mVec[1] * v[1], this->mVec[1] * v[2],
+                               this->mVec[2] * v[0], this->mVec[2] * v[1], this->mVec[2] * v[2]);
     }
-    __hostdev__ T lengthSqr() const
-    {
-        return mVec[0] * mVec[0] + mVec[1] * mVec[1] + mVec[2] * mVec[2]; // 5 flops
-    }
-    __hostdev__ T     length() const { return Sqrt(this->lengthSqr()); }
-    __hostdev__ Vec3  operator-() const { return Vec3(-mVec[0], -mVec[1], -mVec[2]); }
-    __hostdev__ Vec3  operator*(const Vec3& v) const { return Vec3(mVec[0] * v[0], mVec[1] * v[1], mVec[2] * v[2]); }
-    __hostdev__ Vec3  operator/(const Vec3& v) const { return Vec3(mVec[0] / v[0], mVec[1] / v[1], mVec[2] / v[2]); }
-    __hostdev__ Vec3  operator+(const Vec3& v) const { return Vec3(mVec[0] + v[0], mVec[1] + v[1], mVec[2] + v[2]); }
-    __hostdev__ Vec3  operator-(const Vec3& v) const { return Vec3(mVec[0] - v[0], mVec[1] - v[1], mVec[2] - v[2]); }
-    __hostdev__ Vec3  operator+(const Coord& ijk) const { return Vec3(mVec[0] + ijk[0], mVec[1] + ijk[1], mVec[2] + ijk[2]); }
-    __hostdev__ Vec3  operator-(const Coord& ijk) const { return Vec3(mVec[0] - ijk[0], mVec[1] - ijk[1], mVec[2] - ijk[2]); }
-    __hostdev__ Vec3  operator*(const T& s) const { return Vec3(s * mVec[0], s * mVec[1], s * mVec[2]); }
-    __hostdev__ Vec3  operator/(const T& s) const { return (T(1) / s) * (*this); }
-    __hostdev__ Vec3& operator+=(const Vec3& v)
-    {
-        mVec[0] += v[0];
-        mVec[1] += v[1];
-        mVec[2] += v[2];
-        return *this;
-    }
-    __hostdev__ Vec3& operator+=(const Coord& ijk)
-    {
-        mVec[0] += T(ijk[0]);
-        mVec[1] += T(ijk[1]);
-        mVec[2] += T(ijk[2]);
-        return *this;
-    }
-    __hostdev__ Vec3& operator-=(const Vec3& v)
-    {
-        mVec[0] -= v[0];
-        mVec[1] -= v[1];
-        mVec[2] -= v[2];
-        return *this;
-    }
-    __hostdev__ Vec3& operator-=(const Coord& ijk)
-    {
-        mVec[0] -= T(ijk[0]);
-        mVec[1] -= T(ijk[1]);
-        mVec[2] -= T(ijk[2]);
-        return *this;
-    }
-    __hostdev__ Vec3& operator*=(const T& s)
-    {
-        mVec[0] *= s;
-        mVec[1] *= s;
-        mVec[2] *= s;
-        return *this;
-    }
-    __hostdev__ Vec3& operator/=(const T& s) { return (*this) *= T(1) / s; }
-    __hostdev__ Vec3& normalize() { return (*this) /= this->length(); }
-    /// @brief Perform a component-wise minimum with the other Coord.
-    __hostdev__ Vec3& minComponent(const Vec3& other)
-    {
-        if (other[0] < mVec[0])
-            mVec[0] = other[0];
-        if (other[1] < mVec[1])
-            mVec[1] = other[1];
-        if (other[2] < mVec[2])
-            mVec[2] = other[2];
-        return *this;
-    }
-
-    /// @brief Perform a component-wise maximum with the other Coord.
-    __hostdev__ Vec3& maxComponent(const Vec3& other)
-    {
-        if (other[0] > mVec[0])
-            mVec[0] = other[0];
-        if (other[1] > mVec[1])
-            mVec[1] = other[1];
-        if (other[2] > mVec[2])
-            mVec[2] = other[2];
-        return *this;
-    }
-    /// @brief Return the smallest vector component
-    __hostdev__ ValueType min() const
-    {
-        return mVec[0] < mVec[1] ? (mVec[0] < mVec[2] ? mVec[0] : mVec[2]) : (mVec[1] < mVec[2] ? mVec[1] : mVec[2]);
-    }
-    /// @brief Return the largest vector component
-    __hostdev__ ValueType max() const
-    {
-        return mVec[0] > mVec[1] ? (mVec[0] > mVec[2] ? mVec[0] : mVec[2]) : (mVec[1] > mVec[2] ? mVec[1] : mVec[2]);
-    }
-    /// @brief Round each component if this Vec<T> up to its integer value
-    /// @return Return an integer Coord
-    __hostdev__ Coord floor() const { return Coord(Floor(mVec[0]), Floor(mVec[1]), Floor(mVec[2])); }
-    /// @brief Round each component if this Vec<T> down to its integer value
-    /// @return Return an integer Coord
-    __hostdev__ Coord ceil() const { return Coord(Ceil(mVec[0]), Ceil(mVec[1]), Ceil(mVec[2])); }
-    /// @brief Round each component if this Vec<T> to its closest integer value
-    /// @return Return an integer Coord
-    __hostdev__ Coord round() const
-    {
-        if constexpr(util::is_same<T, float>::value) {
-            return Coord(Floor(mVec[0] + 0.5f), Floor(mVec[1] + 0.5f), Floor(mVec[2] + 0.5f));
-        } else if constexpr(util::is_same<T, int>::value) {
-            return Coord(mVec[0], mVec[1], mVec[2]);
-        } else {
-            return Coord(Floor(mVec[0] + 0.5), Floor(mVec[1] + 0.5), Floor(mVec[2] + 0.5));
-        }
-    }
-
-    /// @brief return a non-const raw constant pointer to array of three vector components
-    __hostdev__ T* asPointer() { return mVec; }
-    /// @brief return a const raw constant pointer to array of three vector components
-    __hostdev__ const T* asPointer() const { return mVec; }
 }; // Vec3<T>
 
 template<typename T1, typename T2>
@@ -1556,116 +1702,72 @@ __hostdev__ inline Vec3<double> Coord::asVec3d() const
 
 /// @brief A simple vector class with four components, similar to openvdb::math::Vec4
 template<typename T>
-class Vec4
+class Vec4 : public VecBase<T, 4>
 {
-    T mVec[4];
+    using Base = VecBase<T, 4>;
 
 public:
-    static const int SIZE = 4;
-    static const int size = 4;
     using ValueType = T;
+    static const int size = 4; // openvdb::math::Tuple-compat alias of SIZE
+
     Vec4() = default;
-    __hostdev__ explicit Vec4(T x)
-        : mVec{x, x, x, x}
-    {
-    }
-    __hostdev__ Vec4(T x, T y, T z, T w)
-        : mVec{x, y, z, w}
-    {
-    }
+    __hostdev__ explicit Vec4(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; this->mVec[3] = x; }
+    __hostdev__ Vec4(T x, T y, T z, T w)      { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; this->mVec[3] = w; }
+
     template<typename T2>
-    __hostdev__ explicit Vec4(const Vec4<T2>& v)
-        : mVec{T(v[0]), T(v[1]), T(v[2]), T(v[3])}
-    {
+    __hostdev__ explicit Vec4(const Vec4<T2>& v) {
+        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]); this->mVec[3] = T(v[3]);
     }
     template<template<class> class Vec4T, class T2>
-    __hostdev__ Vec4(const Vec4T<T2>& v)
-        : mVec{T(v[0]), T(v[1]), T(v[2]), T(v[3])}
-    {
-        static_assert(Vec4T<T2>::size == size, "expected Vec4T::size==4!");
+    __hostdev__ Vec4(const Vec4T<T2>& v) {
+        static_assert(Vec4T<T2>::SIZE == 4, "expected Vec4T::SIZE==4!");
+        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]); this->mVec[3] = T(v[3]);
     }
-    __hostdev__ bool operator==(const Vec4& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1] && mVec[2] == rhs[2] && mVec[3] == rhs[3]; }
-    __hostdev__ bool operator!=(const Vec4& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1] || mVec[2] != rhs[2] || mVec[3] != rhs[3]; }
     template<template<class> class Vec4T, class T2>
-    __hostdev__ Vec4& operator=(const Vec4T<T2>& rhs)
-    {
-        static_assert(Vec4T<T2>::size == size, "expected Vec4T::size==4!");
-        mVec[0] = rhs[0];
-        mVec[1] = rhs[1];
-        mVec[2] = rhs[2];
-        mVec[3] = rhs[3];
+    __hostdev__ Vec4& operator=(const Vec4T<T2>& rhs) {
+        static_assert(Vec4T<T2>::SIZE == 4, "expected Vec4T::SIZE==4!");
+        this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1]; this->mVec[2] = rhs[2]; this->mVec[3] = rhs[3];
         return *this;
     }
 
-    __hostdev__ const T& operator[](int i) const { return mVec[i]; }
-    __hostdev__ T&       operator[](int i) { return mVec[i]; }
-    template<typename Vec4T>
-    __hostdev__ T dot(const Vec4T& v) const { return mVec[0] * v[0] + mVec[1] * v[1] + mVec[2] * v[2] + mVec[3] * v[3]; }
-    __hostdev__ T lengthSqr() const
-    {
-        return mVec[0] * mVec[0] + mVec[1] * mVec[1] + mVec[2] * mVec[2] + mVec[3] * mVec[3]; // 7 flops
-    }
-    __hostdev__ T     length() const { return Sqrt(this->lengthSqr()); }
-    __hostdev__ Vec4  operator-() const { return Vec4(-mVec[0], -mVec[1], -mVec[2], -mVec[3]); }
-    __hostdev__ Vec4  operator*(const Vec4& v) const { return Vec4(mVec[0] * v[0], mVec[1] * v[1], mVec[2] * v[2], mVec[3] * v[3]); }
-    __hostdev__ Vec4  operator/(const Vec4& v) const { return Vec4(mVec[0] / v[0], mVec[1] / v[1], mVec[2] / v[2], mVec[3] / v[3]); }
-    __hostdev__ Vec4  operator+(const Vec4& v) const { return Vec4(mVec[0] + v[0], mVec[1] + v[1], mVec[2] + v[2], mVec[3] + v[3]); }
-    __hostdev__ Vec4  operator-(const Vec4& v) const { return Vec4(mVec[0] - v[0], mVec[1] - v[1], mVec[2] - v[2], mVec[3] - v[3]); }
-    __hostdev__ Vec4  operator*(const T& s) const { return Vec4(s * mVec[0], s * mVec[1], s * mVec[2], s * mVec[3]); }
-    __hostdev__ Vec4  operator/(const T& s) const { return (T(1) / s) * (*this); }
-    __hostdev__ Vec4& operator+=(const Vec4& v)
-    {
-        mVec[0] += v[0];
-        mVec[1] += v[1];
-        mVec[2] += v[2];
-        mVec[3] += v[3];
-        return *this;
-    }
-    __hostdev__ Vec4& operator-=(const Vec4& v)
-    {
-        mVec[0] -= v[0];
-        mVec[1] -= v[1];
-        mVec[2] -= v[2];
-        mVec[3] -= v[3];
-        return *this;
-    }
-    __hostdev__ Vec4& operator*=(const T& s)
-    {
-        mVec[0] *= s;
-        mVec[1] *= s;
-        mVec[2] *= s;
-        mVec[3] *= s;
-        return *this;
-    }
-    __hostdev__ Vec4& operator/=(const T& s) { return (*this) *= T(1) / s; }
-    __hostdev__ Vec4& normalize() { return (*this) /= this->length(); }
-    /// @brief Perform a component-wise minimum with the other Coord.
-    __hostdev__ Vec4& minComponent(const Vec4& other)
-    {
-        if (other[0] < mVec[0])
-            mVec[0] = other[0];
-        if (other[1] < mVec[1])
-            mVec[1] = other[1];
-        if (other[2] < mVec[2])
-            mVec[2] = other[2];
-        if (other[3] < mVec[3])
-            mVec[3] = other[3];
-        return *this;
-    }
+    // ---- element-wise (Vec & Vec) ----
+    __hostdev__ Vec4  operator-() const             { return Base::template negate<Vec4>(); }
+    __hostdev__ Vec4  operator+(const Vec4& v) const { return Base::template plus<Vec4>(v); }
+    __hostdev__ Vec4  operator-(const Vec4& v) const { return Base::template minus<Vec4>(v); }
+    __hostdev__ Vec4  operator*(const Vec4& v) const { return Base::template mul<Vec4>(v); }
+    __hostdev__ Vec4  operator/(const Vec4& v) const { return Base::template div<Vec4>(v); }
+    __hostdev__ Vec4& operator+=(const Vec4& v)     { Base::addAssign(v); return *this; }
+    __hostdev__ Vec4& operator-=(const Vec4& v)     { Base::subAssign(v); return *this; }
 
-    /// @brief Perform a component-wise maximum with the other Coord.
-    __hostdev__ Vec4& maxComponent(const Vec4& other)
-    {
-        if (other[0] > mVec[0])
-            mVec[0] = other[0];
-        if (other[1] > mVec[1])
-            mVec[1] = other[1];
-        if (other[2] > mVec[2])
-            mVec[2] = other[2];
-        if (other[3] > mVec[3])
-            mVec[3] = other[3];
-        return *this;
-    }
+    // ---- scalar ----
+    __hostdev__ Vec4  operator*(const T& s) const   { return Base::template scale<Vec4>(s); }
+    __hostdev__ Vec4  operator/(const T& s) const   { return Base::template divideBy<Vec4>(s); }
+    __hostdev__ Vec4& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
+    __hostdev__ Vec4& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
+    __hostdev__ Vec4& normalize()                   { return (*this) /= this->length(); }
+
+    // ---- equality ----
+    __hostdev__ bool operator==(const Vec4& rhs) const { return Base::equals(rhs); }
+    __hostdev__ bool operator!=(const Vec4& rhs) const { return !Base::equals(rhs); }
+
+    // ---- component-wise min/max ----
+    __hostdev__ Vec4& minComponent(const Vec4& other) { Base::mergeMin(other); return *this; }
+    __hostdev__ Vec4& maxComponent(const Vec4& other) { Base::mergeMax(other); return *this; }
+
+    /// @brief Return the smallest vector component
+    __hostdev__ ValueType min() const { return Base::smallestComponent(); }
+    /// @brief Return the largest vector component
+    __hostdev__ ValueType max() const { return Base::largestComponent(); }
+
+    /// @brief Round each component down (toward negative infinity)
+    /// @return Vec4<int32_t> (NanoVDB has no Coord4)
+    __hostdev__ Vec4<int32_t> floor() const { return Base::template floorAs<Vec4<int32_t>>(); }
+    /// @brief Round each component up (toward positive infinity)
+    /// @return Vec4<int32_t>
+    __hostdev__ Vec4<int32_t> ceil()  const { return Base::template ceilAs<Vec4<int32_t>>(); }
+    /// @brief Round each component to its closest integer value
+    /// @return Vec4<int32_t>
+    __hostdev__ Vec4<int32_t> round() const { return Base::template roundAs<Vec4<int32_t>>(); }
 }; // Vec4<T>
 
 template<typename T1, typename T2>
@@ -1678,20 +1780,6 @@ __hostdev__ inline Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
 {
     return Vec4<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2], scalar / vec[3]);
 }
-/// @brief Return the matrix vector product of a 4x4 matrix and a 4d vector
-/// @param m 4x4 matrix
-/// @param v 4d vector
-/// @return result of matrix-vector multiplication, i.e. m x v
-template <typename T>
-__hostdev__ inline Vec4<T> operator*(const Mat4<T>& m, const Vec4<T>& v) {
-    return Vec4<T>(
-        m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2] + m[0][3] * v[3],
-        m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2] + m[1][3] * v[3],
-        m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2] + m[2][3] * v[3],
-        m[3][0] * v[0] + m[3][1] * v[1] + m[3][2] * v[2] + m[3][3] * v[3]
-    );
-}
-
 // ----------------------------> matMult <--------------------------------------
 
 /// @brief Multiply a 3x3 matrix and a 3d vector using 32bit floating point arithmetics

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -395,11 +395,11 @@ public:
 
     /// @brief Return a const reference to the given Coord component.
     /// @warning The argument is assumed to be 0, 1, or 2.
-    __hostdev__ const ValueType& operator[](IndexType i) const { return mVec[i]; }
+    __hostdev__ const ValueType& operator[](IndexType i) const { NANOVDB_ASSERT(i < 3); return mVec[i]; }
 
     /// @brief Return a non-const reference to the given Coord component.
     /// @warning The argument is assumed to be 0, 1, or 2.
-    __hostdev__ ValueType& operator[](IndexType i) { return mVec[i]; }
+    __hostdev__ ValueType& operator[](IndexType i) { NANOVDB_ASSERT(i < 3); return mVec[i]; }
 
     /// @brief Assignment operator that works with openvdb::Coord
     template<typename CoordT>
@@ -646,11 +646,11 @@ public:
 
     /// @brief Return a const reference to the given Coord component.
     /// @warning The argument is assumed to be 0 or 1,
-    __hostdev__ const ValueType& operator[](IndexType i) const { return mVec[i]; }
+    __hostdev__ const ValueType& operator[](IndexType i) const { NANOVDB_ASSERT(i < 2); return mVec[i]; }
 
     /// @brief Return a non-const reference to the given Coord component.
     /// @warning The argument is assumed to be 0 or 1.
-    __hostdev__ ValueType& operator[](IndexType i) { return mVec[i]; }
+    __hostdev__ ValueType& operator[](IndexType i) { NANOVDB_ASSERT(i < 2); return mVec[i]; }
 
     /// @brief Assignment operator that works with openvdb::Coord
     template<typename CoordT>
@@ -827,9 +827,9 @@ public:
 
     VecBase() = default;
 
-    /// @brief Indexed element access (no bounds check; assumes 0 <= i < N)
-    __hostdev__ const T& operator[](int i) const { return mVec[i]; }
-    __hostdev__ T&       operator[](int i)       { return mVec[i]; }
+    /// @brief Indexed element access. Asserts 0 <= i < N in debug builds.
+    __hostdev__ const T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
+    __hostdev__ T&       operator[](int i)       { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
 
     /// @brief raw pointer to the underlying N-element storage
     __hostdev__ T*       asPointer()       { return mVec; }
@@ -1141,11 +1141,14 @@ public:
         }
     }
 
-    // 2D array access
+    // 2D array access. Returns a row pointer; the caller is responsible
+    // for the column bound (0 <= col < COLS).
     __hostdev__ T* operator[](int row) {
+        NANOVDB_ASSERT(row >= 0 && row < ROWS);
         return &mData[row * COLS];
     }
     __hostdev__ const T* operator[](int row) const {
+        NANOVDB_ASSERT(row >= 0 && row < ROWS);
         return &mData[row * COLS];
     }
 
@@ -1906,8 +1909,8 @@ struct BaseBBox
     Vec3T                    mCoord[2];
     __hostdev__ bool         operator==(const BaseBBox& rhs) const { return mCoord[0] == rhs.mCoord[0] && mCoord[1] == rhs.mCoord[1]; };
     __hostdev__ bool         operator!=(const BaseBBox& rhs) const { return mCoord[0] != rhs.mCoord[0] || mCoord[1] != rhs.mCoord[1]; };
-    __hostdev__ const Vec3T& operator[](int i) const { return mCoord[i]; }
-    __hostdev__ Vec3T&       operator[](int i) { return mCoord[i]; }
+    __hostdev__ const Vec3T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
+    __hostdev__ Vec3T&       operator[](int i) { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
     __hostdev__ Vec3T&       min() { return mCoord[0]; }
     __hostdev__ Vec3T&       max() { return mCoord[1]; }
     __hostdev__ const Vec3T& min() const { return mCoord[0]; }
@@ -2290,8 +2293,8 @@ public:
     __hostdev__ float           length() const { return sqrtf(this->lengthSqr()); }
     /// @brief return n'th color channel as a float in the range 0 to 1
     __hostdev__ float           asFloat(int n) const { return 0.003921569f*float(mData.c[n]); }// divide by 255
-    __hostdev__ const uint8_t&  operator[](int n) const { return mData.c[n]; }
-    __hostdev__ uint8_t&        operator[](int n) { return mData.c[n]; }
+    __hostdev__ const uint8_t&  operator[](int n) const { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
+    __hostdev__ uint8_t&        operator[](int n) { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
     __hostdev__ const uint32_t& packed() const { return mData.packed; }
     __hostdev__ uint32_t&       packed() { return mData.packed; }
     __hostdev__ const uint8_t&  r() const { return mData.c[0]; }

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -1002,8 +1002,8 @@ public:
     /// @brief floor-rounded components into the @c Result type (whose @c [i]
     /// must accept int32_t). For integer @c T the value is passed through.
     /// @note Only the integer-@c T specialization is usable as a constant
-    /// expression; the floating-point branch calls @c math::Floor /
-    /// @c math::Ceil, which aren't constexpr until C++23.
+    /// expression; the floating-point branch calls @c math::Floor, which
+    /// isn't constexpr until C++23.
     template<typename Result>
     __hostdev__ [[nodiscard]] constexpr Result floorAs() const noexcept {
         Result r{};
@@ -1014,6 +1014,11 @@ public:
         }
         return r;
     }
+    /// @brief ceil-rounded components into the @c Result type (whose @c [i]
+    /// must accept int32_t). For integer @c T the value is passed through.
+    /// @note Only the integer-@c T specialization is usable as a constant
+    /// expression; the floating-point branch calls @c math::Ceil, which
+    /// isn't constexpr until C++23.
     template<typename Result>
     __hostdev__ [[nodiscard]] constexpr Result ceilAs() const noexcept {
         Result r{};

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -32,22 +32,22 @@ namespace math {// =============================================================
 //@{
 /// @brief Pi constant taken from Boost to match old behaviour
 template<typename T>
-inline __hostdev__ constexpr T pi()
+inline __hostdev__ constexpr T pi() noexcept
 {
     return 3.141592653589793238462643383279502884e+00;
 }
 template<>
-inline __hostdev__ constexpr float pi()
+inline __hostdev__ constexpr float pi() noexcept
 {
     return 3.141592653589793238462643383279502884e+00F;
 }
 template<>
-inline __hostdev__ constexpr double pi()
+inline __hostdev__ constexpr double pi() noexcept
 {
     return 3.141592653589793238462643383279502884e+00;
 }
 template<>
-inline __hostdev__ constexpr long double pi()
+inline __hostdev__ constexpr long double pi() noexcept
 {
     return 3.141592653589793238462643383279502884e+00L;
 }
@@ -60,12 +60,12 @@ struct Tolerance;
 template<>
 struct Tolerance<float>
 {
-    __hostdev__ [[nodiscard]] static constexpr float value() { return 1e-8f; }
+    __hostdev__ [[nodiscard]] static constexpr float value() noexcept { return 1e-8f; }
 };
 template<>
 struct Tolerance<double>
 {
-    __hostdev__ [[nodiscard]] static constexpr double value() { return 1e-15; }
+    __hostdev__ [[nodiscard]] static constexpr double value() noexcept { return 1e-15; }
 };
 //@}
 
@@ -76,12 +76,12 @@ struct Delta;
 template<>
 struct Delta<float>
 {
-    __hostdev__ [[nodiscard]] static constexpr float value() { return 1e-5f; }
+    __hostdev__ [[nodiscard]] static constexpr float value() noexcept { return 1e-5f; }
 };
 template<>
 struct Delta<double>
 {
-    __hostdev__ [[nodiscard]] static constexpr double value() { return 1e-9; }
+    __hostdev__ [[nodiscard]] static constexpr double value() noexcept { return 1e-9; }
 };
 //@}
 
@@ -93,181 +93,181 @@ struct Maximum;
 template<typename T>
 struct Maximum
 {
-    __hostdev__ [[nodiscard]] static constexpr T value() { return ::cuda::std::numeric_limits<T>::max(); }
+    __hostdev__ [[nodiscard]] static constexpr T value() noexcept { return ::cuda::std::numeric_limits<T>::max(); }
 };
 #elif defined(__HIP__)
 template<>
 struct Maximum<int>
 {
-    __hostdev__ [[nodiscard]] static constexpr int value() { return 2147483647; }
+    __hostdev__ [[nodiscard]] static constexpr int value() noexcept { return 2147483647; }
 };
 template<>
 struct Maximum<uint32_t>
 {
-    __hostdev__ [[nodiscard]] static constexpr uint32_t value() { return 4294967295u; }
+    __hostdev__ [[nodiscard]] static constexpr uint32_t value() noexcept { return 4294967295u; }
 };
 template<>
 struct Maximum<float>
 {
-    __hostdev__ [[nodiscard]] static constexpr float value() { return 1e+38f; }
+    __hostdev__ [[nodiscard]] static constexpr float value() noexcept { return 1e+38f; }
 };
 template<>
 struct Maximum<double>
 {
-    __hostdev__ [[nodiscard]] static constexpr double value() { return 1e+308; }
+    __hostdev__ [[nodiscard]] static constexpr double value() noexcept { return 1e+308; }
 };
 #else
 template<typename T>
 struct Maximum
 {
-    [[nodiscard]] static constexpr T value() { return std::numeric_limits<T>::max(); }
+    [[nodiscard]] static constexpr T value() noexcept { return std::numeric_limits<T>::max(); }
 };
 #endif
 //@}
 
 template<typename Type>
-__hostdev__ [[nodiscard]] inline constexpr bool isApproxZero(const Type& x)
+__hostdev__ [[nodiscard]] inline constexpr bool isApproxZero(const Type& x) noexcept
 {
     return !(x > Tolerance<Type>::value()) && !(x < -Tolerance<Type>::value());
 }
 
 template<typename Type>
-__hostdev__ [[nodiscard]] inline constexpr Type Min(Type a, Type b)
+__hostdev__ [[nodiscard]] inline constexpr Type Min(Type a, Type b) noexcept
 {
     return (a < b) ? a : b;
 }
-__hostdev__ [[nodiscard]] inline constexpr int32_t Min(int32_t a, int32_t b)
+__hostdev__ [[nodiscard]] inline constexpr int32_t Min(int32_t a, int32_t b) noexcept
 {
     return a < b ? a : b;
 }
-__hostdev__ [[nodiscard]] inline constexpr uint32_t Min(uint32_t a, uint32_t b)
+__hostdev__ [[nodiscard]] inline constexpr uint32_t Min(uint32_t a, uint32_t b) noexcept
 {
     return a < b ? a : b;
 }
 // Not constexpr — fminf/fmin aren't constexpr until C++23.
-__hostdev__ [[nodiscard]] inline float Min(float a, float b)
+__hostdev__ [[nodiscard]] inline float Min(float a, float b) noexcept
 {
     return fminf(a, b);
 }
 // Not constexpr — fminf/fmin aren't constexpr until C++23.
-__hostdev__ [[nodiscard]] inline double Min(double a, double b)
+__hostdev__ [[nodiscard]] inline double Min(double a, double b) noexcept
 {
     return fmin(a, b);
 }
 template<typename Type>
-__hostdev__ [[nodiscard]] inline constexpr Type Max(Type a, Type b)
+__hostdev__ [[nodiscard]] inline constexpr Type Max(Type a, Type b) noexcept
 {
     return (a > b) ? a : b;
 }
 
-__hostdev__ [[nodiscard]] inline constexpr int32_t Max(int32_t a, int32_t b)
+__hostdev__ [[nodiscard]] inline constexpr int32_t Max(int32_t a, int32_t b) noexcept
 {
     return a > b ? a : b;
 }
-__hostdev__ [[nodiscard]] inline constexpr uint32_t Max(uint32_t a, uint32_t b)
+__hostdev__ [[nodiscard]] inline constexpr uint32_t Max(uint32_t a, uint32_t b) noexcept
 {
     return a > b ? a : b;
 }
 // Not constexpr — fmaxf/fmax aren't constexpr until C++23.
-__hostdev__ [[nodiscard]] inline float Max(float a, float b)
+__hostdev__ [[nodiscard]] inline float Max(float a, float b) noexcept
 {
     return fmaxf(a, b);
 }
 // Not constexpr — fmaxf/fmax aren't constexpr until C++23.
-__hostdev__ [[nodiscard]] inline double Max(double a, double b)
+__hostdev__ [[nodiscard]] inline double Max(double a, double b) noexcept
 {
     return fmax(a, b);
 }
 // Not constexpr — depends on non-constexpr float/double Min/Max overloads.
-__hostdev__ [[nodiscard]] inline float Clamp(float x, float a, float b)
+__hostdev__ [[nodiscard]] inline float Clamp(float x, float a, float b) noexcept
 {
     return Max(Min(x, b), a);
 }
 // Not constexpr — depends on non-constexpr float/double Min/Max overloads.
-__hostdev__ [[nodiscard]] inline double Clamp(double x, double a, double b)
+__hostdev__ [[nodiscard]] inline double Clamp(double x, double a, double b) noexcept
 {
     return Max(Min(x, b), a);
 }
 
-__hostdev__ [[nodiscard]] inline float Fract(float x)
+__hostdev__ [[nodiscard]] inline float Fract(float x) noexcept
 {
     return x - floorf(x);
 }
-__hostdev__ [[nodiscard]] inline double Fract(double x)
+__hostdev__ [[nodiscard]] inline double Fract(double x) noexcept
 {
     return x - floor(x);
 }
 
-__hostdev__ [[nodiscard]] inline int32_t Floor(float x)
+__hostdev__ [[nodiscard]] inline int32_t Floor(float x) noexcept
 {
     return int32_t(floorf(x));
 }
-__hostdev__ [[nodiscard]] inline int32_t Floor(double x)
+__hostdev__ [[nodiscard]] inline int32_t Floor(double x) noexcept
 {
     return int32_t(floor(x));
 }
 
-__hostdev__ [[nodiscard]] inline int32_t Ceil(float x)
+__hostdev__ [[nodiscard]] inline int32_t Ceil(float x) noexcept
 {
     return int32_t(ceilf(x));
 }
-__hostdev__ [[nodiscard]] inline int32_t Ceil(double x)
+__hostdev__ [[nodiscard]] inline int32_t Ceil(double x) noexcept
 {
     return int32_t(ceil(x));
 }
 
 template<typename T>
-__hostdev__ [[nodiscard]] inline constexpr T Pow2(T x)
+__hostdev__ [[nodiscard]] inline constexpr T Pow2(T x) noexcept
 {
     return x * x;
 }
 
 template<typename T>
-__hostdev__ [[nodiscard]] inline constexpr T Pow3(T x)
+__hostdev__ [[nodiscard]] inline constexpr T Pow3(T x) noexcept
 {
     return x * x * x;
 }
 
 template<typename T>
-__hostdev__ [[nodiscard]] inline constexpr T Pow4(T x)
+__hostdev__ [[nodiscard]] inline constexpr T Pow4(T x) noexcept
 {
     return Pow2(x * x);
 }
 template<typename T>
-__hostdev__ [[nodiscard]] inline constexpr T Abs(T x)
+__hostdev__ [[nodiscard]] inline constexpr T Abs(T x) noexcept
 {
     return x < 0 ? -x : x;
 }
 
 // Not constexpr — fabsf isn't constexpr until C++23.
 template<>
-__hostdev__ [[nodiscard]] inline float Abs(float x)
+__hostdev__ [[nodiscard]] inline float Abs(float x) noexcept
 {
     return fabsf(x);
 }
 
 // Not constexpr — fabs isn't constexpr until C++23.
 template<>
-__hostdev__ [[nodiscard]] inline double Abs(double x)
+__hostdev__ [[nodiscard]] inline double Abs(double x) noexcept
 {
     return fabs(x);
 }
 
 // Not constexpr — std::abs(int) isn't constexpr until C++23.
 template<>
-__hostdev__ [[nodiscard]] inline int Abs(int x)
+__hostdev__ [[nodiscard]] inline int Abs(int x) noexcept
 {
     return abs(x);
 }
 
 template<typename CoordT, typename RealT, template<typename> class Vec3T>
-__hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<RealT>& xyz);
+__hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<RealT>& xyz) noexcept;
 
 /// @brief Round each component to its closest integer (round-half-toward-+inf)
 /// using @c floor(x+0.5). Same rule is applied to both single and double
 /// precision so float and double inputs yield the same integer coords.
 template<typename CoordT, template<typename> class Vec3T>
-__hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<float>& xyz)
+__hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<float>& xyz) noexcept
 {
     return CoordT(int32_t(floorf(xyz[0] + 0.5f)),
                   int32_t(floorf(xyz[1] + 0.5f)),
@@ -275,7 +275,7 @@ __hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<float>& xyz)
 }
 
 template<typename CoordT, template<typename> class Vec3T>
-__hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<double>& xyz)
+__hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<double>& xyz) noexcept
 {
     return CoordT(int32_t(floor(xyz[0] + 0.5)),
                   int32_t(floor(xyz[1] + 0.5)),
@@ -283,18 +283,18 @@ __hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<double>& xyz)
 }
 
 template<typename CoordT, typename RealT, template<typename> class Vec3T>
-__hostdev__ [[nodiscard]] inline CoordT RoundDown(const Vec3T<RealT>& xyz)
+__hostdev__ [[nodiscard]] inline CoordT RoundDown(const Vec3T<RealT>& xyz) noexcept
 {
     return CoordT(Floor(xyz[0]), Floor(xyz[1]), Floor(xyz[2]));
 }
 
 //@{
 /// Return the square root of a floating-point value.
-__hostdev__ [[nodiscard]] inline float Sqrt(float x)
+__hostdev__ [[nodiscard]] inline float Sqrt(float x) noexcept
 {
     return sqrtf(x);
 }
-__hostdev__ [[nodiscard]] inline double Sqrt(double x)
+__hostdev__ [[nodiscard]] inline double Sqrt(double x) noexcept
 {
     return sqrt(x);
 }
@@ -302,13 +302,13 @@ __hostdev__ [[nodiscard]] inline double Sqrt(double x)
 
 /// Return the sign of the given value as an integer (either -1, 0 or 1).
 template<typename T>
-__hostdev__ [[nodiscard]] inline constexpr T Sign(const T& x)
+__hostdev__ [[nodiscard]] inline constexpr T Sign(const T& x) noexcept
 {
     return ((T(0) < x) ? T(1) : T(0)) - ((x < T(0)) ? T(1) : T(0));
 }
 
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr int MinIndex(const Vec3T& v)
+__hostdev__ [[nodiscard]] inline constexpr int MinIndex(const Vec3T& v) noexcept
 {
 #if 0
     static const int hashTable[8] = {2, 1, 9, 1, 2, 9, 0, 0}; //9 are dummy values
@@ -325,7 +325,7 @@ __hostdev__ [[nodiscard]] inline constexpr int MinIndex(const Vec3T& v)
 }
 
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr int MaxIndex(const Vec3T& v)
+__hostdev__ [[nodiscard]] inline constexpr int MaxIndex(const Vec3T& v) noexcept
 {
 #if 0
     static const int hashTable[8] = {2, 1, 9, 1, 2, 9, 0, 0}; //9 are dummy values
@@ -345,7 +345,7 @@ __hostdev__ [[nodiscard]] inline constexpr int MaxIndex(const Vec3T& v)
 ///
 /// @details both wordSize and byteSize are in byte units
 template<uint64_t wordSize>
-__hostdev__ [[nodiscard]] inline constexpr uint64_t AlignUp(uint64_t byteCount)
+__hostdev__ [[nodiscard]] inline constexpr uint64_t AlignUp(uint64_t byteCount) noexcept
 {
     const uint64_t r = byteCount % wordSize;
     return r ? byteCount - r + wordSize : byteCount;
@@ -366,53 +366,53 @@ public:
     using IndexType = uint32_t;
 
     /// @brief Initialize all coordinates to zero.
-    __hostdev__ constexpr Coord()
+    __hostdev__ constexpr Coord() noexcept
         : mVec{0, 0, 0}
     {
     }
 
     /// @brief Initializes all coordinates to the given signed integer.
-    __hostdev__ explicit constexpr Coord(ValueType n)
+    __hostdev__ explicit constexpr Coord(ValueType n) noexcept
         : mVec{n, n, n}
     {
     }
 
     /// @brief Initializes coordinate to the given signed integers.
-    __hostdev__ constexpr Coord(ValueType i, ValueType j, ValueType k)
+    __hostdev__ constexpr Coord(ValueType i, ValueType j, ValueType k) noexcept
         : mVec{i, j, k}
     {
     }
 
-    __hostdev__ constexpr Coord(ValueType* ptr)
+    __hostdev__ constexpr Coord(ValueType* ptr) noexcept
         : mVec{ptr[0], ptr[1], ptr[2]}
     {
     }
 
-    __hostdev__ constexpr int32_t x() const { return mVec[0]; }
-    __hostdev__ constexpr int32_t y() const { return mVec[1]; }
-    __hostdev__ constexpr int32_t z() const { return mVec[2]; }
+    __hostdev__ constexpr int32_t x() const noexcept { return mVec[0]; }
+    __hostdev__ constexpr int32_t y() const noexcept { return mVec[1]; }
+    __hostdev__ constexpr int32_t z() const noexcept { return mVec[2]; }
 
-    __hostdev__ constexpr int32_t& x() { return mVec[0]; }
-    __hostdev__ constexpr int32_t& y() { return mVec[1]; }
-    __hostdev__ constexpr int32_t& z() { return mVec[2]; }
+    __hostdev__ constexpr int32_t& x() noexcept { return mVec[0]; }
+    __hostdev__ constexpr int32_t& y() noexcept { return mVec[1]; }
+    __hostdev__ constexpr int32_t& z() noexcept { return mVec[2]; }
 
-    __hostdev__ [[nodiscard]] static constexpr Coord max() { return Coord(int32_t((1u << 31) - 1)); }
+    __hostdev__ [[nodiscard]] static constexpr Coord max() noexcept { return Coord(int32_t((1u << 31) - 1)); }
 
-    __hostdev__ [[nodiscard]] static constexpr Coord min() { return Coord(-int32_t((1u << 31) - 1) - 1); }
+    __hostdev__ [[nodiscard]] static constexpr Coord min() noexcept { return Coord(-int32_t((1u << 31) - 1) - 1); }
 
-    __hostdev__ [[nodiscard]] static constexpr size_t memUsage() { return sizeof(Coord); }
+    __hostdev__ [[nodiscard]] static constexpr size_t memUsage() noexcept { return sizeof(Coord); }
 
     /// @brief Return a const reference to the given Coord component.
     /// @warning The argument is assumed to be 0, 1, or 2.
-    __hostdev__ constexpr const ValueType& operator[](IndexType i) const { NANOVDB_ASSERT(i < 3); return mVec[i]; }
+    __hostdev__ constexpr const ValueType& operator[](IndexType i) const noexcept { NANOVDB_ASSERT(i < 3); return mVec[i]; }
 
     /// @brief Return a non-const reference to the given Coord component.
     /// @warning The argument is assumed to be 0, 1, or 2.
-    __hostdev__ constexpr ValueType& operator[](IndexType i) { NANOVDB_ASSERT(i < 3); return mVec[i]; }
+    __hostdev__ constexpr ValueType& operator[](IndexType i) noexcept { NANOVDB_ASSERT(i < 3); return mVec[i]; }
 
     /// @brief Assignment operator that works with openvdb::Coord
     template<typename CoordT>
-    __hostdev__ constexpr Coord& operator=(const CoordT& other)
+    __hostdev__ constexpr Coord& operator=(const CoordT& other) noexcept
     {
         static_assert(sizeof(Coord) == sizeof(CoordT), "Mis-matched sizeof");
         mVec[0] = other[0];
@@ -422,16 +422,16 @@ public:
     }
 
     /// @brief Return a new instance with coordinates masked by the given unsigned integer.
-    __hostdev__ [[nodiscard]] constexpr Coord operator&(IndexType n) const { return Coord(mVec[0] & n, mVec[1] & n, mVec[2] & n); }
+    __hostdev__ [[nodiscard]] constexpr Coord operator&(IndexType n) const noexcept { return Coord(mVec[0] & n, mVec[1] & n, mVec[2] & n); }
 
     // @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
-    __hostdev__ [[nodiscard]] constexpr Coord operator<<(IndexType n) const { return Coord(mVec[0] << n, mVec[1] << n, mVec[2] << n); }
+    __hostdev__ [[nodiscard]] constexpr Coord operator<<(IndexType n) const noexcept { return Coord(mVec[0] << n, mVec[1] << n, mVec[2] << n); }
 
     // @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
-    __hostdev__ [[nodiscard]] constexpr Coord operator>>(IndexType n) const { return Coord(mVec[0] >> n, mVec[1] >> n, mVec[2] >> n); }
+    __hostdev__ [[nodiscard]] constexpr Coord operator>>(IndexType n) const noexcept { return Coord(mVec[0] >> n, mVec[1] >> n, mVec[2] >> n); }
 
     /// @brief Return true if this Coord is lexicographically less than the given Coord.
-    __hostdev__ [[nodiscard]] constexpr bool operator<(const Coord& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator<(const Coord& rhs) const noexcept
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -441,7 +441,7 @@ public:
     }
 
     /// @brief Return true if this Coord is lexicographically less or equal to the given Coord.
-    __hostdev__ [[nodiscard]] constexpr bool operator<=(const Coord& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator<=(const Coord& rhs) const noexcept
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -451,7 +451,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater than the given Coord.
-    __hostdev__ [[nodiscard]] constexpr bool operator>(const Coord& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator>(const Coord& rhs) const noexcept
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -461,7 +461,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
-    __hostdev__ [[nodiscard]] constexpr bool operator>=(const Coord& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator>=(const Coord& rhs) const noexcept
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -471,47 +471,47 @@ public:
     }
 
     // @brief Return true if the Coord components are identical.
-    __hostdev__ [[nodiscard]] constexpr bool   operator==(const Coord& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1] && mVec[2] == rhs[2]; }
-    __hostdev__ [[nodiscard]] constexpr bool   operator!=(const Coord& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1] || mVec[2] != rhs[2]; }
-    __hostdev__ constexpr Coord& operator&=(int n)
+    __hostdev__ [[nodiscard]] constexpr bool   operator==(const Coord& rhs) const noexcept { return mVec[0] == rhs[0] && mVec[1] == rhs[1] && mVec[2] == rhs[2]; }
+    __hostdev__ [[nodiscard]] constexpr bool   operator!=(const Coord& rhs) const noexcept { return mVec[0] != rhs[0] || mVec[1] != rhs[1] || mVec[2] != rhs[2]; }
+    __hostdev__ constexpr Coord& operator&=(int n) noexcept
     {
         mVec[0] &= n;
         mVec[1] &= n;
         mVec[2] &= n;
         return *this;
     }
-    __hostdev__ constexpr Coord& operator<<=(uint32_t n)
+    __hostdev__ constexpr Coord& operator<<=(uint32_t n) noexcept
     {
         mVec[0] <<= n;
         mVec[1] <<= n;
         mVec[2] <<= n;
         return *this;
     }
-    __hostdev__ constexpr Coord& operator>>=(uint32_t n)
+    __hostdev__ constexpr Coord& operator>>=(uint32_t n) noexcept
     {
         mVec[0] >>= n;
         mVec[1] >>= n;
         mVec[2] >>= n;
         return *this;
     }
-    __hostdev__ constexpr Coord& operator+=(int n)
+    __hostdev__ constexpr Coord& operator+=(int n) noexcept
     {
         mVec[0] += n;
         mVec[1] += n;
         mVec[2] += n;
         return *this;
     }
-    __hostdev__ [[nodiscard]] constexpr Coord  operator+(const Coord& rhs) const { return Coord(mVec[0] + rhs[0], mVec[1] + rhs[1], mVec[2] + rhs[2]); }
-    __hostdev__ [[nodiscard]] constexpr Coord  operator-(const Coord& rhs) const { return Coord(mVec[0] - rhs[0], mVec[1] - rhs[1], mVec[2] - rhs[2]); }
-    __hostdev__ [[nodiscard]] constexpr Coord  operator-() const { return Coord(-mVec[0], -mVec[1], -mVec[2]); }
-    __hostdev__ constexpr Coord& operator+=(const Coord& rhs)
+    __hostdev__ [[nodiscard]] constexpr Coord  operator+(const Coord& rhs) const noexcept { return Coord(mVec[0] + rhs[0], mVec[1] + rhs[1], mVec[2] + rhs[2]); }
+    __hostdev__ [[nodiscard]] constexpr Coord  operator-(const Coord& rhs) const noexcept { return Coord(mVec[0] - rhs[0], mVec[1] - rhs[1], mVec[2] - rhs[2]); }
+    __hostdev__ [[nodiscard]] constexpr Coord  operator-() const noexcept { return Coord(-mVec[0], -mVec[1], -mVec[2]); }
+    __hostdev__ constexpr Coord& operator+=(const Coord& rhs) noexcept
     {
         mVec[0] += rhs[0];
         mVec[1] += rhs[1];
         mVec[2] += rhs[2];
         return *this;
     }
-    __hostdev__ constexpr Coord& operator-=(const Coord& rhs)
+    __hostdev__ constexpr Coord& operator-=(const Coord& rhs) noexcept
     {
         mVec[0] -= rhs[0];
         mVec[1] -= rhs[1];
@@ -520,7 +520,7 @@ public:
     }
 
     /// @brief Perform a component-wise minimum with the other Coord.
-    __hostdev__ constexpr Coord& minComponent(const Coord& other)
+    __hostdev__ constexpr Coord& minComponent(const Coord& other) noexcept
     {
         if (other[0] < mVec[0])
             mVec[0] = other[0];
@@ -532,7 +532,7 @@ public:
     }
 
     /// @brief Perform a component-wise maximum with the other Coord.
-    __hostdev__ constexpr Coord& maxComponent(const Coord& other)
+    __hostdev__ constexpr Coord& maxComponent(const Coord& other) noexcept
     {
         if (other[0] > mVec[0])
             mVec[0] = other[0];
@@ -543,14 +543,14 @@ public:
         return *this;
     }
 #if defined(__CUDACC__) // the following functions only run on the GPU!
-    __device__ inline Coord& minComponentAtomic(const Coord& other)
+    __device__ inline Coord& minComponentAtomic(const Coord& other) noexcept
     {
         atomicMin(&mVec[0], other[0]);
         atomicMin(&mVec[1], other[1]);
         atomicMin(&mVec[2], other[2]);
         return *this;
     }
-    __device__ inline Coord& maxComponentAtomic(const Coord& other)
+    __device__ inline Coord& maxComponentAtomic(const Coord& other) noexcept
     {
         atomicMax(&mVec[0], other[0]);
         atomicMax(&mVec[1], other[1]);
@@ -559,16 +559,16 @@ public:
     }
 #endif
 
-    __hostdev__ [[nodiscard]] constexpr Coord offsetBy(ValueType dx, ValueType dy, ValueType dz) const
+    __hostdev__ [[nodiscard]] constexpr Coord offsetBy(ValueType dx, ValueType dy, ValueType dz) const noexcept
     {
         return Coord(mVec[0] + dx, mVec[1] + dy, mVec[2] + dz);
     }
 
-    __hostdev__ [[nodiscard]] constexpr Coord offsetBy(ValueType n) const { return this->offsetBy(n, n, n); }
+    __hostdev__ [[nodiscard]] constexpr Coord offsetBy(ValueType n) const noexcept { return this->offsetBy(n, n, n); }
 
     /// Return true if any of the components of @a a are smaller than the
     /// corresponding components of @a b.
-    __hostdev__ [[nodiscard]] static inline constexpr bool lessThan(const Coord& a, const Coord& b)
+    __hostdev__ [[nodiscard]] static inline constexpr bool lessThan(const Coord& a, const Coord& b) noexcept
     {
         return (a[0] < b[0] || a[1] < b[1] || a[2] < b[2]);
     }
@@ -577,7 +577,7 @@ public:
     /// than @a xyz (node centered conversion).
     // Not constexpr — math::Floor uses floorf/floor which aren't constexpr until C++23.
     template<typename Vec3T>
-    __hostdev__ [[nodiscard]] static Coord Floor(const Vec3T& xyz) { return Coord(math::Floor(xyz[0]), math::Floor(xyz[1]), math::Floor(xyz[2])); }
+    __hostdev__ [[nodiscard]] static Coord Floor(const Vec3T& xyz) noexcept { return Coord(math::Floor(xyz[0]), math::Floor(xyz[1]), math::Floor(xyz[2])); }
 
     /// @brief Return a hash key derived from the existing coordinates.
     /// @details The hash function is originally taken from the SIGGRAPH paper:
@@ -585,22 +585,22 @@ public:
     ///          and the prime numbers are modified based on the ACM Transactions on Graphics paper:
     ///          "Real-time 3D reconstruction at scale using voxel hashing" (the second number had a typo!)
     template<int Log2N = 3 + 4 + 5>
-    __hostdev__ [[nodiscard]] constexpr uint32_t hash() const { return ((1 << Log2N) - 1) & (mVec[0] * 73856093 ^ mVec[1] * 19349669 ^ mVec[2] * 83492791); }
+    __hostdev__ [[nodiscard]] constexpr uint32_t hash() const noexcept { return ((1 << Log2N) - 1) & (mVec[0] * 73856093 ^ mVec[1] * 19349669 ^ mVec[2] * 83492791); }
 
     /// @brief Return the octant of this Coord
     //__hostdev__ size_t octant() const { return (uint32_t(mVec[0])>>31) | ((uint32_t(mVec[1])>>31)<<1) | ((uint32_t(mVec[2])>>31)<<2); }
-    __hostdev__ [[nodiscard]] constexpr uint8_t octant() const { return (uint8_t(bool(mVec[0] & (1u << 31)))) |
+    __hostdev__ [[nodiscard]] constexpr uint8_t octant() const noexcept { return (uint8_t(bool(mVec[0] & (1u << 31)))) |
                                                 (uint8_t(bool(mVec[1] & (1u << 31))) << 1) |
                                                 (uint8_t(bool(mVec[2] & (1u << 31))) << 2); }
 
     /// @brief Return a single precision floating-point vector of this coordinate
-    __hostdev__ [[nodiscard]] inline constexpr Vec3<float> asVec3s() const;
+    __hostdev__ [[nodiscard]] inline constexpr Vec3<float> asVec3s() const noexcept;
 
     /// @brief Return a double precision floating-point vector of this coordinate
-    __hostdev__ [[nodiscard]] inline constexpr Vec3<double> asVec3d() const;
+    __hostdev__ [[nodiscard]] inline constexpr Vec3<double> asVec3d() const noexcept;
 
     // returns a copy of itself, so it mimics the behaviour of Vec3<T>::round()
-    __hostdev__ [[nodiscard]] inline constexpr Coord round() const { return *this; }
+    __hostdev__ [[nodiscard]] inline constexpr Coord round() const noexcept { return *this; }
 }; // Coord class
 
 
@@ -620,51 +620,51 @@ public:
     using IndexType = uint32_t;
 
     /// @brief Initialize all coordinates to zero.
-    __hostdev__ constexpr Coord2()
+    __hostdev__ constexpr Coord2() noexcept
         : mVec{0, 0}
     {
     }
 
     /// @brief Initializes all coordinates to the given signed integer.
-    __hostdev__ explicit constexpr Coord2(ValueType n)
+    __hostdev__ explicit constexpr Coord2(ValueType n) noexcept
         : mVec{n, n}
     {
     }
 
     /// @brief Initializes coordinate to the given signed integers.
-    __hostdev__ constexpr Coord2(ValueType i, ValueType j)
+    __hostdev__ constexpr Coord2(ValueType i, ValueType j) noexcept
         : mVec{i, j}
     {
     }
 
-    __hostdev__ constexpr Coord2(ValueType* ptr)
+    __hostdev__ constexpr Coord2(ValueType* ptr) noexcept
         : mVec{ptr[0], ptr[1]}
     {
     }
 
-    __hostdev__ constexpr int32_t x() const { return mVec[0]; }
-    __hostdev__ constexpr int32_t y() const { return mVec[1]; }
+    __hostdev__ constexpr int32_t x() const noexcept { return mVec[0]; }
+    __hostdev__ constexpr int32_t y() const noexcept { return mVec[1]; }
 
-    __hostdev__ constexpr int32_t& x() { return mVec[0]; }
-    __hostdev__ constexpr int32_t& y() { return mVec[1]; }
+    __hostdev__ constexpr int32_t& x() noexcept { return mVec[0]; }
+    __hostdev__ constexpr int32_t& y() noexcept { return mVec[1]; }
 
-    __hostdev__ [[nodiscard]] static constexpr Coord2 max() { return Coord2(int32_t((1u << 31) - 1)); }
+    __hostdev__ [[nodiscard]] static constexpr Coord2 max() noexcept { return Coord2(int32_t((1u << 31) - 1)); }
 
-    __hostdev__ [[nodiscard]] static constexpr Coord2 min() { return Coord2(-int32_t((1u << 31) - 1) - 1); }
+    __hostdev__ [[nodiscard]] static constexpr Coord2 min() noexcept { return Coord2(-int32_t((1u << 31) - 1) - 1); }
 
-    __hostdev__ [[nodiscard]] static constexpr size_t memUsage() { return sizeof(Coord2); }
+    __hostdev__ [[nodiscard]] static constexpr size_t memUsage() noexcept { return sizeof(Coord2); }
 
     /// @brief Return a const reference to the given Coord component.
     /// @warning The argument is assumed to be 0 or 1,
-    __hostdev__ constexpr const ValueType& operator[](IndexType i) const { NANOVDB_ASSERT(i < 2); return mVec[i]; }
+    __hostdev__ constexpr const ValueType& operator[](IndexType i) const noexcept { NANOVDB_ASSERT(i < 2); return mVec[i]; }
 
     /// @brief Return a non-const reference to the given Coord component.
     /// @warning The argument is assumed to be 0 or 1.
-    __hostdev__ constexpr ValueType& operator[](IndexType i) { NANOVDB_ASSERT(i < 2); return mVec[i]; }
+    __hostdev__ constexpr ValueType& operator[](IndexType i) noexcept { NANOVDB_ASSERT(i < 2); return mVec[i]; }
 
     /// @brief Assignment operator that works with openvdb::Coord
     template<typename CoordT>
-    __hostdev__ constexpr Coord2& operator=(const CoordT& other)
+    __hostdev__ constexpr Coord2& operator=(const CoordT& other) noexcept
     {
         static_assert(sizeof(Coord2) == sizeof(CoordT), "Mis-matched sizeof");
         mVec[0] = other[0];
@@ -673,16 +673,16 @@ public:
     }
 
     /// @brief Return a new instance with coordinates masked by the given unsigned integer.
-    __hostdev__ [[nodiscard]] constexpr Coord2 operator&(IndexType n) const { return Coord2(mVec[0] & n, mVec[1] & n); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 operator&(IndexType n) const noexcept { return Coord2(mVec[0] & n, mVec[1] & n); }
 
     // @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
-    __hostdev__ [[nodiscard]] constexpr Coord2 operator<<(IndexType n) const { return Coord2(mVec[0] << n, mVec[1] << n); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 operator<<(IndexType n) const noexcept { return Coord2(mVec[0] << n, mVec[1] << n); }
 
     // @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
-    __hostdev__ [[nodiscard]] constexpr Coord2 operator>>(IndexType n) const { return Coord2(mVec[0] >> n, mVec[1] >> n); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 operator>>(IndexType n) const noexcept { return Coord2(mVec[0] >> n, mVec[1] >> n); }
 
     /// @brief Return true if this Coord is lexicographically less than the given Coord.
-    __hostdev__ [[nodiscard]] constexpr bool operator<(const Coord2& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator<(const Coord2& rhs) const noexcept
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -690,7 +690,7 @@ public:
     }
 
     /// @brief Return true if this Coord is lexicographically less or equal to the given Coord.
-    __hostdev__ [[nodiscard]] constexpr bool operator<=(const Coord2& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator<=(const Coord2& rhs) const noexcept
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -698,7 +698,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater than the given Coord.
-    __hostdev__ [[nodiscard]] constexpr bool operator>(const Coord2& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator>(const Coord2& rhs) const noexcept
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -706,7 +706,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
-    __hostdev__ [[nodiscard]] constexpr bool operator>=(const Coord2& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator>=(const Coord2& rhs) const noexcept
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -714,42 +714,42 @@ public:
     }
 
     // @brief Return true if the Coord components are identical.
-    __hostdev__ [[nodiscard]] constexpr bool   operator==(const Coord2& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
-    __hostdev__ [[nodiscard]] constexpr bool   operator!=(const Coord2& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
-    __hostdev__ constexpr Coord2& operator&=(int n)
+    __hostdev__ [[nodiscard]] constexpr bool   operator==(const Coord2& rhs) const noexcept { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
+    __hostdev__ [[nodiscard]] constexpr bool   operator!=(const Coord2& rhs) const noexcept { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
+    __hostdev__ constexpr Coord2& operator&=(int n) noexcept
     {
         mVec[0] &= n;
         mVec[1] &= n;
         return *this;
     }
-    __hostdev__ constexpr Coord2& operator<<=(uint32_t n)
+    __hostdev__ constexpr Coord2& operator<<=(uint32_t n) noexcept
     {
         mVec[0] <<= n;
         mVec[1] <<= n;
         return *this;
     }
-    __hostdev__ constexpr Coord2& operator>>=(uint32_t n)
+    __hostdev__ constexpr Coord2& operator>>=(uint32_t n) noexcept
     {
         mVec[0] >>= n;
         mVec[1] >>= n;
         return *this;
     }
-    __hostdev__ constexpr Coord2& operator+=(int n)
+    __hostdev__ constexpr Coord2& operator+=(int n) noexcept
     {
         mVec[0] += n;
         mVec[1] += n;
         return *this;
     }
-    __hostdev__ [[nodiscard]] constexpr Coord2  operator+(const Coord2& rhs) const { return Coord2(mVec[0] + rhs[0], mVec[1] + rhs[1]); }
-    __hostdev__ [[nodiscard]] constexpr Coord2  operator-(const Coord2& rhs) const { return Coord2(mVec[0] - rhs[0], mVec[1] - rhs[1]); }
-    __hostdev__ [[nodiscard]] constexpr Coord2  operator-() const { return Coord2(-mVec[0], -mVec[1]); }
-    __hostdev__ constexpr Coord2& operator+=(const Coord2& rhs)
+    __hostdev__ [[nodiscard]] constexpr Coord2  operator+(const Coord2& rhs) const noexcept { return Coord2(mVec[0] + rhs[0], mVec[1] + rhs[1]); }
+    __hostdev__ [[nodiscard]] constexpr Coord2  operator-(const Coord2& rhs) const noexcept { return Coord2(mVec[0] - rhs[0], mVec[1] - rhs[1]); }
+    __hostdev__ [[nodiscard]] constexpr Coord2  operator-() const noexcept { return Coord2(-mVec[0], -mVec[1]); }
+    __hostdev__ constexpr Coord2& operator+=(const Coord2& rhs) noexcept
     {
         mVec[0] += rhs[0];
         mVec[1] += rhs[1];
         return *this;
     }
-    __hostdev__ constexpr Coord2& operator-=(const Coord2& rhs)
+    __hostdev__ constexpr Coord2& operator-=(const Coord2& rhs) noexcept
     {
         mVec[0] -= rhs[0];
         mVec[1] -= rhs[1];
@@ -757,7 +757,7 @@ public:
     }
 
     /// @brief Perform a component-wise minimum with the other Coord.
-    __hostdev__ constexpr Coord2& minComponent(const Coord2& other)
+    __hostdev__ constexpr Coord2& minComponent(const Coord2& other) noexcept
     {
         if (other[0] < mVec[0])
             mVec[0] = other[0];
@@ -767,7 +767,7 @@ public:
     }
 
     /// @brief Perform a component-wise maximum with the other Coord.
-    __hostdev__ constexpr Coord2& maxComponent(const Coord2& other)
+    __hostdev__ constexpr Coord2& maxComponent(const Coord2& other) noexcept
     {
         if (other[0] > mVec[0])
             mVec[0] = other[0];
@@ -776,13 +776,13 @@ public:
         return *this;
     }
 #if defined(__CUDACC__) // the following functions only run on the GPU!
-    __device__ inline Coord2& minComponentAtomic(const Coord2& other)
+    __device__ inline Coord2& minComponentAtomic(const Coord2& other) noexcept
     {
         atomicMin(&mVec[0], other[0]);
         atomicMin(&mVec[1], other[1]);
         return *this;
     }
-    __device__ inline Coord2& maxComponentAtomic(const Coord2& other)
+    __device__ inline Coord2& maxComponentAtomic(const Coord2& other) noexcept
     {
         atomicMax(&mVec[0], other[0]);
         atomicMax(&mVec[1], other[1]);
@@ -790,16 +790,16 @@ public:
     }
 #endif
 
-    __hostdev__ [[nodiscard]] constexpr Coord2 offsetBy(ValueType dx, ValueType dy) const
+    __hostdev__ [[nodiscard]] constexpr Coord2 offsetBy(ValueType dx, ValueType dy) const noexcept
     {
         return Coord2(mVec[0] + dx, mVec[1] + dy);
     }
 
-    __hostdev__ [[nodiscard]] constexpr Coord2 offsetBy(ValueType n) const { return this->offsetBy(n, n); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 offsetBy(ValueType n) const noexcept { return this->offsetBy(n, n); }
 
     /// Return true if any of the components of @a a are smaller than the
     /// corresponding components of @a b.
-    __hostdev__ [[nodiscard]] static inline constexpr bool lessThan(const Coord2& a, const Coord2& b)
+    __hostdev__ [[nodiscard]] static inline constexpr bool lessThan(const Coord2& a, const Coord2& b) noexcept
     {
         return (a[0] < b[0] || a[1] < b[1]);
     }
@@ -808,16 +808,16 @@ public:
     /// than @a xyz (node centered conversion).
     // Not constexpr — math::Floor uses floorf/floor which aren't constexpr until C++23.
     template<typename Vec2T>
-    __hostdev__ [[nodiscard]] static Coord2 Floor(const Vec2T& xy) { return Coord2(math::Floor(xy[0]), math::Floor(xy[1])); }
+    __hostdev__ [[nodiscard]] static Coord2 Floor(const Vec2T& xy) noexcept { return Coord2(math::Floor(xy[0]), math::Floor(xy[1])); }
 
     /// @brief Return a single precision floating-point vector of this coordinate
-    __hostdev__ [[nodiscard]] inline constexpr Vec2<float> asVec2s() const;
+    __hostdev__ [[nodiscard]] inline constexpr Vec2<float> asVec2s() const noexcept;
 
     /// @brief Return a double precision floating-point vector of this coordinate
-    __hostdev__ [[nodiscard]] inline constexpr Vec2<double> asVec2d() const;
+    __hostdev__ [[nodiscard]] inline constexpr Vec2<double> asVec2d() const noexcept;
 
     // returns a copy of itself, so it mimics the behaviour of Vec3<T>::round()
-    __hostdev__ [[nodiscard]] inline constexpr Coord2 round() const { return *this; }
+    __hostdev__ [[nodiscard]] inline constexpr Coord2 round() const noexcept { return *this; }
 }; // Coord2 class
 
 // ----------------------------> VecBase <-----------------------------------
@@ -836,63 +836,63 @@ public:
     using ValueType = T;
     static constexpr int SIZE = N;
 
-    VecBase() = default;
+    VecBase() noexcept = default;
 
     /// @brief Indexed element access. Asserts 0 <= i < N in debug builds.
-    __hostdev__ constexpr const T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
-    __hostdev__ constexpr T&       operator[](int i)       { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
+    __hostdev__ constexpr const T& operator[](int i) const noexcept { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
+    __hostdev__ constexpr T&       operator[](int i) noexcept       { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
 
     /// @brief Named component accessors. Available based on dimensionality:
     /// x() requires N >= 1, y() requires N >= 2, z() requires N >= 3, w()
     /// requires N >= 4. A call on a Vec too small for the requested component
     /// triggers a clear compile-time static_assert at the call site.
-    __hostdev__ constexpr const T& x() const { return mVec[0]; }
-    __hostdev__ constexpr       T& x()       { return mVec[0]; }
-    __hostdev__ constexpr const T& y() const { static_assert(N >= 2, "VecBase::y() requires N >= 2"); return mVec[1]; }
-    __hostdev__ constexpr       T& y()       { static_assert(N >= 2, "VecBase::y() requires N >= 2"); return mVec[1]; }
-    __hostdev__ constexpr const T& z() const { static_assert(N >= 3, "VecBase::z() requires N >= 3"); return mVec[2]; }
-    __hostdev__ constexpr       T& z()       { static_assert(N >= 3, "VecBase::z() requires N >= 3"); return mVec[2]; }
-    __hostdev__ constexpr const T& w() const { static_assert(N >= 4, "VecBase::w() requires N >= 4"); return mVec[3]; }
-    __hostdev__ constexpr       T& w()       { static_assert(N >= 4, "VecBase::w() requires N >= 4"); return mVec[3]; }
+    __hostdev__ constexpr const T& x() const noexcept { return mVec[0]; }
+    __hostdev__ constexpr       T& x() noexcept       { return mVec[0]; }
+    __hostdev__ constexpr const T& y() const noexcept { static_assert(N >= 2, "VecBase::y() requires N >= 2"); return mVec[1]; }
+    __hostdev__ constexpr       T& y() noexcept       { static_assert(N >= 2, "VecBase::y() requires N >= 2"); return mVec[1]; }
+    __hostdev__ constexpr const T& z() const noexcept { static_assert(N >= 3, "VecBase::z() requires N >= 3"); return mVec[2]; }
+    __hostdev__ constexpr       T& z() noexcept       { static_assert(N >= 3, "VecBase::z() requires N >= 3"); return mVec[2]; }
+    __hostdev__ constexpr const T& w() const noexcept { static_assert(N >= 4, "VecBase::w() requires N >= 4"); return mVec[3]; }
+    __hostdev__ constexpr       T& w() noexcept       { static_assert(N >= 4, "VecBase::w() requires N >= 4"); return mVec[3]; }
 
     /// @brief raw pointer to the underlying N-element storage
-    __hostdev__ constexpr T*       asPointer()       { return mVec; }
-    __hostdev__ constexpr const T* asPointer() const { return mVec; }
+    __hostdev__ constexpr T*       asPointer() noexcept       { return mVec; }
+    __hostdev__ constexpr const T* asPointer() const noexcept { return mVec; }
 
     // ---- generic element-wise helpers (taking/returning Derived) ----
 
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived plus(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived plus(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] + rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived minus(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived minus(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] - rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived mul(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived mul(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] * rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived div(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived div(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] / rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived negate() const {
+    __hostdev__ [[nodiscard]] constexpr Derived negate() const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = -mVec[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived scale(const T& s) const {
+    __hostdev__ [[nodiscard]] constexpr Derived scale(const T& s) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] * s;
         return out;
@@ -900,7 +900,7 @@ public:
     /// @brief return (*this) / @a s element-wise as a @c Derived. Uses per-element
     /// division (correct for integer @c T, unlike multiplying by 1/s).
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived divideBy(const T& s) const {
+    __hostdev__ [[nodiscard]] constexpr Derived divideBy(const T& s) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] / s;
         return out;
@@ -908,32 +908,32 @@ public:
 
     // ---- in-place compound assignment helpers ----
 
-    __hostdev__ constexpr VecBase& addAssign(const VecBase& rhs) {
+    __hostdev__ constexpr VecBase& addAssign(const VecBase& rhs) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] += rhs.mVec[i];
         return *this;
     }
-    __hostdev__ constexpr VecBase& subAssign(const VecBase& rhs) {
+    __hostdev__ constexpr VecBase& subAssign(const VecBase& rhs) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] -= rhs.mVec[i];
         return *this;
     }
-    __hostdev__ constexpr VecBase& mulAssign(const VecBase& rhs) {
+    __hostdev__ constexpr VecBase& mulAssign(const VecBase& rhs) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] *= rhs.mVec[i];
         return *this;
     }
-    __hostdev__ constexpr VecBase& divAssign(const VecBase& rhs) {
+    __hostdev__ constexpr VecBase& divAssign(const VecBase& rhs) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] /= rhs.mVec[i];
         return *this;
     }
-    __hostdev__ constexpr VecBase& scaleAssign(const T& s) {
+    __hostdev__ constexpr VecBase& scaleAssign(const T& s) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] *= s;
         return *this;
     }
-    __hostdev__ constexpr VecBase& divideAssignScalar(const T& s) {
+    __hostdev__ constexpr VecBase& divideAssignScalar(const T& s) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] /= s;
         return *this;
     }
 
-    __hostdev__ [[nodiscard]] constexpr bool equals(const VecBase& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr bool equals(const VecBase& rhs) const noexcept {
         for (int i = 0; i < N; ++i) if (mVec[i] != rhs.mVec[i]) return false;
         return true;
     }
@@ -942,27 +942,27 @@ public:
 
     /// @brief dot product. @a V must have @c operator[] valid for 0..N-1.
     template<typename V>
-    __hostdev__ [[nodiscard]] constexpr T dot(const V& v) const {
+    __hostdev__ [[nodiscard]] constexpr T dot(const V& v) const noexcept {
         T s = T(0);
         for (int i = 0; i < N; ++i) s += mVec[i] * v[i];
         return s;
     }
-    __hostdev__ [[nodiscard]] constexpr T lengthSqr() const {
+    __hostdev__ [[nodiscard]] constexpr T lengthSqr() const noexcept {
         T s = T(0);
         for (int i = 0; i < N; ++i) s += mVec[i] * mVec[i];
         return s;
     }
     // Not constexpr — std::sqrt isn't constexpr until C++26.
-    __hostdev__ [[nodiscard]] T length() const { return Sqrt(this->lengthSqr()); }
+    __hostdev__ [[nodiscard]] T length() const noexcept { return Sqrt(this->lengthSqr()); }
 
     /// @brief return the smallest of the N components
-    __hostdev__ [[nodiscard]] constexpr T smallestComponent() const {
+    __hostdev__ [[nodiscard]] constexpr T smallestComponent() const noexcept {
         T m = mVec[0];
         for (int i = 1; i < N; ++i) if (mVec[i] < m) m = mVec[i];
         return m;
     }
     /// @brief return the largest of the N components
-    __hostdev__ [[nodiscard]] constexpr T largestComponent() const {
+    __hostdev__ [[nodiscard]] constexpr T largestComponent() const noexcept {
         T m = mVec[0];
         for (int i = 1; i < N; ++i) if (mVec[i] > m) m = mVec[i];
         return m;
@@ -971,12 +971,12 @@ public:
     // ---- component-wise (mutating) min/max ----
 
     template<typename V>
-    __hostdev__ constexpr VecBase& mergeMin(const V& other) {
+    __hostdev__ constexpr VecBase& mergeMin(const V& other) noexcept {
         for (int i = 0; i < N; ++i) if (other[i] < mVec[i]) mVec[i] = other[i];
         return *this;
     }
     template<typename V>
-    __hostdev__ constexpr VecBase& mergeMax(const V& other) {
+    __hostdev__ constexpr VecBase& mergeMax(const V& other) noexcept {
         for (int i = 0; i < N; ++i) if (other[i] > mVec[i]) mVec[i] = other[i];
         return *this;
     }
@@ -1000,7 +1000,7 @@ public:
     /// expression; the floating-point branch calls @c math::Floor /
     /// @c math::Ceil, which aren't constexpr until C++23.
     template<typename Result>
-    __hostdev__ [[nodiscard]] constexpr Result floorAs() const {
+    __hostdev__ [[nodiscard]] constexpr Result floorAs() const noexcept {
         Result r{};
         if constexpr (std::is_floating_point<T>::value) {
             for (int i = 0; i < N; ++i) r[i] = math::Floor(mVec[i]);
@@ -1010,7 +1010,7 @@ public:
         return r;
     }
     template<typename Result>
-    __hostdev__ [[nodiscard]] constexpr Result ceilAs() const {
+    __hostdev__ [[nodiscard]] constexpr Result ceilAs() const noexcept {
         Result r{};
         if constexpr (std::is_floating_point<T>::value) {
             for (int i = 0; i < N; ++i) r[i] = math::Ceil(mVec[i]);
@@ -1024,7 +1024,7 @@ public:
     /// float, double, and long double; pass-through for integer @c T.
     /// @note See @c floorAs — only the integer-@c T branch is constexpr-usable.
     template<typename Result>
-    __hostdev__ [[nodiscard]] constexpr Result roundAs() const {
+    __hostdev__ [[nodiscard]] constexpr Result roundAs() const noexcept {
         Result r{};
         if constexpr (std::is_floating_point<T>::value) {
             const T half = T(0.5);
@@ -1045,7 +1045,7 @@ public:
 /// without any tail padding because the byte size is already a power-of-2
 /// multiple of alignof(T).
 template<typename T>
-class alignas(alignof(T) * 2) Vec2 : public VecBase<T, 2>
+class alignas(alignof(T) * 2) Vec2 final : public VecBase<T, 2>
 {
     using Base = VecBase<T, 2>;
 
@@ -1053,105 +1053,105 @@ public:
     using ValueType = T;
     static constexpr int size = 2; // openvdb::math::Tuple-compat alias of SIZE
 
-    Vec2() = default;
-    __hostdev__ explicit constexpr Vec2(T x)            { this->mVec[0] = x;    this->mVec[1] = x;    }
-    __hostdev__ constexpr Vec2(T x, T y)                { this->mVec[0] = x;    this->mVec[1] = y;    }
+    Vec2() noexcept = default;
+    __hostdev__ explicit constexpr Vec2(T x) noexcept            { this->mVec[0] = x;    this->mVec[1] = x;    }
+    __hostdev__ constexpr Vec2(T x, T y) noexcept                { this->mVec[0] = x;    this->mVec[1] = y;    }
 
     template<template<class> class Vec2T, class T2>
-    __hostdev__ constexpr Vec2(const Vec2T<T2>& v) {
+    __hostdev__ explicit constexpr Vec2(const Vec2T<T2>& v) noexcept {
         static_assert(Vec2T<T2>::size == 2, "expected Vec2T::size==2!");
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]);
     }
     template<typename T2>
-    __hostdev__ explicit constexpr Vec2(const Vec2<T2>& v) {
+    __hostdev__ explicit constexpr Vec2(const Vec2<T2>& v) noexcept {
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]);
     }
-    __hostdev__ explicit constexpr Vec2(const Coord2& ijk) {
+    __hostdev__ explicit constexpr Vec2(const Coord2& ijk) noexcept {
         this->mVec[0] = T(ijk[0]); this->mVec[1] = T(ijk[1]);
     }
 
     template<template<class> class Vec2T, class T2>
-    __hostdev__ constexpr Vec2& operator=(const Vec2T<T2>& rhs) {
+    __hostdev__ constexpr Vec2& operator=(const Vec2T<T2>& rhs) noexcept {
         static_assert(Vec2T<T2>::size == 2, "expected Vec2T::size==2!");
         this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1];
         return *this;
     }
 
     // ---- element-wise (Vec & Vec) ----
-    __hostdev__ [[nodiscard]] constexpr Vec2  operator-() const            { return Base::template negate<Vec2>(); }
-    __hostdev__ [[nodiscard]] constexpr Vec2  operator+(const Vec2& v) const { return Base::template plus<Vec2>(v); }
-    __hostdev__ [[nodiscard]] constexpr Vec2  operator-(const Vec2& v) const { return Base::template minus<Vec2>(v); }
-    __hostdev__ [[nodiscard]] constexpr Vec2  operator*(const Vec2& v) const { return Base::template mul<Vec2>(v); }
-    __hostdev__ [[nodiscard]] constexpr Vec2  operator/(const Vec2& v) const { return Base::template div<Vec2>(v); }
-    __hostdev__ constexpr Vec2& operator+=(const Vec2& v)    { Base::addAssign(v); return *this; }
-    __hostdev__ constexpr Vec2& operator-=(const Vec2& v)    { Base::subAssign(v); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator-() const noexcept            { return Base::template negate<Vec2>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator+(const Vec2& v) const noexcept { return Base::template plus<Vec2>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator-(const Vec2& v) const noexcept { return Base::template minus<Vec2>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator*(const Vec2& v) const noexcept { return Base::template mul<Vec2>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator/(const Vec2& v) const noexcept { return Base::template div<Vec2>(v); }
+    __hostdev__ constexpr Vec2& operator+=(const Vec2& v) noexcept    { Base::addAssign(v); return *this; }
+    __hostdev__ constexpr Vec2& operator-=(const Vec2& v) noexcept    { Base::subAssign(v); return *this; }
 
     // ---- mixed Vec2 / Coord2 ----
-    __hostdev__ [[nodiscard]] constexpr Vec2  operator+(const Coord2& ijk) const { return Vec2(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1]); }
-    __hostdev__ [[nodiscard]] constexpr Vec2  operator-(const Coord2& ijk) const { return Vec2(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1]); }
-    __hostdev__ constexpr Vec2& operator+=(const Coord2& ijk) {
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator+(const Coord2& ijk) const noexcept { return Vec2(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1]); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator-(const Coord2& ijk) const noexcept { return Vec2(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1]); }
+    __hostdev__ constexpr Vec2& operator+=(const Coord2& ijk) noexcept {
         this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]);
         return *this;
     }
-    __hostdev__ constexpr Vec2& operator-=(const Coord2& ijk) {
+    __hostdev__ constexpr Vec2& operator-=(const Coord2& ijk) noexcept {
         this->mVec[0] -= T(ijk[0]); this->mVec[1] -= T(ijk[1]);
         return *this;
     }
 
     // ---- scalar ----
-    __hostdev__ [[nodiscard]] constexpr Vec2  operator*(const T& s) const  { return Base::template scale<Vec2>(s); }
-    __hostdev__ [[nodiscard]] constexpr Vec2  operator/(const T& s) const  { return Base::template divideBy<Vec2>(s); }
-    __hostdev__ constexpr Vec2& operator*=(const T& s)       { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Vec2& operator/=(const T& s)       { Base::divideAssignScalar(s); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator*(const T& s) const noexcept  { return Base::template scale<Vec2>(s); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator/(const T& s) const noexcept  { return Base::template divideBy<Vec2>(s); }
+    __hostdev__ constexpr Vec2& operator*=(const T& s) noexcept       { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Vec2& operator/=(const T& s) noexcept       { Base::divideAssignScalar(s); return *this; }
     // Not constexpr — depends on length() which calls std::sqrt.
-    __hostdev__ Vec2& normalize()                  { return (*this) /= this->length(); }
+    __hostdev__ Vec2& normalize() noexcept                  { return (*this) /= this->length(); }
 
     // ---- equality ----
-    __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec2& rhs) const { return Base::equals(rhs); }
-    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec2& rhs) const { return !Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec2& rhs) const noexcept { return Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec2& rhs) const noexcept { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
-    __hostdev__ constexpr Vec2& minComponent(const Vec2& other) { Base::mergeMin(other); return *this; }
-    __hostdev__ constexpr Vec2& maxComponent(const Vec2& other) { Base::mergeMax(other); return *this; }
+    __hostdev__ constexpr Vec2& minComponent(const Vec2& other) noexcept { Base::mergeMin(other); return *this; }
+    __hostdev__ constexpr Vec2& maxComponent(const Vec2& other) noexcept { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
-    __hostdev__ [[nodiscard]] constexpr ValueType min() const { return Base::smallestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType min() const noexcept { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ [[nodiscard]] constexpr ValueType max() const { return Base::largestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType max() const noexcept { return Base::largestComponent(); }
 
     /// @brief Round each component down (toward negative infinity)
     /// @return integer Coord2
     /// @note Only constexpr for integer @c T (floorAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ [[nodiscard]] constexpr Coord2 floor() const { return Base::template floorAs<Coord2>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 floor() const noexcept { return Base::template floorAs<Coord2>(); }
     /// @brief Round each component up (toward positive infinity)
     /// @return integer Coord2
     /// @note Only constexpr for integer @c T (ceilAs uses non-constexpr math::Ceil for floating point).
-    __hostdev__ [[nodiscard]] constexpr Coord2 ceil()  const { return Base::template ceilAs<Coord2>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 ceil()  const noexcept { return Base::template ceilAs<Coord2>(); }
     /// @brief Round each component to its closest integer value
     /// @return integer Coord2
     /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ [[nodiscard]] constexpr Coord2 round() const { return Base::template roundAs<Coord2>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 round() const noexcept { return Base::template roundAs<Coord2>(); }
 }; // Vec2<T>
 
 template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec2<T2> operator*(T1 scalar, const Vec2<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec2<T2> operator*(T1 scalar, const Vec2<T2>& vec) noexcept
 {
     return Vec2<T2>(scalar * vec[0], scalar * vec[1]);
 }
 template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec2<T2> operator/(T1 scalar, const Vec2<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec2<T2> operator/(T1 scalar, const Vec2<T2>& vec) noexcept
 {
     return Vec2<T2>(scalar / vec[0], scalar / vec[1]);
 }
 
 /// @brief Return a single precision floating-point vector of this coordinate
-__hostdev__ [[nodiscard]] inline constexpr Vec2<float> Coord2::asVec2s() const
+__hostdev__ [[nodiscard]] inline constexpr Vec2<float> Coord2::asVec2s() const noexcept
 {
     return Vec2<float>(float(mVec[0]), float(mVec[1]));
 }
 
 /// @brief Return a double precision floating-point vector of this coordinate
-__hostdev__ [[nodiscard]] inline constexpr Vec2<double> Coord2::asVec2d() const
+__hostdev__ [[nodiscard]] inline constexpr Vec2<double> Coord2::asVec2d() const noexcept
 {
     return Vec2<double>(double(mVec[0]), double(mVec[1]));
 }
@@ -1166,14 +1166,14 @@ protected:
 public:
     using ValueType = T;
 
-    [[nodiscard]] static constexpr int rows() { return ROWS; }
-    [[nodiscard]] static constexpr int cols() { return COLS; }
-    [[nodiscard]] static constexpr int size() { return ROWS * COLS; }
+    [[nodiscard]] static constexpr int rows() noexcept { return ROWS; }
+    [[nodiscard]] static constexpr int cols() noexcept { return COLS; }
+    [[nodiscard]] static constexpr int size() noexcept { return ROWS * COLS; }
 
-    MatBase() = default;
+    MatBase() noexcept = default;
 
     template<typename S>
-    __hostdev__ constexpr MatBase(S* array) {
+    __hostdev__ constexpr MatBase(S* array) noexcept {
         for (int i = 0; i < size(); ++i) {
             mData[i] = static_cast<T>(array[i]);
         }
@@ -1181,25 +1181,25 @@ public:
 
     // 2D array access. Returns a row pointer; the caller is responsible
     // for the column bound (0 <= col < COLS).
-    __hostdev__ constexpr T* operator[](int row) {
+    __hostdev__ constexpr T* operator[](int row) noexcept {
         NANOVDB_ASSERT(row >= 0 && row < ROWS);
         return &mData[row * COLS];
     }
-    __hostdev__ constexpr const T* operator[](int row) const {
+    __hostdev__ constexpr const T* operator[](int row) const noexcept {
         NANOVDB_ASSERT(row >= 0 && row < ROWS);
         return &mData[row * COLS];
     }
 
     /// @brief return a raw pointer to the underlying 1D storage (row-major)
-    __hostdev__ constexpr T*       data()       { return mData; }
+    __hostdev__ constexpr T*       data() noexcept       { return mData; }
     /// @brief return a const raw pointer to the underlying 1D storage (row-major)
-    __hostdev__ constexpr const T* data() const { return mData; }
+    __hostdev__ constexpr const T* data() const noexcept { return mData; }
 
     // ---- generic element-wise helpers ----
 
     /// @brief return @c *this + @a rhs as a @c Derived
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived plus(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived plus(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] + rhs.data()[i];
         return out;
@@ -1207,7 +1207,7 @@ public:
 
     /// @brief return @c *this - @a rhs as a @c Derived
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived minus(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived minus(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] - rhs.data()[i];
         return out;
@@ -1215,7 +1215,7 @@ public:
 
     /// @brief return -(*this) as a @c Derived
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived negate() const {
+    __hostdev__ [[nodiscard]] constexpr Derived negate() const noexcept {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = -mData[i];
         return out;
@@ -1223,21 +1223,21 @@ public:
 
     /// @brief return @a s * (*this) as a @c Derived
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived scale(const T& s) const {
+    __hostdev__ [[nodiscard]] constexpr Derived scale(const T& s) const noexcept {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] * s;
         return out;
     }
 
-    __hostdev__ constexpr MatBase& addAssign(const MatBase& rhs) {
+    __hostdev__ constexpr MatBase& addAssign(const MatBase& rhs) noexcept {
         for (int i = 0; i < size(); ++i) mData[i] += rhs.mData[i];
         return *this;
     }
-    __hostdev__ constexpr MatBase& subAssign(const MatBase& rhs) {
+    __hostdev__ constexpr MatBase& subAssign(const MatBase& rhs) noexcept {
         for (int i = 0; i < size(); ++i) mData[i] -= rhs.mData[i];
         return *this;
     }
-    __hostdev__ constexpr MatBase& scaleAssign(const T& s) {
+    __hostdev__ constexpr MatBase& scaleAssign(const T& s) noexcept {
         for (int i = 0; i < size(); ++i) mData[i] *= s;
         return *this;
     }
@@ -1245,17 +1245,17 @@ public:
     /// @brief return (*this) / @a s element-wise as a @c Derived. Uses
     /// per-element division (correct for integer @c T, unlike multiplying by 1/s).
     template<typename Derived>
-    __hostdev__ [[nodiscard]] constexpr Derived divideBy(const T& s) const {
+    __hostdev__ [[nodiscard]] constexpr Derived divideBy(const T& s) const noexcept {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] / s;
         return out;
     }
-    __hostdev__ constexpr MatBase& divideAssign(const T& s) {
+    __hostdev__ constexpr MatBase& divideAssign(const T& s) noexcept {
         for (int i = 0; i < size(); ++i) mData[i] /= s;
         return *this;
     }
 
-    __hostdev__ [[nodiscard]] constexpr bool equals(const MatBase& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr bool equals(const MatBase& rhs) const noexcept {
         for (int i = 0; i < size(); ++i) if (mData[i] != rhs.mData[i]) return false;
         return true;
     }
@@ -1265,7 +1265,7 @@ public:
     /// @brief return the transpose of @c *this as the @c Result type.
     /// @tparam Result a matrix type whose dimensions are (COLS, ROWS)
     template<typename Result>
-    __hostdev__ [[nodiscard]] constexpr Result transposeAs() const {
+    __hostdev__ [[nodiscard]] constexpr Result transposeAs() const noexcept {
         static_assert(Result::rows() == COLS && Result::cols() == ROWS,
                       "transposeAs: result dims must be (COLS, ROWS)");
         Result r{};
@@ -1281,7 +1281,7 @@ public:
     /// @tparam Result a matrix type whose dimensions are (ROWS, Rhs::cols())
     /// @tparam Rhs    a matrix type whose row count equals @c COLS
     template<typename Result, typename Rhs>
-    __hostdev__ [[nodiscard]] constexpr Result multiply(const Rhs& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Result multiply(const Rhs& rhs) const noexcept {
         static_assert(COLS == Rhs::rows(), "multiply: lhs.cols must equal rhs.rows");
         static_assert(Result::rows() == ROWS && Result::cols() == Rhs::cols(),
                       "multiply: result dims mismatch");
@@ -1303,7 +1303,7 @@ public:
     /// @tparam VecResult a vector type whose @c SIZE equals @c ROWS
     /// @tparam VecRhs    a vector type whose @c SIZE equals @c COLS
     template<typename VecResult, typename VecRhs>
-    __hostdev__ [[nodiscard]] constexpr VecResult multiplyVec(const VecRhs& v) const {
+    __hostdev__ [[nodiscard]] constexpr VecResult multiplyVec(const VecRhs& v) const noexcept {
         static_assert(VecRhs::SIZE == COLS && VecResult::SIZE == ROWS,
                       "multiplyVec: dim mismatch");
         VecResult r{};
@@ -1330,50 +1330,50 @@ template<typename T> class Vec4;
 // a power-of-2 multiple of alignof(T), so this is free in size and gives
 // SIMD-friendly placement (16 bytes for Mat2<float>, 32 bytes for double).
 template <typename T>
-class alignas(alignof(T) * 4) Mat2 : public MatBase<T, 2, 2> {
+class alignas(alignof(T) * 4) Mat2 final : public MatBase<T, 2, 2> {
     using Base = MatBase<T, 2, 2>;
 public:
-    Mat2() = default;
+    Mat2() noexcept = default;
     /// @brief Constructor given individual array elements, the ordering is in row major form:
     /** @verbatim
         a b
         c d
         @endverbatim */
-    __hostdev__ constexpr Mat2(T a, T b, T c, T d) {
+    __hostdev__ constexpr Mat2(T a, T b, T c, T d) noexcept {
         this->mData[0] = a; this->mData[1] = b;
         this->mData[2] = c; this->mData[3] = d;
     }
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ constexpr Mat2(Source* array) : Base(array) {}
+    __hostdev__ constexpr Mat2(Source* array) noexcept : Base(array) {}
 
     // ---- element-wise ----
-    __hostdev__ [[nodiscard]] constexpr Mat2  operator-() const                  { return this->template negate<Mat2>(); }
-    __hostdev__ [[nodiscard]] constexpr Mat2  operator+(const Mat2& m) const     { return this->template plus<Mat2>(m); }
-    __hostdev__ [[nodiscard]] constexpr Mat2  operator-(const Mat2& m) const     { return this->template minus<Mat2>(m); }
-    __hostdev__ constexpr Mat2& operator+=(const Mat2& m)          { Base::addAssign(m); return *this; }
-    __hostdev__ constexpr Mat2& operator-=(const Mat2& m)          { Base::subAssign(m); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator-() const noexcept                  { return this->template negate<Mat2>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator+(const Mat2& m) const noexcept     { return this->template plus<Mat2>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator-(const Mat2& m) const noexcept     { return this->template minus<Mat2>(m); }
+    __hostdev__ constexpr Mat2& operator+=(const Mat2& m) noexcept          { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat2& operator-=(const Mat2& m) noexcept          { Base::subAssign(m); return *this; }
 
     // ---- matrix * matrix / matrix * vector ----
-    __hostdev__ [[nodiscard]] constexpr Mat2     operator*(const Mat2& m) const     { return this->template multiply<Mat2, Mat2>(m); }
-    __hostdev__ [[nodiscard]] constexpr Vec2<T>  operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec2<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Mat2     operator*(const Mat2& m) const noexcept     { return this->template multiply<Mat2, Mat2>(m); }
+    __hostdev__ [[nodiscard]] constexpr Vec2<T>  operator*(const Vec2<T>& v) const noexcept  { return this->template multiplyVec<Vec2<T>, Vec2<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ [[nodiscard]] constexpr Mat2  operator*(const T& s) const        { return this->template scale<Mat2>(s); }
-    __hostdev__ [[nodiscard]] constexpr Mat2  operator/(const T& s) const        { return this->template divideBy<Mat2>(s); }
-    __hostdev__ constexpr Mat2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator*(const T& s) const noexcept        { return this->template scale<Mat2>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator/(const T& s) const noexcept        { return this->template divideBy<Mat2>(s); }
+    __hostdev__ constexpr Mat2& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat2& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat2& m) const     { return Base::equals(m); }
-    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat2& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat2& m) const noexcept     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat2& m) const noexcept     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ [[nodiscard]] constexpr Mat2 transpose() const { return this->template transposeAs<Mat2>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat2 transpose() const noexcept { return this->template transposeAs<Mat2>(); }
 
     /// @brief returns inverse of this
-    __hostdev__ [[nodiscard]] constexpr Mat2<T> inverse() const {
+    __hostdev__ [[nodiscard]] constexpr Mat2<T> inverse() const noexcept {
         T det = (*this)[0][0] * (*this)[1][1] - (*this)[0][1] * (*this)[1][0];
         if (isApproxZero(det)) {
             return Mat2<T>(T(0), T(0), T(0), T(0));
@@ -1389,47 +1389,47 @@ public:
 // alignas(N > alignof(T)) would force tail padding and break
 // packed-array layout plus on-disk format compatibility.
 template <typename T>
-class Mat2x3 : public MatBase<T, 2, 3> {
+class Mat2x3 final : public MatBase<T, 2, 3> {
     using Base = MatBase<T, 2, 3>;
 public:
-    Mat2x3() = default;
+    Mat2x3() noexcept = default;
     /// @brief Constructor given individual array elements, the ordering is in row major form:
     /** @verbatim
         a b c
         d e f
         @endverbatim */
-    __hostdev__ constexpr Mat2x3(T a, T b, T c, T d, T e, T f) {
+    __hostdev__ constexpr Mat2x3(T a, T b, T c, T d, T e, T f) noexcept {
         this->mData[0] = a; this->mData[1] = b; this->mData[2] = c;
         this->mData[3] = d; this->mData[4] = e; this->mData[5] = f;
     }
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ constexpr Mat2x3(Source* array) : Base(array) {}
+    __hostdev__ constexpr Mat2x3(Source* array) noexcept : Base(array) {}
 
 
     // ---- element-wise ----
-    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator-() const                  { return this->template negate<Mat2x3>(); }
-    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator+(const Mat2x3& m) const   { return this->template plus<Mat2x3>(m); }
-    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator-(const Mat2x3& m) const   { return this->template minus<Mat2x3>(m); }
-    __hostdev__ constexpr Mat2x3& operator+=(const Mat2x3& m)        { Base::addAssign(m); return *this; }
-    __hostdev__ constexpr Mat2x3& operator-=(const Mat2x3& m)        { Base::subAssign(m); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator-() const noexcept                  { return this->template negate<Mat2x3>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator+(const Mat2x3& m) const noexcept   { return this->template plus<Mat2x3>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator-(const Mat2x3& m) const noexcept   { return this->template minus<Mat2x3>(m); }
+    __hostdev__ constexpr Mat2x3& operator+=(const Mat2x3& m) noexcept        { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat2x3& operator-=(const Mat2x3& m) noexcept        { Base::subAssign(m); return *this; }
 
     // ---- matrix * vector ----
-    __hostdev__ [[nodiscard]] constexpr Vec2<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec3<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec2<T> operator*(const Vec3<T>& v) const noexcept  { return this->template multiplyVec<Vec2<T>, Vec3<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator*(const T& s) const        { return this->template scale<Mat2x3>(s); }
-    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator/(const T& s) const        { return this->template divideBy<Mat2x3>(s); }
-    __hostdev__ constexpr Mat2x3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat2x3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator*(const T& s) const noexcept        { return this->template scale<Mat2x3>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator/(const T& s) const noexcept        { return this->template divideBy<Mat2x3>(s); }
+    __hostdev__ constexpr Mat2x3& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat2x3& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat2x3& m) const     { return Base::equals(m); }
-    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat2x3& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat2x3& m) const noexcept     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat2x3& m) const noexcept     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ [[nodiscard]] constexpr Mat3x2<T> transpose() const { return this->template transposeAs<Mat3x2<T>>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2<T> transpose() const noexcept { return this->template transposeAs<Mat3x2<T>>(); }
 };
 
 // Mat3x2 is intentionally NOT alignas-elevated: its byte size
@@ -1437,10 +1437,10 @@ public:
 // alignas(N > alignof(T)) would force tail padding and break
 // packed-array layout plus on-disk format compatibility.
 template <typename T>
-class Mat3x2: public MatBase<T, 3, 2> {
+class Mat3x2 final : public MatBase<T, 3, 2> {
     using Base = MatBase<T, 3, 2>;
 public:
-    Mat3x2() = default;
+    Mat3x2() noexcept = default;
 
     /// @brief Constructor given individual array elements, the ordering is in row major form:
     /** @verbatim
@@ -1448,7 +1448,7 @@ public:
         c d
         e f
         @endverbatim */
-    __hostdev__ constexpr Mat3x2(T a, T b, T c, T d, T e, T f)
+    __hostdev__ constexpr Mat3x2(T a, T b, T c, T d, T e, T f) noexcept
     {
         this->mData[0] = a; this->mData[1] = b;
         this->mData[2] = c; this->mData[3] = d;
@@ -1457,30 +1457,30 @@ public:
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ constexpr Mat3x2(Source *a): Base(a) {}
+    __hostdev__ constexpr Mat3x2(Source *a) noexcept : Base(a) {}
 
     // ---- element-wise ----
-    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator-() const                  { return this->template negate<Mat3x2>(); }
-    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator+(const Mat3x2& m) const   { return this->template plus<Mat3x2>(m); }
-    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator-(const Mat3x2& m) const   { return this->template minus<Mat3x2>(m); }
-    __hostdev__ constexpr Mat3x2& operator+=(const Mat3x2& m)        { Base::addAssign(m); return *this; }
-    __hostdev__ constexpr Mat3x2& operator-=(const Mat3x2& m)        { Base::subAssign(m); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator-() const noexcept                  { return this->template negate<Mat3x2>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator+(const Mat3x2& m) const noexcept   { return this->template plus<Mat3x2>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator-(const Mat3x2& m) const noexcept   { return this->template minus<Mat3x2>(m); }
+    __hostdev__ constexpr Mat3x2& operator+=(const Mat3x2& m) noexcept        { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat3x2& operator-=(const Mat3x2& m) noexcept        { Base::subAssign(m); return *this; }
 
     // ---- matrix * vector ----
-    __hostdev__ [[nodiscard]] constexpr Vec3<T> operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec2<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec3<T> operator*(const Vec2<T>& v) const noexcept  { return this->template multiplyVec<Vec3<T>, Vec2<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator*(const T& s) const        { return this->template scale<Mat3x2>(s); }
-    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator/(const T& s) const        { return this->template divideBy<Mat3x2>(s); }
-    __hostdev__ constexpr Mat3x2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat3x2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator*(const T& s) const noexcept        { return this->template scale<Mat3x2>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator/(const T& s) const noexcept        { return this->template divideBy<Mat3x2>(s); }
+    __hostdev__ constexpr Mat3x2& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat3x2& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat3x2& m) const     { return Base::equals(m); }
-    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat3x2& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat3x2& m) const noexcept     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat3x2& m) const noexcept     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ [[nodiscard]] constexpr Mat2x3<T> transpose() const { return this->template transposeAs<Mat2x3<T>>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3<T> transpose() const noexcept { return this->template transposeAs<Mat2x3<T>>(); }
 
 };
 
@@ -1489,10 +1489,10 @@ public:
 // alignas(N > alignof(T)) would force tail padding and break
 // packed-array layout plus on-disk format compatibility.
 template <typename T>
-class Mat3 : public MatBase<T, 3, 3> {
+class Mat3 final : public MatBase<T, 3, 3> {
     using Base = MatBase<T, 3, 3>;
 public:
-    Mat3() = default;
+    Mat3() noexcept = default;
 
     /// @brief Constructor given individual array elements, the ordering is in row major form:
     /** @verbatim
@@ -1502,7 +1502,7 @@ public:
         @endverbatim */
     __hostdev__ constexpr Mat3(T a, T b, T c,
                                T d, T e, T f,
-                               T g, T h, T i)
+                               T g, T h, T i) noexcept
     {
         this->mData[0] = a; this->mData[1] = b; this->mData[2] = c;
         this->mData[3] = d; this->mData[4] = e; this->mData[5] = f;
@@ -1511,32 +1511,32 @@ public:
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ constexpr Mat3(Source *a): Base(a) {}
+    __hostdev__ constexpr Mat3(Source *a) noexcept : Base(a) {}
 
 
     // ---- element-wise ----
-    __hostdev__ [[nodiscard]] constexpr Mat3  operator-() const                  { return this->template negate<Mat3>(); }
-    __hostdev__ [[nodiscard]] constexpr Mat3  operator+(const Mat3& m) const     { return this->template plus<Mat3>(m); }
-    __hostdev__ [[nodiscard]] constexpr Mat3  operator-(const Mat3& m) const     { return this->template minus<Mat3>(m); }
-    __hostdev__ constexpr Mat3& operator+=(const Mat3& m)          { Base::addAssign(m); return *this; }
-    __hostdev__ constexpr Mat3& operator-=(const Mat3& m)          { Base::subAssign(m); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator-() const noexcept                  { return this->template negate<Mat3>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator+(const Mat3& m) const noexcept     { return this->template plus<Mat3>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator-(const Mat3& m) const noexcept     { return this->template minus<Mat3>(m); }
+    __hostdev__ constexpr Mat3& operator+=(const Mat3& m) noexcept          { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat3& operator-=(const Mat3& m) noexcept          { Base::subAssign(m); return *this; }
 
     // ---- matrix * matrix / matrix * vector ----
-    __hostdev__ [[nodiscard]] constexpr Mat3    operator*(const Mat3& m) const     { return this->template multiply<Mat3, Mat3>(m); }
-    __hostdev__ [[nodiscard]] constexpr Vec3<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec3<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Mat3    operator*(const Mat3& m) const noexcept     { return this->template multiply<Mat3, Mat3>(m); }
+    __hostdev__ [[nodiscard]] constexpr Vec3<T> operator*(const Vec3<T>& v) const noexcept  { return this->template multiplyVec<Vec3<T>, Vec3<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ [[nodiscard]] constexpr Mat3  operator*(const T& s) const        { return this->template scale<Mat3>(s); }
-    __hostdev__ [[nodiscard]] constexpr Mat3  operator/(const T& s) const        { return this->template divideBy<Mat3>(s); }
-    __hostdev__ constexpr Mat3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator*(const T& s) const noexcept        { return this->template scale<Mat3>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator/(const T& s) const noexcept        { return this->template divideBy<Mat3>(s); }
+    __hostdev__ constexpr Mat3& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat3& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat3& m) const     { return Base::equals(m); }
-    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat3& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat3& m) const noexcept     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat3& m) const noexcept     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ [[nodiscard]] constexpr Mat3 transpose() const { return this->template transposeAs<Mat3>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat3 transpose() const noexcept { return this->template transposeAs<Mat3>(); }
 };
 
 // Aligned to 16*alignof(T) — Mat4 stores 16 elements (4x4), which is
@@ -1548,10 +1548,10 @@ public:
 // instruction. Drop to alignas(alignof(T) * 4) here if the over-aligned
 // constraint causes friction with downstream allocators.
 template <typename T>
-class alignas(alignof(T) * 16) Mat4 : public MatBase<T, 4, 4> {
+class alignas(alignof(T) * 16) Mat4 final : public MatBase<T, 4, 4> {
     using Base = MatBase<T, 4, 4>;
 public:
-    Mat4() = default;
+    Mat4() noexcept = default;
 
     /// @brief Constructor given individual array elements, the ordering is in row major form:
     /** @verbatim
@@ -1563,7 +1563,7 @@ public:
     __hostdev__ constexpr Mat4(T a, T b, T c, T d,
                                T e, T f, T g, T h,
                                T i, T j, T k, T l,
-                               T m, T n, T o, T p)
+                               T m, T n, T o, T p) noexcept
     {
         this->mData[0] = a; this->mData[1] = b; this->mData[2] = c; this->mData[3] = d;
         this->mData[4] = e; this->mData[5] = f; this->mData[6] = g; this->mData[7] = h;
@@ -1573,77 +1573,77 @@ public:
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ constexpr Mat4(Source *a): Base(a) {}
+    __hostdev__ constexpr Mat4(Source *a) noexcept : Base(a) {}
 
     // ---- element-wise ----
-    __hostdev__ [[nodiscard]] constexpr Mat4  operator-() const                  { return this->template negate<Mat4>(); }
-    __hostdev__ [[nodiscard]] constexpr Mat4  operator+(const Mat4& m) const     { return this->template plus<Mat4>(m); }
-    __hostdev__ [[nodiscard]] constexpr Mat4  operator-(const Mat4& m) const     { return this->template minus<Mat4>(m); }
-    __hostdev__ constexpr Mat4& operator+=(const Mat4& m)          { Base::addAssign(m); return *this; }
-    __hostdev__ constexpr Mat4& operator-=(const Mat4& m)          { Base::subAssign(m); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator-() const noexcept                  { return this->template negate<Mat4>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator+(const Mat4& m) const noexcept     { return this->template plus<Mat4>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator-(const Mat4& m) const noexcept     { return this->template minus<Mat4>(m); }
+    __hostdev__ constexpr Mat4& operator+=(const Mat4& m) noexcept          { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat4& operator-=(const Mat4& m) noexcept          { Base::subAssign(m); return *this; }
 
     // ---- matrix * matrix / matrix * vector ----
-    __hostdev__ [[nodiscard]] constexpr Mat4    operator*(const Mat4& m) const     { return this->template multiply<Mat4, Mat4>(m); }
-    __hostdev__ [[nodiscard]] constexpr Vec4<T> operator*(const Vec4<T>& v) const  { return this->template multiplyVec<Vec4<T>, Vec4<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Mat4    operator*(const Mat4& m) const noexcept     { return this->template multiply<Mat4, Mat4>(m); }
+    __hostdev__ [[nodiscard]] constexpr Vec4<T> operator*(const Vec4<T>& v) const noexcept  { return this->template multiplyVec<Vec4<T>, Vec4<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ [[nodiscard]] constexpr Mat4  operator*(const T& s) const        { return this->template scale<Mat4>(s); }
-    __hostdev__ [[nodiscard]] constexpr Mat4  operator/(const T& s) const        { return this->template divideBy<Mat4>(s); }
-    __hostdev__ constexpr Mat4& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat4& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator*(const T& s) const noexcept        { return this->template scale<Mat4>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator/(const T& s) const noexcept        { return this->template divideBy<Mat4>(s); }
+    __hostdev__ constexpr Mat4& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat4& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat4& m) const     { return Base::equals(m); }
-    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat4& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat4& m) const noexcept     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat4& m) const noexcept     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ [[nodiscard]] constexpr Mat4 transpose() const { return this->template transposeAs<Mat4>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat4 transpose() const noexcept { return this->template transposeAs<Mat4>(); }
 };
 
 /// @brief Multiply a scalar by a 2x2 matrix, result is a 2x2 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat2<T> operator*(const T& s, const Mat2<T>& m) { return m.template scale<Mat2<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat2<T> operator*(const T& s, const Mat2<T>& m) noexcept { return m.template scale<Mat2<T>>(s); }
 /// @brief Multiply a scalar by a 2x3 matrix, result is a 2x3 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const T& s, const Mat2x3<T>& m) { return m.template scale<Mat2x3<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const T& s, const Mat2x3<T>& m) noexcept { return m.template scale<Mat2x3<T>>(s); }
 /// @brief Multiply a scalar by a 3x2 matrix, result is a 3x2 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const T& s, const Mat3x2<T>& m) { return m.template scale<Mat3x2<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const T& s, const Mat3x2<T>& m) noexcept { return m.template scale<Mat3x2<T>>(s); }
 /// @brief Multiply a scalar by a 3x3 matrix, result is a 3x3 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat3<T> operator*(const T& s, const Mat3<T>& m) { return m.template scale<Mat3<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat3<T> operator*(const T& s, const Mat3<T>& m) noexcept { return m.template scale<Mat3<T>>(s); }
 /// @brief Multiply a scalar by a 4x4 matrix, result is a 4x4 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat4<T> operator*(const T& s, const Mat4<T>& m) { return m.template scale<Mat4<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat4<T> operator*(const T& s, const Mat4<T>& m) noexcept { return m.template scale<Mat4<T>>(s); }
 
 /// @brief Multiply a 2x3 matrix by a 3x2 matrix, result is a 2x2 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat2<T> operator*(const Mat2x3<T>& lhs, const Mat3x2<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat2<T> operator*(const Mat2x3<T>& lhs, const Mat3x2<T>& rhs) noexcept {
     return lhs.template multiply<Mat2<T>, Mat3x2<T>>(rhs);
 }
 /// @brief Multiply a 2x3 matrix by a 3x3 matrix, result is a 2x3 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const Mat2x3<T>& lhs, const Mat3<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const Mat2x3<T>& lhs, const Mat3<T>& rhs) noexcept {
     return lhs.template multiply<Mat2x3<T>, Mat3<T>>(rhs);
 }
 /// @brief Multiply a 3x2 matrix by a 2x2 matrix, result is a 3x2 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const Mat3x2<T>& lhs, const Mat2<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const Mat3x2<T>& lhs, const Mat2<T>& rhs) noexcept {
     return lhs.template multiply<Mat3x2<T>, Mat2<T>>(rhs);
 }
 /// @brief Multiply a 2x2 matrix by a 2x3 matrix, result is a 2x3 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const Mat2<T>& lhs, const Mat2x3<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const Mat2<T>& lhs, const Mat2x3<T>& rhs) noexcept {
     return lhs.template multiply<Mat2x3<T>, Mat2x3<T>>(rhs);
 }
 /// @brief Multiply a 3x2 matrix by a 2x3 matrix, result is a 3x3 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat3<T> operator*(const Mat3x2<T>& lhs, const Mat2x3<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat3<T> operator*(const Mat3x2<T>& lhs, const Mat2x3<T>& rhs) noexcept {
     return lhs.template multiply<Mat3<T>, Mat2x3<T>>(rhs);
 }
 /// @brief Multiply a 3x3 matrix by a 3x2 matrix, result is a 3x2 matrix
 template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const Mat3<T>& lhs, const Mat3x2<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const Mat3<T>& lhs, const Mat3x2<T>& rhs) noexcept {
     return lhs.template multiply<Mat3x2<T>, Mat3x2<T>>(rhs);
 }
 // ----------------------------> Vec3 <--------------------------------------
@@ -1657,7 +1657,7 @@ __hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const Mat3<T>& lhs, cons
 /// over-aligned Vec3 wrapper (e.g. for CUDA-coalesced loads) is best
 /// added as a separate type rather than changing Vec3 itself.
 template<typename T>
-class Vec3 : public VecBase<T, 3>
+class Vec3 final : public VecBase<T, 3>
 {
     using Base = VecBase<T, 3>;
 
@@ -1665,90 +1665,90 @@ public:
     using ValueType = T;
     static constexpr int size = 3; // openvdb::math::Tuple-compat alias of SIZE
 
-    Vec3() = default;
-    __hostdev__ explicit constexpr Vec3(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; }
-    __hostdev__ constexpr Vec3(T x, T y, T z)           { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; }
+    Vec3() noexcept = default;
+    __hostdev__ explicit constexpr Vec3(T x) noexcept            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; }
+    __hostdev__ constexpr Vec3(T x, T y, T z) noexcept           { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; }
 
     template<template<class> class Vec3T, class T2>
-    __hostdev__ constexpr Vec3(const Vec3T<T2>& v) {
+    __hostdev__ explicit constexpr Vec3(const Vec3T<T2>& v) noexcept {
         static_assert(Vec3T<T2>::size == 3, "expected Vec3T::size==3!");
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]);
     }
     template<typename T2>
-    __hostdev__ explicit constexpr Vec3(const Vec3<T2>& v) {
+    __hostdev__ explicit constexpr Vec3(const Vec3<T2>& v) noexcept {
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]);
     }
-    __hostdev__ explicit constexpr Vec3(const Coord& ijk) {
+    __hostdev__ explicit constexpr Vec3(const Coord& ijk) noexcept {
         this->mVec[0] = T(ijk[0]); this->mVec[1] = T(ijk[1]); this->mVec[2] = T(ijk[2]);
     }
 
     template<template<class> class Vec3T, class T2>
-    __hostdev__ constexpr Vec3& operator=(const Vec3T<T2>& rhs) {
+    __hostdev__ constexpr Vec3& operator=(const Vec3T<T2>& rhs) noexcept {
         static_assert(Vec3T<T2>::size == 3, "expected Vec3T::size==3!");
         this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1]; this->mVec[2] = rhs[2];
         return *this;
     }
 
     // ---- element-wise (Vec & Vec) ----
-    __hostdev__ [[nodiscard]] constexpr Vec3  operator-() const             { return Base::template negate<Vec3>(); }
-    __hostdev__ [[nodiscard]] constexpr Vec3  operator+(const Vec3& v) const { return Base::template plus<Vec3>(v); }
-    __hostdev__ [[nodiscard]] constexpr Vec3  operator-(const Vec3& v) const { return Base::template minus<Vec3>(v); }
-    __hostdev__ [[nodiscard]] constexpr Vec3  operator*(const Vec3& v) const { return Base::template mul<Vec3>(v); }
-    __hostdev__ [[nodiscard]] constexpr Vec3  operator/(const Vec3& v) const { return Base::template div<Vec3>(v); }
-    __hostdev__ constexpr Vec3& operator+=(const Vec3& v)     { Base::addAssign(v); return *this; }
-    __hostdev__ constexpr Vec3& operator-=(const Vec3& v)     { Base::subAssign(v); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator-() const noexcept             { return Base::template negate<Vec3>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator+(const Vec3& v) const noexcept { return Base::template plus<Vec3>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator-(const Vec3& v) const noexcept { return Base::template minus<Vec3>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator*(const Vec3& v) const noexcept { return Base::template mul<Vec3>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator/(const Vec3& v) const noexcept { return Base::template div<Vec3>(v); }
+    __hostdev__ constexpr Vec3& operator+=(const Vec3& v) noexcept     { Base::addAssign(v); return *this; }
+    __hostdev__ constexpr Vec3& operator-=(const Vec3& v) noexcept     { Base::subAssign(v); return *this; }
 
     // ---- mixed Vec3 / Coord (3D) ----
-    __hostdev__ [[nodiscard]] constexpr Vec3  operator+(const Coord& ijk) const { return Vec3(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1], this->mVec[2] + ijk[2]); }
-    __hostdev__ [[nodiscard]] constexpr Vec3  operator-(const Coord& ijk) const { return Vec3(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1], this->mVec[2] - ijk[2]); }
-    __hostdev__ constexpr Vec3& operator+=(const Coord& ijk) {
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator+(const Coord& ijk) const noexcept { return Vec3(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1], this->mVec[2] + ijk[2]); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator-(const Coord& ijk) const noexcept { return Vec3(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1], this->mVec[2] - ijk[2]); }
+    __hostdev__ constexpr Vec3& operator+=(const Coord& ijk) noexcept {
         this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]); this->mVec[2] += T(ijk[2]);
         return *this;
     }
-    __hostdev__ constexpr Vec3& operator-=(const Coord& ijk) {
+    __hostdev__ constexpr Vec3& operator-=(const Coord& ijk) noexcept {
         this->mVec[0] -= T(ijk[0]); this->mVec[1] -= T(ijk[1]); this->mVec[2] -= T(ijk[2]);
         return *this;
     }
 
     // ---- scalar ----
-    __hostdev__ [[nodiscard]] constexpr Vec3  operator*(const T& s) const   { return Base::template scale<Vec3>(s); }
-    __hostdev__ [[nodiscard]] constexpr Vec3  operator/(const T& s) const   { return Base::template divideBy<Vec3>(s); }
-    __hostdev__ constexpr Vec3& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Vec3& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator*(const T& s) const noexcept   { return Base::template scale<Vec3>(s); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator/(const T& s) const noexcept   { return Base::template divideBy<Vec3>(s); }
+    __hostdev__ constexpr Vec3& operator*=(const T& s) noexcept        { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Vec3& operator/=(const T& s) noexcept        { Base::divideAssignScalar(s); return *this; }
     // Not constexpr — depends on length() which calls std::sqrt.
-    __hostdev__ Vec3& normalize()                   { return (*this) /= this->length(); }
+    __hostdev__ Vec3& normalize() noexcept                   { return (*this) /= this->length(); }
 
     // ---- equality ----
-    __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec3& rhs) const { return Base::equals(rhs); }
-    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec3& rhs) const { return !Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec3& rhs) const noexcept { return Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec3& rhs) const noexcept { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
-    __hostdev__ constexpr Vec3& minComponent(const Vec3& other) { Base::mergeMin(other); return *this; }
-    __hostdev__ constexpr Vec3& maxComponent(const Vec3& other) { Base::mergeMax(other); return *this; }
+    __hostdev__ constexpr Vec3& minComponent(const Vec3& other) noexcept { Base::mergeMin(other); return *this; }
+    __hostdev__ constexpr Vec3& maxComponent(const Vec3& other) noexcept { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
-    __hostdev__ [[nodiscard]] constexpr ValueType min() const { return Base::smallestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType min() const noexcept { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ [[nodiscard]] constexpr ValueType max() const { return Base::largestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType max() const noexcept { return Base::largestComponent(); }
 
     /// @brief Round each component down (toward negative infinity)
     /// @return integer Coord
     /// @note Only constexpr for integer @c T (floorAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ [[nodiscard]] constexpr Coord floor() const { return Base::template floorAs<Coord>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord floor() const noexcept { return Base::template floorAs<Coord>(); }
     /// @brief Round each component up (toward positive infinity)
     /// @return integer Coord
     /// @note Only constexpr for integer @c T (ceilAs uses non-constexpr math::Ceil for floating point).
-    __hostdev__ [[nodiscard]] constexpr Coord ceil()  const { return Base::template ceilAs<Coord>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord ceil()  const noexcept { return Base::template ceilAs<Coord>(); }
     /// @brief Round each component to its closest integer value
     /// @return integer Coord
     /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ [[nodiscard]] constexpr Coord round() const { return Base::template roundAs<Coord>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord round() const noexcept { return Base::template roundAs<Coord>(); }
 
     // ---- 3D-specific ----
 
     /// @brief cross product with another 3-vector
     template<typename Vec3T>
-    __hostdev__ [[nodiscard]] constexpr Vec3 cross(const Vec3T& v) const {
+    __hostdev__ [[nodiscard]] constexpr Vec3 cross(const Vec3T& v) const noexcept {
         return Vec3(this->mVec[1] * v[2] - this->mVec[2] * v[1],
                     this->mVec[2] * v[0] - this->mVec[0] * v[2],
                     this->mVec[0] * v[1] - this->mVec[1] * v[0]);
@@ -1756,7 +1756,7 @@ public:
 
     /// @brief Outer product of a 3x1 vector and a 1x3 vector, result is a 3x3 matrix
     template<typename Vec3T>
-    __hostdev__ [[nodiscard]] constexpr Mat3<ValueType> outer(const Vec3T& v) const {
+    __hostdev__ [[nodiscard]] constexpr Mat3<ValueType> outer(const Vec3T& v) const noexcept {
         return Mat3<ValueType>(this->mVec[0] * v[0], this->mVec[0] * v[1], this->mVec[0] * v[2],
                                this->mVec[1] * v[0], this->mVec[1] * v[1], this->mVec[1] * v[2],
                                this->mVec[2] * v[0], this->mVec[2] * v[1], this->mVec[2] * v[2]);
@@ -1764,24 +1764,24 @@ public:
 }; // Vec3<T>
 
 template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec3<T2> operator*(T1 scalar, const Vec3<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec3<T2> operator*(T1 scalar, const Vec3<T2>& vec) noexcept
 {
     return Vec3<T2>(scalar * vec[0], scalar * vec[1], scalar * vec[2]);
 }
 template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec3<T2> operator/(T1 scalar, const Vec3<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec3<T2> operator/(T1 scalar, const Vec3<T2>& vec) noexcept
 {
     return Vec3<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2]);
 }
 
 /// @brief Return a single precision floating-point vector of this coordinate
-__hostdev__ [[nodiscard]] inline constexpr Vec3<float> Coord::asVec3s() const
+__hostdev__ [[nodiscard]] inline constexpr Vec3<float> Coord::asVec3s() const noexcept
 {
     return Vec3<float>(float(mVec[0]), float(mVec[1]), float(mVec[2]));
 }
 
 /// @brief Return a double precision floating-point vector of this coordinate
-__hostdev__ [[nodiscard]] inline constexpr Vec3<double> Coord::asVec3d() const
+__hostdev__ [[nodiscard]] inline constexpr Vec3<double> Coord::asVec3d() const noexcept
 {
     return Vec3<double>(double(mVec[0]), double(mVec[1]), double(mVec[2]));
 }
@@ -1795,7 +1795,7 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3<double> Coord::asVec3d() const
 /// tail padding because the byte size is already a power-of-2 multiple
 /// of alignof(T).
 template<typename T>
-class alignas(alignof(T) * 4) Vec4 : public VecBase<T, 4>
+class alignas(alignof(T) * 4) Vec4 final : public VecBase<T, 4>
 {
     using Base = VecBase<T, 4>;
 
@@ -1803,77 +1803,77 @@ public:
     using ValueType = T;
     static constexpr int size = 4; // openvdb::math::Tuple-compat alias of SIZE
 
-    Vec4() = default;
-    __hostdev__ explicit constexpr Vec4(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; this->mVec[3] = x; }
-    __hostdev__ constexpr Vec4(T x, T y, T z, T w)      { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; this->mVec[3] = w; }
+    Vec4() noexcept = default;
+    __hostdev__ explicit constexpr Vec4(T x) noexcept            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; this->mVec[3] = x; }
+    __hostdev__ constexpr Vec4(T x, T y, T z, T w) noexcept      { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; this->mVec[3] = w; }
 
     template<typename T2>
-    __hostdev__ explicit constexpr Vec4(const Vec4<T2>& v) {
+    __hostdev__ explicit constexpr Vec4(const Vec4<T2>& v) noexcept {
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]); this->mVec[3] = T(v[3]);
     }
     template<template<class> class Vec4T, class T2>
-    __hostdev__ constexpr Vec4(const Vec4T<T2>& v) {
+    __hostdev__ explicit constexpr Vec4(const Vec4T<T2>& v) noexcept {
         static_assert(Vec4T<T2>::size == 4, "expected Vec4T::size==4!");
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]); this->mVec[3] = T(v[3]);
     }
     template<template<class> class Vec4T, class T2>
-    __hostdev__ constexpr Vec4& operator=(const Vec4T<T2>& rhs) {
+    __hostdev__ constexpr Vec4& operator=(const Vec4T<T2>& rhs) noexcept {
         static_assert(Vec4T<T2>::size == 4, "expected Vec4T::size==4!");
         this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1]; this->mVec[2] = rhs[2]; this->mVec[3] = rhs[3];
         return *this;
     }
 
     // ---- element-wise (Vec & Vec) ----
-    __hostdev__ [[nodiscard]] constexpr Vec4  operator-() const             { return Base::template negate<Vec4>(); }
-    __hostdev__ [[nodiscard]] constexpr Vec4  operator+(const Vec4& v) const { return Base::template plus<Vec4>(v); }
-    __hostdev__ [[nodiscard]] constexpr Vec4  operator-(const Vec4& v) const { return Base::template minus<Vec4>(v); }
-    __hostdev__ [[nodiscard]] constexpr Vec4  operator*(const Vec4& v) const { return Base::template mul<Vec4>(v); }
-    __hostdev__ [[nodiscard]] constexpr Vec4  operator/(const Vec4& v) const { return Base::template div<Vec4>(v); }
-    __hostdev__ constexpr Vec4& operator+=(const Vec4& v)     { Base::addAssign(v); return *this; }
-    __hostdev__ constexpr Vec4& operator-=(const Vec4& v)     { Base::subAssign(v); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator-() const noexcept             { return Base::template negate<Vec4>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator+(const Vec4& v) const noexcept { return Base::template plus<Vec4>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator-(const Vec4& v) const noexcept { return Base::template minus<Vec4>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator*(const Vec4& v) const noexcept { return Base::template mul<Vec4>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator/(const Vec4& v) const noexcept { return Base::template div<Vec4>(v); }
+    __hostdev__ constexpr Vec4& operator+=(const Vec4& v) noexcept     { Base::addAssign(v); return *this; }
+    __hostdev__ constexpr Vec4& operator-=(const Vec4& v) noexcept     { Base::subAssign(v); return *this; }
 
     // ---- scalar ----
-    __hostdev__ [[nodiscard]] constexpr Vec4  operator*(const T& s) const   { return Base::template scale<Vec4>(s); }
-    __hostdev__ [[nodiscard]] constexpr Vec4  operator/(const T& s) const   { return Base::template divideBy<Vec4>(s); }
-    __hostdev__ constexpr Vec4& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Vec4& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator*(const T& s) const noexcept   { return Base::template scale<Vec4>(s); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator/(const T& s) const noexcept   { return Base::template divideBy<Vec4>(s); }
+    __hostdev__ constexpr Vec4& operator*=(const T& s) noexcept        { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Vec4& operator/=(const T& s) noexcept        { Base::divideAssignScalar(s); return *this; }
     // Not constexpr — depends on length() which calls std::sqrt.
-    __hostdev__ Vec4& normalize()                   { return (*this) /= this->length(); }
+    __hostdev__ Vec4& normalize() noexcept                   { return (*this) /= this->length(); }
 
     // ---- equality ----
-    __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec4& rhs) const { return Base::equals(rhs); }
-    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec4& rhs) const { return !Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec4& rhs) const noexcept { return Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec4& rhs) const noexcept { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
-    __hostdev__ constexpr Vec4& minComponent(const Vec4& other) { Base::mergeMin(other); return *this; }
-    __hostdev__ constexpr Vec4& maxComponent(const Vec4& other) { Base::mergeMax(other); return *this; }
+    __hostdev__ constexpr Vec4& minComponent(const Vec4& other) noexcept { Base::mergeMin(other); return *this; }
+    __hostdev__ constexpr Vec4& maxComponent(const Vec4& other) noexcept { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
-    __hostdev__ [[nodiscard]] constexpr ValueType min() const { return Base::smallestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType min() const noexcept { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ [[nodiscard]] constexpr ValueType max() const { return Base::largestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType max() const noexcept { return Base::largestComponent(); }
 
     /// @brief Round each component down (toward negative infinity)
     /// @return Vec4<int32_t> (NanoVDB has no Coord4)
     /// @note Only constexpr for integer @c T (floorAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> floor() const { return Base::template floorAs<Vec4<int32_t>>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> floor() const noexcept { return Base::template floorAs<Vec4<int32_t>>(); }
     /// @brief Round each component up (toward positive infinity)
     /// @return Vec4<int32_t>
     /// @note Only constexpr for integer @c T (ceilAs uses non-constexpr math::Ceil for floating point).
-    __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> ceil()  const { return Base::template ceilAs<Vec4<int32_t>>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> ceil()  const noexcept { return Base::template ceilAs<Vec4<int32_t>>(); }
     /// @brief Round each component to its closest integer value
     /// @return Vec4<int32_t>
     /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> round() const { return Base::template roundAs<Vec4<int32_t>>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> round() const noexcept { return Base::template roundAs<Vec4<int32_t>>(); }
 }; // Vec4<T>
 
 template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec4<T2> operator*(T1 scalar, const Vec4<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec4<T2> operator*(T1 scalar, const Vec4<T2>& vec) noexcept
 {
     return Vec4<T2>(scalar * vec[0], scalar * vec[1], scalar * vec[2], scalar * vec[3]);
 }
 template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec) noexcept
 {
     return Vec4<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2], scalar / vec[3]);
 }
@@ -1898,7 +1898,7 @@ __hostdev__ [[nodiscard]] inline constexpr Vec4<T2> operator/(T1 scalar, const V
 /// @param xyz input vector to be multiplied by the matrix
 /// @return result of matrix-vector multiplication, i.e. mat x xyz
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const float* mat, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const float* mat, const Vec3T& xyz) noexcept
 {
     const float x = static_cast<float>(xyz[0]);
     const float y = static_cast<float>(xyz[1]);
@@ -1915,7 +1915,7 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const float* mat, const
 /// @param xyz input vector to be multiplied by the matrix
 /// @return result of matrix-vector multiplication, i.e. mat x xyz
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const double* mat, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const double* mat, const Vec3T& xyz) noexcept
 {
     const double x = static_cast<double>(xyz[0]);
     const double y = static_cast<double>(xyz[1]);
@@ -1933,7 +1933,7 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const double* mat, cons
 /// @param xyz input vector to be multiplied by the matrix and a translated by @c vec
 /// @return result of affine transformation, i.e. (mat x xyz) + vec
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const float* mat, const float* vec, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const float* mat, const float* vec, const Vec3T& xyz) noexcept
 {
     const float x = static_cast<float>(xyz[0]);
     const float y = static_cast<float>(xyz[1]);
@@ -1951,7 +1951,7 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const float* mat, const
 /// @param xyz input vector to be multiplied by the matrix and a translated by @c vec
 /// @return result of affine transformation, i.e. (mat x xyz) + vec
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const double* mat, const double* vec, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const double* mat, const double* vec, const Vec3T& xyz) noexcept
 {
     const double x = static_cast<double>(xyz[0]);
     const double y = static_cast<double>(xyz[1]);
@@ -1968,7 +1968,7 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const double* mat, cons
 /// @param xyz input vector to be multiplied by the transposed matrix
 /// @return result of matrix-vector multiplication, i.e. mat^T x xyz
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, const Vec3T& xyz) noexcept
 {
     const float x = static_cast<float>(xyz[0]);
     const float y = static_cast<float>(xyz[1]);
@@ -1985,7 +1985,7 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, cons
 /// @param xyz input vector to be multiplied by the transposed matrix
 /// @return result of matrix-vector multiplication, i.e. mat^T x xyz
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, const Vec3T& xyz) noexcept
 {
     const double x = static_cast<double>(xyz[0]);
     const double y = static_cast<double>(xyz[1]);
@@ -1996,7 +1996,7 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, con
 }
 
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, const float* vec, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, const float* vec, const Vec3T& xyz) noexcept
 {
     const float x = static_cast<float>(xyz[0]);
     const float y = static_cast<float>(xyz[1]);
@@ -2007,7 +2007,7 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, cons
 }
 
 template<typename Vec3T>
-__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, const double* vec, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, const double* vec, const Vec3T& xyz) noexcept
 {
     const double x = static_cast<double>(xyz[0]);
     const double y = static_cast<double>(xyz[1]);
@@ -2024,22 +2024,22 @@ template<typename Vec3T>
 struct BaseBBox
 {
     Vec3T                    mCoord[2];
-    __hostdev__ [[nodiscard]] constexpr bool         operator==(const BaseBBox& rhs) const { return mCoord[0] == rhs.mCoord[0] && mCoord[1] == rhs.mCoord[1]; };
-    __hostdev__ [[nodiscard]] constexpr bool         operator!=(const BaseBBox& rhs) const { return mCoord[0] != rhs.mCoord[0] || mCoord[1] != rhs.mCoord[1]; };
-    __hostdev__ constexpr const Vec3T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
-    __hostdev__ constexpr Vec3T&       operator[](int i) { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
-    __hostdev__ constexpr Vec3T&       min() { return mCoord[0]; }
-    __hostdev__ constexpr Vec3T&       max() { return mCoord[1]; }
-    __hostdev__ constexpr const Vec3T& min() const { return mCoord[0]; }
-    __hostdev__ constexpr const Vec3T& max() const { return mCoord[1]; }
-    __hostdev__ constexpr BaseBBox&    translate(const Vec3T& xyz)
+    __hostdev__ [[nodiscard]] constexpr bool         operator==(const BaseBBox& rhs) const noexcept { return mCoord[0] == rhs.mCoord[0] && mCoord[1] == rhs.mCoord[1]; };
+    __hostdev__ [[nodiscard]] constexpr bool         operator!=(const BaseBBox& rhs) const noexcept { return mCoord[0] != rhs.mCoord[0] || mCoord[1] != rhs.mCoord[1]; };
+    __hostdev__ constexpr const Vec3T& operator[](int i) const noexcept { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
+    __hostdev__ constexpr Vec3T&       operator[](int i) noexcept { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
+    __hostdev__ constexpr Vec3T&       min() noexcept { return mCoord[0]; }
+    __hostdev__ constexpr Vec3T&       max() noexcept { return mCoord[1]; }
+    __hostdev__ constexpr const Vec3T& min() const noexcept { return mCoord[0]; }
+    __hostdev__ constexpr const Vec3T& max() const noexcept { return mCoord[1]; }
+    __hostdev__ constexpr BaseBBox&    translate(const Vec3T& xyz) noexcept
     {
         mCoord[0] += xyz;
         mCoord[1] += xyz;
         return *this;
     }
     /// @brief Expand this bounding box to enclose point @c xyz.
-    __hostdev__ constexpr BaseBBox& expand(const Vec3T& xyz)
+    __hostdev__ constexpr BaseBBox& expand(const Vec3T& xyz) noexcept
     {
         mCoord[0].minComponent(xyz);
         mCoord[1].maxComponent(xyz);
@@ -2047,7 +2047,7 @@ struct BaseBBox
     }
 
     /// @brief Expand this bounding box to enclose the given bounding box.
-    __hostdev__ constexpr BaseBBox& expand(const BaseBBox& bbox)
+    __hostdev__ constexpr BaseBBox& expand(const BaseBBox& bbox) noexcept
     {
         mCoord[0].minComponent(bbox[0]);
         mCoord[1].maxComponent(bbox[1]);
@@ -2055,7 +2055,7 @@ struct BaseBBox
     }
 
     /// @brief Intersect this bounding box with the given bounding box.
-    __hostdev__ constexpr BaseBBox& intersect(const BaseBBox& bbox)
+    __hostdev__ constexpr BaseBBox& intersect(const BaseBBox& bbox) noexcept
     {
         mCoord[0].maxComponent(bbox[0]);
         mCoord[1].minComponent(bbox[1]);
@@ -2066,7 +2066,7 @@ struct BaseBBox
 //    {
 //        return BaseBBox(mCoord[0].offsetBy(-padding),mCoord[1].offsetBy(padding));
 //    }
-    __hostdev__ [[nodiscard]] constexpr bool isInside(const Vec3T& xyz)
+    __hostdev__ [[nodiscard]] constexpr bool isInside(const Vec3T& xyz) noexcept
     {
         if (xyz[0] < mCoord[0][0] || xyz[1] < mCoord[0][1] || xyz[2] < mCoord[0][2])
             return false;
@@ -2076,8 +2076,8 @@ struct BaseBBox
     }
 
 protected:
-    __hostdev__ constexpr BaseBBox() {}
-    __hostdev__ constexpr BaseBBox(const Vec3T& min, const Vec3T& max)
+    __hostdev__ constexpr BaseBBox() noexcept {}
+    __hostdev__ constexpr BaseBBox(const Vec3T& min, const Vec3T& max) noexcept
         : mCoord{min, max}
     {
     }
@@ -2099,37 +2099,37 @@ struct BBox<Vec3T, true> : public BaseBBox<Vec3T>
     using BaseT = BaseBBox<Vec3T>;
     using BaseT::mCoord;
     /// @brief Default construction sets BBox to an empty bbox
-    __hostdev__ constexpr BBox()
+    __hostdev__ constexpr BBox() noexcept
         : BaseT(Vec3T( Maximum<typename Vec3T::ValueType>::value()),
                 Vec3T(-Maximum<typename Vec3T::ValueType>::value()))
     {
     }
-    __hostdev__ constexpr BBox(const Vec3T& min, const Vec3T& max)
+    __hostdev__ constexpr BBox(const Vec3T& min, const Vec3T& max) noexcept
         : BaseT(min, max)
     {
     }
-    __hostdev__ constexpr BBox(const Coord& min, const Coord& max)
+    __hostdev__ constexpr BBox(const Coord& min, const Coord& max) noexcept
         : BaseT(Vec3T(ValueType(min[0]), ValueType(min[1]), ValueType(min[2])),
                 Vec3T(ValueType(max[0] + 1), ValueType(max[1] + 1), ValueType(max[2] + 1)))
     {
     }
-    __hostdev__ [[nodiscard]] static constexpr BBox createCube(const Coord& min, typename Coord::ValueType dim)
+    __hostdev__ [[nodiscard]] static constexpr BBox createCube(const Coord& min, typename Coord::ValueType dim) noexcept
     {
         return BBox(min, min.offsetBy(dim));
     }
 
-    __hostdev__ constexpr BBox(const BaseBBox<Coord>& bbox)
+    __hostdev__ constexpr BBox(const BaseBBox<Coord>& bbox) noexcept
         : BBox(bbox[0], bbox[1])
     {
     }
-    __hostdev__ [[nodiscard]] constexpr bool  empty() const { return mCoord[0][0] >= mCoord[1][0] ||
+    __hostdev__ [[nodiscard]] constexpr bool  empty() const noexcept { return mCoord[0][0] >= mCoord[1][0] ||
                                              mCoord[0][1] >= mCoord[1][1] ||
                                              mCoord[0][2] >= mCoord[1][2]; }
-    __hostdev__ [[nodiscard]] constexpr operator bool() const { return mCoord[0][0] < mCoord[1][0] &&
+    __hostdev__ [[nodiscard]] constexpr operator bool() const noexcept { return mCoord[0][0] < mCoord[1][0] &&
                                                mCoord[0][1] < mCoord[1][1] &&
                                                mCoord[0][2] < mCoord[1][2]; }
-    __hostdev__ [[nodiscard]] constexpr Vec3T dim() const { return *this ? this->max() - this->min() : Vec3T(0); }
-    __hostdev__ [[nodiscard]] constexpr bool  isInside(const Vec3T& p) const
+    __hostdev__ [[nodiscard]] constexpr Vec3T dim() const noexcept { return *this ? this->max() - this->min() : Vec3T(0); }
+    __hostdev__ [[nodiscard]] constexpr bool  isInside(const Vec3T& p) const noexcept
     {
         return p[0] > mCoord[0][0] && p[1] > mCoord[0][1] && p[2] > mCoord[0][2] &&
                p[0] < mCoord[1][0] && p[1] < mCoord[1][1] && p[2] < mCoord[1][2];
@@ -2155,17 +2155,17 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
         CoordT      mPos;
 
     public:
-        __hostdev__ constexpr Iterator(const BBox& b)
+        __hostdev__ constexpr Iterator(const BBox& b) noexcept
             : mBBox(b)
             , mPos(b.min())
         {
         }
-        __hostdev__ constexpr Iterator(const BBox& b, const Coord& p)
+        __hostdev__ constexpr Iterator(const BBox& b, const Coord& p) noexcept
             : mBBox(b)
             , mPos(p)
         {
         }
-        __hostdev__ constexpr Iterator& operator++()
+        __hostdev__ constexpr Iterator& operator++() noexcept
         {
             if (mPos[2] < mBBox[1][2]) { // this is the most common case
                 ++mPos[2];// increment z
@@ -2179,49 +2179,49 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
             }
             return *this;
         }
-        __hostdev__ constexpr Iterator operator++(int)
+        __hostdev__ constexpr Iterator operator++(int) noexcept
         {
             auto tmp = *this;
             ++(*this);
             return tmp;
         }
-        __hostdev__ [[nodiscard]] constexpr bool operator==(const Iterator& rhs) const
+        __hostdev__ [[nodiscard]] constexpr bool operator==(const Iterator& rhs) const noexcept
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos == rhs.mPos;
         }
-        __hostdev__ [[nodiscard]] constexpr bool operator!=(const Iterator& rhs) const
+        __hostdev__ [[nodiscard]] constexpr bool operator!=(const Iterator& rhs) const noexcept
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos != rhs.mPos;
         }
-        __hostdev__ [[nodiscard]] constexpr bool operator<(const Iterator& rhs) const
+        __hostdev__ [[nodiscard]] constexpr bool operator<(const Iterator& rhs) const noexcept
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos < rhs.mPos;
         }
-        __hostdev__ [[nodiscard]] constexpr bool operator<=(const Iterator& rhs) const
+        __hostdev__ [[nodiscard]] constexpr bool operator<=(const Iterator& rhs) const noexcept
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos <= rhs.mPos;
         }
         /// @brief Return @c true if the iterator still points to a valid coordinate.
-        __hostdev__ [[nodiscard]] constexpr operator bool() const { return mPos <= mBBox[1]; }
-        __hostdev__ [[nodiscard]] constexpr const CoordT& operator*() const { return mPos; }
+        __hostdev__ [[nodiscard]] constexpr operator bool() const noexcept { return mPos <= mBBox[1]; }
+        __hostdev__ [[nodiscard]] constexpr const CoordT& operator*() const noexcept { return mPos; }
     }; // Iterator
-    __hostdev__ [[nodiscard]] constexpr Iterator begin() const { return Iterator{*this}; }
-    __hostdev__ [[nodiscard]] constexpr Iterator end()   const { return Iterator{*this, CoordT(mCoord[1][0]+1, mCoord[0][1], mCoord[0][2])}; }
-    __hostdev__ constexpr BBox()
+    __hostdev__ [[nodiscard]] constexpr Iterator begin() const noexcept { return Iterator{*this}; }
+    __hostdev__ [[nodiscard]] constexpr Iterator end()   const noexcept { return Iterator{*this, CoordT(mCoord[1][0]+1, mCoord[0][1], mCoord[0][2])}; }
+    __hostdev__ constexpr BBox() noexcept
         : BaseT(CoordT::max(), CoordT::min())
     {
     }
-    __hostdev__ constexpr BBox(const CoordT& min, const CoordT& max)
+    __hostdev__ constexpr BBox(const CoordT& min, const CoordT& max) noexcept
         : BaseT(min, max)
     {
     }
 
     template<typename SplitT>
-    __hostdev__ constexpr BBox(BBox& other, const SplitT&)
+    __hostdev__ constexpr BBox(BBox& other, const SplitT&) noexcept
         : BaseT(other.mCoord[0], other.mCoord[1])
     {
         NANOVDB_ASSERT(this->is_divisible());
@@ -2230,56 +2230,56 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
         other.mCoord[0][n] = mCoord[1][n] + 1;
     }
 
-    __hostdev__ [[nodiscard]] static constexpr BBox createCube(const CoordT& min, typename CoordT::ValueType dim)
+    __hostdev__ [[nodiscard]] static constexpr BBox createCube(const CoordT& min, typename CoordT::ValueType dim) noexcept
     {
         return BBox(min, min.offsetBy(dim - 1));
     }
 
-    __hostdev__ [[nodiscard]] static constexpr BBox createCube(typename CoordT::ValueType min, typename CoordT::ValueType max)
+    __hostdev__ [[nodiscard]] static constexpr BBox createCube(typename CoordT::ValueType min, typename CoordT::ValueType max) noexcept
     {
         return BBox(CoordT(min), CoordT(max));
     }
 
-    __hostdev__ [[nodiscard]] constexpr bool is_divisible() const { return mCoord[0][0] < mCoord[1][0] &&
+    __hostdev__ [[nodiscard]] constexpr bool is_divisible() const noexcept { return mCoord[0][0] < mCoord[1][0] &&
                                                    mCoord[0][1] < mCoord[1][1] &&
                                                    mCoord[0][2] < mCoord[1][2]; }
     /// @brief Return true if this bounding box is empty, e.g. uninitialized
-    __hostdev__ [[nodiscard]] constexpr bool     empty() const { return mCoord[0][0] > mCoord[1][0] ||
+    __hostdev__ [[nodiscard]] constexpr bool     empty() const noexcept { return mCoord[0][0] > mCoord[1][0] ||
                                                 mCoord[0][1] > mCoord[1][1] ||
                                                 mCoord[0][2] > mCoord[1][2]; }
     /// @brief Convert this BBox to boolean true if it is not empty
-    __hostdev__ [[nodiscard]] constexpr operator bool() const { return mCoord[0][0] <= mCoord[1][0] &&
+    __hostdev__ [[nodiscard]] constexpr operator bool() const noexcept { return mCoord[0][0] <= mCoord[1][0] &&
                                                mCoord[0][1] <= mCoord[1][1] &&
                                                mCoord[0][2] <= mCoord[1][2]; }
-    __hostdev__ [[nodiscard]] constexpr CoordT   dim() const { return *this ? this->max() - this->min() + Coord(1) : Coord(0); }
-    __hostdev__ [[nodiscard]] constexpr uint64_t volume() const
+    __hostdev__ [[nodiscard]] constexpr CoordT   dim() const noexcept { return *this ? this->max() - this->min() + Coord(1) : Coord(0); }
+    __hostdev__ [[nodiscard]] constexpr uint64_t volume() const noexcept
     {
         auto d = this->dim();
         return uint64_t(d[0]) * uint64_t(d[1]) * uint64_t(d[2]);
     }
-    __hostdev__ [[nodiscard]] constexpr bool isInside(const CoordT& p) const { return !(CoordT::lessThan(p, this->min()) || CoordT::lessThan(this->max(), p)); }
+    __hostdev__ [[nodiscard]] constexpr bool isInside(const CoordT& p) const noexcept { return !(CoordT::lessThan(p, this->min()) || CoordT::lessThan(this->max(), p)); }
     /// @brief Return @c true if the given bounding box is inside this bounding box.
-    __hostdev__ [[nodiscard]] constexpr bool isInside(const BBox& b) const
+    __hostdev__ [[nodiscard]] constexpr bool isInside(const BBox& b) const noexcept
     {
         return !(CoordT::lessThan(b.min(), this->min()) || CoordT::lessThan(this->max(), b.max()));
     }
 
     /// @brief Return @c true if the given bounding box overlaps with this bounding box.
-    __hostdev__ [[nodiscard]] constexpr bool hasOverlap(const BBox& b) const
+    __hostdev__ [[nodiscard]] constexpr bool hasOverlap(const BBox& b) const noexcept
     {
         return !(CoordT::lessThan(this->max(), b.min()) || CoordT::lessThan(b.max(), this->min()));
     }
 
     /// @warning This converts a CoordBBox into a floating-point bounding box which implies that max += 1 !
     template<typename RealT = double>
-    __hostdev__ [[nodiscard]] constexpr BBox<Vec3<RealT>> asReal() const
+    __hostdev__ [[nodiscard]] constexpr BBox<Vec3<RealT>> asReal() const noexcept
     {
         static_assert(util::is_floating_point<RealT>::value, "CoordBBox::asReal: Expected a floating point coordinate");
         return BBox<Vec3<RealT>>(Vec3<RealT>(RealT(mCoord[0][0]), RealT(mCoord[0][1]), RealT(mCoord[0][2])),
                                  Vec3<RealT>(RealT(mCoord[1][0] + 1), RealT(mCoord[1][1] + 1), RealT(mCoord[1][2] + 1)));
     }
     /// @brief Return a new instance that is expanded by the specified padding.
-    __hostdev__ [[nodiscard]] constexpr BBox expandBy(typename CoordT::ValueType padding) const
+    __hostdev__ [[nodiscard]] constexpr BBox expandBy(typename CoordT::ValueType padding) const noexcept
     {
         return BBox(mCoord[0].offsetBy(-padding), mCoord[1].offsetBy(padding));
     }
@@ -2288,7 +2288,7 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
     /// @param map mapping of index to world coordinates
     /// @return world bounding box
     template<typename Map>
-    __hostdev__ [[nodiscard]] constexpr auto transform(const Map& map) const
+    __hostdev__ [[nodiscard]] constexpr auto transform(const Map& map) const noexcept
     {
         using Vec3T = Vec3<double>;
         const Vec3T tmp = map.applyMap(Vec3T(mCoord[0][0], mCoord[0][1], mCoord[0][2]));
@@ -2304,19 +2304,19 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
     }
 
 #if defined(__CUDACC__) // the following functions only run on the GPU!
-    __device__ inline BBox& expandAtomic(const CoordT& ijk)
+    __device__ inline BBox& expandAtomic(const CoordT& ijk) noexcept
     {
         mCoord[0].minComponentAtomic(ijk);
         mCoord[1].maxComponentAtomic(ijk);
         return *this;
     }
-    __device__ inline BBox& expandAtomic(const BBox& bbox)
+    __device__ inline BBox& expandAtomic(const BBox& bbox) noexcept
     {
         mCoord[0].minComponentAtomic(bbox[0]);
         mCoord[1].maxComponentAtomic(bbox[1]);
         return *this;
     }
-    __device__ inline BBox& intersectAtomic(const BBox& bbox)
+    __device__ inline BBox& intersectAtomic(const BBox& bbox) noexcept
     {
         mCoord[0].maxComponentAtomic(bbox[0]);
         mCoord[1].minComponentAtomic(bbox[1]);
@@ -2341,21 +2341,21 @@ public:
     using ValueType = uint8_t;
 
     /// @brief Default copy constructor
-    Rgba8(const Rgba8&) = default;
+    Rgba8(const Rgba8&) noexcept = default;
 
     /// @brief Default move constructor
-    Rgba8(Rgba8&&) = default;
+    Rgba8(Rgba8&&) noexcept = default;
 
     /// @brief Default move assignment operator
     /// @return non-const reference to this instance
-    Rgba8&      operator=(Rgba8&&) = default;
+    Rgba8&      operator=(Rgba8&&) noexcept = default;
 
     /// @brief Default copy assignment operator
     /// @return non-const reference to this instance
-    Rgba8&      operator=(const Rgba8&) = default;
+    Rgba8&      operator=(const Rgba8&) noexcept = default;
 
     /// @brief Default ctor initializes all channels to zero
-    __hostdev__ constexpr Rgba8()
+    __hostdev__ constexpr Rgba8() noexcept
         : mData{{0, 0, 0, 0}}
     {
         static_assert(sizeof(uint32_t) == sizeof(Rgba8), "Unexpected sizeof");
@@ -2363,21 +2363,21 @@ public:
 
     /// @brief integer r,g,b,a ctor where alpha channel defaults to opaque
     /// @note all values should be in the range 0u to 255u
-    __hostdev__ constexpr Rgba8(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255u)
+    __hostdev__ constexpr Rgba8(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255u) noexcept
         : mData{{r, g, b, a}}
     {
     }
 
     /// @brief  @brief ctor where all channels are initialized to the same value
     /// @note value should be in the range 0u to 255u
-    explicit __hostdev__ constexpr Rgba8(uint8_t v)
+    explicit __hostdev__ constexpr Rgba8(uint8_t v) noexcept
         : mData{{v, v, v, v}}
     {
     }
 
     /// @brief floating-point r,g,b,a ctor where alpha channel defaults to opaque
     /// @note all values should be in the range 0.0f to 1.0f
-    __hostdev__ constexpr Rgba8(float r, float g, float b, float a = 1.0f)
+    __hostdev__ constexpr Rgba8(float r, float g, float b, float a = 1.0f) noexcept
         : mData{{static_cast<uint8_t>(0.5f + r * 255.0f), // round floats to nearest integers
                  static_cast<uint8_t>(0.5f + g * 255.0f), // double {{}} is needed due to union
                  static_cast<uint8_t>(0.5f + b * 255.0f),
@@ -2387,45 +2387,45 @@ public:
 
     /// @brief Vec3f r,g,b ctor (alpha channel it set to 1)
     /// @note all values should be in the range 0.0f to 1.0f
-    __hostdev__ constexpr Rgba8(const Vec3<float>& rgb)
+    __hostdev__ constexpr Rgba8(const Vec3<float>& rgb) noexcept
         : Rgba8(rgb[0], rgb[1], rgb[2])
     {
     }
 
     /// @brief Vec4f r,g,b,a ctor
     /// @note all values should be in the range 0.0f to 1.0f
-    __hostdev__ constexpr Rgba8(const Vec4<float>& rgba)
+    __hostdev__ constexpr Rgba8(const Vec4<float>& rgba) noexcept
         : Rgba8(rgba[0], rgba[1], rgba[2], rgba[3])
     {
     }
 
-    __hostdev__ [[nodiscard]] bool  operator< (const Rgba8& rhs) const { return mData.packed < rhs.mData.packed; }
-    __hostdev__ [[nodiscard]] bool  operator==(const Rgba8& rhs) const { return mData.packed == rhs.mData.packed; }
-    __hostdev__ [[nodiscard]] constexpr float lengthSqr() const
+    __hostdev__ [[nodiscard]] bool  operator< (const Rgba8& rhs) const noexcept { return mData.packed < rhs.mData.packed; }
+    __hostdev__ [[nodiscard]] bool  operator==(const Rgba8& rhs) const noexcept { return mData.packed == rhs.mData.packed; }
+    __hostdev__ [[nodiscard]] constexpr float lengthSqr() const noexcept
     {
         return 0.0000153787005f * (float(mData.c[0]) * mData.c[0] +
                                    float(mData.c[1]) * mData.c[1] +
                                    float(mData.c[2]) * mData.c[2]); //1/255^2
     }
-    __hostdev__ [[nodiscard]] float           length() const { return sqrtf(this->lengthSqr()); }
+    __hostdev__ [[nodiscard]] float           length() const noexcept { return sqrtf(this->lengthSqr()); }
     /// @brief return n'th color channel as a float in the range 0 to 1
-    __hostdev__ [[nodiscard]] constexpr float           asFloat(int n) const { return 0.003921569f*float(mData.c[n]); }// divide by 255
-    __hostdev__ constexpr const uint8_t&  operator[](int n) const { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
-    __hostdev__ constexpr uint8_t&        operator[](int n) { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
-    __hostdev__ const uint32_t& packed() const { return mData.packed; }
-    __hostdev__ uint32_t&       packed() { return mData.packed; }
-    __hostdev__ constexpr const uint8_t&  r() const { return mData.c[0]; }
-    __hostdev__ constexpr const uint8_t&  g() const { return mData.c[1]; }
-    __hostdev__ constexpr const uint8_t&  b() const { return mData.c[2]; }
-    __hostdev__ constexpr const uint8_t&  a() const { return mData.c[3]; }
-    __hostdev__ constexpr uint8_t&        r() { return mData.c[0]; }
-    __hostdev__ constexpr uint8_t&        g() { return mData.c[1]; }
-    __hostdev__ constexpr uint8_t&        b() { return mData.c[2]; }
-    __hostdev__ constexpr uint8_t&        a() { return mData.c[3]; }
-    __hostdev__ [[nodiscard]] constexpr           operator Vec3<float>() const {
+    __hostdev__ [[nodiscard]] constexpr float           asFloat(int n) const noexcept { return 0.003921569f*float(mData.c[n]); }// divide by 255
+    __hostdev__ constexpr const uint8_t&  operator[](int n) const noexcept { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
+    __hostdev__ constexpr uint8_t&        operator[](int n) noexcept { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
+    __hostdev__ const uint32_t& packed() const noexcept { return mData.packed; }
+    __hostdev__ uint32_t&       packed() noexcept { return mData.packed; }
+    __hostdev__ constexpr const uint8_t&  r() const noexcept { return mData.c[0]; }
+    __hostdev__ constexpr const uint8_t&  g() const noexcept { return mData.c[1]; }
+    __hostdev__ constexpr const uint8_t&  b() const noexcept { return mData.c[2]; }
+    __hostdev__ constexpr const uint8_t&  a() const noexcept { return mData.c[3]; }
+    __hostdev__ constexpr uint8_t&        r() noexcept { return mData.c[0]; }
+    __hostdev__ constexpr uint8_t&        g() noexcept { return mData.c[1]; }
+    __hostdev__ constexpr uint8_t&        b() noexcept { return mData.c[2]; }
+    __hostdev__ constexpr uint8_t&        a() noexcept { return mData.c[3]; }
+    __hostdev__ [[nodiscard]] constexpr           operator Vec3<float>() const noexcept {
         return Vec3<float>(this->asFloat(0), this->asFloat(1), this->asFloat(2));
     }
-    __hostdev__ [[nodiscard]] constexpr           operator Vec4<float>() const {
+    __hostdev__ [[nodiscard]] constexpr           operator Vec4<float>() const noexcept {
         return Vec4<float>(this->asFloat(0), this->asFloat(1), this->asFloat(2), this->asFloat(3));
     }
 }; // Rgba8

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -842,6 +842,19 @@ public:
     __hostdev__ constexpr const T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
     __hostdev__ constexpr T&       operator[](int i)       { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
 
+    /// @brief Named component accessors. Available based on dimensionality:
+    /// x() requires N >= 1, y() requires N >= 2, z() requires N >= 3, w()
+    /// requires N >= 4. A call on a Vec too small for the requested component
+    /// triggers a clear compile-time static_assert at the call site.
+    __hostdev__ constexpr const T& x() const { return mVec[0]; }
+    __hostdev__ constexpr       T& x()       { return mVec[0]; }
+    __hostdev__ constexpr const T& y() const { static_assert(N >= 2, "VecBase::y() requires N >= 2"); return mVec[1]; }
+    __hostdev__ constexpr       T& y()       { static_assert(N >= 2, "VecBase::y() requires N >= 2"); return mVec[1]; }
+    __hostdev__ constexpr const T& z() const { static_assert(N >= 3, "VecBase::z() requires N >= 3"); return mVec[2]; }
+    __hostdev__ constexpr       T& z()       { static_assert(N >= 3, "VecBase::z() requires N >= 3"); return mVec[2]; }
+    __hostdev__ constexpr const T& w() const { static_assert(N >= 4, "VecBase::w() requires N >= 4"); return mVec[3]; }
+    __hostdev__ constexpr       T& w()       { static_assert(N >= 4, "VecBase::w() requires N >= 4"); return mVec[3]; }
+
     /// @brief raw pointer to the underlying N-element storage
     __hostdev__ constexpr T*       asPointer()       { return mVec; }
     __hostdev__ constexpr const T* asPointer() const { return mVec; }

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -54,7 +54,11 @@ inline __hostdev__ constexpr long double pi() noexcept
 //@}
 
 //@{
-/// Tolerance for floating-point comparison
+/// @brief Per-type tolerance used by approximate floating-point comparisons.
+/// @details Returned by @c Tolerance<T>::value() and consumed by @c isApproxZero.
+/// Specialized for @c float, @c double, and @c long double. Instantiating on
+/// any other @c T is an "incomplete type" compile error by design — callers
+/// must opt in by adding a specialization.
 template<typename T>
 struct Tolerance;
 template<>
@@ -75,7 +79,11 @@ struct Tolerance<long double>
 //@}
 
 //@{
-/// Delta for small floating-point offsets
+/// @brief Per-type small floating-point offset, useful for nudging boundaries
+/// off-edge in geometric tests.
+/// @details Returned by @c Delta<T>::value(). Specialized for @c float,
+/// @c double, and @c long double; instantiating on any other @c T is a
+/// compile error by design.
 template<typename T>
 struct Delta;
 template<>
@@ -96,7 +104,13 @@ struct Delta<long double>
 //@}
 
 //@{
-/// Maximum floating-point values
+/// @brief Per-type largest representable value (mirrors @c std::numeric_limits::max).
+/// @details Returned by @c Maximum<T>::value(). The host fallback (`#else`
+/// branch) forwards to @c std::numeric_limits so any @c T with a
+/// specialization there works; the CUDA-device branch uses
+/// @c ::cuda::std::numeric_limits; the HIP branch hard-codes a handful of
+/// common types because @c std::numeric_limits is unavailable on the device
+/// in some HIP toolchains.
 template<typename T>
 struct Maximum;
 #if defined(__CUDA_ARCH__)
@@ -135,12 +149,16 @@ struct Maximum
 #endif
 //@}
 
+/// @brief Return @c true if @c |x| is below @c Tolerance<Type>::value().
 template<typename Type>
 __hostdev__ [[nodiscard]] inline constexpr bool isApproxZero(const Type& x) noexcept
 {
     return !(x > Tolerance<Type>::value()) && !(x < -Tolerance<Type>::value());
 }
 
+/// @brief Same-type minimum (the primary template).
+/// @note Float/double overloads below use @c fminf/fmin for NaN handling and are
+/// therefore not @c constexpr.
 template<typename Type>
 __hostdev__ [[nodiscard]] inline constexpr Type Min(Type a, Type b) noexcept
 {
@@ -168,6 +186,9 @@ __hostdev__ [[nodiscard]] inline double Min(double a, double b) noexcept
 {
     return fmin(a, b);
 }
+/// @brief Same-type maximum (the primary template).
+/// @note Float/double overloads below use @c fmaxf/fmax for NaN handling and
+/// are therefore not @c constexpr.
 template<typename Type>
 __hostdev__ [[nodiscard]] inline constexpr Type Max(Type a, Type b) noexcept
 {
@@ -192,17 +213,21 @@ __hostdev__ [[nodiscard]] inline double Max(double a, double b) noexcept
 {
     return fmax(a, b);
 }
-// Not constexpr — depends on non-constexpr float/double Min/Max overloads.
+//@{
+/// @brief Clamp @c x to the closed interval [@c a, @c b].
+/// @note Not @c constexpr — relies on the non-constexpr float/double @c Min/@c Max overloads.
 __hostdev__ [[nodiscard]] inline float Clamp(float x, float a, float b) noexcept
 {
     return Max(Min(x, b), a);
 }
-// Not constexpr — depends on non-constexpr float/double Min/Max overloads.
 __hostdev__ [[nodiscard]] inline double Clamp(double x, double a, double b) noexcept
 {
     return Max(Min(x, b), a);
 }
+//@}
 
+//@{
+/// @brief Fractional part of @c x, i.e. @c x @c - @c floor(x). Always non-negative.
 __hostdev__ [[nodiscard]] inline float Fract(float x) noexcept
 {
     return x - floorf(x);
@@ -211,7 +236,10 @@ __hostdev__ [[nodiscard]] inline double Fract(double x) noexcept
 {
     return x - floor(x);
 }
+//@}
 
+//@{
+/// @brief Floor of @c x as a 32-bit signed integer (truncation toward -inf).
 __hostdev__ [[nodiscard]] inline int32_t Floor(float x) noexcept
 {
     return int32_t(floorf(x));
@@ -220,7 +248,10 @@ __hostdev__ [[nodiscard]] inline int32_t Floor(double x) noexcept
 {
     return int32_t(floor(x));
 }
+//@}
 
+//@{
+/// @brief Ceil of @c x as a 32-bit signed integer (rounding toward +inf).
 __hostdev__ [[nodiscard]] inline int32_t Ceil(float x) noexcept
 {
     return int32_t(ceilf(x));
@@ -229,24 +260,31 @@ __hostdev__ [[nodiscard]] inline int32_t Ceil(double x) noexcept
 {
     return int32_t(ceil(x));
 }
+//@}
 
+/// @brief Return @c x * @c x.
 template<typename T>
 __hostdev__ [[nodiscard]] inline constexpr T Pow2(T x) noexcept
 {
     return x * x;
 }
 
+/// @brief Return @c x * @c x * @c x.
 template<typename T>
 __hostdev__ [[nodiscard]] inline constexpr T Pow3(T x) noexcept
 {
     return x * x * x;
 }
 
+/// @brief Return @c x raised to the fourth power.
 template<typename T>
 __hostdev__ [[nodiscard]] inline constexpr T Pow4(T x) noexcept
 {
     return Pow2(x * x);
 }
+/// @brief Absolute value (generic primary template, branchless for arithmetic types).
+/// @note The @c float / @c double / @c int specializations below are not
+/// @c constexpr because @c fabsf / @c fabs / @c abs are not @c constexpr until C++23.
 template<typename T>
 __hostdev__ [[nodiscard]] inline constexpr T Abs(T x) noexcept
 {
@@ -274,6 +312,12 @@ __hostdev__ [[nodiscard]] inline int Abs(int x) noexcept
     return abs(x);
 }
 
+/// @brief Round each component of @c xyz to its closest integer coordinate.
+/// @details Forward declaration of the primary template — there is no
+/// definition here. Callers resolve to one of the @c float / @c double
+/// overloads below, both of which use the @c floor(x+0.5) rule
+/// (round-half-toward-+inf), so a @c float and @c double input with the
+/// same value yield the same integer coordinate.
 template<typename CoordT, typename RealT, template<typename> class Vec3T>
 __hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<RealT>& xyz) noexcept;
 
@@ -288,6 +332,7 @@ __hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<float>& xyz) noexcept
                   int32_t(floorf(xyz[2] + 0.5f)));
 }
 
+/// @brief Double-precision variant of @c Round — see the @c float overload above.
 template<typename CoordT, template<typename> class Vec3T>
 __hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<double>& xyz) noexcept
 {
@@ -296,6 +341,7 @@ __hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<double>& xyz) noexcept
                   int32_t(floor(xyz[2] + 0.5)));
 }
 
+/// @brief Round each component of @c xyz down (toward -inf) into a @c CoordT.
 template<typename CoordT, typename RealT, template<typename> class Vec3T>
 __hostdev__ [[nodiscard]] inline CoordT RoundDown(const Vec3T<RealT>& xyz) noexcept
 {
@@ -321,6 +367,8 @@ __hostdev__ [[nodiscard]] inline constexpr T Sign(const T& x) noexcept
     return ((T(0) < x) ? T(1) : T(0)) - ((x < T(0)) ? T(1) : T(0));
 }
 
+/// @brief Return the component index (0, 1, or 2) of the smallest element of @c v.
+/// @note Ties resolve to the lowest index (i.e. x beats y, y beats z).
 template<typename Vec3T>
 __hostdev__ [[nodiscard]] inline constexpr int MinIndex(const Vec3T& v) noexcept
 {
@@ -338,6 +386,8 @@ __hostdev__ [[nodiscard]] inline constexpr int MinIndex(const Vec3T& v) noexcept
 #endif
 }
 
+/// @brief Return the component index (0, 1, or 2) of the largest element of @c v.
+/// @note Ties resolve to the lowest index (i.e. x beats y, y beats z).
 template<typename Vec3T>
 __hostdev__ [[nodiscard]] inline constexpr int MaxIndex(const Vec3T& v) noexcept
 {
@@ -397,11 +447,14 @@ public:
     {
     }
 
+    /// @brief Read three signed integers from @a ptr (no bounds check).
     __hostdev__ constexpr Coord(ValueType* ptr) noexcept
         : mVec{ptr[0], ptr[1], ptr[2]}
     {
     }
 
+    //@{
+    /// @brief Named component accessors (x = mVec[0], y = mVec[1], z = mVec[2]).
     __hostdev__ constexpr int32_t x() const noexcept { return mVec[0]; }
     __hostdev__ constexpr int32_t y() const noexcept { return mVec[1]; }
     __hostdev__ constexpr int32_t z() const noexcept { return mVec[2]; }
@@ -409,11 +462,15 @@ public:
     __hostdev__ constexpr int32_t& x() noexcept { return mVec[0]; }
     __hostdev__ constexpr int32_t& y() noexcept { return mVec[1]; }
     __hostdev__ constexpr int32_t& z() noexcept { return mVec[2]; }
+    //@}
 
+    /// @brief Largest representable @c Coord (all components = INT32_MAX).
     __hostdev__ [[nodiscard]] static constexpr Coord max() noexcept { return Coord(int32_t((1u << 31) - 1)); }
 
+    /// @brief Smallest representable @c Coord (all components = INT32_MIN).
     __hostdev__ [[nodiscard]] static constexpr Coord min() noexcept { return Coord(-int32_t((1u << 31) - 1) - 1); }
 
+    /// @brief Byte size of a @c Coord (always 12 on a 32-bit @c int32_t platform).
     __hostdev__ [[nodiscard]] static constexpr size_t memUsage() noexcept { return sizeof(Coord); }
 
     /// @brief Return a const reference to the given Coord component.
@@ -438,10 +495,10 @@ public:
     /// @brief Return a new instance with coordinates masked by the given unsigned integer.
     __hostdev__ [[nodiscard]] constexpr Coord operator&(IndexType n) const noexcept { return Coord(mVec[0] & n, mVec[1] & n, mVec[2] & n); }
 
-    // @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
+    /// @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
     __hostdev__ [[nodiscard]] constexpr Coord operator<<(IndexType n) const noexcept { return Coord(mVec[0] << n, mVec[1] << n, mVec[2] << n); }
 
-    // @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
+    /// @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
     __hostdev__ [[nodiscard]] constexpr Coord operator>>(IndexType n) const noexcept { return Coord(mVec[0] >> n, mVec[1] >> n, mVec[2] >> n); }
 
     /// @brief Return true if this Coord is lexicographically less than the given Coord.
@@ -464,7 +521,7 @@ public:
              : mVec[2] <=rhs[2] ? true : false;
     }
 
-    // @brief Return true if this Coord is lexicographically greater than the given Coord.
+    /// @brief Return true if this Coord is lexicographically greater than the given Coord.
     __hostdev__ [[nodiscard]] constexpr bool operator>(const Coord& rhs) const noexcept
     {
         return mVec[0] > rhs[0] ? true
@@ -474,7 +531,7 @@ public:
              : mVec[2] > rhs[2] ? true : false;
     }
 
-    // @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
+    /// @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
     __hostdev__ [[nodiscard]] constexpr bool operator>=(const Coord& rhs) const noexcept
     {
         return mVec[0] > rhs[0] ? true
@@ -484,9 +541,11 @@ public:
              : mVec[2] >=rhs[2] ? true : false;
     }
 
-    // @brief Return true if the Coord components are identical.
+    /// @brief Return true iff every component matches @a rhs.
     __hostdev__ [[nodiscard]] constexpr bool   operator==(const Coord& rhs) const noexcept { return mVec[0] == rhs[0] && mVec[1] == rhs[1] && mVec[2] == rhs[2]; }
+    /// @brief Return true iff any component differs from @a rhs.
     __hostdev__ [[nodiscard]] constexpr bool   operator!=(const Coord& rhs) const noexcept { return mVec[0] != rhs[0] || mVec[1] != rhs[1] || mVec[2] != rhs[2]; }
+    /// @brief In-place component-wise bitwise AND with the given mask.
     __hostdev__ constexpr Coord& operator&=(int n) noexcept
     {
         mVec[0] &= n;
@@ -494,6 +553,7 @@ public:
         mVec[2] &= n;
         return *this;
     }
+    /// @brief In-place left-shift of every component by @a n bits.
     __hostdev__ constexpr Coord& operator<<=(uint32_t n) noexcept
     {
         mVec[0] <<= n;
@@ -501,6 +561,7 @@ public:
         mVec[2] <<= n;
         return *this;
     }
+    /// @brief In-place right-shift of every component by @a n bits.
     __hostdev__ constexpr Coord& operator>>=(uint32_t n) noexcept
     {
         mVec[0] >>= n;
@@ -508,6 +569,7 @@ public:
         mVec[2] >>= n;
         return *this;
     }
+    /// @brief Add a scalar to every component in place.
     __hostdev__ constexpr Coord& operator+=(int n) noexcept
     {
         mVec[0] += n;
@@ -515,9 +577,13 @@ public:
         mVec[2] += n;
         return *this;
     }
+    /// @brief Component-wise sum of two coordinates.
     __hostdev__ [[nodiscard]] constexpr Coord  operator+(const Coord& rhs) const noexcept { return Coord(mVec[0] + rhs[0], mVec[1] + rhs[1], mVec[2] + rhs[2]); }
+    /// @brief Component-wise difference of two coordinates.
     __hostdev__ [[nodiscard]] constexpr Coord  operator-(const Coord& rhs) const noexcept { return Coord(mVec[0] - rhs[0], mVec[1] - rhs[1], mVec[2] - rhs[2]); }
+    /// @brief Component-wise negation.
     __hostdev__ [[nodiscard]] constexpr Coord  operator-() const noexcept { return Coord(-mVec[0], -mVec[1], -mVec[2]); }
+    /// @brief In-place component-wise addition with another coordinate.
     __hostdev__ constexpr Coord& operator+=(const Coord& rhs) noexcept
     {
         mVec[0] += rhs[0];
@@ -525,6 +591,7 @@ public:
         mVec[2] += rhs[2];
         return *this;
     }
+    /// @brief In-place component-wise subtraction with another coordinate.
     __hostdev__ constexpr Coord& operator-=(const Coord& rhs) noexcept
     {
         mVec[0] -= rhs[0];
@@ -557,6 +624,7 @@ public:
         return *this;
     }
 #if defined(__CUDACC__) // the following functions only run on the GPU!
+    /// @brief Device-only @c atomicMin component-wise.
     __device__ inline Coord& minComponentAtomic(const Coord& other) noexcept
     {
         atomicMin(&mVec[0], other[0]);
@@ -564,6 +632,7 @@ public:
         atomicMin(&mVec[2], other[2]);
         return *this;
     }
+    /// @brief Device-only @c atomicMax component-wise.
     __device__ inline Coord& maxComponentAtomic(const Coord& other) noexcept
     {
         atomicMax(&mVec[0], other[0]);
@@ -573,11 +642,13 @@ public:
     }
 #endif
 
+    /// @brief Return a new @c Coord offset component-by-component by @a (dx, dy, dz).
     __hostdev__ [[nodiscard]] constexpr Coord offsetBy(ValueType dx, ValueType dy, ValueType dz) const noexcept
     {
         return Coord(mVec[0] + dx, mVec[1] + dy, mVec[2] + dz);
     }
 
+    /// @brief Return a new @c Coord offset by the same scalar @a n in every component.
     __hostdev__ [[nodiscard]] constexpr Coord offsetBy(ValueType n) const noexcept { return this->offsetBy(n, n, n); }
 
     /// Return true if any of the components of @a a are smaller than the
@@ -613,7 +684,8 @@ public:
     /// @brief Return a double precision floating-point vector of this coordinate
     __hostdev__ [[nodiscard]] inline constexpr Vec3<double> asVec3d() const noexcept;
 
-    // returns a copy of itself, so it mimics the behaviour of Vec3<T>::round()
+    /// @brief Identity (Coord is already integer); provided so generic code
+    /// can call @c .round() uniformly on @c Coord and @c Vec3<T>.
     __hostdev__ [[nodiscard]] inline constexpr Coord round() const noexcept { return *this; }
 }; // Coord class
 
@@ -651,21 +723,28 @@ public:
     {
     }
 
+    /// @brief Read two signed integers from @a ptr (no bounds check).
     __hostdev__ constexpr Coord2(ValueType* ptr) noexcept
         : mVec{ptr[0], ptr[1]}
     {
     }
 
+    //@{
+    /// @brief Named component accessors (x = mVec[0], y = mVec[1]).
     __hostdev__ constexpr int32_t x() const noexcept { return mVec[0]; }
     __hostdev__ constexpr int32_t y() const noexcept { return mVec[1]; }
 
     __hostdev__ constexpr int32_t& x() noexcept { return mVec[0]; }
     __hostdev__ constexpr int32_t& y() noexcept { return mVec[1]; }
+    //@}
 
+    /// @brief Largest representable @c Coord2 (all components = INT32_MAX).
     __hostdev__ [[nodiscard]] static constexpr Coord2 max() noexcept { return Coord2(int32_t((1u << 31) - 1)); }
 
+    /// @brief Smallest representable @c Coord2 (all components = INT32_MIN).
     __hostdev__ [[nodiscard]] static constexpr Coord2 min() noexcept { return Coord2(-int32_t((1u << 31) - 1) - 1); }
 
+    /// @brief Byte size of a @c Coord2 (always 8 on a 32-bit @c int32_t platform).
     __hostdev__ [[nodiscard]] static constexpr size_t memUsage() noexcept { return sizeof(Coord2); }
 
     /// @brief Return a const reference to the given Coord component.
@@ -689,10 +768,10 @@ public:
     /// @brief Return a new instance with coordinates masked by the given unsigned integer.
     __hostdev__ [[nodiscard]] constexpr Coord2 operator&(IndexType n) const noexcept { return Coord2(mVec[0] & n, mVec[1] & n); }
 
-    // @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
+    /// @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
     __hostdev__ [[nodiscard]] constexpr Coord2 operator<<(IndexType n) const noexcept { return Coord2(mVec[0] << n, mVec[1] << n); }
 
-    // @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
+    /// @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
     __hostdev__ [[nodiscard]] constexpr Coord2 operator>>(IndexType n) const noexcept { return Coord2(mVec[0] >> n, mVec[1] >> n); }
 
     /// @brief Return true if this Coord is lexicographically less than the given Coord.
@@ -711,7 +790,7 @@ public:
              : mVec[1] <= rhs[1] ? true : false;
     }
 
-    // @brief Return true if this Coord is lexicographically greater than the given Coord.
+    /// @brief Return true if this Coord is lexicographically greater than the given Coord.
     __hostdev__ [[nodiscard]] constexpr bool operator>(const Coord2& rhs) const noexcept
     {
         return mVec[0] > rhs[0] ? true
@@ -719,7 +798,7 @@ public:
              : mVec[1] > rhs[1] ? true : false;
     }
 
-    // @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
+    /// @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
     __hostdev__ [[nodiscard]] constexpr bool operator>=(const Coord2& rhs) const noexcept
     {
         return mVec[0] > rhs[0] ? true
@@ -727,42 +806,52 @@ public:
              : mVec[1] >= rhs[1] ? true : false;
     }
 
-    // @brief Return true if the Coord components are identical.
+    /// @brief Return true iff every component matches @a rhs.
     __hostdev__ [[nodiscard]] constexpr bool   operator==(const Coord2& rhs) const noexcept { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
+    /// @brief Return true iff any component differs from @a rhs.
     __hostdev__ [[nodiscard]] constexpr bool   operator!=(const Coord2& rhs) const noexcept { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
+    /// @brief In-place component-wise bitwise AND with the given mask.
     __hostdev__ constexpr Coord2& operator&=(int n) noexcept
     {
         mVec[0] &= n;
         mVec[1] &= n;
         return *this;
     }
+    /// @brief In-place left-shift of every component by @a n bits.
     __hostdev__ constexpr Coord2& operator<<=(uint32_t n) noexcept
     {
         mVec[0] <<= n;
         mVec[1] <<= n;
         return *this;
     }
+    /// @brief In-place right-shift of every component by @a n bits.
     __hostdev__ constexpr Coord2& operator>>=(uint32_t n) noexcept
     {
         mVec[0] >>= n;
         mVec[1] >>= n;
         return *this;
     }
+    /// @brief Add a scalar to every component in place.
     __hostdev__ constexpr Coord2& operator+=(int n) noexcept
     {
         mVec[0] += n;
         mVec[1] += n;
         return *this;
     }
+    /// @brief Component-wise sum of two coordinates.
     __hostdev__ [[nodiscard]] constexpr Coord2  operator+(const Coord2& rhs) const noexcept { return Coord2(mVec[0] + rhs[0], mVec[1] + rhs[1]); }
+    /// @brief Component-wise difference of two coordinates.
     __hostdev__ [[nodiscard]] constexpr Coord2  operator-(const Coord2& rhs) const noexcept { return Coord2(mVec[0] - rhs[0], mVec[1] - rhs[1]); }
+    /// @brief Component-wise negation.
     __hostdev__ [[nodiscard]] constexpr Coord2  operator-() const noexcept { return Coord2(-mVec[0], -mVec[1]); }
+    /// @brief In-place component-wise addition with another coordinate.
     __hostdev__ constexpr Coord2& operator+=(const Coord2& rhs) noexcept
     {
         mVec[0] += rhs[0];
         mVec[1] += rhs[1];
         return *this;
     }
+    /// @brief In-place component-wise subtraction with another coordinate.
     __hostdev__ constexpr Coord2& operator-=(const Coord2& rhs) noexcept
     {
         mVec[0] -= rhs[0];
@@ -790,12 +879,14 @@ public:
         return *this;
     }
 #if defined(__CUDACC__) // the following functions only run on the GPU!
+    /// @brief Device-only @c atomicMin component-wise.
     __device__ inline Coord2& minComponentAtomic(const Coord2& other) noexcept
     {
         atomicMin(&mVec[0], other[0]);
         atomicMin(&mVec[1], other[1]);
         return *this;
     }
+    /// @brief Device-only @c atomicMax component-wise.
     __device__ inline Coord2& maxComponentAtomic(const Coord2& other) noexcept
     {
         atomicMax(&mVec[0], other[0]);
@@ -804,11 +895,13 @@ public:
     }
 #endif
 
+    /// @brief Return a new @c Coord2 offset component-by-component by @a (dx, dy).
     __hostdev__ [[nodiscard]] constexpr Coord2 offsetBy(ValueType dx, ValueType dy) const noexcept
     {
         return Coord2(mVec[0] + dx, mVec[1] + dy);
     }
 
+    /// @brief Return a new @c Coord2 offset by the same scalar @a n in both components.
     __hostdev__ [[nodiscard]] constexpr Coord2 offsetBy(ValueType n) const noexcept { return this->offsetBy(n, n); }
 
     /// Return true if any of the components of @a a are smaller than the
@@ -830,7 +923,8 @@ public:
     /// @brief Return a double precision floating-point vector of this coordinate
     __hostdev__ [[nodiscard]] inline constexpr Vec2<double> asVec2d() const noexcept;
 
-    // returns a copy of itself, so it mimics the behaviour of Vec3<T>::round()
+    /// @brief Identity (Coord2 is already integer); provided so generic code
+    /// can call @c .round() uniformly on @c Coord2 and @c Vec2<T>.
     __hostdev__ [[nodiscard]] inline constexpr Coord2 round() const noexcept { return *this; }
 }; // Coord2 class
 
@@ -850,6 +944,7 @@ public:
     using ValueType = T;
     static constexpr int SIZE = N;
 
+    /// @brief Default-construct (mVec is left uninitialized for trivially-default-constructible @c T).
     VecBase() noexcept = default;
 
 protected:
@@ -887,43 +982,49 @@ public:
 
     // ---- generic element-wise helpers (taking/returning Derived) ----
 
+    /// @brief Return @c *this + @a rhs as a @c Derived.
     template<typename Derived>
     __hostdev__ [[nodiscard]] constexpr Derived plus(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] + rhs[i];
         return out;
     }
+    /// @brief Return @c *this - @a rhs as a @c Derived.
     template<typename Derived>
     __hostdev__ [[nodiscard]] constexpr Derived minus(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] - rhs[i];
         return out;
     }
+    /// @brief Return component-wise @c *this * @a rhs as a @c Derived (Hadamard product).
     template<typename Derived>
     __hostdev__ [[nodiscard]] constexpr Derived mul(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] * rhs[i];
         return out;
     }
+    /// @brief Return component-wise @c *this / @a rhs as a @c Derived.
     template<typename Derived>
     __hostdev__ [[nodiscard]] constexpr Derived div(const Derived& rhs) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] / rhs[i];
         return out;
     }
+    /// @brief Return @c -(*this) as a @c Derived.
     template<typename Derived>
     __hostdev__ [[nodiscard]] constexpr Derived negate() const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = -mVec[i];
         return out;
     }
+    /// @brief Return @c s * (*this) as a @c Derived (scalar broadcast).
     template<typename Derived>
     __hostdev__ [[nodiscard]] constexpr Derived scale(const T& s) const noexcept {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] * s;
         return out;
     }
-    /// @brief return (*this) / @a s element-wise as a @c Derived. Uses per-element
+    /// @brief Return @c (*this) / @a s element-wise as a @c Derived. Uses per-element
     /// division (correct for integer @c T, unlike multiplying by 1/s).
     template<typename Derived>
     __hostdev__ [[nodiscard]] constexpr Derived divideBy(const T& s) const noexcept {
@@ -934,31 +1035,39 @@ public:
 
     // ---- in-place compound assignment helpers ----
 
+    /// @brief Component-wise add @a rhs into @c *this and return @c *this.
     __hostdev__ constexpr VecBase& addAssign(const VecBase& rhs) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] += rhs.mVec[i];
         return *this;
     }
+    /// @brief Component-wise subtract @a rhs from @c *this and return @c *this.
     __hostdev__ constexpr VecBase& subAssign(const VecBase& rhs) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] -= rhs.mVec[i];
         return *this;
     }
+    /// @brief Component-wise multiply @c *this by @a rhs (Hadamard product) and return @c *this.
     __hostdev__ constexpr VecBase& mulAssign(const VecBase& rhs) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] *= rhs.mVec[i];
         return *this;
     }
+    /// @brief Component-wise divide @c *this by @a rhs and return @c *this.
     __hostdev__ constexpr VecBase& divAssign(const VecBase& rhs) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] /= rhs.mVec[i];
         return *this;
     }
+    /// @brief Multiply every component by scalar @a s in place; return @c *this.
     __hostdev__ constexpr VecBase& scaleAssign(const T& s) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] *= s;
         return *this;
     }
+    /// @brief Divide every component by scalar @a s in place (per-element, integer-safe);
+    /// return @c *this.
     __hostdev__ constexpr VecBase& divideAssignScalar(const T& s) noexcept {
         for (int i = 0; i < N; ++i) mVec[i] /= s;
         return *this;
     }
 
+    /// @brief Return @c true iff every component compares equal to @a rhs.
     __hostdev__ [[nodiscard]] constexpr bool equals(const VecBase& rhs) const noexcept {
         for (int i = 0; i < N; ++i) if (mVec[i] != rhs.mVec[i]) return false;
         return true;
@@ -973,12 +1082,13 @@ public:
         for (int i = 0; i < N; ++i) s += mVec[i] * v[i];
         return s;
     }
+    /// @brief Squared L2 length (sum of squared components). Constexpr, no sqrt.
     __hostdev__ [[nodiscard]] constexpr T lengthSqr() const noexcept {
         T s = T(0);
         for (int i = 0; i < N; ++i) s += mVec[i] * mVec[i];
         return s;
     }
-    // Not constexpr — std::sqrt isn't constexpr until C++26.
+    /// @brief L2 length (Euclidean norm). Not @c constexpr — calls @c Sqrt.
     __hostdev__ [[nodiscard]] T length() const noexcept { return Sqrt(this->lengthSqr()); }
 
     /// @brief return the smallest of the N components
@@ -996,11 +1106,13 @@ public:
 
     // ---- component-wise (mutating) min/max ----
 
+    /// @brief Component-wise take the @c min of @c *this and @a other (in place); return @c *this.
     template<typename V>
     __hostdev__ constexpr VecBase& mergeMin(const V& other) noexcept {
         for (int i = 0; i < N; ++i) if (other[i] < mVec[i]) mVec[i] = other[i];
         return *this;
     }
+    /// @brief Component-wise take the @c max of @c *this and @a other (in place); return @c *this.
     template<typename V>
     __hostdev__ constexpr VecBase& mergeMax(const V& other) noexcept {
         for (int i = 0; i < N; ++i) if (other[i] > mVec[i]) mVec[i] = other[i];
@@ -1084,19 +1196,27 @@ public:
     using ValueType = T;
     static constexpr int size = 2; // openvdb::math::Tuple-compat alias of SIZE
 
+    /// @brief Default-construct (components are left uninitialized for fundamental @c T).
     Vec2() noexcept = default;
+    /// @brief Broadcast: set both components to @a x.
     __hostdev__ explicit constexpr Vec2(T x) noexcept            : Base(x, x) {}
+    /// @brief Component-wise construction.
     __hostdev__ constexpr Vec2(T x, T y) noexcept                : Base(x, y) {}
 
+    /// @brief Cross-template converting ctor (e.g. from @c openvdb::Vec2). Implicit
+    /// to preserve foreign-type interop; same-class ctor below is @c explicit.
     template<template<class> class Vec2T, class T2>
     __hostdev__ explicit constexpr Vec2(const Vec2T<T2>& v) noexcept : Base(v[0], v[1])
     {
         static_assert(Vec2T<T2>::size == 2, "expected Vec2T::size==2!");
     }
+    /// @brief Explicit cross-precision conversion within nanovdb (e.g. @c Vec2d → @c Vec2f).
     template<typename T2>
     __hostdev__ explicit constexpr Vec2(const Vec2<T2>& v) noexcept : Base(v[0], v[1]) {}
+    /// @brief Construct from a 2D integer coordinate.
     __hostdev__ explicit constexpr Vec2(const Coord2& ijk) noexcept : Base(ijk[0], ijk[1]) {}
 
+    /// @brief Assign from any 2-component vector type (foreign or nanovdb).
     template<template<class> class Vec2T, class T2>
     __hostdev__ constexpr Vec2& operator=(const Vec2T<T2>& rhs) noexcept {
         static_assert(Vec2T<T2>::size == 2, "expected Vec2T::size==2!");
@@ -1105,40 +1225,59 @@ public:
     }
 
     // ---- element-wise (Vec & Vec) ----
+    /// @brief Component-wise negation.
     __hostdev__ [[nodiscard]] constexpr Vec2  operator-() const noexcept            { return Base::template negate<Vec2>(); }
+    /// @brief Component-wise sum.
     __hostdev__ [[nodiscard]] constexpr Vec2  operator+(const Vec2& v) const noexcept { return Base::template plus<Vec2>(v); }
+    /// @brief Component-wise difference.
     __hostdev__ [[nodiscard]] constexpr Vec2  operator-(const Vec2& v) const noexcept { return Base::template minus<Vec2>(v); }
+    /// @brief Component-wise (Hadamard) product.
     __hostdev__ [[nodiscard]] constexpr Vec2  operator*(const Vec2& v) const noexcept { return Base::template mul<Vec2>(v); }
+    /// @brief Component-wise division.
     __hostdev__ [[nodiscard]] constexpr Vec2  operator/(const Vec2& v) const noexcept { return Base::template div<Vec2>(v); }
+    /// @brief In-place component-wise addition.
     __hostdev__ constexpr Vec2& operator+=(const Vec2& v) noexcept    { Base::addAssign(v); return *this; }
+    /// @brief In-place component-wise subtraction.
     __hostdev__ constexpr Vec2& operator-=(const Vec2& v) noexcept    { Base::subAssign(v); return *this; }
 
     // ---- mixed Vec2 / Coord2 ----
+    /// @brief Add an integer @c Coord2 to this vector (component-wise).
     __hostdev__ [[nodiscard]] constexpr Vec2  operator+(const Coord2& ijk) const noexcept { return Vec2(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1]); }
+    /// @brief Subtract an integer @c Coord2 from this vector (component-wise).
     __hostdev__ [[nodiscard]] constexpr Vec2  operator-(const Coord2& ijk) const noexcept { return Vec2(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1]); }
+    /// @brief In-place component-wise addition of an integer @c Coord2.
     __hostdev__ constexpr Vec2& operator+=(const Coord2& ijk) noexcept {
         this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]);
         return *this;
     }
+    /// @brief In-place component-wise subtraction of an integer @c Coord2.
     __hostdev__ constexpr Vec2& operator-=(const Coord2& ijk) noexcept {
         this->mVec[0] -= T(ijk[0]); this->mVec[1] -= T(ijk[1]);
         return *this;
     }
 
     // ---- scalar ----
+    /// @brief Component-wise multiply by scalar @a s.
     __hostdev__ [[nodiscard]] constexpr Vec2  operator*(const T& s) const noexcept  { return Base::template scale<Vec2>(s); }
+    /// @brief Component-wise divide by scalar @a s (integer-safe).
     __hostdev__ [[nodiscard]] constexpr Vec2  operator/(const T& s) const noexcept  { return Base::template divideBy<Vec2>(s); }
+    /// @brief In-place component-wise multiply by scalar @a s.
     __hostdev__ constexpr Vec2& operator*=(const T& s) noexcept       { Base::scaleAssign(s); return *this; }
+    /// @brief In-place component-wise divide by scalar @a s.
     __hostdev__ constexpr Vec2& operator/=(const T& s) noexcept       { Base::divideAssignScalar(s); return *this; }
-    // Not constexpr — depends on length() which calls std::sqrt.
+    /// @brief Normalize in place (divide by @c length()). Not @c constexpr — calls @c std::sqrt.
     __hostdev__ Vec2& normalize() noexcept                  { return (*this) /= this->length(); }
 
     // ---- equality ----
+    /// @brief Component-wise equality.
     __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec2& rhs) const noexcept { return Base::equals(rhs); }
+    /// @brief Component-wise inequality.
     __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec2& rhs) const noexcept { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
+    /// @brief Take the component-wise minimum of @c *this and @a other in place.
     __hostdev__ constexpr Vec2& minComponent(const Vec2& other) noexcept { Base::mergeMin(other); return *this; }
+    /// @brief Take the component-wise maximum of @c *this and @a other in place.
     __hostdev__ constexpr Vec2& maxComponent(const Vec2& other) noexcept { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
@@ -1161,11 +1300,14 @@ public:
 
     // ---- scalar * Vec / scalar / Vec (hidden friends — found only via ADL on Vec2,
     // never participate in unrelated namespace-scope overload sets) ----
+
+    /// @brief Scalar-on-the-left multiplication (hidden friend; found only via ADL on @c Vec2).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec2 operator*(T1 scalar, const Vec2& vec) noexcept
     {
         return Vec2(scalar * vec[0], scalar * vec[1]);
     }
+    /// @brief Scalar-on-the-left division (hidden friend; found only via ADL on @c Vec2).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec2 operator/(T1 scalar, const Vec2& vec) noexcept
     {
@@ -1186,7 +1328,11 @@ __hostdev__ [[nodiscard]] inline constexpr Vec2<double> Coord2::asVec2d() const 
 }
 
 
-// Matrix base class
+/// @brief Base class for fixed-size matrices. Provides shared element-wise
+/// arithmetic, scalar arithmetic, equality, transpose, mat*mat, and mat*vec.
+/// Storage is a flat row-major array @c mData[ROWS * COLS]. Derived classes
+/// supply constructors plus any dimension-specific extras (e.g. @c inverse()
+/// on @c Mat2).
 template<typename T, int ROWS, int COLS>
 class MatBase {
 protected:
@@ -1195,12 +1341,18 @@ protected:
 public:
     using ValueType = T;
 
+    /// @brief Compile-time row count.
     [[nodiscard]] static constexpr int rows() noexcept { return ROWS; }
+    /// @brief Compile-time column count.
     [[nodiscard]] static constexpr int cols() noexcept { return COLS; }
+    /// @brief Compile-time element count, i.e. @c ROWS * @c COLS.
     [[nodiscard]] static constexpr int size() noexcept { return ROWS * COLS; }
 
+    /// @brief Default-construct (entries are left uninitialized for trivially-default-constructible @c T).
     MatBase() noexcept = default;
 
+    /// @brief Read @c ROWS*COLS elements from @a array in row-major order, converting each
+    /// element from @c S to @c T via @c static_cast.
     template<typename S>
     __hostdev__ constexpr MatBase(S* array) noexcept {
         for (int i = 0; i < size(); ++i) {
@@ -1222,12 +1374,14 @@ protected:
 
 public:
 
-    // 2D array access. Returns a row pointer; the caller is responsible
-    // for the column bound (0 <= col < COLS).
+    /// @brief 2D row access. Returns a pointer to the start of @a row; the caller
+    /// indexes into it with the column. Asserts @c 0 <= @a row < @c ROWS in debug
+    /// builds; column index is the caller's responsibility (use @c 0 <= col < @c COLS).
     __hostdev__ constexpr T* operator[](int row) noexcept {
         NANOVDB_ASSERT(row >= 0 && row < ROWS);
         return &mData[row * COLS];
     }
+    /// @brief Const overload of @c operator[](int); see non-const variant.
     __hostdev__ constexpr const T* operator[](int row) const noexcept {
         NANOVDB_ASSERT(row >= 0 && row < ROWS);
         return &mData[row * COLS];
@@ -1272,14 +1426,17 @@ public:
         return out;
     }
 
+    /// @brief Element-wise add @a rhs into @c *this and return @c *this.
     __hostdev__ constexpr MatBase& addAssign(const MatBase& rhs) noexcept {
         for (int i = 0; i < size(); ++i) mData[i] += rhs.mData[i];
         return *this;
     }
+    /// @brief Element-wise subtract @a rhs from @c *this and return @c *this.
     __hostdev__ constexpr MatBase& subAssign(const MatBase& rhs) noexcept {
         for (int i = 0; i < size(); ++i) mData[i] -= rhs.mData[i];
         return *this;
     }
+    /// @brief Multiply every element by scalar @a s in place; return @c *this.
     __hostdev__ constexpr MatBase& scaleAssign(const T& s) noexcept {
         for (int i = 0; i < size(); ++i) mData[i] *= s;
         return *this;
@@ -1293,11 +1450,13 @@ public:
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] / s;
         return out;
     }
+    /// @brief Divide every element by scalar @a s in place; return @c *this.
     __hostdev__ constexpr MatBase& divideAssignScalar(const T& s) noexcept {
         for (int i = 0; i < size(); ++i) mData[i] /= s;
         return *this;
     }
 
+    /// @brief Return @c true iff every element compares equal to @a rhs.
     __hostdev__ [[nodiscard]] constexpr bool equals(const MatBase& rhs) const noexcept {
         for (int i = 0; i < size(); ++i) if (mData[i] != rhs.mData[i]) return false;
         return true;
@@ -1369,13 +1528,16 @@ template<typename T> class Vec4;
 
 
 
-// Aligned to 4*alignof(T) — Mat2 stores 4 elements (2x2), which is already
-// a power-of-2 multiple of alignof(T), so this is free in size and gives
-// SIMD-friendly placement (16 bytes for Mat2<float>, 32 bytes for double).
+/// @brief 2x2 row-major matrix.
+/// @details Aligned to 4*alignof(T) — @c Mat2 stores 4 elements (2x2), which is
+/// already a power-of-2 multiple of @c alignof(T), so this is free in size
+/// and gives SIMD-friendly placement (16 bytes for @c Mat2<float>, 32 bytes
+/// for @c Mat2<double>).
 template <typename T>
 class alignas(alignof(T) * 4) Mat2 final : public MatBase<T, 2, 2> {
     using Base = MatBase<T, 2, 2>;
 public:
+    /// @brief Default-construct (entries left uninitialized for fundamental @c T).
     Mat2() noexcept = default;
     /// @brief Constructor given individual array elements, the ordering is in row major form:
     /** @verbatim
@@ -1429,14 +1591,16 @@ public:
     }
 };
 
-// Mat2x3 is intentionally NOT alignas-elevated: its byte size
-// (6*sizeof(T)) is not a power-of-2 multiple of alignof(T), so any
-// alignas(N > alignof(T)) would force tail padding and break
-// packed-array layout plus on-disk format compatibility.
+/// @brief 2x3 row-major matrix.
+/// @details Intentionally NOT @c alignas-elevated: its byte size
+/// (6*sizeof(T)) is not a power-of-2 multiple of @c alignof(T), so any
+/// @c alignas(N > alignof(T)) would force tail padding and break
+/// packed-array layout plus on-disk format compatibility.
 template <typename T>
 class Mat2x3 final : public MatBase<T, 2, 3> {
     using Base = MatBase<T, 2, 3>;
 public:
+    /// @brief Default-construct (entries left uninitialized for fundamental @c T).
     Mat2x3() noexcept = default;
     /// @brief Constructor given individual array elements, the ordering is in row major form:
     /** @verbatim
@@ -1479,14 +1643,16 @@ public:
     }
 };
 
-// Mat3x2 is intentionally NOT alignas-elevated: its byte size
-// (6*sizeof(T)) is not a power-of-2 multiple of alignof(T), so any
-// alignas(N > alignof(T)) would force tail padding and break
-// packed-array layout plus on-disk format compatibility.
+/// @brief 3x2 row-major matrix.
+/// @details Intentionally NOT @c alignas-elevated: its byte size
+/// (6*sizeof(T)) is not a power-of-2 multiple of @c alignof(T), so any
+/// @c alignas(N > alignof(T)) would force tail padding and break
+/// packed-array layout plus on-disk format compatibility.
 template <typename T>
 class Mat3x2 final : public MatBase<T, 3, 2> {
     using Base = MatBase<T, 3, 2>;
 public:
+    /// @brief Default-construct (entries left uninitialized for fundamental @c T).
     Mat3x2() noexcept = default;
 
     /// @brief Constructor given individual array elements, the ordering is in row major form:
@@ -1530,14 +1696,16 @@ public:
     }
 };
 
-// Mat3 is intentionally NOT alignas-elevated: its byte size
-// (9*sizeof(T)) is not a power-of-2 multiple of alignof(T), so any
-// alignas(N > alignof(T)) would force tail padding and break
-// packed-array layout plus on-disk format compatibility.
+/// @brief 3x3 row-major matrix.
+/// @details Intentionally NOT @c alignas-elevated: its byte size
+/// (9*sizeof(T)) is not a power-of-2 multiple of @c alignof(T), so any
+/// @c alignas(N > alignof(T)) would force tail padding and break
+/// packed-array layout plus on-disk format compatibility.
 template <typename T>
 class Mat3 final : public MatBase<T, 3, 3> {
     using Base = MatBase<T, 3, 3>;
 public:
+    /// @brief Default-construct (entries left uninitialized for fundamental @c T).
     Mat3() noexcept = default;
 
     /// @brief Constructor given individual array elements, the ordering is in row major form:
@@ -1585,18 +1753,20 @@ public:
     }
 };
 
-// Aligned to 16*alignof(T) — Mat4 stores 16 elements (4x4), which is
-// already a power-of-2 multiple of alignof(T), so the alignment is free
-// in size. Whole-matrix alignment (64 bytes for Mat4<float>, 128 bytes
-// for Mat4<double>) is heavy compared to row-alignment (4*alignof(T))
-// but matches the per-class "align to full size" rule used for Vec2 /
-// Vec4 / Mat2 above and lets a Mat4<float> load with a single AVX-512
-// instruction. Drop to alignas(alignof(T) * 4) here if the over-aligned
-// constraint causes friction with downstream allocators.
+/// @brief 4x4 row-major matrix.
+/// @details Aligned to 16*alignof(T) — @c Mat4 stores 16 elements (4x4), which is
+/// already a power-of-2 multiple of @c alignof(T), so the alignment is free
+/// in size. Whole-matrix alignment (64 bytes for @c Mat4<float>, 128 bytes
+/// for @c Mat4<double>) is heavy compared to row-alignment (4*alignof(T))
+/// but matches the per-class "align to full size" rule used for @c Vec2 /
+/// @c Vec4 / @c Mat2 above and lets a @c Mat4<float> load with a single
+/// AVX-512 instruction. Drop to @c alignas(alignof(T) * 4) here if the
+/// over-aligned constraint causes friction with downstream allocators.
 template <typename T>
 class alignas(alignof(T) * 16) Mat4 final : public MatBase<T, 4, 4> {
     using Base = MatBase<T, 4, 4>;
 public:
+    /// @brief Default-construct (entries left uninitialized for fundamental @c T).
     Mat4() noexcept = default;
 
     /// @brief Constructor given individual array elements, the ordering is in row major form:
@@ -1696,19 +1866,27 @@ public:
     using ValueType = T;
     static constexpr int size = 3; // openvdb::math::Tuple-compat alias of SIZE
 
+    /// @brief Default-construct (components are left uninitialized for fundamental @c T).
     Vec3() noexcept = default;
+    /// @brief Broadcast: set all three components to @a x.
     __hostdev__ explicit constexpr Vec3(T x) noexcept            : Base(x, x, x) {}
+    /// @brief Component-wise construction.
     __hostdev__ constexpr Vec3(T x, T y, T z) noexcept           : Base(x, y, z) {}
 
+    /// @brief Cross-template converting ctor (e.g. from @c openvdb::Vec3). Implicit
+    /// to preserve foreign-type interop; same-class ctor below is @c explicit.
     template<template<class> class Vec3T, class T2>
     __hostdev__ explicit constexpr Vec3(const Vec3T<T2>& v) noexcept : Base(v[0], v[1], v[2])
     {
         static_assert(Vec3T<T2>::size == 3, "expected Vec3T::size==3!");
     }
+    /// @brief Explicit cross-precision conversion within nanovdb (e.g. @c Vec3d → @c Vec3f).
     template<typename T2>
     __hostdev__ explicit constexpr Vec3(const Vec3<T2>& v) noexcept : Base(v[0], v[1], v[2]) {}
+    /// @brief Construct from a 3D integer coordinate.
     __hostdev__ explicit constexpr Vec3(const Coord& ijk) noexcept : Base(ijk[0], ijk[1], ijk[2]) {}
 
+    /// @brief Assign from any 3-component vector type (foreign or nanovdb).
     template<template<class> class Vec3T, class T2>
     __hostdev__ constexpr Vec3& operator=(const Vec3T<T2>& rhs) noexcept {
         static_assert(Vec3T<T2>::size == 3, "expected Vec3T::size==3!");
@@ -1717,40 +1895,59 @@ public:
     }
 
     // ---- element-wise (Vec & Vec) ----
+    /// @brief Component-wise negation.
     __hostdev__ [[nodiscard]] constexpr Vec3  operator-() const noexcept             { return Base::template negate<Vec3>(); }
+    /// @brief Component-wise sum.
     __hostdev__ [[nodiscard]] constexpr Vec3  operator+(const Vec3& v) const noexcept { return Base::template plus<Vec3>(v); }
+    /// @brief Component-wise difference.
     __hostdev__ [[nodiscard]] constexpr Vec3  operator-(const Vec3& v) const noexcept { return Base::template minus<Vec3>(v); }
+    /// @brief Component-wise (Hadamard) product.
     __hostdev__ [[nodiscard]] constexpr Vec3  operator*(const Vec3& v) const noexcept { return Base::template mul<Vec3>(v); }
+    /// @brief Component-wise division.
     __hostdev__ [[nodiscard]] constexpr Vec3  operator/(const Vec3& v) const noexcept { return Base::template div<Vec3>(v); }
+    /// @brief In-place component-wise addition.
     __hostdev__ constexpr Vec3& operator+=(const Vec3& v) noexcept     { Base::addAssign(v); return *this; }
+    /// @brief In-place component-wise subtraction.
     __hostdev__ constexpr Vec3& operator-=(const Vec3& v) noexcept     { Base::subAssign(v); return *this; }
 
     // ---- mixed Vec3 / Coord (3D) ----
+    /// @brief Add an integer @c Coord to this vector (component-wise).
     __hostdev__ [[nodiscard]] constexpr Vec3  operator+(const Coord& ijk) const noexcept { return Vec3(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1], this->mVec[2] + ijk[2]); }
+    /// @brief Subtract an integer @c Coord from this vector (component-wise).
     __hostdev__ [[nodiscard]] constexpr Vec3  operator-(const Coord& ijk) const noexcept { return Vec3(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1], this->mVec[2] - ijk[2]); }
+    /// @brief In-place component-wise addition of an integer @c Coord.
     __hostdev__ constexpr Vec3& operator+=(const Coord& ijk) noexcept {
         this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]); this->mVec[2] += T(ijk[2]);
         return *this;
     }
+    /// @brief In-place component-wise subtraction of an integer @c Coord.
     __hostdev__ constexpr Vec3& operator-=(const Coord& ijk) noexcept {
         this->mVec[0] -= T(ijk[0]); this->mVec[1] -= T(ijk[1]); this->mVec[2] -= T(ijk[2]);
         return *this;
     }
 
     // ---- scalar ----
+    /// @brief Component-wise multiply by scalar @a s.
     __hostdev__ [[nodiscard]] constexpr Vec3  operator*(const T& s) const noexcept   { return Base::template scale<Vec3>(s); }
+    /// @brief Component-wise divide by scalar @a s (integer-safe).
     __hostdev__ [[nodiscard]] constexpr Vec3  operator/(const T& s) const noexcept   { return Base::template divideBy<Vec3>(s); }
+    /// @brief In-place component-wise multiply by scalar @a s.
     __hostdev__ constexpr Vec3& operator*=(const T& s) noexcept        { Base::scaleAssign(s); return *this; }
+    /// @brief In-place component-wise divide by scalar @a s.
     __hostdev__ constexpr Vec3& operator/=(const T& s) noexcept        { Base::divideAssignScalar(s); return *this; }
-    // Not constexpr — depends on length() which calls std::sqrt.
+    /// @brief Normalize in place (divide by @c length()). Not @c constexpr — calls @c std::sqrt.
     __hostdev__ Vec3& normalize() noexcept                   { return (*this) /= this->length(); }
 
     // ---- equality ----
+    /// @brief Component-wise equality.
     __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec3& rhs) const noexcept { return Base::equals(rhs); }
+    /// @brief Component-wise inequality.
     __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec3& rhs) const noexcept { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
+    /// @brief Take the component-wise minimum of @c *this and @a other in place.
     __hostdev__ constexpr Vec3& minComponent(const Vec3& other) noexcept { Base::mergeMin(other); return *this; }
+    /// @brief Take the component-wise maximum of @c *this and @a other in place.
     __hostdev__ constexpr Vec3& maxComponent(const Vec3& other) noexcept { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
@@ -1791,11 +1988,14 @@ public:
 
     // ---- scalar * Vec / scalar / Vec (hidden friends — found only via ADL on Vec3,
     // never participate in unrelated namespace-scope overload sets) ----
+
+    /// @brief Scalar-on-the-left multiplication (hidden friend; found only via ADL on @c Vec3).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec3 operator*(T1 scalar, const Vec3& vec) noexcept
     {
         return Vec3(scalar * vec[0], scalar * vec[1], scalar * vec[2]);
     }
+    /// @brief Scalar-on-the-left division (hidden friend; found only via ADL on @c Vec3).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec3 operator/(T1 scalar, const Vec3& vec) noexcept
     {
@@ -1832,17 +2032,24 @@ public:
     using ValueType = T;
     static constexpr int size = 4; // openvdb::math::Tuple-compat alias of SIZE
 
+    /// @brief Default-construct (components are left uninitialized for fundamental @c T).
     Vec4() noexcept = default;
+    /// @brief Broadcast: set all four components to @a x.
     __hostdev__ explicit constexpr Vec4(T x) noexcept            : Base(x, x, x, x) {}
+    /// @brief Component-wise construction.
     __hostdev__ constexpr Vec4(T x, T y, T z, T w) noexcept      : Base(x, y, z, w) {}
 
+    /// @brief Explicit cross-precision conversion within nanovdb (e.g. @c Vec4d → @c Vec4f).
     template<typename T2>
     __hostdev__ explicit constexpr Vec4(const Vec4<T2>& v) noexcept : Base(v[0], v[1], v[2], v[3]) {}
+    /// @brief Cross-template converting ctor (e.g. from @c openvdb::Vec4). Implicit
+    /// to preserve foreign-type interop.
     template<template<class> class Vec4T, class T2>
     __hostdev__ explicit constexpr Vec4(const Vec4T<T2>& v) noexcept : Base(v[0], v[1], v[2], v[3])
     {
         static_assert(Vec4T<T2>::size == 4, "expected Vec4T::size==4!");
     }
+    /// @brief Assign from any 4-component vector type (foreign or nanovdb).
     template<template<class> class Vec4T, class T2>
     __hostdev__ constexpr Vec4& operator=(const Vec4T<T2>& rhs) noexcept {
         static_assert(Vec4T<T2>::size == 4, "expected Vec4T::size==4!");
@@ -1851,28 +2058,43 @@ public:
     }
 
     // ---- element-wise (Vec & Vec) ----
+    /// @brief Component-wise negation.
     __hostdev__ [[nodiscard]] constexpr Vec4  operator-() const noexcept             { return Base::template negate<Vec4>(); }
+    /// @brief Component-wise sum.
     __hostdev__ [[nodiscard]] constexpr Vec4  operator+(const Vec4& v) const noexcept { return Base::template plus<Vec4>(v); }
+    /// @brief Component-wise difference.
     __hostdev__ [[nodiscard]] constexpr Vec4  operator-(const Vec4& v) const noexcept { return Base::template minus<Vec4>(v); }
+    /// @brief Component-wise (Hadamard) product.
     __hostdev__ [[nodiscard]] constexpr Vec4  operator*(const Vec4& v) const noexcept { return Base::template mul<Vec4>(v); }
+    /// @brief Component-wise division.
     __hostdev__ [[nodiscard]] constexpr Vec4  operator/(const Vec4& v) const noexcept { return Base::template div<Vec4>(v); }
+    /// @brief In-place component-wise addition.
     __hostdev__ constexpr Vec4& operator+=(const Vec4& v) noexcept     { Base::addAssign(v); return *this; }
+    /// @brief In-place component-wise subtraction.
     __hostdev__ constexpr Vec4& operator-=(const Vec4& v) noexcept     { Base::subAssign(v); return *this; }
 
     // ---- scalar ----
+    /// @brief Component-wise multiply by scalar @a s.
     __hostdev__ [[nodiscard]] constexpr Vec4  operator*(const T& s) const noexcept   { return Base::template scale<Vec4>(s); }
+    /// @brief Component-wise divide by scalar @a s (integer-safe).
     __hostdev__ [[nodiscard]] constexpr Vec4  operator/(const T& s) const noexcept   { return Base::template divideBy<Vec4>(s); }
+    /// @brief In-place component-wise multiply by scalar @a s.
     __hostdev__ constexpr Vec4& operator*=(const T& s) noexcept        { Base::scaleAssign(s); return *this; }
+    /// @brief In-place component-wise divide by scalar @a s.
     __hostdev__ constexpr Vec4& operator/=(const T& s) noexcept        { Base::divideAssignScalar(s); return *this; }
-    // Not constexpr — depends on length() which calls std::sqrt.
+    /// @brief Normalize in place (divide by @c length()). Not @c constexpr — calls @c std::sqrt.
     __hostdev__ Vec4& normalize() noexcept                   { return (*this) /= this->length(); }
 
     // ---- equality ----
+    /// @brief Component-wise equality.
     __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec4& rhs) const noexcept { return Base::equals(rhs); }
+    /// @brief Component-wise inequality.
     __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec4& rhs) const noexcept { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
+    /// @brief Take the component-wise minimum of @c *this and @a other in place.
     __hostdev__ constexpr Vec4& minComponent(const Vec4& other) noexcept { Base::mergeMin(other); return *this; }
+    /// @brief Take the component-wise maximum of @c *this and @a other in place.
     __hostdev__ constexpr Vec4& maxComponent(const Vec4& other) noexcept { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
@@ -1895,11 +2117,14 @@ public:
 
     // ---- scalar * Vec / scalar / Vec (hidden friends — found only via ADL on Vec4,
     // never participate in unrelated namespace-scope overload sets) ----
+
+    /// @brief Scalar-on-the-left multiplication (hidden friend; found only via ADL on @c Vec4).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec4 operator*(T1 scalar, const Vec4& vec) noexcept
     {
         return Vec4(scalar * vec[0], scalar * vec[1], scalar * vec[2], scalar * vec[3]);
     }
+    /// @brief Scalar-on-the-left division (hidden friend; found only via ADL on @c Vec4).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec4 operator/(T1 scalar, const Vec4& vec) noexcept
     {
@@ -2024,6 +2249,9 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, con
                  x * mat[2] + y * mat[5] + z * mat[8]);
 }
 
+/// @brief Multiply the transpose of a 3x3 matrix by @a xyz and add @a vec (32-bit floats).
+/// @note Corresponds to an inverse affine transform: @c (mat^T x xyz) + @c vec.
+/// @tparam Vec3T Template type of the input and output 3d vectors
 template<typename Vec3T>
 __hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, const float* vec, const Vec3T& xyz) noexcept
 {
@@ -2035,6 +2263,9 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, cons
                  x * mat[2] + y * mat[5] + z * mat[8] + vec[2]);
 }
 
+/// @brief Multiply the transpose of a 3x3 matrix by @a xyz and add @a vec (64-bit floats).
+/// @note Corresponds to an inverse affine transform: @c (mat^T x xyz) + @c vec.
+/// @tparam Vec3T Template type of the input and output 3d vectors
 template<typename Vec3T>
 __hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, const double* vec, const Vec3T& xyz) noexcept
 {
@@ -2048,19 +2279,33 @@ __hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, con
 
 // ----------------------------> BBox <-------------------------------------
 
-// Base-class for static polymorphism (cannot be constructed directly)
+/// @brief Common base for floating-point and integer bounding boxes; not
+/// constructible directly (only as a base of @c BBox).
+/// @details Stores the closed-segment endpoints @c mCoord[0] (min corner) and
+/// @c mCoord[1] (max corner). Whether the box is "min-inclusive max-inclusive"
+/// or "min-inclusive max-exclusive" depends on the derived @c BBox
+/// specialization (integer vs floating point).
 template<typename Vec3T>
 struct BaseBBox
 {
     Vec3T                    mCoord[2];
+    /// @brief Equality on the two corner points.
     __hostdev__ [[nodiscard]] constexpr bool         operator==(const BaseBBox& rhs) const noexcept { return mCoord[0] == rhs.mCoord[0] && mCoord[1] == rhs.mCoord[1]; };
+    /// @brief Inequality on the two corner points.
     __hostdev__ [[nodiscard]] constexpr bool         operator!=(const BaseBBox& rhs) const noexcept { return mCoord[0] != rhs.mCoord[0] || mCoord[1] != rhs.mCoord[1]; };
+    /// @brief Indexed corner access: @a i = 0 returns min, @a i = 1 returns max.
     __hostdev__ constexpr const Vec3T& operator[](int i) const noexcept { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
+    /// @brief Mutable variant of @c operator[].
     __hostdev__ constexpr Vec3T&       operator[](int i) noexcept { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
+    /// @brief Mutable accessor for the min corner.
     __hostdev__ constexpr Vec3T&       min() noexcept { return mCoord[0]; }
+    /// @brief Mutable accessor for the max corner.
     __hostdev__ constexpr Vec3T&       max() noexcept { return mCoord[1]; }
+    /// @brief Const accessor for the min corner.
     __hostdev__ constexpr const Vec3T& min() const noexcept { return mCoord[0]; }
+    /// @brief Const accessor for the max corner.
     __hostdev__ constexpr const Vec3T& max() const noexcept { return mCoord[1]; }
+    /// @brief Translate (rigid-shift) both corners by @a xyz; return @c *this.
     __hostdev__ constexpr BaseBBox&    translate(const Vec3T& xyz) noexcept
     {
         mCoord[0] += xyz;
@@ -2095,6 +2340,8 @@ struct BaseBBox
 //    {
 //        return BaseBBox(mCoord[0].offsetBy(-padding),mCoord[1].offsetBy(padding));
 //    }
+    /// @brief Return @c true iff @a xyz lies in the closed box (each component
+    /// satisfies @c min[i] <= @c xyz[i] <= @c max[i]).
     __hostdev__ [[nodiscard]] constexpr bool isInside(const Vec3T& xyz) const noexcept
     {
         if (xyz[0] < mCoord[0][0] || xyz[1] < mCoord[0][1] || xyz[2] < mCoord[0][2])
@@ -2105,7 +2352,10 @@ struct BaseBBox
     }
 
 protected:
+    /// @brief Default-construct (leaves corners uninitialized — derived classes
+    /// supply a meaningful default).
     __hostdev__ constexpr BaseBBox() noexcept {}
+    /// @brief Construct from @a min and @a max corners directly.
     __hostdev__ constexpr BaseBBox(const Vec3T& min, const Vec3T& max) noexcept
         : mCoord{min, max}
     {
@@ -2133,31 +2383,41 @@ struct BBox<Vec3T, true> : public BaseBBox<Vec3T>
                 Vec3T(-Maximum<typename Vec3T::ValueType>::value()))
     {
     }
+    /// @brief Construct from explicit @a min / @a max corners.
     __hostdev__ constexpr BBox(const Vec3T& min, const Vec3T& max) noexcept
         : BaseT(min, max)
     {
     }
+    /// @brief Convert an integer @c Coord box into this floating-point box.
+    /// @note @c max is exclusive in the floating-point convention, so the
+    /// integer @c max corner is incremented by 1 before conversion.
     __hostdev__ constexpr BBox(const Coord& min, const Coord& max) noexcept
         : BaseT(Vec3T(ValueType(min[0]), ValueType(min[1]), ValueType(min[2])),
                 Vec3T(ValueType(max[0] + 1), ValueType(max[1] + 1), ValueType(max[2] + 1)))
     {
     }
+    /// @brief Return a cube-shaped @c BBox with min corner @a min and edge length @a dim.
     __hostdev__ [[nodiscard]] static constexpr BBox createCube(const Coord& min, typename Coord::ValueType dim) noexcept
     {
         return BBox(min, min.offsetBy(dim));
     }
 
+    /// @brief Construct from a @c BaseBBox<Coord>; delegates to the @c (min, @c max) ctor.
     __hostdev__ constexpr BBox(const BaseBBox<Coord>& bbox) noexcept
         : BBox(bbox[0], bbox[1])
     {
     }
+    /// @brief Return @c true if this bounding box is empty (max <= min in any axis).
     __hostdev__ [[nodiscard]] constexpr bool  empty() const noexcept { return mCoord[0][0] >= mCoord[1][0] ||
                                              mCoord[0][1] >= mCoord[1][1] ||
                                              mCoord[0][2] >= mCoord[1][2]; }
+    /// @brief Convert to bool: @c true iff this bounding box has positive volume.
     __hostdev__ [[nodiscard]] constexpr operator bool() const noexcept { return mCoord[0][0] < mCoord[1][0] &&
                                                mCoord[0][1] < mCoord[1][1] &&
                                                mCoord[0][2] < mCoord[1][2]; }
+    /// @brief Return @c max - @c min when non-empty, else the zero vector.
     __hostdev__ [[nodiscard]] constexpr Vec3T dim() const noexcept { return *this ? this->max() - this->min() : Vec3T(0); }
+    /// @brief Return @c true iff @a p is strictly inside the box (open interval — min is exclusive, max is exclusive).
     __hostdev__ [[nodiscard]] constexpr bool  isInside(const Vec3T& p) const noexcept
     {
         return p[0] > mCoord[0][0] && p[1] > mCoord[0][1] && p[2] > mCoord[0][2] &&
@@ -2184,16 +2444,19 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
         CoordT      mPos;
 
     public:
+        /// @brief Construct an iterator positioned at @c b.min().
         __hostdev__ constexpr Iterator(const BBox& b) noexcept
             : mBBox(b)
             , mPos(b.min())
         {
         }
+        /// @brief Construct an iterator positioned at the given @a p inside @a b.
         __hostdev__ constexpr Iterator(const BBox& b, const Coord& p) noexcept
             : mBBox(b)
             , mPos(p)
         {
         }
+        /// @brief Pre-increment: advance to the next coordinate in row-major z-fastest order.
         __hostdev__ constexpr Iterator& operator++() noexcept
         {
             if (mPos[2] < mBBox[1][2]) { // this is the most common case
@@ -2208,27 +2471,32 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
             }
             return *this;
         }
+        /// @brief Post-increment: advance to the next coordinate; return a copy of the previous state.
         __hostdev__ constexpr Iterator operator++(int) noexcept
         {
             auto tmp = *this;
             ++(*this);
             return tmp;
         }
+        /// @brief Iterator equality (asserts both iterators belong to the same @c BBox).
         __hostdev__ [[nodiscard]] constexpr bool operator==(const Iterator& rhs) const noexcept
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos == rhs.mPos;
         }
+        /// @brief Iterator inequality (asserts both iterators belong to the same @c BBox).
         __hostdev__ [[nodiscard]] constexpr bool operator!=(const Iterator& rhs) const noexcept
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos != rhs.mPos;
         }
+        /// @brief Lexicographic less-than over the underlying position.
         __hostdev__ [[nodiscard]] constexpr bool operator<(const Iterator& rhs) const noexcept
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos < rhs.mPos;
         }
+        /// @brief Lexicographic less-than-or-equal over the underlying position.
         __hostdev__ [[nodiscard]] constexpr bool operator<=(const Iterator& rhs) const noexcept
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
@@ -2236,19 +2504,29 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
         }
         /// @brief Return @c true if the iterator still points to a valid coordinate.
         __hostdev__ [[nodiscard]] constexpr operator bool() const noexcept { return mPos <= mBBox[1]; }
+        /// @brief Dereference to the current coordinate.
         __hostdev__ [[nodiscard]] constexpr const CoordT& operator*() const noexcept { return mPos; }
     }; // Iterator
+    /// @brief Iterator positioned at the min corner.
     __hostdev__ [[nodiscard]] constexpr Iterator begin() const noexcept { return Iterator{*this}; }
+    /// @brief One-past-the-end iterator (max corner shifted by one in @c x).
     __hostdev__ [[nodiscard]] constexpr Iterator end()   const noexcept { return Iterator{*this, CoordT(mCoord[1][0]+1, mCoord[0][1], mCoord[0][2])}; }
+    /// @brief Default construct an empty bbox (@c min = @c CoordT::max(), @c max = @c CoordT::min()).
     __hostdev__ constexpr BBox() noexcept
         : BaseT(CoordT::max(), CoordT::min())
     {
     }
+    /// @brief Construct from explicit @a min / @a max integer corners.
     __hostdev__ constexpr BBox(const CoordT& min, const CoordT& max) noexcept
         : BaseT(min, max)
     {
     }
 
+    /// @brief Splitting constructor (used by parallel range-based iteration).
+    /// @details Halves the box along its longest axis: @c other keeps the upper
+    /// half, the newly constructed @c BBox is the lower half. The @c SplitT tag
+    /// type is ignored; it exists so this overload doesn't collide with the
+    /// copy constructor.
     template<typename SplitT>
     __hostdev__ constexpr BBox(BBox& other, const SplitT&) noexcept
         : BaseT(other.mCoord[0], other.mCoord[1])
@@ -2259,16 +2537,20 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
         other.mCoord[0][n] = mCoord[1][n] + 1;
     }
 
+    /// @brief Return a cube-shaped @c BBox with min corner @a min and edge length @a dim.
+    /// @note Subtracts 1 from @a dim because the integer convention is min/max inclusive.
     __hostdev__ [[nodiscard]] static constexpr BBox createCube(const CoordT& min, typename CoordT::ValueType dim) noexcept
     {
         return BBox(min, min.offsetBy(dim - 1));
     }
 
+    /// @brief Return a cube-shaped @c BBox spanning @a min..@a max in every axis.
     __hostdev__ [[nodiscard]] static constexpr BBox createCube(typename CoordT::ValueType min, typename CoordT::ValueType max) noexcept
     {
         return BBox(CoordT(min), CoordT(max));
     }
 
+    /// @brief Return @c true iff the box has more than one cell along every axis.
     __hostdev__ [[nodiscard]] constexpr bool is_divisible() const noexcept { return mCoord[0][0] < mCoord[1][0] &&
                                                    mCoord[0][1] < mCoord[1][1] &&
                                                    mCoord[0][2] < mCoord[1][2]; }
@@ -2280,12 +2562,15 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
     __hostdev__ [[nodiscard]] constexpr operator bool() const noexcept { return mCoord[0][0] <= mCoord[1][0] &&
                                                mCoord[0][1] <= mCoord[1][1] &&
                                                mCoord[0][2] <= mCoord[1][2]; }
+    /// @brief Return the per-axis extent (max - min + 1 when non-empty, else 0).
     __hostdev__ [[nodiscard]] constexpr CoordT   dim() const noexcept { return *this ? this->max() - this->min() + Coord(1) : Coord(0); }
+    /// @brief Return the number of integer cells in the box, i.e. @c dim().x * @c dim().y * @c dim().z.
     __hostdev__ [[nodiscard]] constexpr uint64_t volume() const noexcept
     {
         auto d = this->dim();
         return uint64_t(d[0]) * uint64_t(d[1]) * uint64_t(d[2]);
     }
+    /// @brief Return @c true iff the integer coordinate @a p lies inside the closed box.
     __hostdev__ [[nodiscard]] constexpr bool isInside(const CoordT& p) const noexcept { return !(CoordT::lessThan(p, this->min()) || CoordT::lessThan(this->max(), p)); }
     /// @brief Return @c true if the given bounding box is inside this bounding box.
     __hostdev__ [[nodiscard]] constexpr bool isInside(const BBox& b) const noexcept
@@ -2313,7 +2598,7 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
         return BBox(mCoord[0].offsetBy(-padding), mCoord[1].offsetBy(padding));
     }
 
-    /// @brief  @brief transform this coordinate bounding box by the specified map
+    /// @brief Transform this coordinate bounding box by the specified map.
     /// @param map mapping of index to world coordinates
     /// @return world bounding box
     template<typename Map>
@@ -2333,18 +2618,21 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
     }
 
 #if defined(__CUDACC__) // the following functions only run on the GPU!
+    /// @brief Device-only: atomically expand the box to enclose the integer point @a ijk.
     __device__ inline BBox& expandAtomic(const CoordT& ijk) noexcept
     {
         mCoord[0].minComponentAtomic(ijk);
         mCoord[1].maxComponentAtomic(ijk);
         return *this;
     }
+    /// @brief Device-only: atomically expand the box to enclose another @a bbox.
     __device__ inline BBox& expandAtomic(const BBox& bbox) noexcept
     {
         mCoord[0].minComponentAtomic(bbox[0]);
         mCoord[1].maxComponentAtomic(bbox[1]);
         return *this;
     }
+    /// @brief Device-only: atomically intersect this box with @a bbox.
     __device__ inline BBox& intersectAtomic(const BBox& bbox) noexcept
     {
         mCoord[0].maxComponentAtomic(bbox[0]);
@@ -2397,7 +2685,7 @@ public:
     {
     }
 
-    /// @brief  @brief ctor where all channels are initialized to the same value
+    /// @brief Ctor where all channels are initialized to the same value.
     /// @note value should be in the range 0u to 255u
     explicit __hostdev__ constexpr Rgba8(uint8_t v) noexcept
         : mData{{v, v, v, v}}
@@ -2414,35 +2702,46 @@ public:
     {
     }
 
-    /// @brief Vec3f r,g,b ctor (alpha channel it set to 1)
+    /// @brief Construct from a @c Vec3<float> with rgb components (alpha set to opaque).
     /// @note all values should be in the range 0.0f to 1.0f
     __hostdev__ constexpr Rgba8(const Vec3<float>& rgb) noexcept
         : Rgba8(rgb[0], rgb[1], rgb[2])
     {
     }
 
-    /// @brief Vec4f r,g,b,a ctor
+    /// @brief Construct from a @c Vec4<float> with rgba components.
     /// @note all values should be in the range 0.0f to 1.0f
     __hostdev__ constexpr Rgba8(const Vec4<float>& rgba) noexcept
         : Rgba8(rgba[0], rgba[1], rgba[2], rgba[3])
     {
     }
 
+    /// @brief Compare on the 32-bit packed integer representation (lexicographic by byte).
     __hostdev__ [[nodiscard]] bool  operator< (const Rgba8& rhs) const noexcept { return mData.packed < rhs.mData.packed; }
+    /// @brief Equality on the 32-bit packed integer representation.
     __hostdev__ [[nodiscard]] bool  operator==(const Rgba8& rhs) const noexcept { return mData.packed == rhs.mData.packed; }
+    /// @brief Return the squared L2 length of the rgb channels in the [0, 1] range
+    /// (alpha is ignored). @c 0.0000153787005f is @c 1/255^2.
     __hostdev__ [[nodiscard]] constexpr float lengthSqr() const noexcept
     {
         return 0.0000153787005f * (float(mData.c[0]) * mData.c[0] +
                                    float(mData.c[1]) * mData.c[1] +
                                    float(mData.c[2]) * mData.c[2]); //1/255^2
     }
+    /// @brief L2 length of the rgb channels (alpha ignored). Not @c constexpr — calls @c sqrtf.
     __hostdev__ [[nodiscard]] float           length() const noexcept { return sqrtf(this->lengthSqr()); }
-    /// @brief return n'th color channel as a float in the range 0 to 1
+    /// @brief Return the @a n'th color channel as a float in the range 0 to 1.
     __hostdev__ [[nodiscard]] constexpr float           asFloat(int n) const noexcept { return 0.003921569f*float(mData.c[n]); }// divide by 255
+    /// @brief Indexed channel access. Asserts @c 0 <= @a n < 4 in debug builds.
     __hostdev__ constexpr const uint8_t&  operator[](int n) const noexcept { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
+    /// @brief Mutable variant of @c operator[].
     __hostdev__ constexpr uint8_t&        operator[](int n) noexcept { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
+    /// @brief Const access to the 32-bit packed integer representation.
     __hostdev__ const uint32_t& packed() const noexcept { return mData.packed; }
+    /// @brief Mutable access to the 32-bit packed integer representation.
     __hostdev__ uint32_t&       packed() noexcept { return mData.packed; }
+    //@{
+    /// @brief Named channel accessors (r, g, b, a). Both const and non-const variants.
     __hostdev__ constexpr const uint8_t&  r() const noexcept { return mData.c[0]; }
     __hostdev__ constexpr const uint8_t&  g() const noexcept { return mData.c[1]; }
     __hostdev__ constexpr const uint8_t&  b() const noexcept { return mData.c[2]; }
@@ -2451,9 +2750,12 @@ public:
     __hostdev__ constexpr uint8_t&        g() noexcept { return mData.c[1]; }
     __hostdev__ constexpr uint8_t&        b() noexcept { return mData.c[2]; }
     __hostdev__ constexpr uint8_t&        a() noexcept { return mData.c[3]; }
+    //@}
+    /// @brief Implicit conversion to a @c Vec3<float> with channels in [0, 1] (alpha dropped).
     __hostdev__ [[nodiscard]] constexpr           operator Vec3<float>() const noexcept {
         return Vec3<float>(this->asFloat(0), this->asFloat(1), this->asFloat(2));
     }
+    /// @brief Implicit conversion to a @c Vec4<float> with rgba channels in [0, 1].
     __hostdev__ [[nodiscard]] constexpr           operator Vec4<float>() const noexcept {
         return Vec4<float>(this->asFloat(0), this->asFloat(1), this->asFloat(2), this->asFloat(3));
     }

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -1131,18 +1131,20 @@ public:
     /// @return integer Coord2
     /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
     __hostdev__ [[nodiscard]] constexpr Coord2 round() const noexcept { return Base::template roundAs<Coord2>(); }
-}; // Vec2<T>
 
-template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec2<T2> operator*(T1 scalar, const Vec2<T2>& vec) noexcept
-{
-    return Vec2<T2>(scalar * vec[0], scalar * vec[1]);
-}
-template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec2<T2> operator/(T1 scalar, const Vec2<T2>& vec) noexcept
-{
-    return Vec2<T2>(scalar / vec[0], scalar / vec[1]);
-}
+    // ---- scalar * Vec / scalar / Vec (hidden friends — found only via ADL on Vec2,
+    // never participate in unrelated namespace-scope overload sets) ----
+    template<typename T1>
+    __hostdev__ [[nodiscard]] friend constexpr Vec2 operator*(T1 scalar, const Vec2& vec) noexcept
+    {
+        return Vec2(scalar * vec[0], scalar * vec[1]);
+    }
+    template<typename T1>
+    __hostdev__ [[nodiscard]] friend constexpr Vec2 operator/(T1 scalar, const Vec2& vec) noexcept
+    {
+        return Vec2(scalar / vec[0], scalar / vec[1]);
+    }
+}; // Vec2<T>
 
 /// @brief Return a single precision floating-point vector of this coordinate
 __hostdev__ [[nodiscard]] inline constexpr Vec2<float> Coord2::asVec2s() const noexcept
@@ -1382,6 +1384,11 @@ public:
         return Mat2<T>((*this)[1][1] * invDet, -(*this)[0][1] * invDet,
                       -(*this)[1][0] * invDet,  (*this)[0][0] * invDet);
     }
+
+    /// @brief scalar * Mat (hidden friend — found only via ADL on Mat2)
+    __hostdev__ [[nodiscard]] friend constexpr Mat2 operator*(const T& s, const Mat2& m) noexcept {
+        return m.template scale<Mat2>(s);
+    }
 };
 
 // Mat2x3 is intentionally NOT alignas-elevated: its byte size
@@ -1430,6 +1437,11 @@ public:
 
     /// @brief returns transpose of this
     __hostdev__ [[nodiscard]] constexpr Mat3x2<T> transpose() const noexcept { return this->template transposeAs<Mat3x2<T>>(); }
+
+    /// @brief scalar * Mat (hidden friend — found only via ADL on Mat2x3)
+    __hostdev__ [[nodiscard]] friend constexpr Mat2x3 operator*(const T& s, const Mat2x3& m) noexcept {
+        return m.template scale<Mat2x3>(s);
+    }
 };
 
 // Mat3x2 is intentionally NOT alignas-elevated: its byte size
@@ -1482,6 +1494,10 @@ public:
     /// @brief returns transpose of this
     __hostdev__ [[nodiscard]] constexpr Mat2x3<T> transpose() const noexcept { return this->template transposeAs<Mat2x3<T>>(); }
 
+    /// @brief scalar * Mat (hidden friend — found only via ADL on Mat3x2)
+    __hostdev__ [[nodiscard]] friend constexpr Mat3x2 operator*(const T& s, const Mat3x2& m) noexcept {
+        return m.template scale<Mat3x2>(s);
+    }
 };
 
 // Mat3 is intentionally NOT alignas-elevated: its byte size
@@ -1537,6 +1553,11 @@ public:
 
     /// @brief returns transpose of this
     __hostdev__ [[nodiscard]] constexpr Mat3 transpose() const noexcept { return this->template transposeAs<Mat3>(); }
+
+    /// @brief scalar * Mat (hidden friend — found only via ADL on Mat3)
+    __hostdev__ [[nodiscard]] friend constexpr Mat3 operator*(const T& s, const Mat3& m) noexcept {
+        return m.template scale<Mat3>(s);
+    }
 };
 
 // Aligned to 16*alignof(T) — Mat4 stores 16 elements (4x4), which is
@@ -1598,23 +1619,13 @@ public:
 
     /// @brief returns transpose of this
     __hostdev__ [[nodiscard]] constexpr Mat4 transpose() const noexcept { return this->template transposeAs<Mat4>(); }
+
+    /// @brief scalar * Mat (hidden friend — found only via ADL on Mat4)
+    __hostdev__ [[nodiscard]] friend constexpr Mat4 operator*(const T& s, const Mat4& m) noexcept {
+        return m.template scale<Mat4>(s);
+    }
 };
 
-/// @brief Multiply a scalar by a 2x2 matrix, result is a 2x2 matrix
-template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat2<T> operator*(const T& s, const Mat2<T>& m) noexcept { return m.template scale<Mat2<T>>(s); }
-/// @brief Multiply a scalar by a 2x3 matrix, result is a 2x3 matrix
-template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const T& s, const Mat2x3<T>& m) noexcept { return m.template scale<Mat2x3<T>>(s); }
-/// @brief Multiply a scalar by a 3x2 matrix, result is a 3x2 matrix
-template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const T& s, const Mat3x2<T>& m) noexcept { return m.template scale<Mat3x2<T>>(s); }
-/// @brief Multiply a scalar by a 3x3 matrix, result is a 3x3 matrix
-template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat3<T> operator*(const T& s, const Mat3<T>& m) noexcept { return m.template scale<Mat3<T>>(s); }
-/// @brief Multiply a scalar by a 4x4 matrix, result is a 4x4 matrix
-template<typename T>
-__hostdev__ [[nodiscard]] constexpr Mat4<T> operator*(const T& s, const Mat4<T>& m) noexcept { return m.template scale<Mat4<T>>(s); }
 
 /// @brief Multiply a 2x3 matrix by a 3x2 matrix, result is a 2x2 matrix
 template<typename T>
@@ -1761,18 +1772,20 @@ public:
                                this->mVec[1] * v[0], this->mVec[1] * v[1], this->mVec[1] * v[2],
                                this->mVec[2] * v[0], this->mVec[2] * v[1], this->mVec[2] * v[2]);
     }
-}; // Vec3<T>
 
-template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec3<T2> operator*(T1 scalar, const Vec3<T2>& vec) noexcept
-{
-    return Vec3<T2>(scalar * vec[0], scalar * vec[1], scalar * vec[2]);
-}
-template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec3<T2> operator/(T1 scalar, const Vec3<T2>& vec) noexcept
-{
-    return Vec3<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2]);
-}
+    // ---- scalar * Vec / scalar / Vec (hidden friends — found only via ADL on Vec3,
+    // never participate in unrelated namespace-scope overload sets) ----
+    template<typename T1>
+    __hostdev__ [[nodiscard]] friend constexpr Vec3 operator*(T1 scalar, const Vec3& vec) noexcept
+    {
+        return Vec3(scalar * vec[0], scalar * vec[1], scalar * vec[2]);
+    }
+    template<typename T1>
+    __hostdev__ [[nodiscard]] friend constexpr Vec3 operator/(T1 scalar, const Vec3& vec) noexcept
+    {
+        return Vec3(scalar / vec[0], scalar / vec[1], scalar / vec[2]);
+    }
+}; // Vec3<T>
 
 /// @brief Return a single precision floating-point vector of this coordinate
 __hostdev__ [[nodiscard]] inline constexpr Vec3<float> Coord::asVec3s() const noexcept
@@ -1865,18 +1878,20 @@ public:
     /// @return Vec4<int32_t>
     /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
     __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> round() const noexcept { return Base::template roundAs<Vec4<int32_t>>(); }
-}; // Vec4<T>
 
-template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec4<T2> operator*(T1 scalar, const Vec4<T2>& vec) noexcept
-{
-    return Vec4<T2>(scalar * vec[0], scalar * vec[1], scalar * vec[2], scalar * vec[3]);
-}
-template<typename T1, typename T2>
-__hostdev__ [[nodiscard]] inline constexpr Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec) noexcept
-{
-    return Vec4<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2], scalar / vec[3]);
-}
+    // ---- scalar * Vec / scalar / Vec (hidden friends — found only via ADL on Vec4,
+    // never participate in unrelated namespace-scope overload sets) ----
+    template<typename T1>
+    __hostdev__ [[nodiscard]] friend constexpr Vec4 operator*(T1 scalar, const Vec4& vec) noexcept
+    {
+        return Vec4(scalar * vec[0], scalar * vec[1], scalar * vec[2], scalar * vec[3]);
+    }
+    template<typename T1>
+    __hostdev__ [[nodiscard]] friend constexpr Vec4 operator/(T1 scalar, const Vec4& vec) noexcept
+    {
+        return Vec4(scalar / vec[0], scalar / vec[1], scalar / vec[2], scalar / vec[3]);
+    }
+}; // Vec4<T>
 // ----------------------------> matMult <--------------------------------------
 //
 // All six matMult / matMultT overloads were originally written with

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -60,12 +60,12 @@ struct Tolerance;
 template<>
 struct Tolerance<float>
 {
-    __hostdev__ static constexpr float value() { return 1e-8f; }
+    __hostdev__ [[nodiscard]] static constexpr float value() { return 1e-8f; }
 };
 template<>
 struct Tolerance<double>
 {
-    __hostdev__ static constexpr double value() { return 1e-15; }
+    __hostdev__ [[nodiscard]] static constexpr double value() { return 1e-15; }
 };
 //@}
 
@@ -76,12 +76,12 @@ struct Delta;
 template<>
 struct Delta<float>
 {
-    __hostdev__ static constexpr float value() { return 1e-5f; }
+    __hostdev__ [[nodiscard]] static constexpr float value() { return 1e-5f; }
 };
 template<>
 struct Delta<double>
 {
-    __hostdev__ static constexpr double value() { return 1e-9; }
+    __hostdev__ [[nodiscard]] static constexpr double value() { return 1e-9; }
 };
 //@}
 
@@ -93,181 +93,181 @@ struct Maximum;
 template<typename T>
 struct Maximum
 {
-    __hostdev__ static constexpr T value() { return ::cuda::std::numeric_limits<T>::max(); }
+    __hostdev__ [[nodiscard]] static constexpr T value() { return ::cuda::std::numeric_limits<T>::max(); }
 };
 #elif defined(__HIP__)
 template<>
 struct Maximum<int>
 {
-    __hostdev__ static constexpr int value() { return 2147483647; }
+    __hostdev__ [[nodiscard]] static constexpr int value() { return 2147483647; }
 };
 template<>
 struct Maximum<uint32_t>
 {
-    __hostdev__ static constexpr uint32_t value() { return 4294967295u; }
+    __hostdev__ [[nodiscard]] static constexpr uint32_t value() { return 4294967295u; }
 };
 template<>
 struct Maximum<float>
 {
-    __hostdev__ static constexpr float value() { return 1e+38f; }
+    __hostdev__ [[nodiscard]] static constexpr float value() { return 1e+38f; }
 };
 template<>
 struct Maximum<double>
 {
-    __hostdev__ static constexpr double value() { return 1e+308; }
+    __hostdev__ [[nodiscard]] static constexpr double value() { return 1e+308; }
 };
 #else
 template<typename T>
 struct Maximum
 {
-    static constexpr T value() { return std::numeric_limits<T>::max(); }
+    [[nodiscard]] static constexpr T value() { return std::numeric_limits<T>::max(); }
 };
 #endif
 //@}
 
 template<typename Type>
-__hostdev__ inline constexpr bool isApproxZero(const Type& x)
+__hostdev__ [[nodiscard]] inline constexpr bool isApproxZero(const Type& x)
 {
     return !(x > Tolerance<Type>::value()) && !(x < -Tolerance<Type>::value());
 }
 
 template<typename Type>
-__hostdev__ inline constexpr Type Min(Type a, Type b)
+__hostdev__ [[nodiscard]] inline constexpr Type Min(Type a, Type b)
 {
     return (a < b) ? a : b;
 }
-__hostdev__ inline constexpr int32_t Min(int32_t a, int32_t b)
+__hostdev__ [[nodiscard]] inline constexpr int32_t Min(int32_t a, int32_t b)
 {
     return a < b ? a : b;
 }
-__hostdev__ inline constexpr uint32_t Min(uint32_t a, uint32_t b)
+__hostdev__ [[nodiscard]] inline constexpr uint32_t Min(uint32_t a, uint32_t b)
 {
     return a < b ? a : b;
 }
 // Not constexpr — fminf/fmin aren't constexpr until C++23.
-__hostdev__ inline float Min(float a, float b)
+__hostdev__ [[nodiscard]] inline float Min(float a, float b)
 {
     return fminf(a, b);
 }
 // Not constexpr — fminf/fmin aren't constexpr until C++23.
-__hostdev__ inline double Min(double a, double b)
+__hostdev__ [[nodiscard]] inline double Min(double a, double b)
 {
     return fmin(a, b);
 }
 template<typename Type>
-__hostdev__ inline constexpr Type Max(Type a, Type b)
+__hostdev__ [[nodiscard]] inline constexpr Type Max(Type a, Type b)
 {
     return (a > b) ? a : b;
 }
 
-__hostdev__ inline constexpr int32_t Max(int32_t a, int32_t b)
+__hostdev__ [[nodiscard]] inline constexpr int32_t Max(int32_t a, int32_t b)
 {
     return a > b ? a : b;
 }
-__hostdev__ inline constexpr uint32_t Max(uint32_t a, uint32_t b)
+__hostdev__ [[nodiscard]] inline constexpr uint32_t Max(uint32_t a, uint32_t b)
 {
     return a > b ? a : b;
 }
 // Not constexpr — fmaxf/fmax aren't constexpr until C++23.
-__hostdev__ inline float Max(float a, float b)
+__hostdev__ [[nodiscard]] inline float Max(float a, float b)
 {
     return fmaxf(a, b);
 }
 // Not constexpr — fmaxf/fmax aren't constexpr until C++23.
-__hostdev__ inline double Max(double a, double b)
+__hostdev__ [[nodiscard]] inline double Max(double a, double b)
 {
     return fmax(a, b);
 }
 // Not constexpr — depends on non-constexpr float/double Min/Max overloads.
-__hostdev__ inline float Clamp(float x, float a, float b)
+__hostdev__ [[nodiscard]] inline float Clamp(float x, float a, float b)
 {
     return Max(Min(x, b), a);
 }
 // Not constexpr — depends on non-constexpr float/double Min/Max overloads.
-__hostdev__ inline double Clamp(double x, double a, double b)
+__hostdev__ [[nodiscard]] inline double Clamp(double x, double a, double b)
 {
     return Max(Min(x, b), a);
 }
 
-__hostdev__ inline float Fract(float x)
+__hostdev__ [[nodiscard]] inline float Fract(float x)
 {
     return x - floorf(x);
 }
-__hostdev__ inline double Fract(double x)
+__hostdev__ [[nodiscard]] inline double Fract(double x)
 {
     return x - floor(x);
 }
 
-__hostdev__ inline int32_t Floor(float x)
+__hostdev__ [[nodiscard]] inline int32_t Floor(float x)
 {
     return int32_t(floorf(x));
 }
-__hostdev__ inline int32_t Floor(double x)
+__hostdev__ [[nodiscard]] inline int32_t Floor(double x)
 {
     return int32_t(floor(x));
 }
 
-__hostdev__ inline int32_t Ceil(float x)
+__hostdev__ [[nodiscard]] inline int32_t Ceil(float x)
 {
     return int32_t(ceilf(x));
 }
-__hostdev__ inline int32_t Ceil(double x)
+__hostdev__ [[nodiscard]] inline int32_t Ceil(double x)
 {
     return int32_t(ceil(x));
 }
 
 template<typename T>
-__hostdev__ inline constexpr T Pow2(T x)
+__hostdev__ [[nodiscard]] inline constexpr T Pow2(T x)
 {
     return x * x;
 }
 
 template<typename T>
-__hostdev__ inline constexpr T Pow3(T x)
+__hostdev__ [[nodiscard]] inline constexpr T Pow3(T x)
 {
     return x * x * x;
 }
 
 template<typename T>
-__hostdev__ inline constexpr T Pow4(T x)
+__hostdev__ [[nodiscard]] inline constexpr T Pow4(T x)
 {
     return Pow2(x * x);
 }
 template<typename T>
-__hostdev__ inline constexpr T Abs(T x)
+__hostdev__ [[nodiscard]] inline constexpr T Abs(T x)
 {
     return x < 0 ? -x : x;
 }
 
 // Not constexpr — fabsf isn't constexpr until C++23.
 template<>
-__hostdev__ inline float Abs(float x)
+__hostdev__ [[nodiscard]] inline float Abs(float x)
 {
     return fabsf(x);
 }
 
 // Not constexpr — fabs isn't constexpr until C++23.
 template<>
-__hostdev__ inline double Abs(double x)
+__hostdev__ [[nodiscard]] inline double Abs(double x)
 {
     return fabs(x);
 }
 
 // Not constexpr — std::abs(int) isn't constexpr until C++23.
 template<>
-__hostdev__ inline int Abs(int x)
+__hostdev__ [[nodiscard]] inline int Abs(int x)
 {
     return abs(x);
 }
 
 template<typename CoordT, typename RealT, template<typename> class Vec3T>
-__hostdev__ inline CoordT Round(const Vec3T<RealT>& xyz);
+__hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<RealT>& xyz);
 
 /// @brief Round each component to its closest integer (round-half-toward-+inf)
 /// using @c floor(x+0.5). Same rule is applied to both single and double
 /// precision so float and double inputs yield the same integer coords.
 template<typename CoordT, template<typename> class Vec3T>
-__hostdev__ inline CoordT Round(const Vec3T<float>& xyz)
+__hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<float>& xyz)
 {
     return CoordT(int32_t(floorf(xyz[0] + 0.5f)),
                   int32_t(floorf(xyz[1] + 0.5f)),
@@ -275,7 +275,7 @@ __hostdev__ inline CoordT Round(const Vec3T<float>& xyz)
 }
 
 template<typename CoordT, template<typename> class Vec3T>
-__hostdev__ inline CoordT Round(const Vec3T<double>& xyz)
+__hostdev__ [[nodiscard]] inline CoordT Round(const Vec3T<double>& xyz)
 {
     return CoordT(int32_t(floor(xyz[0] + 0.5)),
                   int32_t(floor(xyz[1] + 0.5)),
@@ -283,18 +283,18 @@ __hostdev__ inline CoordT Round(const Vec3T<double>& xyz)
 }
 
 template<typename CoordT, typename RealT, template<typename> class Vec3T>
-__hostdev__ inline CoordT RoundDown(const Vec3T<RealT>& xyz)
+__hostdev__ [[nodiscard]] inline CoordT RoundDown(const Vec3T<RealT>& xyz)
 {
     return CoordT(Floor(xyz[0]), Floor(xyz[1]), Floor(xyz[2]));
 }
 
 //@{
 /// Return the square root of a floating-point value.
-__hostdev__ inline float Sqrt(float x)
+__hostdev__ [[nodiscard]] inline float Sqrt(float x)
 {
     return sqrtf(x);
 }
-__hostdev__ inline double Sqrt(double x)
+__hostdev__ [[nodiscard]] inline double Sqrt(double x)
 {
     return sqrt(x);
 }
@@ -302,13 +302,13 @@ __hostdev__ inline double Sqrt(double x)
 
 /// Return the sign of the given value as an integer (either -1, 0 or 1).
 template<typename T>
-__hostdev__ inline constexpr T Sign(const T& x)
+__hostdev__ [[nodiscard]] inline constexpr T Sign(const T& x)
 {
     return ((T(0) < x) ? T(1) : T(0)) - ((x < T(0)) ? T(1) : T(0));
 }
 
 template<typename Vec3T>
-__hostdev__ inline constexpr int MinIndex(const Vec3T& v)
+__hostdev__ [[nodiscard]] inline constexpr int MinIndex(const Vec3T& v)
 {
 #if 0
     static const int hashTable[8] = {2, 1, 9, 1, 2, 9, 0, 0}; //9 are dummy values
@@ -325,7 +325,7 @@ __hostdev__ inline constexpr int MinIndex(const Vec3T& v)
 }
 
 template<typename Vec3T>
-__hostdev__ inline constexpr int MaxIndex(const Vec3T& v)
+__hostdev__ [[nodiscard]] inline constexpr int MaxIndex(const Vec3T& v)
 {
 #if 0
     static const int hashTable[8] = {2, 1, 9, 1, 2, 9, 0, 0}; //9 are dummy values
@@ -345,7 +345,7 @@ __hostdev__ inline constexpr int MaxIndex(const Vec3T& v)
 ///
 /// @details both wordSize and byteSize are in byte units
 template<uint64_t wordSize>
-__hostdev__ inline constexpr uint64_t AlignUp(uint64_t byteCount)
+__hostdev__ [[nodiscard]] inline constexpr uint64_t AlignUp(uint64_t byteCount)
 {
     const uint64_t r = byteCount % wordSize;
     return r ? byteCount - r + wordSize : byteCount;
@@ -396,11 +396,11 @@ public:
     __hostdev__ constexpr int32_t& y() { return mVec[1]; }
     __hostdev__ constexpr int32_t& z() { return mVec[2]; }
 
-    __hostdev__ static constexpr Coord max() { return Coord(int32_t((1u << 31) - 1)); }
+    __hostdev__ [[nodiscard]] static constexpr Coord max() { return Coord(int32_t((1u << 31) - 1)); }
 
-    __hostdev__ static constexpr Coord min() { return Coord(-int32_t((1u << 31) - 1) - 1); }
+    __hostdev__ [[nodiscard]] static constexpr Coord min() { return Coord(-int32_t((1u << 31) - 1) - 1); }
 
-    __hostdev__ static constexpr size_t memUsage() { return sizeof(Coord); }
+    __hostdev__ [[nodiscard]] static constexpr size_t memUsage() { return sizeof(Coord); }
 
     /// @brief Return a const reference to the given Coord component.
     /// @warning The argument is assumed to be 0, 1, or 2.
@@ -422,16 +422,16 @@ public:
     }
 
     /// @brief Return a new instance with coordinates masked by the given unsigned integer.
-    __hostdev__ constexpr Coord operator&(IndexType n) const { return Coord(mVec[0] & n, mVec[1] & n, mVec[2] & n); }
+    __hostdev__ [[nodiscard]] constexpr Coord operator&(IndexType n) const { return Coord(mVec[0] & n, mVec[1] & n, mVec[2] & n); }
 
     // @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
-    __hostdev__ constexpr Coord operator<<(IndexType n) const { return Coord(mVec[0] << n, mVec[1] << n, mVec[2] << n); }
+    __hostdev__ [[nodiscard]] constexpr Coord operator<<(IndexType n) const { return Coord(mVec[0] << n, mVec[1] << n, mVec[2] << n); }
 
     // @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
-    __hostdev__ constexpr Coord operator>>(IndexType n) const { return Coord(mVec[0] >> n, mVec[1] >> n, mVec[2] >> n); }
+    __hostdev__ [[nodiscard]] constexpr Coord operator>>(IndexType n) const { return Coord(mVec[0] >> n, mVec[1] >> n, mVec[2] >> n); }
 
     /// @brief Return true if this Coord is lexicographically less than the given Coord.
-    __hostdev__ constexpr bool operator<(const Coord& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator<(const Coord& rhs) const
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -441,7 +441,7 @@ public:
     }
 
     /// @brief Return true if this Coord is lexicographically less or equal to the given Coord.
-    __hostdev__ constexpr bool operator<=(const Coord& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator<=(const Coord& rhs) const
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -451,7 +451,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater than the given Coord.
-    __hostdev__ constexpr bool operator>(const Coord& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator>(const Coord& rhs) const
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -461,7 +461,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
-    __hostdev__ constexpr bool operator>=(const Coord& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator>=(const Coord& rhs) const
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -471,8 +471,8 @@ public:
     }
 
     // @brief Return true if the Coord components are identical.
-    __hostdev__ constexpr bool   operator==(const Coord& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1] && mVec[2] == rhs[2]; }
-    __hostdev__ constexpr bool   operator!=(const Coord& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1] || mVec[2] != rhs[2]; }
+    __hostdev__ [[nodiscard]] constexpr bool   operator==(const Coord& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1] && mVec[2] == rhs[2]; }
+    __hostdev__ [[nodiscard]] constexpr bool   operator!=(const Coord& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1] || mVec[2] != rhs[2]; }
     __hostdev__ constexpr Coord& operator&=(int n)
     {
         mVec[0] &= n;
@@ -501,9 +501,9 @@ public:
         mVec[2] += n;
         return *this;
     }
-    __hostdev__ constexpr Coord  operator+(const Coord& rhs) const { return Coord(mVec[0] + rhs[0], mVec[1] + rhs[1], mVec[2] + rhs[2]); }
-    __hostdev__ constexpr Coord  operator-(const Coord& rhs) const { return Coord(mVec[0] - rhs[0], mVec[1] - rhs[1], mVec[2] - rhs[2]); }
-    __hostdev__ constexpr Coord  operator-() const { return Coord(-mVec[0], -mVec[1], -mVec[2]); }
+    __hostdev__ [[nodiscard]] constexpr Coord  operator+(const Coord& rhs) const { return Coord(mVec[0] + rhs[0], mVec[1] + rhs[1], mVec[2] + rhs[2]); }
+    __hostdev__ [[nodiscard]] constexpr Coord  operator-(const Coord& rhs) const { return Coord(mVec[0] - rhs[0], mVec[1] - rhs[1], mVec[2] - rhs[2]); }
+    __hostdev__ [[nodiscard]] constexpr Coord  operator-() const { return Coord(-mVec[0], -mVec[1], -mVec[2]); }
     __hostdev__ constexpr Coord& operator+=(const Coord& rhs)
     {
         mVec[0] += rhs[0];
@@ -559,16 +559,16 @@ public:
     }
 #endif
 
-    __hostdev__ constexpr Coord offsetBy(ValueType dx, ValueType dy, ValueType dz) const
+    __hostdev__ [[nodiscard]] constexpr Coord offsetBy(ValueType dx, ValueType dy, ValueType dz) const
     {
         return Coord(mVec[0] + dx, mVec[1] + dy, mVec[2] + dz);
     }
 
-    __hostdev__ constexpr Coord offsetBy(ValueType n) const { return this->offsetBy(n, n, n); }
+    __hostdev__ [[nodiscard]] constexpr Coord offsetBy(ValueType n) const { return this->offsetBy(n, n, n); }
 
     /// Return true if any of the components of @a a are smaller than the
     /// corresponding components of @a b.
-    __hostdev__ static inline constexpr bool lessThan(const Coord& a, const Coord& b)
+    __hostdev__ [[nodiscard]] static inline constexpr bool lessThan(const Coord& a, const Coord& b)
     {
         return (a[0] < b[0] || a[1] < b[1] || a[2] < b[2]);
     }
@@ -577,7 +577,7 @@ public:
     /// than @a xyz (node centered conversion).
     // Not constexpr — math::Floor uses floorf/floor which aren't constexpr until C++23.
     template<typename Vec3T>
-    __hostdev__ static Coord Floor(const Vec3T& xyz) { return Coord(math::Floor(xyz[0]), math::Floor(xyz[1]), math::Floor(xyz[2])); }
+    __hostdev__ [[nodiscard]] static Coord Floor(const Vec3T& xyz) { return Coord(math::Floor(xyz[0]), math::Floor(xyz[1]), math::Floor(xyz[2])); }
 
     /// @brief Return a hash key derived from the existing coordinates.
     /// @details The hash function is originally taken from the SIGGRAPH paper:
@@ -585,22 +585,22 @@ public:
     ///          and the prime numbers are modified based on the ACM Transactions on Graphics paper:
     ///          "Real-time 3D reconstruction at scale using voxel hashing" (the second number had a typo!)
     template<int Log2N = 3 + 4 + 5>
-    __hostdev__ constexpr uint32_t hash() const { return ((1 << Log2N) - 1) & (mVec[0] * 73856093 ^ mVec[1] * 19349669 ^ mVec[2] * 83492791); }
+    __hostdev__ [[nodiscard]] constexpr uint32_t hash() const { return ((1 << Log2N) - 1) & (mVec[0] * 73856093 ^ mVec[1] * 19349669 ^ mVec[2] * 83492791); }
 
     /// @brief Return the octant of this Coord
     //__hostdev__ size_t octant() const { return (uint32_t(mVec[0])>>31) | ((uint32_t(mVec[1])>>31)<<1) | ((uint32_t(mVec[2])>>31)<<2); }
-    __hostdev__ constexpr uint8_t octant() const { return (uint8_t(bool(mVec[0] & (1u << 31)))) |
+    __hostdev__ [[nodiscard]] constexpr uint8_t octant() const { return (uint8_t(bool(mVec[0] & (1u << 31)))) |
                                                 (uint8_t(bool(mVec[1] & (1u << 31))) << 1) |
                                                 (uint8_t(bool(mVec[2] & (1u << 31))) << 2); }
 
     /// @brief Return a single precision floating-point vector of this coordinate
-    __hostdev__ inline constexpr Vec3<float> asVec3s() const;
+    __hostdev__ [[nodiscard]] inline constexpr Vec3<float> asVec3s() const;
 
     /// @brief Return a double precision floating-point vector of this coordinate
-    __hostdev__ inline constexpr Vec3<double> asVec3d() const;
+    __hostdev__ [[nodiscard]] inline constexpr Vec3<double> asVec3d() const;
 
     // returns a copy of itself, so it mimics the behaviour of Vec3<T>::round()
-    __hostdev__ inline constexpr Coord round() const { return *this; }
+    __hostdev__ [[nodiscard]] inline constexpr Coord round() const { return *this; }
 }; // Coord class
 
 
@@ -648,11 +648,11 @@ public:
     __hostdev__ constexpr int32_t& x() { return mVec[0]; }
     __hostdev__ constexpr int32_t& y() { return mVec[1]; }
 
-    __hostdev__ static constexpr Coord2 max() { return Coord2(int32_t((1u << 31) - 1)); }
+    __hostdev__ [[nodiscard]] static constexpr Coord2 max() { return Coord2(int32_t((1u << 31) - 1)); }
 
-    __hostdev__ static constexpr Coord2 min() { return Coord2(-int32_t((1u << 31) - 1) - 1); }
+    __hostdev__ [[nodiscard]] static constexpr Coord2 min() { return Coord2(-int32_t((1u << 31) - 1) - 1); }
 
-    __hostdev__ static constexpr size_t memUsage() { return sizeof(Coord2); }
+    __hostdev__ [[nodiscard]] static constexpr size_t memUsage() { return sizeof(Coord2); }
 
     /// @brief Return a const reference to the given Coord component.
     /// @warning The argument is assumed to be 0 or 1,
@@ -673,16 +673,16 @@ public:
     }
 
     /// @brief Return a new instance with coordinates masked by the given unsigned integer.
-    __hostdev__ constexpr Coord2 operator&(IndexType n) const { return Coord2(mVec[0] & n, mVec[1] & n); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 operator&(IndexType n) const { return Coord2(mVec[0] & n, mVec[1] & n); }
 
     // @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
-    __hostdev__ constexpr Coord2 operator<<(IndexType n) const { return Coord2(mVec[0] << n, mVec[1] << n); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 operator<<(IndexType n) const { return Coord2(mVec[0] << n, mVec[1] << n); }
 
     // @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
-    __hostdev__ constexpr Coord2 operator>>(IndexType n) const { return Coord2(mVec[0] >> n, mVec[1] >> n); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 operator>>(IndexType n) const { return Coord2(mVec[0] >> n, mVec[1] >> n); }
 
     /// @brief Return true if this Coord is lexicographically less than the given Coord.
-    __hostdev__ constexpr bool operator<(const Coord2& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator<(const Coord2& rhs) const
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -690,7 +690,7 @@ public:
     }
 
     /// @brief Return true if this Coord is lexicographically less or equal to the given Coord.
-    __hostdev__ constexpr bool operator<=(const Coord2& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator<=(const Coord2& rhs) const
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -698,7 +698,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater than the given Coord.
-    __hostdev__ constexpr bool operator>(const Coord2& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator>(const Coord2& rhs) const
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -706,7 +706,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
-    __hostdev__ constexpr bool operator>=(const Coord2& rhs) const
+    __hostdev__ [[nodiscard]] constexpr bool operator>=(const Coord2& rhs) const
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -714,8 +714,8 @@ public:
     }
 
     // @brief Return true if the Coord components are identical.
-    __hostdev__ constexpr bool   operator==(const Coord2& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
-    __hostdev__ constexpr bool   operator!=(const Coord2& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
+    __hostdev__ [[nodiscard]] constexpr bool   operator==(const Coord2& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
+    __hostdev__ [[nodiscard]] constexpr bool   operator!=(const Coord2& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
     __hostdev__ constexpr Coord2& operator&=(int n)
     {
         mVec[0] &= n;
@@ -740,9 +740,9 @@ public:
         mVec[1] += n;
         return *this;
     }
-    __hostdev__ constexpr Coord2  operator+(const Coord2& rhs) const { return Coord2(mVec[0] + rhs[0], mVec[1] + rhs[1]); }
-    __hostdev__ constexpr Coord2  operator-(const Coord2& rhs) const { return Coord2(mVec[0] - rhs[0], mVec[1] - rhs[1]); }
-    __hostdev__ constexpr Coord2  operator-() const { return Coord2(-mVec[0], -mVec[1]); }
+    __hostdev__ [[nodiscard]] constexpr Coord2  operator+(const Coord2& rhs) const { return Coord2(mVec[0] + rhs[0], mVec[1] + rhs[1]); }
+    __hostdev__ [[nodiscard]] constexpr Coord2  operator-(const Coord2& rhs) const { return Coord2(mVec[0] - rhs[0], mVec[1] - rhs[1]); }
+    __hostdev__ [[nodiscard]] constexpr Coord2  operator-() const { return Coord2(-mVec[0], -mVec[1]); }
     __hostdev__ constexpr Coord2& operator+=(const Coord2& rhs)
     {
         mVec[0] += rhs[0];
@@ -790,16 +790,16 @@ public:
     }
 #endif
 
-    __hostdev__ constexpr Coord2 offsetBy(ValueType dx, ValueType dy) const
+    __hostdev__ [[nodiscard]] constexpr Coord2 offsetBy(ValueType dx, ValueType dy) const
     {
         return Coord2(mVec[0] + dx, mVec[1] + dy);
     }
 
-    __hostdev__ constexpr Coord2 offsetBy(ValueType n) const { return this->offsetBy(n, n); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 offsetBy(ValueType n) const { return this->offsetBy(n, n); }
 
     /// Return true if any of the components of @a a are smaller than the
     /// corresponding components of @a b.
-    __hostdev__ static inline constexpr bool lessThan(const Coord2& a, const Coord2& b)
+    __hostdev__ [[nodiscard]] static inline constexpr bool lessThan(const Coord2& a, const Coord2& b)
     {
         return (a[0] < b[0] || a[1] < b[1]);
     }
@@ -808,16 +808,16 @@ public:
     /// than @a xyz (node centered conversion).
     // Not constexpr — math::Floor uses floorf/floor which aren't constexpr until C++23.
     template<typename Vec2T>
-    __hostdev__ static Coord2 Floor(const Vec2T& xy) { return Coord2(math::Floor(xy[0]), math::Floor(xy[1])); }
+    __hostdev__ [[nodiscard]] static Coord2 Floor(const Vec2T& xy) { return Coord2(math::Floor(xy[0]), math::Floor(xy[1])); }
 
     /// @brief Return a single precision floating-point vector of this coordinate
-    __hostdev__ inline constexpr Vec2<float> asVec2s() const;
+    __hostdev__ [[nodiscard]] inline constexpr Vec2<float> asVec2s() const;
 
     /// @brief Return a double precision floating-point vector of this coordinate
-    __hostdev__ inline constexpr Vec2<double> asVec2d() const;
+    __hostdev__ [[nodiscard]] inline constexpr Vec2<double> asVec2d() const;
 
     // returns a copy of itself, so it mimics the behaviour of Vec3<T>::round()
-    __hostdev__ inline constexpr Coord2 round() const { return *this; }
+    __hostdev__ [[nodiscard]] inline constexpr Coord2 round() const { return *this; }
 }; // Coord2 class
 
 // ----------------------------> VecBase <-----------------------------------
@@ -862,37 +862,37 @@ public:
     // ---- generic element-wise helpers (taking/returning Derived) ----
 
     template<typename Derived>
-    __hostdev__ constexpr Derived plus(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived plus(const Derived& rhs) const {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] + rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ constexpr Derived minus(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived minus(const Derived& rhs) const {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] - rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ constexpr Derived mul(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived mul(const Derived& rhs) const {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] * rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ constexpr Derived div(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived div(const Derived& rhs) const {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] / rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ constexpr Derived negate() const {
+    __hostdev__ [[nodiscard]] constexpr Derived negate() const {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = -mVec[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ constexpr Derived scale(const T& s) const {
+    __hostdev__ [[nodiscard]] constexpr Derived scale(const T& s) const {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] * s;
         return out;
@@ -900,7 +900,7 @@ public:
     /// @brief return (*this) / @a s element-wise as a @c Derived. Uses per-element
     /// division (correct for integer @c T, unlike multiplying by 1/s).
     template<typename Derived>
-    __hostdev__ constexpr Derived divideBy(const T& s) const {
+    __hostdev__ [[nodiscard]] constexpr Derived divideBy(const T& s) const {
         Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] / s;
         return out;
@@ -933,7 +933,7 @@ public:
         return *this;
     }
 
-    __hostdev__ constexpr bool equals(const VecBase& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr bool equals(const VecBase& rhs) const {
         for (int i = 0; i < N; ++i) if (mVec[i] != rhs.mVec[i]) return false;
         return true;
     }
@@ -942,27 +942,27 @@ public:
 
     /// @brief dot product. @a V must have @c operator[] valid for 0..N-1.
     template<typename V>
-    __hostdev__ constexpr T dot(const V& v) const {
+    __hostdev__ [[nodiscard]] constexpr T dot(const V& v) const {
         T s = T(0);
         for (int i = 0; i < N; ++i) s += mVec[i] * v[i];
         return s;
     }
-    __hostdev__ constexpr T lengthSqr() const {
+    __hostdev__ [[nodiscard]] constexpr T lengthSqr() const {
         T s = T(0);
         for (int i = 0; i < N; ++i) s += mVec[i] * mVec[i];
         return s;
     }
     // Not constexpr — std::sqrt isn't constexpr until C++26.
-    __hostdev__ T length() const { return Sqrt(this->lengthSqr()); }
+    __hostdev__ [[nodiscard]] T length() const { return Sqrt(this->lengthSqr()); }
 
     /// @brief return the smallest of the N components
-    __hostdev__ constexpr T smallestComponent() const {
+    __hostdev__ [[nodiscard]] constexpr T smallestComponent() const {
         T m = mVec[0];
         for (int i = 1; i < N; ++i) if (mVec[i] < m) m = mVec[i];
         return m;
     }
     /// @brief return the largest of the N components
-    __hostdev__ constexpr T largestComponent() const {
+    __hostdev__ [[nodiscard]] constexpr T largestComponent() const {
         T m = mVec[0];
         for (int i = 1; i < N; ++i) if (mVec[i] > m) m = mVec[i];
         return m;
@@ -1000,7 +1000,7 @@ public:
     /// expression; the floating-point branch calls @c math::Floor /
     /// @c math::Ceil, which aren't constexpr until C++23.
     template<typename Result>
-    __hostdev__ constexpr Result floorAs() const {
+    __hostdev__ [[nodiscard]] constexpr Result floorAs() const {
         Result r{};
         if constexpr (std::is_floating_point<T>::value) {
             for (int i = 0; i < N; ++i) r[i] = math::Floor(mVec[i]);
@@ -1010,7 +1010,7 @@ public:
         return r;
     }
     template<typename Result>
-    __hostdev__ constexpr Result ceilAs() const {
+    __hostdev__ [[nodiscard]] constexpr Result ceilAs() const {
         Result r{};
         if constexpr (std::is_floating_point<T>::value) {
             for (int i = 0; i < N; ++i) r[i] = math::Ceil(mVec[i]);
@@ -1024,7 +1024,7 @@ public:
     /// float, double, and long double; pass-through for integer @c T.
     /// @note See @c floorAs — only the integer-@c T branch is constexpr-usable.
     template<typename Result>
-    __hostdev__ constexpr Result roundAs() const {
+    __hostdev__ [[nodiscard]] constexpr Result roundAs() const {
         Result r{};
         if constexpr (std::is_floating_point<T>::value) {
             const T half = T(0.5);
@@ -1078,17 +1078,17 @@ public:
     }
 
     // ---- element-wise (Vec & Vec) ----
-    __hostdev__ constexpr Vec2  operator-() const            { return Base::template negate<Vec2>(); }
-    __hostdev__ constexpr Vec2  operator+(const Vec2& v) const { return Base::template plus<Vec2>(v); }
-    __hostdev__ constexpr Vec2  operator-(const Vec2& v) const { return Base::template minus<Vec2>(v); }
-    __hostdev__ constexpr Vec2  operator*(const Vec2& v) const { return Base::template mul<Vec2>(v); }
-    __hostdev__ constexpr Vec2  operator/(const Vec2& v) const { return Base::template div<Vec2>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator-() const            { return Base::template negate<Vec2>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator+(const Vec2& v) const { return Base::template plus<Vec2>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator-(const Vec2& v) const { return Base::template minus<Vec2>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator*(const Vec2& v) const { return Base::template mul<Vec2>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator/(const Vec2& v) const { return Base::template div<Vec2>(v); }
     __hostdev__ constexpr Vec2& operator+=(const Vec2& v)    { Base::addAssign(v); return *this; }
     __hostdev__ constexpr Vec2& operator-=(const Vec2& v)    { Base::subAssign(v); return *this; }
 
     // ---- mixed Vec2 / Coord2 ----
-    __hostdev__ constexpr Vec2  operator+(const Coord2& ijk) const { return Vec2(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1]); }
-    __hostdev__ constexpr Vec2  operator-(const Coord2& ijk) const { return Vec2(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1]); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator+(const Coord2& ijk) const { return Vec2(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1]); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator-(const Coord2& ijk) const { return Vec2(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1]); }
     __hostdev__ constexpr Vec2& operator+=(const Coord2& ijk) {
         this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]);
         return *this;
@@ -1099,59 +1099,59 @@ public:
     }
 
     // ---- scalar ----
-    __hostdev__ constexpr Vec2  operator*(const T& s) const  { return Base::template scale<Vec2>(s); }
-    __hostdev__ constexpr Vec2  operator/(const T& s) const  { return Base::template divideBy<Vec2>(s); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator*(const T& s) const  { return Base::template scale<Vec2>(s); }
+    __hostdev__ [[nodiscard]] constexpr Vec2  operator/(const T& s) const  { return Base::template divideBy<Vec2>(s); }
     __hostdev__ constexpr Vec2& operator*=(const T& s)       { Base::scaleAssign(s); return *this; }
     __hostdev__ constexpr Vec2& operator/=(const T& s)       { Base::divideAssignScalar(s); return *this; }
     // Not constexpr — depends on length() which calls std::sqrt.
     __hostdev__ Vec2& normalize()                  { return (*this) /= this->length(); }
 
     // ---- equality ----
-    __hostdev__ constexpr bool operator==(const Vec2& rhs) const { return Base::equals(rhs); }
-    __hostdev__ constexpr bool operator!=(const Vec2& rhs) const { return !Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec2& rhs) const { return Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec2& rhs) const { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
     __hostdev__ constexpr Vec2& minComponent(const Vec2& other) { Base::mergeMin(other); return *this; }
     __hostdev__ constexpr Vec2& maxComponent(const Vec2& other) { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
-    __hostdev__ constexpr ValueType min() const { return Base::smallestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType min() const { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ constexpr ValueType max() const { return Base::largestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType max() const { return Base::largestComponent(); }
 
     /// @brief Round each component down (toward negative infinity)
     /// @return integer Coord2
     /// @note Only constexpr for integer @c T (floorAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ constexpr Coord2 floor() const { return Base::template floorAs<Coord2>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 floor() const { return Base::template floorAs<Coord2>(); }
     /// @brief Round each component up (toward positive infinity)
     /// @return integer Coord2
     /// @note Only constexpr for integer @c T (ceilAs uses non-constexpr math::Ceil for floating point).
-    __hostdev__ constexpr Coord2 ceil()  const { return Base::template ceilAs<Coord2>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 ceil()  const { return Base::template ceilAs<Coord2>(); }
     /// @brief Round each component to its closest integer value
     /// @return integer Coord2
     /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ constexpr Coord2 round() const { return Base::template roundAs<Coord2>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord2 round() const { return Base::template roundAs<Coord2>(); }
 }; // Vec2<T>
 
 template<typename T1, typename T2>
-__hostdev__ inline constexpr Vec2<T2> operator*(T1 scalar, const Vec2<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec2<T2> operator*(T1 scalar, const Vec2<T2>& vec)
 {
     return Vec2<T2>(scalar * vec[0], scalar * vec[1]);
 }
 template<typename T1, typename T2>
-__hostdev__ inline constexpr Vec2<T2> operator/(T1 scalar, const Vec2<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec2<T2> operator/(T1 scalar, const Vec2<T2>& vec)
 {
     return Vec2<T2>(scalar / vec[0], scalar / vec[1]);
 }
 
 /// @brief Return a single precision floating-point vector of this coordinate
-__hostdev__ inline constexpr Vec2<float> Coord2::asVec2s() const
+__hostdev__ [[nodiscard]] inline constexpr Vec2<float> Coord2::asVec2s() const
 {
     return Vec2<float>(float(mVec[0]), float(mVec[1]));
 }
 
 /// @brief Return a double precision floating-point vector of this coordinate
-__hostdev__ inline constexpr Vec2<double> Coord2::asVec2d() const
+__hostdev__ [[nodiscard]] inline constexpr Vec2<double> Coord2::asVec2d() const
 {
     return Vec2<double>(double(mVec[0]), double(mVec[1]));
 }
@@ -1166,9 +1166,9 @@ protected:
 public:
     using ValueType = T;
 
-    static constexpr int rows() { return ROWS; }
-    static constexpr int cols() { return COLS; }
-    static constexpr int size() { return ROWS * COLS; }
+    [[nodiscard]] static constexpr int rows() { return ROWS; }
+    [[nodiscard]] static constexpr int cols() { return COLS; }
+    [[nodiscard]] static constexpr int size() { return ROWS * COLS; }
 
     MatBase() = default;
 
@@ -1199,7 +1199,7 @@ public:
 
     /// @brief return @c *this + @a rhs as a @c Derived
     template<typename Derived>
-    __hostdev__ constexpr Derived plus(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived plus(const Derived& rhs) const {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] + rhs.data()[i];
         return out;
@@ -1207,7 +1207,7 @@ public:
 
     /// @brief return @c *this - @a rhs as a @c Derived
     template<typename Derived>
-    __hostdev__ constexpr Derived minus(const Derived& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Derived minus(const Derived& rhs) const {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] - rhs.data()[i];
         return out;
@@ -1215,7 +1215,7 @@ public:
 
     /// @brief return -(*this) as a @c Derived
     template<typename Derived>
-    __hostdev__ constexpr Derived negate() const {
+    __hostdev__ [[nodiscard]] constexpr Derived negate() const {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = -mData[i];
         return out;
@@ -1223,7 +1223,7 @@ public:
 
     /// @brief return @a s * (*this) as a @c Derived
     template<typename Derived>
-    __hostdev__ constexpr Derived scale(const T& s) const {
+    __hostdev__ [[nodiscard]] constexpr Derived scale(const T& s) const {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] * s;
         return out;
@@ -1245,7 +1245,7 @@ public:
     /// @brief return (*this) / @a s element-wise as a @c Derived. Uses
     /// per-element division (correct for integer @c T, unlike multiplying by 1/s).
     template<typename Derived>
-    __hostdev__ constexpr Derived divideBy(const T& s) const {
+    __hostdev__ [[nodiscard]] constexpr Derived divideBy(const T& s) const {
         Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] / s;
         return out;
@@ -1255,7 +1255,7 @@ public:
         return *this;
     }
 
-    __hostdev__ constexpr bool equals(const MatBase& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr bool equals(const MatBase& rhs) const {
         for (int i = 0; i < size(); ++i) if (mData[i] != rhs.mData[i]) return false;
         return true;
     }
@@ -1265,7 +1265,7 @@ public:
     /// @brief return the transpose of @c *this as the @c Result type.
     /// @tparam Result a matrix type whose dimensions are (COLS, ROWS)
     template<typename Result>
-    __hostdev__ constexpr Result transposeAs() const {
+    __hostdev__ [[nodiscard]] constexpr Result transposeAs() const {
         static_assert(Result::rows() == COLS && Result::cols() == ROWS,
                       "transposeAs: result dims must be (COLS, ROWS)");
         Result r{};
@@ -1281,7 +1281,7 @@ public:
     /// @tparam Result a matrix type whose dimensions are (ROWS, Rhs::cols())
     /// @tparam Rhs    a matrix type whose row count equals @c COLS
     template<typename Result, typename Rhs>
-    __hostdev__ constexpr Result multiply(const Rhs& rhs) const {
+    __hostdev__ [[nodiscard]] constexpr Result multiply(const Rhs& rhs) const {
         static_assert(COLS == Rhs::rows(), "multiply: lhs.cols must equal rhs.rows");
         static_assert(Result::rows() == ROWS && Result::cols() == Rhs::cols(),
                       "multiply: result dims mismatch");
@@ -1303,7 +1303,7 @@ public:
     /// @tparam VecResult a vector type whose @c SIZE equals @c ROWS
     /// @tparam VecRhs    a vector type whose @c SIZE equals @c COLS
     template<typename VecResult, typename VecRhs>
-    __hostdev__ constexpr VecResult multiplyVec(const VecRhs& v) const {
+    __hostdev__ [[nodiscard]] constexpr VecResult multiplyVec(const VecRhs& v) const {
         static_assert(VecRhs::SIZE == COLS && VecResult::SIZE == ROWS,
                       "multiplyVec: dim mismatch");
         VecResult r{};
@@ -1349,31 +1349,31 @@ public:
     __hostdev__ constexpr Mat2(Source* array) : Base(array) {}
 
     // ---- element-wise ----
-    __hostdev__ constexpr Mat2  operator-() const                  { return this->template negate<Mat2>(); }
-    __hostdev__ constexpr Mat2  operator+(const Mat2& m) const     { return this->template plus<Mat2>(m); }
-    __hostdev__ constexpr Mat2  operator-(const Mat2& m) const     { return this->template minus<Mat2>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator-() const                  { return this->template negate<Mat2>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator+(const Mat2& m) const     { return this->template plus<Mat2>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator-(const Mat2& m) const     { return this->template minus<Mat2>(m); }
     __hostdev__ constexpr Mat2& operator+=(const Mat2& m)          { Base::addAssign(m); return *this; }
     __hostdev__ constexpr Mat2& operator-=(const Mat2& m)          { Base::subAssign(m); return *this; }
 
     // ---- matrix * matrix / matrix * vector ----
-    __hostdev__ constexpr Mat2     operator*(const Mat2& m) const     { return this->template multiply<Mat2, Mat2>(m); }
-    __hostdev__ constexpr Vec2<T>  operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec2<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Mat2     operator*(const Mat2& m) const     { return this->template multiply<Mat2, Mat2>(m); }
+    __hostdev__ [[nodiscard]] constexpr Vec2<T>  operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec2<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ constexpr Mat2  operator*(const T& s) const        { return this->template scale<Mat2>(s); }
-    __hostdev__ constexpr Mat2  operator/(const T& s) const        { return this->template divideBy<Mat2>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator*(const T& s) const        { return this->template scale<Mat2>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat2  operator/(const T& s) const        { return this->template divideBy<Mat2>(s); }
     __hostdev__ constexpr Mat2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
     __hostdev__ constexpr Mat2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ constexpr bool operator==(const Mat2& m) const     { return Base::equals(m); }
-    __hostdev__ constexpr bool operator!=(const Mat2& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat2& m) const     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat2& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ constexpr Mat2 transpose() const { return this->template transposeAs<Mat2>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat2 transpose() const { return this->template transposeAs<Mat2>(); }
 
     /// @brief returns inverse of this
-    __hostdev__ constexpr Mat2<T> inverse() const {
+    __hostdev__ [[nodiscard]] constexpr Mat2<T> inverse() const {
         T det = (*this)[0][0] * (*this)[1][1] - (*this)[0][1] * (*this)[1][0];
         if (isApproxZero(det)) {
             return Mat2<T>(T(0), T(0), T(0), T(0));
@@ -1409,27 +1409,27 @@ public:
 
 
     // ---- element-wise ----
-    __hostdev__ constexpr Mat2x3  operator-() const                  { return this->template negate<Mat2x3>(); }
-    __hostdev__ constexpr Mat2x3  operator+(const Mat2x3& m) const   { return this->template plus<Mat2x3>(m); }
-    __hostdev__ constexpr Mat2x3  operator-(const Mat2x3& m) const   { return this->template minus<Mat2x3>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator-() const                  { return this->template negate<Mat2x3>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator+(const Mat2x3& m) const   { return this->template plus<Mat2x3>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator-(const Mat2x3& m) const   { return this->template minus<Mat2x3>(m); }
     __hostdev__ constexpr Mat2x3& operator+=(const Mat2x3& m)        { Base::addAssign(m); return *this; }
     __hostdev__ constexpr Mat2x3& operator-=(const Mat2x3& m)        { Base::subAssign(m); return *this; }
 
     // ---- matrix * vector ----
-    __hostdev__ constexpr Vec2<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec3<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec2<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec3<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ constexpr Mat2x3  operator*(const T& s) const        { return this->template scale<Mat2x3>(s); }
-    __hostdev__ constexpr Mat2x3  operator/(const T& s) const        { return this->template divideBy<Mat2x3>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator*(const T& s) const        { return this->template scale<Mat2x3>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3  operator/(const T& s) const        { return this->template divideBy<Mat2x3>(s); }
     __hostdev__ constexpr Mat2x3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
     __hostdev__ constexpr Mat2x3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ constexpr bool operator==(const Mat2x3& m) const     { return Base::equals(m); }
-    __hostdev__ constexpr bool operator!=(const Mat2x3& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat2x3& m) const     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat2x3& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ constexpr Mat3x2<T> transpose() const { return this->template transposeAs<Mat3x2<T>>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2<T> transpose() const { return this->template transposeAs<Mat3x2<T>>(); }
 };
 
 // Mat3x2 is intentionally NOT alignas-elevated: its byte size
@@ -1460,27 +1460,27 @@ public:
     __hostdev__ constexpr Mat3x2(Source *a): Base(a) {}
 
     // ---- element-wise ----
-    __hostdev__ constexpr Mat3x2  operator-() const                  { return this->template negate<Mat3x2>(); }
-    __hostdev__ constexpr Mat3x2  operator+(const Mat3x2& m) const   { return this->template plus<Mat3x2>(m); }
-    __hostdev__ constexpr Mat3x2  operator-(const Mat3x2& m) const   { return this->template minus<Mat3x2>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator-() const                  { return this->template negate<Mat3x2>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator+(const Mat3x2& m) const   { return this->template plus<Mat3x2>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator-(const Mat3x2& m) const   { return this->template minus<Mat3x2>(m); }
     __hostdev__ constexpr Mat3x2& operator+=(const Mat3x2& m)        { Base::addAssign(m); return *this; }
     __hostdev__ constexpr Mat3x2& operator-=(const Mat3x2& m)        { Base::subAssign(m); return *this; }
 
     // ---- matrix * vector ----
-    __hostdev__ constexpr Vec3<T> operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec2<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec3<T> operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec2<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ constexpr Mat3x2  operator*(const T& s) const        { return this->template scale<Mat3x2>(s); }
-    __hostdev__ constexpr Mat3x2  operator/(const T& s) const        { return this->template divideBy<Mat3x2>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator*(const T& s) const        { return this->template scale<Mat3x2>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat3x2  operator/(const T& s) const        { return this->template divideBy<Mat3x2>(s); }
     __hostdev__ constexpr Mat3x2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
     __hostdev__ constexpr Mat3x2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ constexpr bool operator==(const Mat3x2& m) const     { return Base::equals(m); }
-    __hostdev__ constexpr bool operator!=(const Mat3x2& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat3x2& m) const     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat3x2& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ constexpr Mat2x3<T> transpose() const { return this->template transposeAs<Mat2x3<T>>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat2x3<T> transpose() const { return this->template transposeAs<Mat2x3<T>>(); }
 
 };
 
@@ -1515,28 +1515,28 @@ public:
 
 
     // ---- element-wise ----
-    __hostdev__ constexpr Mat3  operator-() const                  { return this->template negate<Mat3>(); }
-    __hostdev__ constexpr Mat3  operator+(const Mat3& m) const     { return this->template plus<Mat3>(m); }
-    __hostdev__ constexpr Mat3  operator-(const Mat3& m) const     { return this->template minus<Mat3>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator-() const                  { return this->template negate<Mat3>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator+(const Mat3& m) const     { return this->template plus<Mat3>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator-(const Mat3& m) const     { return this->template minus<Mat3>(m); }
     __hostdev__ constexpr Mat3& operator+=(const Mat3& m)          { Base::addAssign(m); return *this; }
     __hostdev__ constexpr Mat3& operator-=(const Mat3& m)          { Base::subAssign(m); return *this; }
 
     // ---- matrix * matrix / matrix * vector ----
-    __hostdev__ constexpr Mat3    operator*(const Mat3& m) const     { return this->template multiply<Mat3, Mat3>(m); }
-    __hostdev__ constexpr Vec3<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec3<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Mat3    operator*(const Mat3& m) const     { return this->template multiply<Mat3, Mat3>(m); }
+    __hostdev__ [[nodiscard]] constexpr Vec3<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec3<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ constexpr Mat3  operator*(const T& s) const        { return this->template scale<Mat3>(s); }
-    __hostdev__ constexpr Mat3  operator/(const T& s) const        { return this->template divideBy<Mat3>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator*(const T& s) const        { return this->template scale<Mat3>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat3  operator/(const T& s) const        { return this->template divideBy<Mat3>(s); }
     __hostdev__ constexpr Mat3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
     __hostdev__ constexpr Mat3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ constexpr bool operator==(const Mat3& m) const     { return Base::equals(m); }
-    __hostdev__ constexpr bool operator!=(const Mat3& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat3& m) const     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat3& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ constexpr Mat3 transpose() const { return this->template transposeAs<Mat3>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat3 transpose() const { return this->template transposeAs<Mat3>(); }
 };
 
 // Aligned to 16*alignof(T) — Mat4 stores 16 elements (4x4), which is
@@ -1576,74 +1576,74 @@ public:
     __hostdev__ constexpr Mat4(Source *a): Base(a) {}
 
     // ---- element-wise ----
-    __hostdev__ constexpr Mat4  operator-() const                  { return this->template negate<Mat4>(); }
-    __hostdev__ constexpr Mat4  operator+(const Mat4& m) const     { return this->template plus<Mat4>(m); }
-    __hostdev__ constexpr Mat4  operator-(const Mat4& m) const     { return this->template minus<Mat4>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator-() const                  { return this->template negate<Mat4>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator+(const Mat4& m) const     { return this->template plus<Mat4>(m); }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator-(const Mat4& m) const     { return this->template minus<Mat4>(m); }
     __hostdev__ constexpr Mat4& operator+=(const Mat4& m)          { Base::addAssign(m); return *this; }
     __hostdev__ constexpr Mat4& operator-=(const Mat4& m)          { Base::subAssign(m); return *this; }
 
     // ---- matrix * matrix / matrix * vector ----
-    __hostdev__ constexpr Mat4    operator*(const Mat4& m) const     { return this->template multiply<Mat4, Mat4>(m); }
-    __hostdev__ constexpr Vec4<T> operator*(const Vec4<T>& v) const  { return this->template multiplyVec<Vec4<T>, Vec4<T>>(v); }
+    __hostdev__ [[nodiscard]] constexpr Mat4    operator*(const Mat4& m) const     { return this->template multiply<Mat4, Mat4>(m); }
+    __hostdev__ [[nodiscard]] constexpr Vec4<T> operator*(const Vec4<T>& v) const  { return this->template multiplyVec<Vec4<T>, Vec4<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ constexpr Mat4  operator*(const T& s) const        { return this->template scale<Mat4>(s); }
-    __hostdev__ constexpr Mat4  operator/(const T& s) const        { return this->template divideBy<Mat4>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator*(const T& s) const        { return this->template scale<Mat4>(s); }
+    __hostdev__ [[nodiscard]] constexpr Mat4  operator/(const T& s) const        { return this->template divideBy<Mat4>(s); }
     __hostdev__ constexpr Mat4& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
     __hostdev__ constexpr Mat4& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ constexpr bool operator==(const Mat4& m) const     { return Base::equals(m); }
-    __hostdev__ constexpr bool operator!=(const Mat4& m) const     { return !Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat4& m) const     { return Base::equals(m); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Mat4& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ constexpr Mat4 transpose() const { return this->template transposeAs<Mat4>(); }
+    __hostdev__ [[nodiscard]] constexpr Mat4 transpose() const { return this->template transposeAs<Mat4>(); }
 };
 
 /// @brief Multiply a scalar by a 2x2 matrix, result is a 2x2 matrix
 template<typename T>
-__hostdev__ constexpr Mat2<T> operator*(const T& s, const Mat2<T>& m) { return m.template scale<Mat2<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat2<T> operator*(const T& s, const Mat2<T>& m) { return m.template scale<Mat2<T>>(s); }
 /// @brief Multiply a scalar by a 2x3 matrix, result is a 2x3 matrix
 template<typename T>
-__hostdev__ constexpr Mat2x3<T> operator*(const T& s, const Mat2x3<T>& m) { return m.template scale<Mat2x3<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const T& s, const Mat2x3<T>& m) { return m.template scale<Mat2x3<T>>(s); }
 /// @brief Multiply a scalar by a 3x2 matrix, result is a 3x2 matrix
 template<typename T>
-__hostdev__ constexpr Mat3x2<T> operator*(const T& s, const Mat3x2<T>& m) { return m.template scale<Mat3x2<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const T& s, const Mat3x2<T>& m) { return m.template scale<Mat3x2<T>>(s); }
 /// @brief Multiply a scalar by a 3x3 matrix, result is a 3x3 matrix
 template<typename T>
-__hostdev__ constexpr Mat3<T> operator*(const T& s, const Mat3<T>& m) { return m.template scale<Mat3<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat3<T> operator*(const T& s, const Mat3<T>& m) { return m.template scale<Mat3<T>>(s); }
 /// @brief Multiply a scalar by a 4x4 matrix, result is a 4x4 matrix
 template<typename T>
-__hostdev__ constexpr Mat4<T> operator*(const T& s, const Mat4<T>& m) { return m.template scale<Mat4<T>>(s); }
+__hostdev__ [[nodiscard]] constexpr Mat4<T> operator*(const T& s, const Mat4<T>& m) { return m.template scale<Mat4<T>>(s); }
 
 /// @brief Multiply a 2x3 matrix by a 3x2 matrix, result is a 2x2 matrix
 template<typename T>
-__hostdev__ constexpr Mat2<T> operator*(const Mat2x3<T>& lhs, const Mat3x2<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat2<T> operator*(const Mat2x3<T>& lhs, const Mat3x2<T>& rhs) {
     return lhs.template multiply<Mat2<T>, Mat3x2<T>>(rhs);
 }
 /// @brief Multiply a 2x3 matrix by a 3x3 matrix, result is a 2x3 matrix
 template<typename T>
-__hostdev__ constexpr Mat2x3<T> operator*(const Mat2x3<T>& lhs, const Mat3<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const Mat2x3<T>& lhs, const Mat3<T>& rhs) {
     return lhs.template multiply<Mat2x3<T>, Mat3<T>>(rhs);
 }
 /// @brief Multiply a 3x2 matrix by a 2x2 matrix, result is a 3x2 matrix
 template<typename T>
-__hostdev__ constexpr Mat3x2<T> operator*(const Mat3x2<T>& lhs, const Mat2<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const Mat3x2<T>& lhs, const Mat2<T>& rhs) {
     return lhs.template multiply<Mat3x2<T>, Mat2<T>>(rhs);
 }
 /// @brief Multiply a 2x2 matrix by a 2x3 matrix, result is a 2x3 matrix
 template<typename T>
-__hostdev__ constexpr Mat2x3<T> operator*(const Mat2<T>& lhs, const Mat2x3<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat2x3<T> operator*(const Mat2<T>& lhs, const Mat2x3<T>& rhs) {
     return lhs.template multiply<Mat2x3<T>, Mat2x3<T>>(rhs);
 }
 /// @brief Multiply a 3x2 matrix by a 2x3 matrix, result is a 3x3 matrix
 template<typename T>
-__hostdev__ constexpr Mat3<T> operator*(const Mat3x2<T>& lhs, const Mat2x3<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat3<T> operator*(const Mat3x2<T>& lhs, const Mat2x3<T>& rhs) {
     return lhs.template multiply<Mat3<T>, Mat2x3<T>>(rhs);
 }
 /// @brief Multiply a 3x3 matrix by a 3x2 matrix, result is a 3x2 matrix
 template<typename T>
-__hostdev__ constexpr Mat3x2<T> operator*(const Mat3<T>& lhs, const Mat3x2<T>& rhs) {
+__hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const Mat3<T>& lhs, const Mat3x2<T>& rhs) {
     return lhs.template multiply<Mat3x2<T>, Mat3x2<T>>(rhs);
 }
 // ----------------------------> Vec3 <--------------------------------------
@@ -1690,17 +1690,17 @@ public:
     }
 
     // ---- element-wise (Vec & Vec) ----
-    __hostdev__ constexpr Vec3  operator-() const             { return Base::template negate<Vec3>(); }
-    __hostdev__ constexpr Vec3  operator+(const Vec3& v) const { return Base::template plus<Vec3>(v); }
-    __hostdev__ constexpr Vec3  operator-(const Vec3& v) const { return Base::template minus<Vec3>(v); }
-    __hostdev__ constexpr Vec3  operator*(const Vec3& v) const { return Base::template mul<Vec3>(v); }
-    __hostdev__ constexpr Vec3  operator/(const Vec3& v) const { return Base::template div<Vec3>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator-() const             { return Base::template negate<Vec3>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator+(const Vec3& v) const { return Base::template plus<Vec3>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator-(const Vec3& v) const { return Base::template minus<Vec3>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator*(const Vec3& v) const { return Base::template mul<Vec3>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator/(const Vec3& v) const { return Base::template div<Vec3>(v); }
     __hostdev__ constexpr Vec3& operator+=(const Vec3& v)     { Base::addAssign(v); return *this; }
     __hostdev__ constexpr Vec3& operator-=(const Vec3& v)     { Base::subAssign(v); return *this; }
 
     // ---- mixed Vec3 / Coord (3D) ----
-    __hostdev__ constexpr Vec3  operator+(const Coord& ijk) const { return Vec3(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1], this->mVec[2] + ijk[2]); }
-    __hostdev__ constexpr Vec3  operator-(const Coord& ijk) const { return Vec3(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1], this->mVec[2] - ijk[2]); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator+(const Coord& ijk) const { return Vec3(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1], this->mVec[2] + ijk[2]); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator-(const Coord& ijk) const { return Vec3(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1], this->mVec[2] - ijk[2]); }
     __hostdev__ constexpr Vec3& operator+=(const Coord& ijk) {
         this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]); this->mVec[2] += T(ijk[2]);
         return *this;
@@ -1711,44 +1711,44 @@ public:
     }
 
     // ---- scalar ----
-    __hostdev__ constexpr Vec3  operator*(const T& s) const   { return Base::template scale<Vec3>(s); }
-    __hostdev__ constexpr Vec3  operator/(const T& s) const   { return Base::template divideBy<Vec3>(s); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator*(const T& s) const   { return Base::template scale<Vec3>(s); }
+    __hostdev__ [[nodiscard]] constexpr Vec3  operator/(const T& s) const   { return Base::template divideBy<Vec3>(s); }
     __hostdev__ constexpr Vec3& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
     __hostdev__ constexpr Vec3& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
     // Not constexpr — depends on length() which calls std::sqrt.
     __hostdev__ Vec3& normalize()                   { return (*this) /= this->length(); }
 
     // ---- equality ----
-    __hostdev__ constexpr bool operator==(const Vec3& rhs) const { return Base::equals(rhs); }
-    __hostdev__ constexpr bool operator!=(const Vec3& rhs) const { return !Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec3& rhs) const { return Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec3& rhs) const { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
     __hostdev__ constexpr Vec3& minComponent(const Vec3& other) { Base::mergeMin(other); return *this; }
     __hostdev__ constexpr Vec3& maxComponent(const Vec3& other) { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
-    __hostdev__ constexpr ValueType min() const { return Base::smallestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType min() const { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ constexpr ValueType max() const { return Base::largestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType max() const { return Base::largestComponent(); }
 
     /// @brief Round each component down (toward negative infinity)
     /// @return integer Coord
     /// @note Only constexpr for integer @c T (floorAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ constexpr Coord floor() const { return Base::template floorAs<Coord>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord floor() const { return Base::template floorAs<Coord>(); }
     /// @brief Round each component up (toward positive infinity)
     /// @return integer Coord
     /// @note Only constexpr for integer @c T (ceilAs uses non-constexpr math::Ceil for floating point).
-    __hostdev__ constexpr Coord ceil()  const { return Base::template ceilAs<Coord>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord ceil()  const { return Base::template ceilAs<Coord>(); }
     /// @brief Round each component to its closest integer value
     /// @return integer Coord
     /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ constexpr Coord round() const { return Base::template roundAs<Coord>(); }
+    __hostdev__ [[nodiscard]] constexpr Coord round() const { return Base::template roundAs<Coord>(); }
 
     // ---- 3D-specific ----
 
     /// @brief cross product with another 3-vector
     template<typename Vec3T>
-    __hostdev__ constexpr Vec3 cross(const Vec3T& v) const {
+    __hostdev__ [[nodiscard]] constexpr Vec3 cross(const Vec3T& v) const {
         return Vec3(this->mVec[1] * v[2] - this->mVec[2] * v[1],
                     this->mVec[2] * v[0] - this->mVec[0] * v[2],
                     this->mVec[0] * v[1] - this->mVec[1] * v[0]);
@@ -1756,7 +1756,7 @@ public:
 
     /// @brief Outer product of a 3x1 vector and a 1x3 vector, result is a 3x3 matrix
     template<typename Vec3T>
-    __hostdev__ constexpr Mat3<ValueType> outer(const Vec3T& v) const {
+    __hostdev__ [[nodiscard]] constexpr Mat3<ValueType> outer(const Vec3T& v) const {
         return Mat3<ValueType>(this->mVec[0] * v[0], this->mVec[0] * v[1], this->mVec[0] * v[2],
                                this->mVec[1] * v[0], this->mVec[1] * v[1], this->mVec[1] * v[2],
                                this->mVec[2] * v[0], this->mVec[2] * v[1], this->mVec[2] * v[2]);
@@ -1764,24 +1764,24 @@ public:
 }; // Vec3<T>
 
 template<typename T1, typename T2>
-__hostdev__ inline constexpr Vec3<T2> operator*(T1 scalar, const Vec3<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec3<T2> operator*(T1 scalar, const Vec3<T2>& vec)
 {
     return Vec3<T2>(scalar * vec[0], scalar * vec[1], scalar * vec[2]);
 }
 template<typename T1, typename T2>
-__hostdev__ inline constexpr Vec3<T2> operator/(T1 scalar, const Vec3<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec3<T2> operator/(T1 scalar, const Vec3<T2>& vec)
 {
     return Vec3<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2]);
 }
 
 /// @brief Return a single precision floating-point vector of this coordinate
-__hostdev__ inline constexpr Vec3<float> Coord::asVec3s() const
+__hostdev__ [[nodiscard]] inline constexpr Vec3<float> Coord::asVec3s() const
 {
     return Vec3<float>(float(mVec[0]), float(mVec[1]), float(mVec[2]));
 }
 
 /// @brief Return a double precision floating-point vector of this coordinate
-__hostdev__ inline constexpr Vec3<double> Coord::asVec3d() const
+__hostdev__ [[nodiscard]] inline constexpr Vec3<double> Coord::asVec3d() const
 {
     return Vec3<double>(double(mVec[0]), double(mVec[1]), double(mVec[2]));
 }
@@ -1824,56 +1824,56 @@ public:
     }
 
     // ---- element-wise (Vec & Vec) ----
-    __hostdev__ constexpr Vec4  operator-() const             { return Base::template negate<Vec4>(); }
-    __hostdev__ constexpr Vec4  operator+(const Vec4& v) const { return Base::template plus<Vec4>(v); }
-    __hostdev__ constexpr Vec4  operator-(const Vec4& v) const { return Base::template minus<Vec4>(v); }
-    __hostdev__ constexpr Vec4  operator*(const Vec4& v) const { return Base::template mul<Vec4>(v); }
-    __hostdev__ constexpr Vec4  operator/(const Vec4& v) const { return Base::template div<Vec4>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator-() const             { return Base::template negate<Vec4>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator+(const Vec4& v) const { return Base::template plus<Vec4>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator-(const Vec4& v) const { return Base::template minus<Vec4>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator*(const Vec4& v) const { return Base::template mul<Vec4>(v); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator/(const Vec4& v) const { return Base::template div<Vec4>(v); }
     __hostdev__ constexpr Vec4& operator+=(const Vec4& v)     { Base::addAssign(v); return *this; }
     __hostdev__ constexpr Vec4& operator-=(const Vec4& v)     { Base::subAssign(v); return *this; }
 
     // ---- scalar ----
-    __hostdev__ constexpr Vec4  operator*(const T& s) const   { return Base::template scale<Vec4>(s); }
-    __hostdev__ constexpr Vec4  operator/(const T& s) const   { return Base::template divideBy<Vec4>(s); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator*(const T& s) const   { return Base::template scale<Vec4>(s); }
+    __hostdev__ [[nodiscard]] constexpr Vec4  operator/(const T& s) const   { return Base::template divideBy<Vec4>(s); }
     __hostdev__ constexpr Vec4& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
     __hostdev__ constexpr Vec4& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
     // Not constexpr — depends on length() which calls std::sqrt.
     __hostdev__ Vec4& normalize()                   { return (*this) /= this->length(); }
 
     // ---- equality ----
-    __hostdev__ constexpr bool operator==(const Vec4& rhs) const { return Base::equals(rhs); }
-    __hostdev__ constexpr bool operator!=(const Vec4& rhs) const { return !Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator==(const Vec4& rhs) const { return Base::equals(rhs); }
+    __hostdev__ [[nodiscard]] constexpr bool operator!=(const Vec4& rhs) const { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
     __hostdev__ constexpr Vec4& minComponent(const Vec4& other) { Base::mergeMin(other); return *this; }
     __hostdev__ constexpr Vec4& maxComponent(const Vec4& other) { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
-    __hostdev__ constexpr ValueType min() const { return Base::smallestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType min() const { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ constexpr ValueType max() const { return Base::largestComponent(); }
+    __hostdev__ [[nodiscard]] constexpr ValueType max() const { return Base::largestComponent(); }
 
     /// @brief Round each component down (toward negative infinity)
     /// @return Vec4<int32_t> (NanoVDB has no Coord4)
     /// @note Only constexpr for integer @c T (floorAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ constexpr Vec4<int32_t> floor() const { return Base::template floorAs<Vec4<int32_t>>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> floor() const { return Base::template floorAs<Vec4<int32_t>>(); }
     /// @brief Round each component up (toward positive infinity)
     /// @return Vec4<int32_t>
     /// @note Only constexpr for integer @c T (ceilAs uses non-constexpr math::Ceil for floating point).
-    __hostdev__ constexpr Vec4<int32_t> ceil()  const { return Base::template ceilAs<Vec4<int32_t>>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> ceil()  const { return Base::template ceilAs<Vec4<int32_t>>(); }
     /// @brief Round each component to its closest integer value
     /// @return Vec4<int32_t>
     /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
-    __hostdev__ constexpr Vec4<int32_t> round() const { return Base::template roundAs<Vec4<int32_t>>(); }
+    __hostdev__ [[nodiscard]] constexpr Vec4<int32_t> round() const { return Base::template roundAs<Vec4<int32_t>>(); }
 }; // Vec4<T>
 
 template<typename T1, typename T2>
-__hostdev__ inline constexpr Vec4<T2> operator*(T1 scalar, const Vec4<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec4<T2> operator*(T1 scalar, const Vec4<T2>& vec)
 {
     return Vec4<T2>(scalar * vec[0], scalar * vec[1], scalar * vec[2], scalar * vec[3]);
 }
 template<typename T1, typename T2>
-__hostdev__ inline constexpr Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
+__hostdev__ [[nodiscard]] inline constexpr Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
 {
     return Vec4<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2], scalar / vec[3]);
 }
@@ -1898,7 +1898,7 @@ __hostdev__ inline constexpr Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
 /// @param xyz input vector to be multiplied by the matrix
 /// @return result of matrix-vector multiplication, i.e. mat x xyz
 template<typename Vec3T>
-__hostdev__ inline constexpr Vec3T matMult(const float* mat, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const float* mat, const Vec3T& xyz)
 {
     const float x = static_cast<float>(xyz[0]);
     const float y = static_cast<float>(xyz[1]);
@@ -1915,7 +1915,7 @@ __hostdev__ inline constexpr Vec3T matMult(const float* mat, const Vec3T& xyz)
 /// @param xyz input vector to be multiplied by the matrix
 /// @return result of matrix-vector multiplication, i.e. mat x xyz
 template<typename Vec3T>
-__hostdev__ inline constexpr Vec3T matMult(const double* mat, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const double* mat, const Vec3T& xyz)
 {
     const double x = static_cast<double>(xyz[0]);
     const double y = static_cast<double>(xyz[1]);
@@ -1933,7 +1933,7 @@ __hostdev__ inline constexpr Vec3T matMult(const double* mat, const Vec3T& xyz)
 /// @param xyz input vector to be multiplied by the matrix and a translated by @c vec
 /// @return result of affine transformation, i.e. (mat x xyz) + vec
 template<typename Vec3T>
-__hostdev__ inline constexpr Vec3T matMult(const float* mat, const float* vec, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const float* mat, const float* vec, const Vec3T& xyz)
 {
     const float x = static_cast<float>(xyz[0]);
     const float y = static_cast<float>(xyz[1]);
@@ -1951,7 +1951,7 @@ __hostdev__ inline constexpr Vec3T matMult(const float* mat, const float* vec, c
 /// @param xyz input vector to be multiplied by the matrix and a translated by @c vec
 /// @return result of affine transformation, i.e. (mat x xyz) + vec
 template<typename Vec3T>
-__hostdev__ inline constexpr Vec3T matMult(const double* mat, const double* vec, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMult(const double* mat, const double* vec, const Vec3T& xyz)
 {
     const double x = static_cast<double>(xyz[0]);
     const double y = static_cast<double>(xyz[1]);
@@ -1968,7 +1968,7 @@ __hostdev__ inline constexpr Vec3T matMult(const double* mat, const double* vec,
 /// @param xyz input vector to be multiplied by the transposed matrix
 /// @return result of matrix-vector multiplication, i.e. mat^T x xyz
 template<typename Vec3T>
-__hostdev__ inline constexpr Vec3T matMultT(const float* mat, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, const Vec3T& xyz)
 {
     const float x = static_cast<float>(xyz[0]);
     const float y = static_cast<float>(xyz[1]);
@@ -1985,7 +1985,7 @@ __hostdev__ inline constexpr Vec3T matMultT(const float* mat, const Vec3T& xyz)
 /// @param xyz input vector to be multiplied by the transposed matrix
 /// @return result of matrix-vector multiplication, i.e. mat^T x xyz
 template<typename Vec3T>
-__hostdev__ inline constexpr Vec3T matMultT(const double* mat, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, const Vec3T& xyz)
 {
     const double x = static_cast<double>(xyz[0]);
     const double y = static_cast<double>(xyz[1]);
@@ -1996,7 +1996,7 @@ __hostdev__ inline constexpr Vec3T matMultT(const double* mat, const Vec3T& xyz)
 }
 
 template<typename Vec3T>
-__hostdev__ inline constexpr Vec3T matMultT(const float* mat, const float* vec, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const float* mat, const float* vec, const Vec3T& xyz)
 {
     const float x = static_cast<float>(xyz[0]);
     const float y = static_cast<float>(xyz[1]);
@@ -2007,7 +2007,7 @@ __hostdev__ inline constexpr Vec3T matMultT(const float* mat, const float* vec, 
 }
 
 template<typename Vec3T>
-__hostdev__ inline constexpr Vec3T matMultT(const double* mat, const double* vec, const Vec3T& xyz)
+__hostdev__ [[nodiscard]] inline constexpr Vec3T matMultT(const double* mat, const double* vec, const Vec3T& xyz)
 {
     const double x = static_cast<double>(xyz[0]);
     const double y = static_cast<double>(xyz[1]);
@@ -2024,8 +2024,8 @@ template<typename Vec3T>
 struct BaseBBox
 {
     Vec3T                    mCoord[2];
-    __hostdev__ constexpr bool         operator==(const BaseBBox& rhs) const { return mCoord[0] == rhs.mCoord[0] && mCoord[1] == rhs.mCoord[1]; };
-    __hostdev__ constexpr bool         operator!=(const BaseBBox& rhs) const { return mCoord[0] != rhs.mCoord[0] || mCoord[1] != rhs.mCoord[1]; };
+    __hostdev__ [[nodiscard]] constexpr bool         operator==(const BaseBBox& rhs) const { return mCoord[0] == rhs.mCoord[0] && mCoord[1] == rhs.mCoord[1]; };
+    __hostdev__ [[nodiscard]] constexpr bool         operator!=(const BaseBBox& rhs) const { return mCoord[0] != rhs.mCoord[0] || mCoord[1] != rhs.mCoord[1]; };
     __hostdev__ constexpr const Vec3T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
     __hostdev__ constexpr Vec3T&       operator[](int i) { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
     __hostdev__ constexpr Vec3T&       min() { return mCoord[0]; }
@@ -2066,7 +2066,7 @@ struct BaseBBox
 //    {
 //        return BaseBBox(mCoord[0].offsetBy(-padding),mCoord[1].offsetBy(padding));
 //    }
-    __hostdev__ constexpr bool isInside(const Vec3T& xyz)
+    __hostdev__ [[nodiscard]] constexpr bool isInside(const Vec3T& xyz)
     {
         if (xyz[0] < mCoord[0][0] || xyz[1] < mCoord[0][1] || xyz[2] < mCoord[0][2])
             return false;
@@ -2113,7 +2113,7 @@ struct BBox<Vec3T, true> : public BaseBBox<Vec3T>
                 Vec3T(ValueType(max[0] + 1), ValueType(max[1] + 1), ValueType(max[2] + 1)))
     {
     }
-    __hostdev__ static constexpr BBox createCube(const Coord& min, typename Coord::ValueType dim)
+    __hostdev__ [[nodiscard]] static constexpr BBox createCube(const Coord& min, typename Coord::ValueType dim)
     {
         return BBox(min, min.offsetBy(dim));
     }
@@ -2122,14 +2122,14 @@ struct BBox<Vec3T, true> : public BaseBBox<Vec3T>
         : BBox(bbox[0], bbox[1])
     {
     }
-    __hostdev__ constexpr bool  empty() const { return mCoord[0][0] >= mCoord[1][0] ||
+    __hostdev__ [[nodiscard]] constexpr bool  empty() const { return mCoord[0][0] >= mCoord[1][0] ||
                                              mCoord[0][1] >= mCoord[1][1] ||
                                              mCoord[0][2] >= mCoord[1][2]; }
-    __hostdev__ constexpr operator bool() const { return mCoord[0][0] < mCoord[1][0] &&
+    __hostdev__ [[nodiscard]] constexpr operator bool() const { return mCoord[0][0] < mCoord[1][0] &&
                                                mCoord[0][1] < mCoord[1][1] &&
                                                mCoord[0][2] < mCoord[1][2]; }
-    __hostdev__ constexpr Vec3T dim() const { return *this ? this->max() - this->min() : Vec3T(0); }
-    __hostdev__ constexpr bool  isInside(const Vec3T& p) const
+    __hostdev__ [[nodiscard]] constexpr Vec3T dim() const { return *this ? this->max() - this->min() : Vec3T(0); }
+    __hostdev__ [[nodiscard]] constexpr bool  isInside(const Vec3T& p) const
     {
         return p[0] > mCoord[0][0] && p[1] > mCoord[0][1] && p[2] > mCoord[0][2] &&
                p[0] < mCoord[1][0] && p[1] < mCoord[1][1] && p[2] < mCoord[1][2];
@@ -2185,32 +2185,32 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
             ++(*this);
             return tmp;
         }
-        __hostdev__ constexpr bool operator==(const Iterator& rhs) const
+        __hostdev__ [[nodiscard]] constexpr bool operator==(const Iterator& rhs) const
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos == rhs.mPos;
         }
-        __hostdev__ constexpr bool operator!=(const Iterator& rhs) const
+        __hostdev__ [[nodiscard]] constexpr bool operator!=(const Iterator& rhs) const
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos != rhs.mPos;
         }
-        __hostdev__ constexpr bool operator<(const Iterator& rhs) const
+        __hostdev__ [[nodiscard]] constexpr bool operator<(const Iterator& rhs) const
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos < rhs.mPos;
         }
-        __hostdev__ constexpr bool operator<=(const Iterator& rhs) const
+        __hostdev__ [[nodiscard]] constexpr bool operator<=(const Iterator& rhs) const
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos <= rhs.mPos;
         }
         /// @brief Return @c true if the iterator still points to a valid coordinate.
-        __hostdev__ constexpr operator bool() const { return mPos <= mBBox[1]; }
-        __hostdev__ constexpr const CoordT& operator*() const { return mPos; }
+        __hostdev__ [[nodiscard]] constexpr operator bool() const { return mPos <= mBBox[1]; }
+        __hostdev__ [[nodiscard]] constexpr const CoordT& operator*() const { return mPos; }
     }; // Iterator
-    __hostdev__ constexpr Iterator begin() const { return Iterator{*this}; }
-    __hostdev__ constexpr Iterator end()   const { return Iterator{*this, CoordT(mCoord[1][0]+1, mCoord[0][1], mCoord[0][2])}; }
+    __hostdev__ [[nodiscard]] constexpr Iterator begin() const { return Iterator{*this}; }
+    __hostdev__ [[nodiscard]] constexpr Iterator end()   const { return Iterator{*this, CoordT(mCoord[1][0]+1, mCoord[0][1], mCoord[0][2])}; }
     __hostdev__ constexpr BBox()
         : BaseT(CoordT::max(), CoordT::min())
     {
@@ -2230,56 +2230,56 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
         other.mCoord[0][n] = mCoord[1][n] + 1;
     }
 
-    __hostdev__ static constexpr BBox createCube(const CoordT& min, typename CoordT::ValueType dim)
+    __hostdev__ [[nodiscard]] static constexpr BBox createCube(const CoordT& min, typename CoordT::ValueType dim)
     {
         return BBox(min, min.offsetBy(dim - 1));
     }
 
-    __hostdev__ static constexpr BBox createCube(typename CoordT::ValueType min, typename CoordT::ValueType max)
+    __hostdev__ [[nodiscard]] static constexpr BBox createCube(typename CoordT::ValueType min, typename CoordT::ValueType max)
     {
         return BBox(CoordT(min), CoordT(max));
     }
 
-    __hostdev__ constexpr bool is_divisible() const { return mCoord[0][0] < mCoord[1][0] &&
+    __hostdev__ [[nodiscard]] constexpr bool is_divisible() const { return mCoord[0][0] < mCoord[1][0] &&
                                                    mCoord[0][1] < mCoord[1][1] &&
                                                    mCoord[0][2] < mCoord[1][2]; }
     /// @brief Return true if this bounding box is empty, e.g. uninitialized
-    __hostdev__ constexpr bool     empty() const { return mCoord[0][0] > mCoord[1][0] ||
+    __hostdev__ [[nodiscard]] constexpr bool     empty() const { return mCoord[0][0] > mCoord[1][0] ||
                                                 mCoord[0][1] > mCoord[1][1] ||
                                                 mCoord[0][2] > mCoord[1][2]; }
     /// @brief Convert this BBox to boolean true if it is not empty
-    __hostdev__ constexpr operator bool() const { return mCoord[0][0] <= mCoord[1][0] &&
+    __hostdev__ [[nodiscard]] constexpr operator bool() const { return mCoord[0][0] <= mCoord[1][0] &&
                                                mCoord[0][1] <= mCoord[1][1] &&
                                                mCoord[0][2] <= mCoord[1][2]; }
-    __hostdev__ constexpr CoordT   dim() const { return *this ? this->max() - this->min() + Coord(1) : Coord(0); }
-    __hostdev__ constexpr uint64_t volume() const
+    __hostdev__ [[nodiscard]] constexpr CoordT   dim() const { return *this ? this->max() - this->min() + Coord(1) : Coord(0); }
+    __hostdev__ [[nodiscard]] constexpr uint64_t volume() const
     {
         auto d = this->dim();
         return uint64_t(d[0]) * uint64_t(d[1]) * uint64_t(d[2]);
     }
-    __hostdev__ constexpr bool isInside(const CoordT& p) const { return !(CoordT::lessThan(p, this->min()) || CoordT::lessThan(this->max(), p)); }
+    __hostdev__ [[nodiscard]] constexpr bool isInside(const CoordT& p) const { return !(CoordT::lessThan(p, this->min()) || CoordT::lessThan(this->max(), p)); }
     /// @brief Return @c true if the given bounding box is inside this bounding box.
-    __hostdev__ constexpr bool isInside(const BBox& b) const
+    __hostdev__ [[nodiscard]] constexpr bool isInside(const BBox& b) const
     {
         return !(CoordT::lessThan(b.min(), this->min()) || CoordT::lessThan(this->max(), b.max()));
     }
 
     /// @brief Return @c true if the given bounding box overlaps with this bounding box.
-    __hostdev__ constexpr bool hasOverlap(const BBox& b) const
+    __hostdev__ [[nodiscard]] constexpr bool hasOverlap(const BBox& b) const
     {
         return !(CoordT::lessThan(this->max(), b.min()) || CoordT::lessThan(b.max(), this->min()));
     }
 
     /// @warning This converts a CoordBBox into a floating-point bounding box which implies that max += 1 !
     template<typename RealT = double>
-    __hostdev__ constexpr BBox<Vec3<RealT>> asReal() const
+    __hostdev__ [[nodiscard]] constexpr BBox<Vec3<RealT>> asReal() const
     {
         static_assert(util::is_floating_point<RealT>::value, "CoordBBox::asReal: Expected a floating point coordinate");
         return BBox<Vec3<RealT>>(Vec3<RealT>(RealT(mCoord[0][0]), RealT(mCoord[0][1]), RealT(mCoord[0][2])),
                                  Vec3<RealT>(RealT(mCoord[1][0] + 1), RealT(mCoord[1][1] + 1), RealT(mCoord[1][2] + 1)));
     }
     /// @brief Return a new instance that is expanded by the specified padding.
-    __hostdev__ constexpr BBox expandBy(typename CoordT::ValueType padding) const
+    __hostdev__ [[nodiscard]] constexpr BBox expandBy(typename CoordT::ValueType padding) const
     {
         return BBox(mCoord[0].offsetBy(-padding), mCoord[1].offsetBy(padding));
     }
@@ -2288,7 +2288,7 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
     /// @param map mapping of index to world coordinates
     /// @return world bounding box
     template<typename Map>
-    __hostdev__ constexpr auto transform(const Map& map) const
+    __hostdev__ [[nodiscard]] constexpr auto transform(const Map& map) const
     {
         using Vec3T = Vec3<double>;
         const Vec3T tmp = map.applyMap(Vec3T(mCoord[0][0], mCoord[0][1], mCoord[0][2]));
@@ -2399,17 +2399,17 @@ public:
     {
     }
 
-    __hostdev__ bool  operator< (const Rgba8& rhs) const { return mData.packed < rhs.mData.packed; }
-    __hostdev__ bool  operator==(const Rgba8& rhs) const { return mData.packed == rhs.mData.packed; }
-    __hostdev__ constexpr float lengthSqr() const
+    __hostdev__ [[nodiscard]] bool  operator< (const Rgba8& rhs) const { return mData.packed < rhs.mData.packed; }
+    __hostdev__ [[nodiscard]] bool  operator==(const Rgba8& rhs) const { return mData.packed == rhs.mData.packed; }
+    __hostdev__ [[nodiscard]] constexpr float lengthSqr() const
     {
         return 0.0000153787005f * (float(mData.c[0]) * mData.c[0] +
                                    float(mData.c[1]) * mData.c[1] +
                                    float(mData.c[2]) * mData.c[2]); //1/255^2
     }
-    __hostdev__ float           length() const { return sqrtf(this->lengthSqr()); }
+    __hostdev__ [[nodiscard]] float           length() const { return sqrtf(this->lengthSqr()); }
     /// @brief return n'th color channel as a float in the range 0 to 1
-    __hostdev__ constexpr float           asFloat(int n) const { return 0.003921569f*float(mData.c[n]); }// divide by 255
+    __hostdev__ [[nodiscard]] constexpr float           asFloat(int n) const { return 0.003921569f*float(mData.c[n]); }// divide by 255
     __hostdev__ constexpr const uint8_t&  operator[](int n) const { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
     __hostdev__ constexpr uint8_t&        operator[](int n) { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
     __hostdev__ const uint32_t& packed() const { return mData.packed; }
@@ -2422,10 +2422,10 @@ public:
     __hostdev__ constexpr uint8_t&        g() { return mData.c[1]; }
     __hostdev__ constexpr uint8_t&        b() { return mData.c[2]; }
     __hostdev__ constexpr uint8_t&        a() { return mData.c[3]; }
-    __hostdev__ constexpr           operator Vec3<float>() const {
+    __hostdev__ [[nodiscard]] constexpr           operator Vec3<float>() const {
         return Vec3<float>(this->asFloat(0), this->asFloat(1), this->asFloat(2));
     }
-    __hostdev__ constexpr           operator Vec4<float>() const {
+    __hostdev__ [[nodiscard]] constexpr           operator Vec4<float>() const {
         return Vec4<float>(this->asFloat(0), this->asFloat(1), this->asFloat(2), this->asFloat(3));
     }
 }; // Rgba8

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -1825,6 +1825,18 @@ __hostdev__ inline constexpr Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
     return Vec4<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2], scalar / vec[3]);
 }
 // ----------------------------> matMult <--------------------------------------
+//
+// All six matMult / matMultT overloads were originally written with
+// fma / fmaf for the single-rounding precision benefit. Those stdlib
+// functions are not constexpr in C++17, which transitively blocked
+// Map::applyMap and BBox<CoordT,false>::transform<Map> from being
+// constexpr. Switching to plain `a * b + c` form gives back the
+// constexpr-eligibility (worth ~1 ulp of rounding accuracy in the
+// worst case, well below NanoVDB's geometric precision) and the
+// device-side codegen is unchanged in practice — nvcc contracts
+// `a * b + c` back into a hardware FMA by default (-fmad=true).
+//
+// (C++23's constexpr fma will eventually obviate this trade-off.)
 
 /// @brief Multiply a 3x3 matrix and a 3d vector using 32bit floating point arithmetics
 /// @note This corresponds to a linear mapping, e.g. scaling, rotation etc.
@@ -1833,11 +1845,14 @@ __hostdev__ inline constexpr Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
 /// @param xyz input vector to be multiplied by the matrix
 /// @return result of matrix-vector multiplication, i.e. mat x xyz
 template<typename Vec3T>
-__hostdev__ inline Vec3T matMult(const float* mat, const Vec3T& xyz)
+__hostdev__ inline constexpr Vec3T matMult(const float* mat, const Vec3T& xyz)
 {
-    return Vec3T(fmaf(static_cast<float>(xyz[0]), mat[0], fmaf(static_cast<float>(xyz[1]), mat[1], static_cast<float>(xyz[2]) * mat[2])),
-                 fmaf(static_cast<float>(xyz[0]), mat[3], fmaf(static_cast<float>(xyz[1]), mat[4], static_cast<float>(xyz[2]) * mat[5])),
-                 fmaf(static_cast<float>(xyz[0]), mat[6], fmaf(static_cast<float>(xyz[1]), mat[7], static_cast<float>(xyz[2]) * mat[8]))); // 6 fmaf + 3 mult = 9 flops
+    const float x = static_cast<float>(xyz[0]);
+    const float y = static_cast<float>(xyz[1]);
+    const float z = static_cast<float>(xyz[2]);
+    return Vec3T(x * mat[0] + y * mat[1] + z * mat[2],
+                 x * mat[3] + y * mat[4] + z * mat[5],
+                 x * mat[6] + y * mat[7] + z * mat[8]);
 }
 
 /// @brief Multiply a 3x3 matrix and a 3d vector using 64bit floating point arithmetics
@@ -1847,11 +1862,14 @@ __hostdev__ inline Vec3T matMult(const float* mat, const Vec3T& xyz)
 /// @param xyz input vector to be multiplied by the matrix
 /// @return result of matrix-vector multiplication, i.e. mat x xyz
 template<typename Vec3T>
-__hostdev__ inline Vec3T matMult(const double* mat, const Vec3T& xyz)
+__hostdev__ inline constexpr Vec3T matMult(const double* mat, const Vec3T& xyz)
 {
-    return Vec3T(fma(static_cast<double>(xyz[0]), mat[0], fma(static_cast<double>(xyz[1]), mat[1], static_cast<double>(xyz[2]) * mat[2])),
-                 fma(static_cast<double>(xyz[0]), mat[3], fma(static_cast<double>(xyz[1]), mat[4], static_cast<double>(xyz[2]) * mat[5])),
-                 fma(static_cast<double>(xyz[0]), mat[6], fma(static_cast<double>(xyz[1]), mat[7], static_cast<double>(xyz[2]) * mat[8]))); // 6 fmaf + 3 mult = 9 flops
+    const double x = static_cast<double>(xyz[0]);
+    const double y = static_cast<double>(xyz[1]);
+    const double z = static_cast<double>(xyz[2]);
+    return Vec3T(x * mat[0] + y * mat[1] + z * mat[2],
+                 x * mat[3] + y * mat[4] + z * mat[5],
+                 x * mat[6] + y * mat[7] + z * mat[8]);
 }
 
 /// @brief Multiply a 3x3 matrix to a 3d vector and add another 3d vector using 32bit floating point arithmetics
@@ -1862,11 +1880,14 @@ __hostdev__ inline Vec3T matMult(const double* mat, const Vec3T& xyz)
 /// @param xyz input vector to be multiplied by the matrix and a translated by @c vec
 /// @return result of affine transformation, i.e. (mat x xyz) + vec
 template<typename Vec3T>
-__hostdev__ inline Vec3T matMult(const float* mat, const float* vec, const Vec3T& xyz)
+__hostdev__ inline constexpr Vec3T matMult(const float* mat, const float* vec, const Vec3T& xyz)
 {
-    return Vec3T(fmaf(static_cast<float>(xyz[0]), mat[0], fmaf(static_cast<float>(xyz[1]), mat[1], fmaf(static_cast<float>(xyz[2]), mat[2], vec[0]))),
-                 fmaf(static_cast<float>(xyz[0]), mat[3], fmaf(static_cast<float>(xyz[1]), mat[4], fmaf(static_cast<float>(xyz[2]), mat[5], vec[1]))),
-                 fmaf(static_cast<float>(xyz[0]), mat[6], fmaf(static_cast<float>(xyz[1]), mat[7], fmaf(static_cast<float>(xyz[2]), mat[8], vec[2])))); // 9 fmaf = 9 flops
+    const float x = static_cast<float>(xyz[0]);
+    const float y = static_cast<float>(xyz[1]);
+    const float z = static_cast<float>(xyz[2]);
+    return Vec3T(x * mat[0] + y * mat[1] + z * mat[2] + vec[0],
+                 x * mat[3] + y * mat[4] + z * mat[5] + vec[1],
+                 x * mat[6] + y * mat[7] + z * mat[8] + vec[2]);
 }
 
 /// @brief Multiply a 3x3 matrix to a 3d vector and add another 3d vector using 64bit floating point arithmetics
@@ -1877,11 +1898,14 @@ __hostdev__ inline Vec3T matMult(const float* mat, const float* vec, const Vec3T
 /// @param xyz input vector to be multiplied by the matrix and a translated by @c vec
 /// @return result of affine transformation, i.e. (mat x xyz) + vec
 template<typename Vec3T>
-__hostdev__ inline Vec3T matMult(const double* mat, const double* vec, const Vec3T& xyz)
+__hostdev__ inline constexpr Vec3T matMult(const double* mat, const double* vec, const Vec3T& xyz)
 {
-    return Vec3T(fma(static_cast<double>(xyz[0]), mat[0], fma(static_cast<double>(xyz[1]), mat[1], fma(static_cast<double>(xyz[2]), mat[2], vec[0]))),
-                 fma(static_cast<double>(xyz[0]), mat[3], fma(static_cast<double>(xyz[1]), mat[4], fma(static_cast<double>(xyz[2]), mat[5], vec[1]))),
-                 fma(static_cast<double>(xyz[0]), mat[6], fma(static_cast<double>(xyz[1]), mat[7], fma(static_cast<double>(xyz[2]), mat[8], vec[2])))); // 9 fma = 9 flops
+    const double x = static_cast<double>(xyz[0]);
+    const double y = static_cast<double>(xyz[1]);
+    const double z = static_cast<double>(xyz[2]);
+    return Vec3T(x * mat[0] + y * mat[1] + z * mat[2] + vec[0],
+                 x * mat[3] + y * mat[4] + z * mat[5] + vec[1],
+                 x * mat[6] + y * mat[7] + z * mat[8] + vec[2]);
 }
 
 /// @brief Multiply the transposed of a 3x3 matrix and a 3d vector using 32bit floating point arithmetics
@@ -1891,11 +1915,14 @@ __hostdev__ inline Vec3T matMult(const double* mat, const double* vec, const Vec
 /// @param xyz input vector to be multiplied by the transposed matrix
 /// @return result of matrix-vector multiplication, i.e. mat^T x xyz
 template<typename Vec3T>
-__hostdev__ inline Vec3T matMultT(const float* mat, const Vec3T& xyz)
+__hostdev__ inline constexpr Vec3T matMultT(const float* mat, const Vec3T& xyz)
 {
-    return Vec3T(fmaf(static_cast<float>(xyz[0]), mat[0], fmaf(static_cast<float>(xyz[1]), mat[3], static_cast<float>(xyz[2]) * mat[6])),
-                 fmaf(static_cast<float>(xyz[0]), mat[1], fmaf(static_cast<float>(xyz[1]), mat[4], static_cast<float>(xyz[2]) * mat[7])),
-                 fmaf(static_cast<float>(xyz[0]), mat[2], fmaf(static_cast<float>(xyz[1]), mat[5], static_cast<float>(xyz[2]) * mat[8]))); // 6 fmaf + 3 mult = 9 flops
+    const float x = static_cast<float>(xyz[0]);
+    const float y = static_cast<float>(xyz[1]);
+    const float z = static_cast<float>(xyz[2]);
+    return Vec3T(x * mat[0] + y * mat[3] + z * mat[6],
+                 x * mat[1] + y * mat[4] + z * mat[7],
+                 x * mat[2] + y * mat[5] + z * mat[8]);
 }
 
 /// @brief Multiply the transposed of a 3x3 matrix and a 3d vector using 64bit floating point arithmetics
@@ -1905,27 +1932,36 @@ __hostdev__ inline Vec3T matMultT(const float* mat, const Vec3T& xyz)
 /// @param xyz input vector to be multiplied by the transposed matrix
 /// @return result of matrix-vector multiplication, i.e. mat^T x xyz
 template<typename Vec3T>
-__hostdev__ inline Vec3T matMultT(const double* mat, const Vec3T& xyz)
+__hostdev__ inline constexpr Vec3T matMultT(const double* mat, const Vec3T& xyz)
 {
-    return Vec3T(fma(static_cast<double>(xyz[0]), mat[0], fma(static_cast<double>(xyz[1]), mat[3], static_cast<double>(xyz[2]) * mat[6])),
-                 fma(static_cast<double>(xyz[0]), mat[1], fma(static_cast<double>(xyz[1]), mat[4], static_cast<double>(xyz[2]) * mat[7])),
-                 fma(static_cast<double>(xyz[0]), mat[2], fma(static_cast<double>(xyz[1]), mat[5], static_cast<double>(xyz[2]) * mat[8]))); // 6 fmaf + 3 mult = 9 flops
+    const double x = static_cast<double>(xyz[0]);
+    const double y = static_cast<double>(xyz[1]);
+    const double z = static_cast<double>(xyz[2]);
+    return Vec3T(x * mat[0] + y * mat[3] + z * mat[6],
+                 x * mat[1] + y * mat[4] + z * mat[7],
+                 x * mat[2] + y * mat[5] + z * mat[8]);
 }
 
 template<typename Vec3T>
-__hostdev__ inline Vec3T matMultT(const float* mat, const float* vec, const Vec3T& xyz)
+__hostdev__ inline constexpr Vec3T matMultT(const float* mat, const float* vec, const Vec3T& xyz)
 {
-    return Vec3T(fmaf(static_cast<float>(xyz[0]), mat[0], fmaf(static_cast<float>(xyz[1]), mat[3], fmaf(static_cast<float>(xyz[2]), mat[6], vec[0]))),
-                 fmaf(static_cast<float>(xyz[0]), mat[1], fmaf(static_cast<float>(xyz[1]), mat[4], fmaf(static_cast<float>(xyz[2]), mat[7], vec[1]))),
-                 fmaf(static_cast<float>(xyz[0]), mat[2], fmaf(static_cast<float>(xyz[1]), mat[5], fmaf(static_cast<float>(xyz[2]), mat[8], vec[2])))); // 9 fmaf = 9 flops
+    const float x = static_cast<float>(xyz[0]);
+    const float y = static_cast<float>(xyz[1]);
+    const float z = static_cast<float>(xyz[2]);
+    return Vec3T(x * mat[0] + y * mat[3] + z * mat[6] + vec[0],
+                 x * mat[1] + y * mat[4] + z * mat[7] + vec[1],
+                 x * mat[2] + y * mat[5] + z * mat[8] + vec[2]);
 }
 
 template<typename Vec3T>
-__hostdev__ inline Vec3T matMultT(const double* mat, const double* vec, const Vec3T& xyz)
+__hostdev__ inline constexpr Vec3T matMultT(const double* mat, const double* vec, const Vec3T& xyz)
 {
-    return Vec3T(fma(static_cast<double>(xyz[0]), mat[0], fma(static_cast<double>(xyz[1]), mat[3], fma(static_cast<double>(xyz[2]), mat[6], vec[0]))),
-                 fma(static_cast<double>(xyz[0]), mat[1], fma(static_cast<double>(xyz[1]), mat[4], fma(static_cast<double>(xyz[2]), mat[7], vec[1]))),
-                 fma(static_cast<double>(xyz[0]), mat[2], fma(static_cast<double>(xyz[1]), mat[5], fma(static_cast<double>(xyz[2]), mat[8], vec[2])))); // 9 fma = 9 flops
+    const double x = static_cast<double>(xyz[0]);
+    const double y = static_cast<double>(xyz[1]);
+    const double z = static_cast<double>(xyz[2]);
+    return Vec3T(x * mat[0] + y * mat[3] + z * mat[6] + vec[0],
+                 x * mat[1] + y * mat[4] + z * mat[7] + vec[1],
+                 x * mat[2] + y * mat[5] + z * mat[8] + vec[2]);
 }
 
 // ----------------------------> BBox <-------------------------------------
@@ -2199,7 +2235,7 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
     /// @param map mapping of index to world coordinates
     /// @return world bounding box
     template<typename Map>
-    __hostdev__ auto transform(const Map& map) const
+    __hostdev__ constexpr auto transform(const Map& map) const
     {
         using Vec3T = Vec3<double>;
         const Vec3T tmp = map.applyMap(Vec3T(mCoord[0][0], mCoord[0][1], mCoord[0][2]));

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -1012,6 +1012,13 @@ public:
         for (int i = 0; i < N; ++i) out[i] = mVec[i] / s;
         return out;
     }
+    /// @brief Return a unit-length copy (@c *this divided by @c length()) as a @c Derived.
+    /// Const, non-mutating counterpart of the derived @c normalize(). Not @c constexpr —
+    /// @c length() calls @c Sqrt.
+    template<typename Derived>
+    __hostdev__ [[nodiscard]] Derived normalized() const noexcept {
+        return this->template divideBy<Derived>(this->length());
+    }
 
     // ---- in-place compound assignment helpers ----
 
@@ -1235,6 +1242,10 @@ public:
     __hostdev__ constexpr Vec2& operator/=(const T& s) noexcept       { Base::divideAssignScalar(s); return *this; }
     /// @brief Normalize in place (divide by @c length()). Not @c constexpr — calls @c std::sqrt.
     __hostdev__ Vec2& normalize() noexcept                  { return (*this) /= this->length(); }
+    /// @brief Return a normalized (unit-length) copy; const counterpart of @c normalize().
+    __hostdev__ [[nodiscard]] Vec2 normalized() const noexcept {
+        return Base::template normalized<Vec2>();
+    }
 
     // ---- equality ----
     /// @brief Component-wise equality.
@@ -1902,6 +1913,10 @@ public:
     __hostdev__ constexpr Vec3& operator/=(const T& s) noexcept        { Base::divideAssignScalar(s); return *this; }
     /// @brief Normalize in place (divide by @c length()). Not @c constexpr — calls @c std::sqrt.
     __hostdev__ Vec3& normalize() noexcept                   { return (*this) /= this->length(); }
+    /// @brief Return a normalized (unit-length) copy; const counterpart of @c normalize().
+    __hostdev__ [[nodiscard]] Vec3 normalized() const noexcept {
+        return Base::template normalized<Vec3>();
+    }
 
     // ---- equality ----
     /// @brief Component-wise equality.
@@ -2049,6 +2064,10 @@ public:
     __hostdev__ constexpr Vec4& operator/=(const T& s) noexcept        { Base::divideAssignScalar(s); return *this; }
     /// @brief Normalize in place (divide by @c length()). Not @c constexpr — calls @c std::sqrt.
     __hostdev__ Vec4& normalize() noexcept                   { return (*this) /= this->length(); }
+    /// @brief Return a normalized (unit-length) copy; const counterpart of @c normalize().
+    __hostdev__ [[nodiscard]] Vec4 normalized() const noexcept {
+        return Base::template normalized<Vec4>();
+    }
 
     // ---- equality ----
     /// @brief Component-wise equality.

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -67,6 +67,11 @@ struct Tolerance<double>
 {
     __hostdev__ [[nodiscard]] static constexpr double value() noexcept { return 1e-15; }
 };
+template<>
+struct Tolerance<long double>
+{
+    __hostdev__ [[nodiscard]] static constexpr long double value() noexcept { return 1e-18L; }
+};
 //@}
 
 //@{
@@ -82,6 +87,11 @@ template<>
 struct Delta<double>
 {
     __hostdev__ [[nodiscard]] static constexpr double value() noexcept { return 1e-9; }
+};
+template<>
+struct Delta<long double>
+{
+    __hostdev__ [[nodiscard]] static constexpr long double value() noexcept { return 1e-12L; }
 };
 //@}
 
@@ -136,14 +146,6 @@ __hostdev__ [[nodiscard]] inline constexpr Type Min(Type a, Type b) noexcept
 {
     return (a < b) ? a : b;
 }
-__hostdev__ [[nodiscard]] inline constexpr int32_t Min(int32_t a, int32_t b) noexcept
-{
-    return a < b ? a : b;
-}
-__hostdev__ [[nodiscard]] inline constexpr uint32_t Min(uint32_t a, uint32_t b) noexcept
-{
-    return a < b ? a : b;
-}
 // Not constexpr — fminf/fmin aren't constexpr until C++23.
 __hostdev__ [[nodiscard]] inline float Min(float a, float b) noexcept
 {
@@ -158,15 +160,6 @@ template<typename Type>
 __hostdev__ [[nodiscard]] inline constexpr Type Max(Type a, Type b) noexcept
 {
     return (a > b) ? a : b;
-}
-
-__hostdev__ [[nodiscard]] inline constexpr int32_t Max(int32_t a, int32_t b) noexcept
-{
-    return a > b ? a : b;
-}
-__hostdev__ [[nodiscard]] inline constexpr uint32_t Max(uint32_t a, uint32_t b) noexcept
-{
-    return a > b ? a : b;
 }
 // Not constexpr — fmaxf/fmax aren't constexpr until C++23.
 __hostdev__ [[nodiscard]] inline float Max(float a, float b) noexcept
@@ -1274,7 +1267,7 @@ public:
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] / s;
         return out;
     }
-    __hostdev__ constexpr MatBase& divideAssign(const T& s) noexcept {
+    __hostdev__ constexpr MatBase& divideAssignScalar(const T& s) noexcept {
         for (int i = 0; i < size(); ++i) mData[i] /= s;
         return *this;
     }
@@ -1384,7 +1377,7 @@ public:
     __hostdev__ [[nodiscard]] constexpr Mat2  operator*(const T& s) const noexcept        { return this->template scale<Mat2>(s); }
     __hostdev__ [[nodiscard]] constexpr Mat2  operator/(const T& s) const noexcept        { return this->template divideBy<Mat2>(s); }
     __hostdev__ constexpr Mat2& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat2& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat2& operator/=(const T& s) noexcept             { Base::divideAssignScalar(s); return *this; }
 
     // ---- equality ----
     __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat2& m) const noexcept     { return Base::equals(m); }
@@ -1445,7 +1438,7 @@ public:
     __hostdev__ [[nodiscard]] constexpr Mat2x3  operator*(const T& s) const noexcept        { return this->template scale<Mat2x3>(s); }
     __hostdev__ [[nodiscard]] constexpr Mat2x3  operator/(const T& s) const noexcept        { return this->template divideBy<Mat2x3>(s); }
     __hostdev__ constexpr Mat2x3& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat2x3& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat2x3& operator/=(const T& s) noexcept             { Base::divideAssignScalar(s); return *this; }
 
     // ---- equality ----
     __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat2x3& m) const noexcept     { return Base::equals(m); }
@@ -1496,7 +1489,7 @@ public:
     __hostdev__ [[nodiscard]] constexpr Mat3x2  operator*(const T& s) const noexcept        { return this->template scale<Mat3x2>(s); }
     __hostdev__ [[nodiscard]] constexpr Mat3x2  operator/(const T& s) const noexcept        { return this->template divideBy<Mat3x2>(s); }
     __hostdev__ constexpr Mat3x2& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat3x2& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat3x2& operator/=(const T& s) noexcept             { Base::divideAssignScalar(s); return *this; }
 
     // ---- equality ----
     __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat3x2& m) const noexcept     { return Base::equals(m); }
@@ -1551,7 +1544,7 @@ public:
     __hostdev__ [[nodiscard]] constexpr Mat3  operator*(const T& s) const noexcept        { return this->template scale<Mat3>(s); }
     __hostdev__ [[nodiscard]] constexpr Mat3  operator/(const T& s) const noexcept        { return this->template divideBy<Mat3>(s); }
     __hostdev__ constexpr Mat3& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat3& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat3& operator/=(const T& s) noexcept             { Base::divideAssignScalar(s); return *this; }
 
     // ---- equality ----
     __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat3& m) const noexcept     { return Base::equals(m); }
@@ -1612,7 +1605,7 @@ public:
     __hostdev__ [[nodiscard]] constexpr Mat4  operator*(const T& s) const noexcept        { return this->template scale<Mat4>(s); }
     __hostdev__ [[nodiscard]] constexpr Mat4  operator/(const T& s) const noexcept        { return this->template divideBy<Mat4>(s); }
     __hostdev__ constexpr Mat4& operator*=(const T& s) noexcept             { Base::scaleAssign(s); return *this; }
-    __hostdev__ constexpr Mat4& operator/=(const T& s) noexcept             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat4& operator/=(const T& s) noexcept             { Base::divideAssignScalar(s); return *this; }
 
     // ---- equality ----
     __hostdev__ [[nodiscard]] constexpr bool operator==(const Mat4& m) const noexcept     { return Base::equals(m); }
@@ -2076,7 +2069,7 @@ struct BaseBBox
 //    {
 //        return BaseBBox(mCoord[0].offsetBy(-padding),mCoord[1].offsetBy(padding));
 //    }
-    __hostdev__ [[nodiscard]] constexpr bool isInside(const Vec3T& xyz) noexcept
+    __hostdev__ [[nodiscard]] constexpr bool isInside(const Vec3T& xyz) const noexcept
     {
         if (xyz[0] < mCoord[0][0] || xyz[1] < mCoord[0][1] || xyz[2] < mCoord[0][2])
             return false;

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -1004,7 +1004,7 @@ class Vec2 : public VecBase<T, 2>
 
 public:
     using ValueType = T;
-    static const int size = 2; // openvdb::math::Tuple-compat alias of SIZE
+    static constexpr int size = 2; // openvdb::math::Tuple-compat alias of SIZE
 
     Vec2() = default;
     __hostdev__ explicit Vec2(T x)            { this->mVec[0] = x;    this->mVec[1] = x;    }
@@ -1579,7 +1579,7 @@ class Vec3 : public VecBase<T, 3>
 
 public:
     using ValueType = T;
-    static const int size = 3; // openvdb::math::Tuple-compat alias of SIZE
+    static constexpr int size = 3; // openvdb::math::Tuple-compat alias of SIZE
 
     Vec3() = default;
     __hostdev__ explicit Vec3(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; }
@@ -1708,7 +1708,7 @@ class Vec4 : public VecBase<T, 4>
 
 public:
     using ValueType = T;
-    static const int size = 4; // openvdb::math::Tuple-compat alias of SIZE
+    static constexpr int size = 4; // openvdb::math::Tuple-compat alias of SIZE
 
     Vec4() = default;
     __hostdev__ explicit Vec4(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; this->mVec[3] = x; }

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -2310,11 +2310,6 @@ public:
     {
     }
 
-    // Not constexpr — every Rgba8 ctor initialises @c mData.c[4] (the first
-    // union member), so reading @c mData.packed is undefined behaviour at
-    // constant evaluation in C++17 / C++20. (C++20 relaxes the rule only
-    // for layout-compatible types sharing a "common initial sequence",
-    // which doesn't apply to uint8_t[4] vs uint32_t.)
     __hostdev__ bool  operator< (const Rgba8& rhs) const { return mData.packed < rhs.mData.packed; }
     __hostdev__ bool  operator==(const Rgba8& rhs) const { return mData.packed == rhs.mData.packed; }
     __hostdev__ constexpr float lengthSqr() const
@@ -2323,13 +2318,11 @@ public:
                                    float(mData.c[1]) * mData.c[1] +
                                    float(mData.c[2]) * mData.c[2]); //1/255^2
     }
-    // Not constexpr — sqrtf isn't constexpr until C++26.
     __hostdev__ float           length() const { return sqrtf(this->lengthSqr()); }
     /// @brief return n'th color channel as a float in the range 0 to 1
     __hostdev__ constexpr float           asFloat(int n) const { return 0.003921569f*float(mData.c[n]); }// divide by 255
     __hostdev__ constexpr const uint8_t&  operator[](int n) const { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
     __hostdev__ constexpr uint8_t&        operator[](int n) { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
-    // Not constexpr — see note above operator<.
     __hostdev__ const uint32_t& packed() const { return mData.packed; }
     __hostdev__ uint32_t&       packed() { return mData.packed; }
     __hostdev__ constexpr const uint8_t&  r() const { return mData.c[0]; }

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -17,6 +17,8 @@
 
 #include <nanovdb/util/Util.h>// for __hostdev__ and lots of other utility functions
 
+#include <type_traits>// for std::is_floating_point (matches long double in addition to float / double)
+
 #if defined(__CUDA_ARCH__)
 #include <cuda/std/limits>// for ::cuda::std::numeric_limits
 #endif
@@ -955,13 +957,24 @@ public:
     }
 
     // ---- integer rounding (toward -inf / +inf / nearest) ----
+    //
+    // We test against `std::is_floating_point<T>` rather than
+    // `util::is_floating_point<T>` because the latter only matches `float`
+    // and `double` whereas the former (correctly) also matches
+    // `long double`. Without the broader predicate, `Vec<long double>`
+    // would silently truncate via `static_cast<int32_t>` instead of using
+    // the floor/ceil/round rounding rules. The inner `math::Floor` /
+    // `math::Ceil` only have float/double overloads, so `long double`
+    // implicitly converts to `double` at the call site — matching the
+    // pre-refactor behaviour of `Vec*::round()` which routed `long
+    // double` through the same `Floor(x + 0.5)` path.
 
     /// @brief floor-rounded components into the @c Result type (whose @c [i]
     /// must accept int32_t). For integer @c T the value is passed through.
     template<typename Result>
     __hostdev__ Result floorAs() const {
         Result r;
-        if constexpr (util::is_floating_point<T>::value) {
+        if constexpr (std::is_floating_point<T>::value) {
             for (int i = 0; i < N; ++i) r[i] = math::Floor(mVec[i]);
         } else {
             for (int i = 0; i < N; ++i) r[i] = static_cast<int32_t>(mVec[i]);
@@ -971,7 +984,7 @@ public:
     template<typename Result>
     __hostdev__ Result ceilAs() const {
         Result r;
-        if constexpr (util::is_floating_point<T>::value) {
+        if constexpr (std::is_floating_point<T>::value) {
             for (int i = 0; i < N; ++i) r[i] = math::Ceil(mVec[i]);
         } else {
             for (int i = 0; i < N; ++i) r[i] = static_cast<int32_t>(mVec[i]);
@@ -979,12 +992,12 @@ public:
         return r;
     }
     /// @brief nearest-integer rounding using floor(x + 0.5) for floating @c T
-    /// (round-half-toward-positive-infinity). Unifies behaviour between float
-    /// and double; pass-through for integer @c T.
+    /// (round-half-toward-positive-infinity). Unifies behaviour between
+    /// float, double, and long double; pass-through for integer @c T.
     template<typename Result>
     __hostdev__ Result roundAs() const {
         Result r;
-        if constexpr (util::is_floating_point<T>::value) {
+        if constexpr (std::is_floating_point<T>::value) {
             const T half = T(0.5);
             for (int i = 0; i < N; ++i) r[i] = math::Floor(mVec[i] + half);
         } else {

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -146,6 +146,18 @@ __hostdev__ [[nodiscard]] inline constexpr Type Min(Type a, Type b) noexcept
 {
     return (a < b) ? a : b;
 }
+// Mixed integer-type tiebreakers: the templated `Min<Type>` requires both
+// args to deduce to the same `Type`, so calls like `Min(uint32_t, size_t)`
+// would otherwise fall through to the float/double overloads with equal
+// implicit-conversion cost — ambiguous. These integer overloads win.
+__hostdev__ [[nodiscard]] inline constexpr int32_t Min(int32_t a, int32_t b) noexcept
+{
+    return a < b ? a : b;
+}
+__hostdev__ [[nodiscard]] inline constexpr uint32_t Min(uint32_t a, uint32_t b) noexcept
+{
+    return a < b ? a : b;
+}
 // Not constexpr — fminf/fmin aren't constexpr until C++23.
 __hostdev__ [[nodiscard]] inline float Min(float a, float b) noexcept
 {
@@ -160,6 +172,15 @@ template<typename Type>
 __hostdev__ [[nodiscard]] inline constexpr Type Max(Type a, Type b) noexcept
 {
     return (a > b) ? a : b;
+}
+// See Min above: these integer overloads disambiguate mixed-int calls.
+__hostdev__ [[nodiscard]] inline constexpr int32_t Max(int32_t a, int32_t b) noexcept
+{
+    return a > b ? a : b;
+}
+__hostdev__ [[nodiscard]] inline constexpr uint32_t Max(uint32_t a, uint32_t b) noexcept
+{
+    return a > b ? a : b;
 }
 // Not constexpr — fmaxf/fmax aren't constexpr until C++23.
 __hostdev__ [[nodiscard]] inline float Max(float a, float b) noexcept

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -60,12 +60,12 @@ struct Tolerance;
 template<>
 struct Tolerance<float>
 {
-    __hostdev__ static float value() { return 1e-8f; }
+    __hostdev__ static constexpr float value() { return 1e-8f; }
 };
 template<>
 struct Tolerance<double>
 {
-    __hostdev__ static double value() { return 1e-15; }
+    __hostdev__ static constexpr double value() { return 1e-15; }
 };
 //@}
 
@@ -76,12 +76,12 @@ struct Delta;
 template<>
 struct Delta<float>
 {
-    __hostdev__ static float value() { return 1e-5f; }
+    __hostdev__ static constexpr float value() { return 1e-5f; }
 };
 template<>
 struct Delta<double>
 {
-    __hostdev__ static double value() { return 1e-9; }
+    __hostdev__ static constexpr double value() { return 1e-9; }
 };
 //@}
 
@@ -93,91 +93,97 @@ struct Maximum;
 template<typename T>
 struct Maximum
 {
-    __hostdev__ static T value() { return ::cuda::std::numeric_limits<T>::max(); }
+    __hostdev__ static constexpr T value() { return ::cuda::std::numeric_limits<T>::max(); }
 };
 #elif defined(__HIP__)
 template<>
 struct Maximum<int>
 {
-    __hostdev__ static int value() { return 2147483647; }
+    __hostdev__ static constexpr int value() { return 2147483647; }
 };
 template<>
 struct Maximum<uint32_t>
 {
-    __hostdev__ static uint32_t value() { return 4294967295u; }
+    __hostdev__ static constexpr uint32_t value() { return 4294967295u; }
 };
 template<>
 struct Maximum<float>
 {
-    __hostdev__ static float value() { return 1e+38f; }
+    __hostdev__ static constexpr float value() { return 1e+38f; }
 };
 template<>
 struct Maximum<double>
 {
-    __hostdev__ static double value() { return 1e+308; }
+    __hostdev__ static constexpr double value() { return 1e+308; }
 };
 #else
 template<typename T>
 struct Maximum
 {
-    static T value() { return std::numeric_limits<T>::max(); }
+    static constexpr T value() { return std::numeric_limits<T>::max(); }
 };
 #endif
 //@}
 
 template<typename Type>
-__hostdev__ inline bool isApproxZero(const Type& x)
+__hostdev__ inline constexpr bool isApproxZero(const Type& x)
 {
     return !(x > Tolerance<Type>::value()) && !(x < -Tolerance<Type>::value());
 }
 
 template<typename Type>
-__hostdev__ inline Type Min(Type a, Type b)
+__hostdev__ inline constexpr Type Min(Type a, Type b)
 {
     return (a < b) ? a : b;
 }
-__hostdev__ inline int32_t Min(int32_t a, int32_t b)
+__hostdev__ inline constexpr int32_t Min(int32_t a, int32_t b)
 {
     return a < b ? a : b;
 }
-__hostdev__ inline uint32_t Min(uint32_t a, uint32_t b)
+__hostdev__ inline constexpr uint32_t Min(uint32_t a, uint32_t b)
 {
     return a < b ? a : b;
 }
+// Not constexpr — fminf/fmin aren't constexpr until C++23.
 __hostdev__ inline float Min(float a, float b)
 {
     return fminf(a, b);
 }
+// Not constexpr — fminf/fmin aren't constexpr until C++23.
 __hostdev__ inline double Min(double a, double b)
 {
     return fmin(a, b);
 }
 template<typename Type>
-__hostdev__ inline Type Max(Type a, Type b)
+__hostdev__ inline constexpr Type Max(Type a, Type b)
 {
     return (a > b) ? a : b;
 }
 
-__hostdev__ inline int32_t Max(int32_t a, int32_t b)
+__hostdev__ inline constexpr int32_t Max(int32_t a, int32_t b)
 {
     return a > b ? a : b;
 }
-__hostdev__ inline uint32_t Max(uint32_t a, uint32_t b)
+__hostdev__ inline constexpr uint32_t Max(uint32_t a, uint32_t b)
 {
     return a > b ? a : b;
 }
+// Not constexpr — fmaxf/fmax aren't constexpr until C++23.
 __hostdev__ inline float Max(float a, float b)
 {
     return fmaxf(a, b);
 }
+// Not constexpr — fmaxf/fmax aren't constexpr until C++23.
 __hostdev__ inline double Max(double a, double b)
 {
     return fmax(a, b);
 }
+// Not constexpr — depends on non-constexpr float/double Min/Max overloads.
 __hostdev__ inline float Clamp(float x, float a, float b)
 {
     return Max(Min(x, b), a);
 }
+// Not constexpr — depends on non-constexpr float/double Min/Max overloads.
 __hostdev__ inline double Clamp(double x, double a, double b)
 {
     return Max(Min(x, b), a);
@@ -211,40 +217,43 @@ __hostdev__ inline int32_t Ceil(double x)
 }
 
 template<typename T>
-__hostdev__ inline T Pow2(T x)
+__hostdev__ inline constexpr T Pow2(T x)
 {
     return x * x;
 }
 
 template<typename T>
-__hostdev__ inline T Pow3(T x)
+__hostdev__ inline constexpr T Pow3(T x)
 {
     return x * x * x;
 }
 
 template<typename T>
-__hostdev__ inline T Pow4(T x)
+__hostdev__ inline constexpr T Pow4(T x)
 {
     return Pow2(x * x);
 }
 template<typename T>
-__hostdev__ inline T Abs(T x)
+__hostdev__ inline constexpr T Abs(T x)
 {
     return x < 0 ? -x : x;
 }
 
+// Not constexpr — fabsf isn't constexpr until C++23.
 template<>
 __hostdev__ inline float Abs(float x)
 {
     return fabsf(x);
 }
 
+// Not constexpr — fabs isn't constexpr until C++23.
 template<>
 __hostdev__ inline double Abs(double x)
 {
     return fabs(x);
 }
 
+// Not constexpr — std::abs(int) isn't constexpr until C++23.
 template<>
 __hostdev__ inline int Abs(int x)
 {
@@ -293,13 +302,13 @@ __hostdev__ inline double Sqrt(double x)
 
 /// Return the sign of the given value as an integer (either -1, 0 or 1).
 template<typename T>
-__hostdev__ inline T Sign(const T& x)
+__hostdev__ inline constexpr T Sign(const T& x)
 {
     return ((T(0) < x) ? T(1) : T(0)) - ((x < T(0)) ? T(1) : T(0));
 }
 
 template<typename Vec3T>
-__hostdev__ inline int MinIndex(const Vec3T& v)
+__hostdev__ inline constexpr int MinIndex(const Vec3T& v)
 {
 #if 0
     static const int hashTable[8] = {2, 1, 9, 1, 2, 9, 0, 0}; //9 are dummy values
@@ -316,7 +325,7 @@ __hostdev__ inline int MinIndex(const Vec3T& v)
 }
 
 template<typename Vec3T>
-__hostdev__ inline int MaxIndex(const Vec3T& v)
+__hostdev__ inline constexpr int MaxIndex(const Vec3T& v)
 {
 #if 0
     static const int hashTable[8] = {2, 1, 9, 1, 2, 9, 0, 0}; //9 are dummy values
@@ -336,7 +345,7 @@ __hostdev__ inline int MaxIndex(const Vec3T& v)
 ///
 /// @details both wordSize and byteSize are in byte units
 template<uint64_t wordSize>
-__hostdev__ inline uint64_t AlignUp(uint64_t byteCount)
+__hostdev__ inline constexpr uint64_t AlignUp(uint64_t byteCount)
 {
     const uint64_t r = byteCount % wordSize;
     return r ? byteCount - r + wordSize : byteCount;
@@ -357,53 +366,53 @@ public:
     using IndexType = uint32_t;
 
     /// @brief Initialize all coordinates to zero.
-    __hostdev__ Coord()
+    __hostdev__ constexpr Coord()
         : mVec{0, 0, 0}
     {
     }
 
     /// @brief Initializes all coordinates to the given signed integer.
-    __hostdev__ explicit Coord(ValueType n)
+    __hostdev__ explicit constexpr Coord(ValueType n)
         : mVec{n, n, n}
     {
     }
 
     /// @brief Initializes coordinate to the given signed integers.
-    __hostdev__ Coord(ValueType i, ValueType j, ValueType k)
+    __hostdev__ constexpr Coord(ValueType i, ValueType j, ValueType k)
         : mVec{i, j, k}
     {
     }
 
-    __hostdev__ Coord(ValueType* ptr)
+    __hostdev__ constexpr Coord(ValueType* ptr)
         : mVec{ptr[0], ptr[1], ptr[2]}
     {
     }
 
-    __hostdev__ int32_t x() const { return mVec[0]; }
-    __hostdev__ int32_t y() const { return mVec[1]; }
-    __hostdev__ int32_t z() const { return mVec[2]; }
+    __hostdev__ constexpr int32_t x() const { return mVec[0]; }
+    __hostdev__ constexpr int32_t y() const { return mVec[1]; }
+    __hostdev__ constexpr int32_t z() const { return mVec[2]; }
 
-    __hostdev__ int32_t& x() { return mVec[0]; }
-    __hostdev__ int32_t& y() { return mVec[1]; }
-    __hostdev__ int32_t& z() { return mVec[2]; }
+    __hostdev__ constexpr int32_t& x() { return mVec[0]; }
+    __hostdev__ constexpr int32_t& y() { return mVec[1]; }
+    __hostdev__ constexpr int32_t& z() { return mVec[2]; }
 
-    __hostdev__ static Coord max() { return Coord(int32_t((1u << 31) - 1)); }
+    __hostdev__ static constexpr Coord max() { return Coord(int32_t((1u << 31) - 1)); }
 
-    __hostdev__ static Coord min() { return Coord(-int32_t((1u << 31) - 1) - 1); }
+    __hostdev__ static constexpr Coord min() { return Coord(-int32_t((1u << 31) - 1) - 1); }
 
-    __hostdev__ static size_t memUsage() { return sizeof(Coord); }
+    __hostdev__ static constexpr size_t memUsage() { return sizeof(Coord); }
 
     /// @brief Return a const reference to the given Coord component.
     /// @warning The argument is assumed to be 0, 1, or 2.
-    __hostdev__ const ValueType& operator[](IndexType i) const { NANOVDB_ASSERT(i < 3); return mVec[i]; }
+    __hostdev__ constexpr const ValueType& operator[](IndexType i) const { NANOVDB_ASSERT(i < 3); return mVec[i]; }
 
     /// @brief Return a non-const reference to the given Coord component.
     /// @warning The argument is assumed to be 0, 1, or 2.
-    __hostdev__ ValueType& operator[](IndexType i) { NANOVDB_ASSERT(i < 3); return mVec[i]; }
+    __hostdev__ constexpr ValueType& operator[](IndexType i) { NANOVDB_ASSERT(i < 3); return mVec[i]; }
 
     /// @brief Assignment operator that works with openvdb::Coord
     template<typename CoordT>
-    __hostdev__ Coord& operator=(const CoordT& other)
+    __hostdev__ constexpr Coord& operator=(const CoordT& other)
     {
         static_assert(sizeof(Coord) == sizeof(CoordT), "Mis-matched sizeof");
         mVec[0] = other[0];
@@ -413,16 +422,16 @@ public:
     }
 
     /// @brief Return a new instance with coordinates masked by the given unsigned integer.
-    __hostdev__ Coord operator&(IndexType n) const { return Coord(mVec[0] & n, mVec[1] & n, mVec[2] & n); }
+    __hostdev__ constexpr Coord operator&(IndexType n) const { return Coord(mVec[0] & n, mVec[1] & n, mVec[2] & n); }
 
     // @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
-    __hostdev__ Coord operator<<(IndexType n) const { return Coord(mVec[0] << n, mVec[1] << n, mVec[2] << n); }
+    __hostdev__ constexpr Coord operator<<(IndexType n) const { return Coord(mVec[0] << n, mVec[1] << n, mVec[2] << n); }
 
     // @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
-    __hostdev__ Coord operator>>(IndexType n) const { return Coord(mVec[0] >> n, mVec[1] >> n, mVec[2] >> n); }
+    __hostdev__ constexpr Coord operator>>(IndexType n) const { return Coord(mVec[0] >> n, mVec[1] >> n, mVec[2] >> n); }
 
     /// @brief Return true if this Coord is lexicographically less than the given Coord.
-    __hostdev__ bool operator<(const Coord& rhs) const
+    __hostdev__ constexpr bool operator<(const Coord& rhs) const
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -432,7 +441,7 @@ public:
     }
 
     /// @brief Return true if this Coord is lexicographically less or equal to the given Coord.
-    __hostdev__ bool operator<=(const Coord& rhs) const
+    __hostdev__ constexpr bool operator<=(const Coord& rhs) const
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -442,7 +451,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater than the given Coord.
-    __hostdev__ bool operator>(const Coord& rhs) const
+    __hostdev__ constexpr bool operator>(const Coord& rhs) const
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -452,7 +461,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
-    __hostdev__ bool operator>=(const Coord& rhs) const
+    __hostdev__ constexpr bool operator>=(const Coord& rhs) const
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -462,47 +471,47 @@ public:
     }
 
     // @brief Return true if the Coord components are identical.
-    __hostdev__ bool   operator==(const Coord& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1] && mVec[2] == rhs[2]; }
-    __hostdev__ bool   operator!=(const Coord& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1] || mVec[2] != rhs[2]; }
-    __hostdev__ Coord& operator&=(int n)
+    __hostdev__ constexpr bool   operator==(const Coord& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1] && mVec[2] == rhs[2]; }
+    __hostdev__ constexpr bool   operator!=(const Coord& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1] || mVec[2] != rhs[2]; }
+    __hostdev__ constexpr Coord& operator&=(int n)
     {
         mVec[0] &= n;
         mVec[1] &= n;
         mVec[2] &= n;
         return *this;
     }
-    __hostdev__ Coord& operator<<=(uint32_t n)
+    __hostdev__ constexpr Coord& operator<<=(uint32_t n)
     {
         mVec[0] <<= n;
         mVec[1] <<= n;
         mVec[2] <<= n;
         return *this;
     }
-    __hostdev__ Coord& operator>>=(uint32_t n)
+    __hostdev__ constexpr Coord& operator>>=(uint32_t n)
     {
         mVec[0] >>= n;
         mVec[1] >>= n;
         mVec[2] >>= n;
         return *this;
     }
-    __hostdev__ Coord& operator+=(int n)
+    __hostdev__ constexpr Coord& operator+=(int n)
     {
         mVec[0] += n;
         mVec[1] += n;
         mVec[2] += n;
         return *this;
     }
-    __hostdev__ Coord  operator+(const Coord& rhs) const { return Coord(mVec[0] + rhs[0], mVec[1] + rhs[1], mVec[2] + rhs[2]); }
-    __hostdev__ Coord  operator-(const Coord& rhs) const { return Coord(mVec[0] - rhs[0], mVec[1] - rhs[1], mVec[2] - rhs[2]); }
-    __hostdev__ Coord  operator-() const { return Coord(-mVec[0], -mVec[1], -mVec[2]); }
-    __hostdev__ Coord& operator+=(const Coord& rhs)
+    __hostdev__ constexpr Coord  operator+(const Coord& rhs) const { return Coord(mVec[0] + rhs[0], mVec[1] + rhs[1], mVec[2] + rhs[2]); }
+    __hostdev__ constexpr Coord  operator-(const Coord& rhs) const { return Coord(mVec[0] - rhs[0], mVec[1] - rhs[1], mVec[2] - rhs[2]); }
+    __hostdev__ constexpr Coord  operator-() const { return Coord(-mVec[0], -mVec[1], -mVec[2]); }
+    __hostdev__ constexpr Coord& operator+=(const Coord& rhs)
     {
         mVec[0] += rhs[0];
         mVec[1] += rhs[1];
         mVec[2] += rhs[2];
         return *this;
     }
-    __hostdev__ Coord& operator-=(const Coord& rhs)
+    __hostdev__ constexpr Coord& operator-=(const Coord& rhs)
     {
         mVec[0] -= rhs[0];
         mVec[1] -= rhs[1];
@@ -511,7 +520,7 @@ public:
     }
 
     /// @brief Perform a component-wise minimum with the other Coord.
-    __hostdev__ Coord& minComponent(const Coord& other)
+    __hostdev__ constexpr Coord& minComponent(const Coord& other)
     {
         if (other[0] < mVec[0])
             mVec[0] = other[0];
@@ -523,7 +532,7 @@ public:
     }
 
     /// @brief Perform a component-wise maximum with the other Coord.
-    __hostdev__ Coord& maxComponent(const Coord& other)
+    __hostdev__ constexpr Coord& maxComponent(const Coord& other)
     {
         if (other[0] > mVec[0])
             mVec[0] = other[0];
@@ -550,22 +559,23 @@ public:
     }
 #endif
 
-    __hostdev__ Coord offsetBy(ValueType dx, ValueType dy, ValueType dz) const
+    __hostdev__ constexpr Coord offsetBy(ValueType dx, ValueType dy, ValueType dz) const
     {
         return Coord(mVec[0] + dx, mVec[1] + dy, mVec[2] + dz);
     }
 
-    __hostdev__ Coord offsetBy(ValueType n) const { return this->offsetBy(n, n, n); }
+    __hostdev__ constexpr Coord offsetBy(ValueType n) const { return this->offsetBy(n, n, n); }
 
     /// Return true if any of the components of @a a are smaller than the
     /// corresponding components of @a b.
-    __hostdev__ static inline bool lessThan(const Coord& a, const Coord& b)
+    __hostdev__ static inline constexpr bool lessThan(const Coord& a, const Coord& b)
     {
         return (a[0] < b[0] || a[1] < b[1] || a[2] < b[2]);
     }
 
     /// @brief Return the largest integer coordinates that are not greater
     /// than @a xyz (node centered conversion).
+    // Not constexpr — math::Floor uses floorf/floor which aren't constexpr until C++23.
     template<typename Vec3T>
     __hostdev__ static Coord Floor(const Vec3T& xyz) { return Coord(math::Floor(xyz[0]), math::Floor(xyz[1]), math::Floor(xyz[2])); }
 
@@ -575,22 +585,22 @@ public:
     ///          and the prime numbers are modified based on the ACM Transactions on Graphics paper:
     ///          "Real-time 3D reconstruction at scale using voxel hashing" (the second number had a typo!)
     template<int Log2N = 3 + 4 + 5>
-    __hostdev__ uint32_t hash() const { return ((1 << Log2N) - 1) & (mVec[0] * 73856093 ^ mVec[1] * 19349669 ^ mVec[2] * 83492791); }
+    __hostdev__ constexpr uint32_t hash() const { return ((1 << Log2N) - 1) & (mVec[0] * 73856093 ^ mVec[1] * 19349669 ^ mVec[2] * 83492791); }
 
     /// @brief Return the octant of this Coord
     //__hostdev__ size_t octant() const { return (uint32_t(mVec[0])>>31) | ((uint32_t(mVec[1])>>31)<<1) | ((uint32_t(mVec[2])>>31)<<2); }
-    __hostdev__ uint8_t octant() const { return (uint8_t(bool(mVec[0] & (1u << 31)))) |
+    __hostdev__ constexpr uint8_t octant() const { return (uint8_t(bool(mVec[0] & (1u << 31)))) |
                                                 (uint8_t(bool(mVec[1] & (1u << 31))) << 1) |
                                                 (uint8_t(bool(mVec[2] & (1u << 31))) << 2); }
 
     /// @brief Return a single precision floating-point vector of this coordinate
-    __hostdev__ inline Vec3<float> asVec3s() const;
+    __hostdev__ inline constexpr Vec3<float> asVec3s() const;
 
     /// @brief Return a double precision floating-point vector of this coordinate
-    __hostdev__ inline Vec3<double> asVec3d() const;
+    __hostdev__ inline constexpr Vec3<double> asVec3d() const;
 
     // returns a copy of itself, so it mimics the behaviour of Vec3<T>::round()
-    __hostdev__ inline Coord round() const { return *this; }
+    __hostdev__ inline constexpr Coord round() const { return *this; }
 }; // Coord class
 
 
@@ -610,51 +620,51 @@ public:
     using IndexType = uint32_t;
 
     /// @brief Initialize all coordinates to zero.
-    __hostdev__ Coord2()
+    __hostdev__ constexpr Coord2()
         : mVec{0, 0}
     {
     }
 
     /// @brief Initializes all coordinates to the given signed integer.
-    __hostdev__ explicit Coord2(ValueType n)
+    __hostdev__ explicit constexpr Coord2(ValueType n)
         : mVec{n, n}
     {
     }
 
     /// @brief Initializes coordinate to the given signed integers.
-    __hostdev__ Coord2(ValueType i, ValueType j)
+    __hostdev__ constexpr Coord2(ValueType i, ValueType j)
         : mVec{i, j}
     {
     }
 
-    __hostdev__ Coord2(ValueType* ptr)
+    __hostdev__ constexpr Coord2(ValueType* ptr)
         : mVec{ptr[0], ptr[1]}
     {
     }
 
-    __hostdev__ int32_t x() const { return mVec[0]; }
-    __hostdev__ int32_t y() const { return mVec[1]; }
+    __hostdev__ constexpr int32_t x() const { return mVec[0]; }
+    __hostdev__ constexpr int32_t y() const { return mVec[1]; }
 
-    __hostdev__ int32_t& x() { return mVec[0]; }
-    __hostdev__ int32_t& y() { return mVec[1]; }
+    __hostdev__ constexpr int32_t& x() { return mVec[0]; }
+    __hostdev__ constexpr int32_t& y() { return mVec[1]; }
 
-    __hostdev__ static Coord2 max() { return Coord2(int32_t((1u << 31) - 1)); }
+    __hostdev__ static constexpr Coord2 max() { return Coord2(int32_t((1u << 31) - 1)); }
 
-    __hostdev__ static Coord2 min() { return Coord2(-int32_t((1u << 31) - 1) - 1); }
+    __hostdev__ static constexpr Coord2 min() { return Coord2(-int32_t((1u << 31) - 1) - 1); }
 
-    __hostdev__ static size_t memUsage() { return sizeof(Coord2); }
+    __hostdev__ static constexpr size_t memUsage() { return sizeof(Coord2); }
 
     /// @brief Return a const reference to the given Coord component.
     /// @warning The argument is assumed to be 0 or 1,
-    __hostdev__ const ValueType& operator[](IndexType i) const { NANOVDB_ASSERT(i < 2); return mVec[i]; }
+    __hostdev__ constexpr const ValueType& operator[](IndexType i) const { NANOVDB_ASSERT(i < 2); return mVec[i]; }
 
     /// @brief Return a non-const reference to the given Coord component.
     /// @warning The argument is assumed to be 0 or 1.
-    __hostdev__ ValueType& operator[](IndexType i) { NANOVDB_ASSERT(i < 2); return mVec[i]; }
+    __hostdev__ constexpr ValueType& operator[](IndexType i) { NANOVDB_ASSERT(i < 2); return mVec[i]; }
 
     /// @brief Assignment operator that works with openvdb::Coord
     template<typename CoordT>
-    __hostdev__ Coord2& operator=(const CoordT& other)
+    __hostdev__ constexpr Coord2& operator=(const CoordT& other)
     {
         static_assert(sizeof(Coord2) == sizeof(CoordT), "Mis-matched sizeof");
         mVec[0] = other[0];
@@ -663,16 +673,16 @@ public:
     }
 
     /// @brief Return a new instance with coordinates masked by the given unsigned integer.
-    __hostdev__ Coord2 operator&(IndexType n) const { return Coord2(mVec[0] & n, mVec[1] & n); }
+    __hostdev__ constexpr Coord2 operator&(IndexType n) const { return Coord2(mVec[0] & n, mVec[1] & n); }
 
     // @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
-    __hostdev__ Coord2 operator<<(IndexType n) const { return Coord2(mVec[0] << n, mVec[1] << n); }
+    __hostdev__ constexpr Coord2 operator<<(IndexType n) const { return Coord2(mVec[0] << n, mVec[1] << n); }
 
     // @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
-    __hostdev__ Coord2 operator>>(IndexType n) const { return Coord2(mVec[0] >> n, mVec[1] >> n); }
+    __hostdev__ constexpr Coord2 operator>>(IndexType n) const { return Coord2(mVec[0] >> n, mVec[1] >> n); }
 
     /// @brief Return true if this Coord is lexicographically less than the given Coord.
-    __hostdev__ bool operator<(const Coord2& rhs) const
+    __hostdev__ constexpr bool operator<(const Coord2& rhs) const
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -680,7 +690,7 @@ public:
     }
 
     /// @brief Return true if this Coord is lexicographically less or equal to the given Coord.
-    __hostdev__ bool operator<=(const Coord2& rhs) const
+    __hostdev__ constexpr bool operator<=(const Coord2& rhs) const
     {
         return mVec[0] < rhs[0] ? true
              : mVec[0] > rhs[0] ? false
@@ -688,7 +698,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater than the given Coord.
-    __hostdev__ bool operator>(const Coord2& rhs) const
+    __hostdev__ constexpr bool operator>(const Coord2& rhs) const
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -696,7 +706,7 @@ public:
     }
 
     // @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
-    __hostdev__ bool operator>=(const Coord2& rhs) const
+    __hostdev__ constexpr bool operator>=(const Coord2& rhs) const
     {
         return mVec[0] > rhs[0] ? true
              : mVec[0] < rhs[0] ? false
@@ -704,42 +714,42 @@ public:
     }
 
     // @brief Return true if the Coord components are identical.
-    __hostdev__ bool   operator==(const Coord2& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
-    __hostdev__ bool   operator!=(const Coord2& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
-    __hostdev__ Coord2& operator&=(int n)
+    __hostdev__ constexpr bool   operator==(const Coord2& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
+    __hostdev__ constexpr bool   operator!=(const Coord2& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
+    __hostdev__ constexpr Coord2& operator&=(int n)
     {
         mVec[0] &= n;
         mVec[1] &= n;
         return *this;
     }
-    __hostdev__ Coord2& operator<<=(uint32_t n)
+    __hostdev__ constexpr Coord2& operator<<=(uint32_t n)
     {
         mVec[0] <<= n;
         mVec[1] <<= n;
         return *this;
     }
-    __hostdev__ Coord2& operator>>=(uint32_t n)
+    __hostdev__ constexpr Coord2& operator>>=(uint32_t n)
     {
         mVec[0] >>= n;
         mVec[1] >>= n;
         return *this;
     }
-    __hostdev__ Coord2& operator+=(int n)
+    __hostdev__ constexpr Coord2& operator+=(int n)
     {
         mVec[0] += n;
         mVec[1] += n;
         return *this;
     }
-    __hostdev__ Coord2  operator+(const Coord2& rhs) const { return Coord2(mVec[0] + rhs[0], mVec[1] + rhs[1]); }
-    __hostdev__ Coord2  operator-(const Coord2& rhs) const { return Coord2(mVec[0] - rhs[0], mVec[1] - rhs[1]); }
-    __hostdev__ Coord2  operator-() const { return Coord2(-mVec[0], -mVec[1]); }
-    __hostdev__ Coord2& operator+=(const Coord2& rhs)
+    __hostdev__ constexpr Coord2  operator+(const Coord2& rhs) const { return Coord2(mVec[0] + rhs[0], mVec[1] + rhs[1]); }
+    __hostdev__ constexpr Coord2  operator-(const Coord2& rhs) const { return Coord2(mVec[0] - rhs[0], mVec[1] - rhs[1]); }
+    __hostdev__ constexpr Coord2  operator-() const { return Coord2(-mVec[0], -mVec[1]); }
+    __hostdev__ constexpr Coord2& operator+=(const Coord2& rhs)
     {
         mVec[0] += rhs[0];
         mVec[1] += rhs[1];
         return *this;
     }
-    __hostdev__ Coord2& operator-=(const Coord2& rhs)
+    __hostdev__ constexpr Coord2& operator-=(const Coord2& rhs)
     {
         mVec[0] -= rhs[0];
         mVec[1] -= rhs[1];
@@ -747,7 +757,7 @@ public:
     }
 
     /// @brief Perform a component-wise minimum with the other Coord.
-    __hostdev__ Coord2& minComponent(const Coord2& other)
+    __hostdev__ constexpr Coord2& minComponent(const Coord2& other)
     {
         if (other[0] < mVec[0])
             mVec[0] = other[0];
@@ -757,7 +767,7 @@ public:
     }
 
     /// @brief Perform a component-wise maximum with the other Coord.
-    __hostdev__ Coord2& maxComponent(const Coord2& other)
+    __hostdev__ constexpr Coord2& maxComponent(const Coord2& other)
     {
         if (other[0] > mVec[0])
             mVec[0] = other[0];
@@ -780,33 +790,34 @@ public:
     }
 #endif
 
-    __hostdev__ Coord2 offsetBy(ValueType dx, ValueType dy) const
+    __hostdev__ constexpr Coord2 offsetBy(ValueType dx, ValueType dy) const
     {
         return Coord2(mVec[0] + dx, mVec[1] + dy);
     }
 
-    __hostdev__ Coord2 offsetBy(ValueType n) const { return this->offsetBy(n, n); }
+    __hostdev__ constexpr Coord2 offsetBy(ValueType n) const { return this->offsetBy(n, n); }
 
     /// Return true if any of the components of @a a are smaller than the
     /// corresponding components of @a b.
-    __hostdev__ static inline bool lessThan(const Coord2& a, const Coord2& b)
+    __hostdev__ static inline constexpr bool lessThan(const Coord2& a, const Coord2& b)
     {
         return (a[0] < b[0] || a[1] < b[1]);
     }
 
     /// @brief Return the largest integer coordinates that are not greater
     /// than @a xyz (node centered conversion).
+    // Not constexpr — math::Floor uses floorf/floor which aren't constexpr until C++23.
     template<typename Vec2T>
     __hostdev__ static Coord2 Floor(const Vec2T& xy) { return Coord2(math::Floor(xy[0]), math::Floor(xy[1])); }
 
     /// @brief Return a single precision floating-point vector of this coordinate
-    __hostdev__ inline Vec2<float> asVec2s() const;
+    __hostdev__ inline constexpr Vec2<float> asVec2s() const;
 
     /// @brief Return a double precision floating-point vector of this coordinate
-    __hostdev__ inline Vec2<double> asVec2d() const;
+    __hostdev__ inline constexpr Vec2<double> asVec2d() const;
 
     // returns a copy of itself, so it mimics the behaviour of Vec3<T>::round()
-    __hostdev__ inline Coord2 round() const { return *this; }
+    __hostdev__ inline constexpr Coord2 round() const { return *this; }
 }; // Coord2 class
 
 // ----------------------------> VecBase <-----------------------------------
@@ -828,88 +839,88 @@ public:
     VecBase() = default;
 
     /// @brief Indexed element access. Asserts 0 <= i < N in debug builds.
-    __hostdev__ const T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
-    __hostdev__ T&       operator[](int i)       { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
+    __hostdev__ constexpr const T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
+    __hostdev__ constexpr T&       operator[](int i)       { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
 
     /// @brief raw pointer to the underlying N-element storage
-    __hostdev__ T*       asPointer()       { return mVec; }
-    __hostdev__ const T* asPointer() const { return mVec; }
+    __hostdev__ constexpr T*       asPointer()       { return mVec; }
+    __hostdev__ constexpr const T* asPointer() const { return mVec; }
 
     // ---- generic element-wise helpers (taking/returning Derived) ----
 
     template<typename Derived>
-    __hostdev__ Derived plus(const Derived& rhs) const {
-        Derived out;
+    __hostdev__ constexpr Derived plus(const Derived& rhs) const {
+        Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] + rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ Derived minus(const Derived& rhs) const {
-        Derived out;
+    __hostdev__ constexpr Derived minus(const Derived& rhs) const {
+        Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] - rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ Derived mul(const Derived& rhs) const {
-        Derived out;
+    __hostdev__ constexpr Derived mul(const Derived& rhs) const {
+        Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] * rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ Derived div(const Derived& rhs) const {
-        Derived out;
+    __hostdev__ constexpr Derived div(const Derived& rhs) const {
+        Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] / rhs[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ Derived negate() const {
-        Derived out;
+    __hostdev__ constexpr Derived negate() const {
+        Derived out{};
         for (int i = 0; i < N; ++i) out[i] = -mVec[i];
         return out;
     }
     template<typename Derived>
-    __hostdev__ Derived scale(const T& s) const {
-        Derived out;
+    __hostdev__ constexpr Derived scale(const T& s) const {
+        Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] * s;
         return out;
     }
     /// @brief return (*this) / @a s element-wise as a @c Derived. Uses per-element
     /// division (correct for integer @c T, unlike multiplying by 1/s).
     template<typename Derived>
-    __hostdev__ Derived divideBy(const T& s) const {
-        Derived out;
+    __hostdev__ constexpr Derived divideBy(const T& s) const {
+        Derived out{};
         for (int i = 0; i < N; ++i) out[i] = mVec[i] / s;
         return out;
     }
 
     // ---- in-place compound assignment helpers ----
 
-    __hostdev__ VecBase& addAssign(const VecBase& rhs) {
+    __hostdev__ constexpr VecBase& addAssign(const VecBase& rhs) {
         for (int i = 0; i < N; ++i) mVec[i] += rhs.mVec[i];
         return *this;
     }
-    __hostdev__ VecBase& subAssign(const VecBase& rhs) {
+    __hostdev__ constexpr VecBase& subAssign(const VecBase& rhs) {
         for (int i = 0; i < N; ++i) mVec[i] -= rhs.mVec[i];
         return *this;
     }
-    __hostdev__ VecBase& mulAssign(const VecBase& rhs) {
+    __hostdev__ constexpr VecBase& mulAssign(const VecBase& rhs) {
         for (int i = 0; i < N; ++i) mVec[i] *= rhs.mVec[i];
         return *this;
     }
-    __hostdev__ VecBase& divAssign(const VecBase& rhs) {
+    __hostdev__ constexpr VecBase& divAssign(const VecBase& rhs) {
         for (int i = 0; i < N; ++i) mVec[i] /= rhs.mVec[i];
         return *this;
     }
-    __hostdev__ VecBase& scaleAssign(const T& s) {
+    __hostdev__ constexpr VecBase& scaleAssign(const T& s) {
         for (int i = 0; i < N; ++i) mVec[i] *= s;
         return *this;
     }
-    __hostdev__ VecBase& divideAssignScalar(const T& s) {
+    __hostdev__ constexpr VecBase& divideAssignScalar(const T& s) {
         for (int i = 0; i < N; ++i) mVec[i] /= s;
         return *this;
     }
 
-    __hostdev__ bool equals(const VecBase& rhs) const {
+    __hostdev__ constexpr bool equals(const VecBase& rhs) const {
         for (int i = 0; i < N; ++i) if (mVec[i] != rhs.mVec[i]) return false;
         return true;
     }
@@ -918,26 +929,27 @@ public:
 
     /// @brief dot product. @a V must have @c operator[] valid for 0..N-1.
     template<typename V>
-    __hostdev__ T dot(const V& v) const {
+    __hostdev__ constexpr T dot(const V& v) const {
         T s = T(0);
         for (int i = 0; i < N; ++i) s += mVec[i] * v[i];
         return s;
     }
-    __hostdev__ T lengthSqr() const {
+    __hostdev__ constexpr T lengthSqr() const {
         T s = T(0);
         for (int i = 0; i < N; ++i) s += mVec[i] * mVec[i];
         return s;
     }
+    // Not constexpr — std::sqrt isn't constexpr until C++26.
     __hostdev__ T length() const { return Sqrt(this->lengthSqr()); }
 
     /// @brief return the smallest of the N components
-    __hostdev__ T smallestComponent() const {
+    __hostdev__ constexpr T smallestComponent() const {
         T m = mVec[0];
         for (int i = 1; i < N; ++i) if (mVec[i] < m) m = mVec[i];
         return m;
     }
     /// @brief return the largest of the N components
-    __hostdev__ T largestComponent() const {
+    __hostdev__ constexpr T largestComponent() const {
         T m = mVec[0];
         for (int i = 1; i < N; ++i) if (mVec[i] > m) m = mVec[i];
         return m;
@@ -946,12 +958,12 @@ public:
     // ---- component-wise (mutating) min/max ----
 
     template<typename V>
-    __hostdev__ VecBase& mergeMin(const V& other) {
+    __hostdev__ constexpr VecBase& mergeMin(const V& other) {
         for (int i = 0; i < N; ++i) if (other[i] < mVec[i]) mVec[i] = other[i];
         return *this;
     }
     template<typename V>
-    __hostdev__ VecBase& mergeMax(const V& other) {
+    __hostdev__ constexpr VecBase& mergeMax(const V& other) {
         for (int i = 0; i < N; ++i) if (other[i] > mVec[i]) mVec[i] = other[i];
         return *this;
     }
@@ -971,9 +983,12 @@ public:
 
     /// @brief floor-rounded components into the @c Result type (whose @c [i]
     /// must accept int32_t). For integer @c T the value is passed through.
+    /// @note Only the integer-@c T specialization is usable as a constant
+    /// expression; the floating-point branch calls @c math::Floor /
+    /// @c math::Ceil, which aren't constexpr until C++23.
     template<typename Result>
-    __hostdev__ Result floorAs() const {
-        Result r;
+    __hostdev__ constexpr Result floorAs() const {
+        Result r{};
         if constexpr (std::is_floating_point<T>::value) {
             for (int i = 0; i < N; ++i) r[i] = math::Floor(mVec[i]);
         } else {
@@ -982,8 +997,8 @@ public:
         return r;
     }
     template<typename Result>
-    __hostdev__ Result ceilAs() const {
-        Result r;
+    __hostdev__ constexpr Result ceilAs() const {
+        Result r{};
         if constexpr (std::is_floating_point<T>::value) {
             for (int i = 0; i < N; ++i) r[i] = math::Ceil(mVec[i]);
         } else {
@@ -994,9 +1009,10 @@ public:
     /// @brief nearest-integer rounding using floor(x + 0.5) for floating @c T
     /// (round-half-toward-positive-infinity). Unifies behaviour between
     /// float, double, and long double; pass-through for integer @c T.
+    /// @note See @c floorAs — only the integer-@c T branch is constexpr-usable.
     template<typename Result>
-    __hostdev__ Result roundAs() const {
-        Result r;
+    __hostdev__ constexpr Result roundAs() const {
+        Result r{};
         if constexpr (std::is_floating_point<T>::value) {
             const T half = T(0.5);
             for (int i = 0; i < N; ++i) r[i] = math::Floor(mVec[i] + half);
@@ -1020,100 +1036,104 @@ public:
     static constexpr int size = 2; // openvdb::math::Tuple-compat alias of SIZE
 
     Vec2() = default;
-    __hostdev__ explicit Vec2(T x)            { this->mVec[0] = x;    this->mVec[1] = x;    }
-    __hostdev__ Vec2(T x, T y)                { this->mVec[0] = x;    this->mVec[1] = y;    }
+    __hostdev__ explicit constexpr Vec2(T x)            { this->mVec[0] = x;    this->mVec[1] = x;    }
+    __hostdev__ constexpr Vec2(T x, T y)                { this->mVec[0] = x;    this->mVec[1] = y;    }
 
     template<template<class> class Vec2T, class T2>
-    __hostdev__ Vec2(const Vec2T<T2>& v) {
+    __hostdev__ constexpr Vec2(const Vec2T<T2>& v) {
         static_assert(Vec2T<T2>::size == 2, "expected Vec2T::size==2!");
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]);
     }
     template<typename T2>
-    __hostdev__ explicit Vec2(const Vec2<T2>& v) {
+    __hostdev__ explicit constexpr Vec2(const Vec2<T2>& v) {
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]);
     }
-    __hostdev__ explicit Vec2(const Coord2& ijk) {
+    __hostdev__ explicit constexpr Vec2(const Coord2& ijk) {
         this->mVec[0] = T(ijk[0]); this->mVec[1] = T(ijk[1]);
     }
 
     template<template<class> class Vec2T, class T2>
-    __hostdev__ Vec2& operator=(const Vec2T<T2>& rhs) {
+    __hostdev__ constexpr Vec2& operator=(const Vec2T<T2>& rhs) {
         static_assert(Vec2T<T2>::size == 2, "expected Vec2T::size==2!");
         this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1];
         return *this;
     }
 
     // ---- element-wise (Vec & Vec) ----
-    __hostdev__ Vec2  operator-() const            { return Base::template negate<Vec2>(); }
-    __hostdev__ Vec2  operator+(const Vec2& v) const { return Base::template plus<Vec2>(v); }
-    __hostdev__ Vec2  operator-(const Vec2& v) const { return Base::template minus<Vec2>(v); }
-    __hostdev__ Vec2  operator*(const Vec2& v) const { return Base::template mul<Vec2>(v); }
-    __hostdev__ Vec2  operator/(const Vec2& v) const { return Base::template div<Vec2>(v); }
-    __hostdev__ Vec2& operator+=(const Vec2& v)    { Base::addAssign(v); return *this; }
-    __hostdev__ Vec2& operator-=(const Vec2& v)    { Base::subAssign(v); return *this; }
+    __hostdev__ constexpr Vec2  operator-() const            { return Base::template negate<Vec2>(); }
+    __hostdev__ constexpr Vec2  operator+(const Vec2& v) const { return Base::template plus<Vec2>(v); }
+    __hostdev__ constexpr Vec2  operator-(const Vec2& v) const { return Base::template minus<Vec2>(v); }
+    __hostdev__ constexpr Vec2  operator*(const Vec2& v) const { return Base::template mul<Vec2>(v); }
+    __hostdev__ constexpr Vec2  operator/(const Vec2& v) const { return Base::template div<Vec2>(v); }
+    __hostdev__ constexpr Vec2& operator+=(const Vec2& v)    { Base::addAssign(v); return *this; }
+    __hostdev__ constexpr Vec2& operator-=(const Vec2& v)    { Base::subAssign(v); return *this; }
 
     // ---- mixed Vec2 / Coord2 ----
-    __hostdev__ Vec2  operator+(const Coord2& ijk) const { return Vec2(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1]); }
-    __hostdev__ Vec2  operator-(const Coord2& ijk) const { return Vec2(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1]); }
-    __hostdev__ Vec2& operator+=(const Coord2& ijk) {
+    __hostdev__ constexpr Vec2  operator+(const Coord2& ijk) const { return Vec2(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1]); }
+    __hostdev__ constexpr Vec2  operator-(const Coord2& ijk) const { return Vec2(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1]); }
+    __hostdev__ constexpr Vec2& operator+=(const Coord2& ijk) {
         this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]);
         return *this;
     }
-    __hostdev__ Vec2& operator-=(const Coord2& ijk) {
+    __hostdev__ constexpr Vec2& operator-=(const Coord2& ijk) {
         this->mVec[0] -= T(ijk[0]); this->mVec[1] -= T(ijk[1]);
         return *this;
     }
 
     // ---- scalar ----
-    __hostdev__ Vec2  operator*(const T& s) const  { return Base::template scale<Vec2>(s); }
-    __hostdev__ Vec2  operator/(const T& s) const  { return Base::template divideBy<Vec2>(s); }
-    __hostdev__ Vec2& operator*=(const T& s)       { Base::scaleAssign(s); return *this; }
-    __hostdev__ Vec2& operator/=(const T& s)       { Base::divideAssignScalar(s); return *this; }
+    __hostdev__ constexpr Vec2  operator*(const T& s) const  { return Base::template scale<Vec2>(s); }
+    __hostdev__ constexpr Vec2  operator/(const T& s) const  { return Base::template divideBy<Vec2>(s); }
+    __hostdev__ constexpr Vec2& operator*=(const T& s)       { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Vec2& operator/=(const T& s)       { Base::divideAssignScalar(s); return *this; }
+    // Not constexpr — depends on length() which calls std::sqrt.
     __hostdev__ Vec2& normalize()                  { return (*this) /= this->length(); }
 
     // ---- equality ----
-    __hostdev__ bool operator==(const Vec2& rhs) const { return Base::equals(rhs); }
-    __hostdev__ bool operator!=(const Vec2& rhs) const { return !Base::equals(rhs); }
+    __hostdev__ constexpr bool operator==(const Vec2& rhs) const { return Base::equals(rhs); }
+    __hostdev__ constexpr bool operator!=(const Vec2& rhs) const { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
-    __hostdev__ Vec2& minComponent(const Vec2& other) { Base::mergeMin(other); return *this; }
-    __hostdev__ Vec2& maxComponent(const Vec2& other) { Base::mergeMax(other); return *this; }
+    __hostdev__ constexpr Vec2& minComponent(const Vec2& other) { Base::mergeMin(other); return *this; }
+    __hostdev__ constexpr Vec2& maxComponent(const Vec2& other) { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
-    __hostdev__ ValueType min() const { return Base::smallestComponent(); }
+    __hostdev__ constexpr ValueType min() const { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ ValueType max() const { return Base::largestComponent(); }
+    __hostdev__ constexpr ValueType max() const { return Base::largestComponent(); }
 
     /// @brief Round each component down (toward negative infinity)
     /// @return integer Coord2
-    __hostdev__ Coord2 floor() const { return Base::template floorAs<Coord2>(); }
+    /// @note Only constexpr for integer @c T (floorAs uses non-constexpr math::Floor for floating point).
+    __hostdev__ constexpr Coord2 floor() const { return Base::template floorAs<Coord2>(); }
     /// @brief Round each component up (toward positive infinity)
     /// @return integer Coord2
-    __hostdev__ Coord2 ceil()  const { return Base::template ceilAs<Coord2>(); }
+    /// @note Only constexpr for integer @c T (ceilAs uses non-constexpr math::Ceil for floating point).
+    __hostdev__ constexpr Coord2 ceil()  const { return Base::template ceilAs<Coord2>(); }
     /// @brief Round each component to its closest integer value
     /// @return integer Coord2
-    __hostdev__ Coord2 round() const { return Base::template roundAs<Coord2>(); }
+    /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
+    __hostdev__ constexpr Coord2 round() const { return Base::template roundAs<Coord2>(); }
 }; // Vec2<T>
 
 template<typename T1, typename T2>
-__hostdev__ inline Vec2<T2> operator*(T1 scalar, const Vec2<T2>& vec)
+__hostdev__ inline constexpr Vec2<T2> operator*(T1 scalar, const Vec2<T2>& vec)
 {
     return Vec2<T2>(scalar * vec[0], scalar * vec[1]);
 }
 template<typename T1, typename T2>
-__hostdev__ inline Vec2<T2> operator/(T1 scalar, const Vec2<T2>& vec)
+__hostdev__ inline constexpr Vec2<T2> operator/(T1 scalar, const Vec2<T2>& vec)
 {
     return Vec2<T2>(scalar / vec[0], scalar / vec[1]);
 }
 
 /// @brief Return a single precision floating-point vector of this coordinate
-__hostdev__ inline Vec2<float> Coord2::asVec2s() const
+__hostdev__ inline constexpr Vec2<float> Coord2::asVec2s() const
 {
     return Vec2<float>(float(mVec[0]), float(mVec[1]));
 }
 
 /// @brief Return a double precision floating-point vector of this coordinate
-__hostdev__ inline Vec2<double> Coord2::asVec2d() const
+__hostdev__ inline constexpr Vec2<double> Coord2::asVec2d() const
 {
     return Vec2<double>(double(mVec[0]), double(mVec[1]));
 }
@@ -1135,7 +1155,7 @@ public:
     MatBase() = default;
 
     template<typename S>
-    __hostdev__ MatBase(S* array) {
+    __hostdev__ constexpr MatBase(S* array) {
         for (int i = 0; i < size(); ++i) {
             mData[i] = static_cast<T>(array[i]);
         }
@@ -1143,63 +1163,63 @@ public:
 
     // 2D array access. Returns a row pointer; the caller is responsible
     // for the column bound (0 <= col < COLS).
-    __hostdev__ T* operator[](int row) {
+    __hostdev__ constexpr T* operator[](int row) {
         NANOVDB_ASSERT(row >= 0 && row < ROWS);
         return &mData[row * COLS];
     }
-    __hostdev__ const T* operator[](int row) const {
+    __hostdev__ constexpr const T* operator[](int row) const {
         NANOVDB_ASSERT(row >= 0 && row < ROWS);
         return &mData[row * COLS];
     }
 
     /// @brief return a raw pointer to the underlying 1D storage (row-major)
-    __hostdev__ T*       data()       { return mData; }
+    __hostdev__ constexpr T*       data()       { return mData; }
     /// @brief return a const raw pointer to the underlying 1D storage (row-major)
-    __hostdev__ const T* data() const { return mData; }
+    __hostdev__ constexpr const T* data() const { return mData; }
 
     // ---- generic element-wise helpers ----
 
     /// @brief return @c *this + @a rhs as a @c Derived
     template<typename Derived>
-    __hostdev__ Derived plus(const Derived& rhs) const {
-        Derived out;
+    __hostdev__ constexpr Derived plus(const Derived& rhs) const {
+        Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] + rhs.data()[i];
         return out;
     }
 
     /// @brief return @c *this - @a rhs as a @c Derived
     template<typename Derived>
-    __hostdev__ Derived minus(const Derived& rhs) const {
-        Derived out;
+    __hostdev__ constexpr Derived minus(const Derived& rhs) const {
+        Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] - rhs.data()[i];
         return out;
     }
 
     /// @brief return -(*this) as a @c Derived
     template<typename Derived>
-    __hostdev__ Derived negate() const {
-        Derived out;
+    __hostdev__ constexpr Derived negate() const {
+        Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = -mData[i];
         return out;
     }
 
     /// @brief return @a s * (*this) as a @c Derived
     template<typename Derived>
-    __hostdev__ Derived scale(const T& s) const {
-        Derived out;
+    __hostdev__ constexpr Derived scale(const T& s) const {
+        Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] * s;
         return out;
     }
 
-    __hostdev__ MatBase& addAssign(const MatBase& rhs) {
+    __hostdev__ constexpr MatBase& addAssign(const MatBase& rhs) {
         for (int i = 0; i < size(); ++i) mData[i] += rhs.mData[i];
         return *this;
     }
-    __hostdev__ MatBase& subAssign(const MatBase& rhs) {
+    __hostdev__ constexpr MatBase& subAssign(const MatBase& rhs) {
         for (int i = 0; i < size(); ++i) mData[i] -= rhs.mData[i];
         return *this;
     }
-    __hostdev__ MatBase& scaleAssign(const T& s) {
+    __hostdev__ constexpr MatBase& scaleAssign(const T& s) {
         for (int i = 0; i < size(); ++i) mData[i] *= s;
         return *this;
     }
@@ -1207,17 +1227,17 @@ public:
     /// @brief return (*this) / @a s element-wise as a @c Derived. Uses
     /// per-element division (correct for integer @c T, unlike multiplying by 1/s).
     template<typename Derived>
-    __hostdev__ Derived divideBy(const T& s) const {
-        Derived out;
+    __hostdev__ constexpr Derived divideBy(const T& s) const {
+        Derived out{};
         for (int i = 0; i < size(); ++i) out.data()[i] = mData[i] / s;
         return out;
     }
-    __hostdev__ MatBase& divideAssign(const T& s) {
+    __hostdev__ constexpr MatBase& divideAssign(const T& s) {
         for (int i = 0; i < size(); ++i) mData[i] /= s;
         return *this;
     }
 
-    __hostdev__ bool equals(const MatBase& rhs) const {
+    __hostdev__ constexpr bool equals(const MatBase& rhs) const {
         for (int i = 0; i < size(); ++i) if (mData[i] != rhs.mData[i]) return false;
         return true;
     }
@@ -1227,10 +1247,10 @@ public:
     /// @brief return the transpose of @c *this as the @c Result type.
     /// @tparam Result a matrix type whose dimensions are (COLS, ROWS)
     template<typename Result>
-    __hostdev__ Result transposeAs() const {
+    __hostdev__ constexpr Result transposeAs() const {
         static_assert(Result::rows() == COLS && Result::cols() == ROWS,
                       "transposeAs: result dims must be (COLS, ROWS)");
-        Result r;
+        Result r{};
         for (int i = 0; i < ROWS; ++i)
             for (int j = 0; j < COLS; ++j)
                 r[j][i] = mData[i * COLS + j];
@@ -1243,11 +1263,11 @@ public:
     /// @tparam Result a matrix type whose dimensions are (ROWS, Rhs::cols())
     /// @tparam Rhs    a matrix type whose row count equals @c COLS
     template<typename Result, typename Rhs>
-    __hostdev__ Result multiply(const Rhs& rhs) const {
+    __hostdev__ constexpr Result multiply(const Rhs& rhs) const {
         static_assert(COLS == Rhs::rows(), "multiply: lhs.cols must equal rhs.rows");
         static_assert(Result::rows() == ROWS && Result::cols() == Rhs::cols(),
                       "multiply: result dims mismatch");
-        Result r;
+        Result r{};
         for (int i = 0; i < ROWS; ++i) {
             for (int j = 0; j < Rhs::cols(); ++j) {
                 T sum = T(0);
@@ -1265,10 +1285,10 @@ public:
     /// @tparam VecResult a vector type whose @c SIZE equals @c ROWS
     /// @tparam VecRhs    a vector type whose @c SIZE equals @c COLS
     template<typename VecResult, typename VecRhs>
-    __hostdev__ VecResult multiplyVec(const VecRhs& v) const {
+    __hostdev__ constexpr VecResult multiplyVec(const VecRhs& v) const {
         static_assert(VecRhs::SIZE == COLS && VecResult::SIZE == ROWS,
                       "multiplyVec: dim mismatch");
-        VecResult r;
+        VecResult r{};
         for (int i = 0; i < ROWS; ++i) {
             T sum = T(0);
             for (int k = 0; k < COLS; ++k) sum += mData[i * COLS + k] * v[k];
@@ -1298,41 +1318,41 @@ public:
         a b
         c d
         @endverbatim */
-    __hostdev__ Mat2(T a, T b, T c, T d) {
+    __hostdev__ constexpr Mat2(T a, T b, T c, T d) {
         this->mData[0] = a; this->mData[1] = b;
         this->mData[2] = c; this->mData[3] = d;
     }
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ Mat2(Source* array) : Base(array) {}
+    __hostdev__ constexpr Mat2(Source* array) : Base(array) {}
 
     // ---- element-wise ----
-    __hostdev__ Mat2  operator-() const                  { return this->template negate<Mat2>(); }
-    __hostdev__ Mat2  operator+(const Mat2& m) const     { return this->template plus<Mat2>(m); }
-    __hostdev__ Mat2  operator-(const Mat2& m) const     { return this->template minus<Mat2>(m); }
-    __hostdev__ Mat2& operator+=(const Mat2& m)          { Base::addAssign(m); return *this; }
-    __hostdev__ Mat2& operator-=(const Mat2& m)          { Base::subAssign(m); return *this; }
+    __hostdev__ constexpr Mat2  operator-() const                  { return this->template negate<Mat2>(); }
+    __hostdev__ constexpr Mat2  operator+(const Mat2& m) const     { return this->template plus<Mat2>(m); }
+    __hostdev__ constexpr Mat2  operator-(const Mat2& m) const     { return this->template minus<Mat2>(m); }
+    __hostdev__ constexpr Mat2& operator+=(const Mat2& m)          { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat2& operator-=(const Mat2& m)          { Base::subAssign(m); return *this; }
 
     // ---- matrix * matrix / matrix * vector ----
-    __hostdev__ Mat2     operator*(const Mat2& m) const     { return this->template multiply<Mat2, Mat2>(m); }
-    __hostdev__ Vec2<T>  operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec2<T>>(v); }
+    __hostdev__ constexpr Mat2     operator*(const Mat2& m) const     { return this->template multiply<Mat2, Mat2>(m); }
+    __hostdev__ constexpr Vec2<T>  operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec2<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ Mat2  operator*(const T& s) const        { return this->template scale<Mat2>(s); }
-    __hostdev__ Mat2  operator/(const T& s) const        { return this->template divideBy<Mat2>(s); }
-    __hostdev__ Mat2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ Mat2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat2  operator*(const T& s) const        { return this->template scale<Mat2>(s); }
+    __hostdev__ constexpr Mat2  operator/(const T& s) const        { return this->template divideBy<Mat2>(s); }
+    __hostdev__ constexpr Mat2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ bool operator==(const Mat2& m) const     { return Base::equals(m); }
-    __hostdev__ bool operator!=(const Mat2& m) const     { return !Base::equals(m); }
+    __hostdev__ constexpr bool operator==(const Mat2& m) const     { return Base::equals(m); }
+    __hostdev__ constexpr bool operator!=(const Mat2& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ Mat2 transpose() const { return this->template transposeAs<Mat2>(); }
+    __hostdev__ constexpr Mat2 transpose() const { return this->template transposeAs<Mat2>(); }
 
     /// @brief returns inverse of this
-    __hostdev__ Mat2<T> inverse() const {
+    __hostdev__ constexpr Mat2<T> inverse() const {
         T det = (*this)[0][0] * (*this)[1][1] - (*this)[0][1] * (*this)[1][0];
         if (isApproxZero(det)) {
             return Mat2<T>(T(0), T(0), T(0), T(0));
@@ -1353,38 +1373,38 @@ public:
         a b c
         d e f
         @endverbatim */
-    __hostdev__ Mat2x3(T a, T b, T c, T d, T e, T f) {
+    __hostdev__ constexpr Mat2x3(T a, T b, T c, T d, T e, T f) {
         this->mData[0] = a; this->mData[1] = b; this->mData[2] = c;
         this->mData[3] = d; this->mData[4] = e; this->mData[5] = f;
     }
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ Mat2x3(Source* array) : Base(array) {}
+    __hostdev__ constexpr Mat2x3(Source* array) : Base(array) {}
 
 
     // ---- element-wise ----
-    __hostdev__ Mat2x3  operator-() const                  { return this->template negate<Mat2x3>(); }
-    __hostdev__ Mat2x3  operator+(const Mat2x3& m) const   { return this->template plus<Mat2x3>(m); }
-    __hostdev__ Mat2x3  operator-(const Mat2x3& m) const   { return this->template minus<Mat2x3>(m); }
-    __hostdev__ Mat2x3& operator+=(const Mat2x3& m)        { Base::addAssign(m); return *this; }
-    __hostdev__ Mat2x3& operator-=(const Mat2x3& m)        { Base::subAssign(m); return *this; }
+    __hostdev__ constexpr Mat2x3  operator-() const                  { return this->template negate<Mat2x3>(); }
+    __hostdev__ constexpr Mat2x3  operator+(const Mat2x3& m) const   { return this->template plus<Mat2x3>(m); }
+    __hostdev__ constexpr Mat2x3  operator-(const Mat2x3& m) const   { return this->template minus<Mat2x3>(m); }
+    __hostdev__ constexpr Mat2x3& operator+=(const Mat2x3& m)        { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat2x3& operator-=(const Mat2x3& m)        { Base::subAssign(m); return *this; }
 
     // ---- matrix * vector ----
-    __hostdev__ Vec2<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec3<T>>(v); }
+    __hostdev__ constexpr Vec2<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec2<T>, Vec3<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ Mat2x3  operator*(const T& s) const        { return this->template scale<Mat2x3>(s); }
-    __hostdev__ Mat2x3  operator/(const T& s) const        { return this->template divideBy<Mat2x3>(s); }
-    __hostdev__ Mat2x3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ Mat2x3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat2x3  operator*(const T& s) const        { return this->template scale<Mat2x3>(s); }
+    __hostdev__ constexpr Mat2x3  operator/(const T& s) const        { return this->template divideBy<Mat2x3>(s); }
+    __hostdev__ constexpr Mat2x3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat2x3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ bool operator==(const Mat2x3& m) const     { return Base::equals(m); }
-    __hostdev__ bool operator!=(const Mat2x3& m) const     { return !Base::equals(m); }
+    __hostdev__ constexpr bool operator==(const Mat2x3& m) const     { return Base::equals(m); }
+    __hostdev__ constexpr bool operator!=(const Mat2x3& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ Mat3x2<T> transpose() const { return this->template transposeAs<Mat3x2<T>>(); }
+    __hostdev__ constexpr Mat3x2<T> transpose() const { return this->template transposeAs<Mat3x2<T>>(); }
 };
 
 template <typename T>
@@ -1399,7 +1419,7 @@ public:
         c d
         e f
         @endverbatim */
-    __hostdev__ Mat3x2(T a, T b, T c, T d, T e, T f)
+    __hostdev__ constexpr Mat3x2(T a, T b, T c, T d, T e, T f)
     {
         this->mData[0] = a; this->mData[1] = b;
         this->mData[2] = c; this->mData[3] = d;
@@ -1408,30 +1428,30 @@ public:
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ Mat3x2(Source *a): Base(a) {}
+    __hostdev__ constexpr Mat3x2(Source *a): Base(a) {}
 
     // ---- element-wise ----
-    __hostdev__ Mat3x2  operator-() const                  { return this->template negate<Mat3x2>(); }
-    __hostdev__ Mat3x2  operator+(const Mat3x2& m) const   { return this->template plus<Mat3x2>(m); }
-    __hostdev__ Mat3x2  operator-(const Mat3x2& m) const   { return this->template minus<Mat3x2>(m); }
-    __hostdev__ Mat3x2& operator+=(const Mat3x2& m)        { Base::addAssign(m); return *this; }
-    __hostdev__ Mat3x2& operator-=(const Mat3x2& m)        { Base::subAssign(m); return *this; }
+    __hostdev__ constexpr Mat3x2  operator-() const                  { return this->template negate<Mat3x2>(); }
+    __hostdev__ constexpr Mat3x2  operator+(const Mat3x2& m) const   { return this->template plus<Mat3x2>(m); }
+    __hostdev__ constexpr Mat3x2  operator-(const Mat3x2& m) const   { return this->template minus<Mat3x2>(m); }
+    __hostdev__ constexpr Mat3x2& operator+=(const Mat3x2& m)        { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat3x2& operator-=(const Mat3x2& m)        { Base::subAssign(m); return *this; }
 
     // ---- matrix * vector ----
-    __hostdev__ Vec3<T> operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec2<T>>(v); }
+    __hostdev__ constexpr Vec3<T> operator*(const Vec2<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec2<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ Mat3x2  operator*(const T& s) const        { return this->template scale<Mat3x2>(s); }
-    __hostdev__ Mat3x2  operator/(const T& s) const        { return this->template divideBy<Mat3x2>(s); }
-    __hostdev__ Mat3x2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ Mat3x2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat3x2  operator*(const T& s) const        { return this->template scale<Mat3x2>(s); }
+    __hostdev__ constexpr Mat3x2  operator/(const T& s) const        { return this->template divideBy<Mat3x2>(s); }
+    __hostdev__ constexpr Mat3x2& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat3x2& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ bool operator==(const Mat3x2& m) const     { return Base::equals(m); }
-    __hostdev__ bool operator!=(const Mat3x2& m) const     { return !Base::equals(m); }
+    __hostdev__ constexpr bool operator==(const Mat3x2& m) const     { return Base::equals(m); }
+    __hostdev__ constexpr bool operator!=(const Mat3x2& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ Mat2x3<T> transpose() const { return this->template transposeAs<Mat2x3<T>>(); }
+    __hostdev__ constexpr Mat2x3<T> transpose() const { return this->template transposeAs<Mat2x3<T>>(); }
 
 };
 
@@ -1447,9 +1467,9 @@ public:
         d e f
         g h i
         @endverbatim */
-    __hostdev__ Mat3(T a, T b, T c,
-                     T d, T e, T f,
-                     T g, T h, T i)
+    __hostdev__ constexpr Mat3(T a, T b, T c,
+                               T d, T e, T f,
+                               T g, T h, T i)
     {
         this->mData[0] = a; this->mData[1] = b; this->mData[2] = c;
         this->mData[3] = d; this->mData[4] = e; this->mData[5] = f;
@@ -1458,32 +1478,32 @@ public:
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ Mat3(Source *a): Base(a) {}
+    __hostdev__ constexpr Mat3(Source *a): Base(a) {}
 
 
     // ---- element-wise ----
-    __hostdev__ Mat3  operator-() const                  { return this->template negate<Mat3>(); }
-    __hostdev__ Mat3  operator+(const Mat3& m) const     { return this->template plus<Mat3>(m); }
-    __hostdev__ Mat3  operator-(const Mat3& m) const     { return this->template minus<Mat3>(m); }
-    __hostdev__ Mat3& operator+=(const Mat3& m)          { Base::addAssign(m); return *this; }
-    __hostdev__ Mat3& operator-=(const Mat3& m)          { Base::subAssign(m); return *this; }
+    __hostdev__ constexpr Mat3  operator-() const                  { return this->template negate<Mat3>(); }
+    __hostdev__ constexpr Mat3  operator+(const Mat3& m) const     { return this->template plus<Mat3>(m); }
+    __hostdev__ constexpr Mat3  operator-(const Mat3& m) const     { return this->template minus<Mat3>(m); }
+    __hostdev__ constexpr Mat3& operator+=(const Mat3& m)          { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat3& operator-=(const Mat3& m)          { Base::subAssign(m); return *this; }
 
     // ---- matrix * matrix / matrix * vector ----
-    __hostdev__ Mat3    operator*(const Mat3& m) const     { return this->template multiply<Mat3, Mat3>(m); }
-    __hostdev__ Vec3<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec3<T>>(v); }
+    __hostdev__ constexpr Mat3    operator*(const Mat3& m) const     { return this->template multiply<Mat3, Mat3>(m); }
+    __hostdev__ constexpr Vec3<T> operator*(const Vec3<T>& v) const  { return this->template multiplyVec<Vec3<T>, Vec3<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ Mat3  operator*(const T& s) const        { return this->template scale<Mat3>(s); }
-    __hostdev__ Mat3  operator/(const T& s) const        { return this->template divideBy<Mat3>(s); }
-    __hostdev__ Mat3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ Mat3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat3  operator*(const T& s) const        { return this->template scale<Mat3>(s); }
+    __hostdev__ constexpr Mat3  operator/(const T& s) const        { return this->template divideBy<Mat3>(s); }
+    __hostdev__ constexpr Mat3& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat3& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ bool operator==(const Mat3& m) const     { return Base::equals(m); }
-    __hostdev__ bool operator!=(const Mat3& m) const     { return !Base::equals(m); }
+    __hostdev__ constexpr bool operator==(const Mat3& m) const     { return Base::equals(m); }
+    __hostdev__ constexpr bool operator!=(const Mat3& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ Mat3 transpose() const { return this->template transposeAs<Mat3>(); }
+    __hostdev__ constexpr Mat3 transpose() const { return this->template transposeAs<Mat3>(); }
 };
 
 template <typename T>
@@ -1499,10 +1519,10 @@ public:
         i j k l
         m n o p
         @endverbatim */
-    __hostdev__ Mat4(T a, T b, T c, T d,
-                     T e, T f, T g, T h,
-                     T i, T j, T k, T l,
-                     T m, T n, T o, T p)
+    __hostdev__ constexpr Mat4(T a, T b, T c, T d,
+                               T e, T f, T g, T h,
+                               T i, T j, T k, T l,
+                               T m, T n, T o, T p)
     {
         this->mData[0] = a; this->mData[1] = b; this->mData[2] = c; this->mData[3] = d;
         this->mData[4] = e; this->mData[5] = f; this->mData[6] = g; this->mData[7] = h;
@@ -1512,77 +1532,77 @@ public:
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
-    __hostdev__ Mat4(Source *a): Base(a) {}
+    __hostdev__ constexpr Mat4(Source *a): Base(a) {}
 
     // ---- element-wise ----
-    __hostdev__ Mat4  operator-() const                  { return this->template negate<Mat4>(); }
-    __hostdev__ Mat4  operator+(const Mat4& m) const     { return this->template plus<Mat4>(m); }
-    __hostdev__ Mat4  operator-(const Mat4& m) const     { return this->template minus<Mat4>(m); }
-    __hostdev__ Mat4& operator+=(const Mat4& m)          { Base::addAssign(m); return *this; }
-    __hostdev__ Mat4& operator-=(const Mat4& m)          { Base::subAssign(m); return *this; }
+    __hostdev__ constexpr Mat4  operator-() const                  { return this->template negate<Mat4>(); }
+    __hostdev__ constexpr Mat4  operator+(const Mat4& m) const     { return this->template plus<Mat4>(m); }
+    __hostdev__ constexpr Mat4  operator-(const Mat4& m) const     { return this->template minus<Mat4>(m); }
+    __hostdev__ constexpr Mat4& operator+=(const Mat4& m)          { Base::addAssign(m); return *this; }
+    __hostdev__ constexpr Mat4& operator-=(const Mat4& m)          { Base::subAssign(m); return *this; }
 
     // ---- matrix * matrix / matrix * vector ----
-    __hostdev__ Mat4    operator*(const Mat4& m) const     { return this->template multiply<Mat4, Mat4>(m); }
-    __hostdev__ Vec4<T> operator*(const Vec4<T>& v) const  { return this->template multiplyVec<Vec4<T>, Vec4<T>>(v); }
+    __hostdev__ constexpr Mat4    operator*(const Mat4& m) const     { return this->template multiply<Mat4, Mat4>(m); }
+    __hostdev__ constexpr Vec4<T> operator*(const Vec4<T>& v) const  { return this->template multiplyVec<Vec4<T>, Vec4<T>>(v); }
 
     // ---- scalar ----
-    __hostdev__ Mat4  operator*(const T& s) const        { return this->template scale<Mat4>(s); }
-    __hostdev__ Mat4  operator/(const T& s) const        { return this->template divideBy<Mat4>(s); }
-    __hostdev__ Mat4& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
-    __hostdev__ Mat4& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
+    __hostdev__ constexpr Mat4  operator*(const T& s) const        { return this->template scale<Mat4>(s); }
+    __hostdev__ constexpr Mat4  operator/(const T& s) const        { return this->template divideBy<Mat4>(s); }
+    __hostdev__ constexpr Mat4& operator*=(const T& s)             { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Mat4& operator/=(const T& s)             { Base::divideAssign(s); return *this; }
 
     // ---- equality ----
-    __hostdev__ bool operator==(const Mat4& m) const     { return Base::equals(m); }
-    __hostdev__ bool operator!=(const Mat4& m) const     { return !Base::equals(m); }
+    __hostdev__ constexpr bool operator==(const Mat4& m) const     { return Base::equals(m); }
+    __hostdev__ constexpr bool operator!=(const Mat4& m) const     { return !Base::equals(m); }
 
     /// @brief returns transpose of this
-    __hostdev__ Mat4 transpose() const { return this->template transposeAs<Mat4>(); }
+    __hostdev__ constexpr Mat4 transpose() const { return this->template transposeAs<Mat4>(); }
 };
 
 /// @brief Multiply a scalar by a 2x2 matrix, result is a 2x2 matrix
 template<typename T>
-__hostdev__ Mat2<T> operator*(const T& s, const Mat2<T>& m) { return m.template scale<Mat2<T>>(s); }
+__hostdev__ constexpr Mat2<T> operator*(const T& s, const Mat2<T>& m) { return m.template scale<Mat2<T>>(s); }
 /// @brief Multiply a scalar by a 2x3 matrix, result is a 2x3 matrix
 template<typename T>
-__hostdev__ Mat2x3<T> operator*(const T& s, const Mat2x3<T>& m) { return m.template scale<Mat2x3<T>>(s); }
+__hostdev__ constexpr Mat2x3<T> operator*(const T& s, const Mat2x3<T>& m) { return m.template scale<Mat2x3<T>>(s); }
 /// @brief Multiply a scalar by a 3x2 matrix, result is a 3x2 matrix
 template<typename T>
-__hostdev__ Mat3x2<T> operator*(const T& s, const Mat3x2<T>& m) { return m.template scale<Mat3x2<T>>(s); }
+__hostdev__ constexpr Mat3x2<T> operator*(const T& s, const Mat3x2<T>& m) { return m.template scale<Mat3x2<T>>(s); }
 /// @brief Multiply a scalar by a 3x3 matrix, result is a 3x3 matrix
 template<typename T>
-__hostdev__ Mat3<T> operator*(const T& s, const Mat3<T>& m) { return m.template scale<Mat3<T>>(s); }
+__hostdev__ constexpr Mat3<T> operator*(const T& s, const Mat3<T>& m) { return m.template scale<Mat3<T>>(s); }
 /// @brief Multiply a scalar by a 4x4 matrix, result is a 4x4 matrix
 template<typename T>
-__hostdev__ Mat4<T> operator*(const T& s, const Mat4<T>& m) { return m.template scale<Mat4<T>>(s); }
+__hostdev__ constexpr Mat4<T> operator*(const T& s, const Mat4<T>& m) { return m.template scale<Mat4<T>>(s); }
 
 /// @brief Multiply a 2x3 matrix by a 3x2 matrix, result is a 2x2 matrix
 template<typename T>
-__hostdev__ Mat2<T> operator*(const Mat2x3<T>& lhs, const Mat3x2<T>& rhs) {
+__hostdev__ constexpr Mat2<T> operator*(const Mat2x3<T>& lhs, const Mat3x2<T>& rhs) {
     return lhs.template multiply<Mat2<T>, Mat3x2<T>>(rhs);
 }
 /// @brief Multiply a 2x3 matrix by a 3x3 matrix, result is a 2x3 matrix
 template<typename T>
-__hostdev__ Mat2x3<T> operator*(const Mat2x3<T>& lhs, const Mat3<T>& rhs) {
+__hostdev__ constexpr Mat2x3<T> operator*(const Mat2x3<T>& lhs, const Mat3<T>& rhs) {
     return lhs.template multiply<Mat2x3<T>, Mat3<T>>(rhs);
 }
 /// @brief Multiply a 3x2 matrix by a 2x2 matrix, result is a 3x2 matrix
 template<typename T>
-__hostdev__ Mat3x2<T> operator*(const Mat3x2<T>& lhs, const Mat2<T>& rhs) {
+__hostdev__ constexpr Mat3x2<T> operator*(const Mat3x2<T>& lhs, const Mat2<T>& rhs) {
     return lhs.template multiply<Mat3x2<T>, Mat2<T>>(rhs);
 }
 /// @brief Multiply a 2x2 matrix by a 2x3 matrix, result is a 2x3 matrix
 template<typename T>
-__hostdev__ Mat2x3<T> operator*(const Mat2<T>& lhs, const Mat2x3<T>& rhs) {
+__hostdev__ constexpr Mat2x3<T> operator*(const Mat2<T>& lhs, const Mat2x3<T>& rhs) {
     return lhs.template multiply<Mat2x3<T>, Mat2x3<T>>(rhs);
 }
 /// @brief Multiply a 3x2 matrix by a 2x3 matrix, result is a 3x3 matrix
 template<typename T>
-__hostdev__ Mat3<T> operator*(const Mat3x2<T>& lhs, const Mat2x3<T>& rhs) {
+__hostdev__ constexpr Mat3<T> operator*(const Mat3x2<T>& lhs, const Mat2x3<T>& rhs) {
     return lhs.template multiply<Mat3<T>, Mat2x3<T>>(rhs);
 }
 /// @brief Multiply a 3x3 matrix by a 3x2 matrix, result is a 3x2 matrix
 template<typename T>
-__hostdev__ Mat3x2<T> operator*(const Mat3<T>& lhs, const Mat3x2<T>& rhs) {
+__hostdev__ constexpr Mat3x2<T> operator*(const Mat3<T>& lhs, const Mat3x2<T>& rhs) {
     return lhs.template multiply<Mat3x2<T>, Mat3x2<T>>(rhs);
 }
 // ----------------------------> Vec3 <--------------------------------------
@@ -1598,85 +1618,89 @@ public:
     static constexpr int size = 3; // openvdb::math::Tuple-compat alias of SIZE
 
     Vec3() = default;
-    __hostdev__ explicit Vec3(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; }
-    __hostdev__ Vec3(T x, T y, T z)           { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; }
+    __hostdev__ explicit constexpr Vec3(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; }
+    __hostdev__ constexpr Vec3(T x, T y, T z)           { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; }
 
     template<template<class> class Vec3T, class T2>
-    __hostdev__ Vec3(const Vec3T<T2>& v) {
+    __hostdev__ constexpr Vec3(const Vec3T<T2>& v) {
         static_assert(Vec3T<T2>::size == 3, "expected Vec3T::size==3!");
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]);
     }
     template<typename T2>
-    __hostdev__ explicit Vec3(const Vec3<T2>& v) {
+    __hostdev__ explicit constexpr Vec3(const Vec3<T2>& v) {
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]);
     }
-    __hostdev__ explicit Vec3(const Coord& ijk) {
+    __hostdev__ explicit constexpr Vec3(const Coord& ijk) {
         this->mVec[0] = T(ijk[0]); this->mVec[1] = T(ijk[1]); this->mVec[2] = T(ijk[2]);
     }
 
     template<template<class> class Vec3T, class T2>
-    __hostdev__ Vec3& operator=(const Vec3T<T2>& rhs) {
+    __hostdev__ constexpr Vec3& operator=(const Vec3T<T2>& rhs) {
         static_assert(Vec3T<T2>::size == 3, "expected Vec3T::size==3!");
         this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1]; this->mVec[2] = rhs[2];
         return *this;
     }
 
     // ---- element-wise (Vec & Vec) ----
-    __hostdev__ Vec3  operator-() const             { return Base::template negate<Vec3>(); }
-    __hostdev__ Vec3  operator+(const Vec3& v) const { return Base::template plus<Vec3>(v); }
-    __hostdev__ Vec3  operator-(const Vec3& v) const { return Base::template minus<Vec3>(v); }
-    __hostdev__ Vec3  operator*(const Vec3& v) const { return Base::template mul<Vec3>(v); }
-    __hostdev__ Vec3  operator/(const Vec3& v) const { return Base::template div<Vec3>(v); }
-    __hostdev__ Vec3& operator+=(const Vec3& v)     { Base::addAssign(v); return *this; }
-    __hostdev__ Vec3& operator-=(const Vec3& v)     { Base::subAssign(v); return *this; }
+    __hostdev__ constexpr Vec3  operator-() const             { return Base::template negate<Vec3>(); }
+    __hostdev__ constexpr Vec3  operator+(const Vec3& v) const { return Base::template plus<Vec3>(v); }
+    __hostdev__ constexpr Vec3  operator-(const Vec3& v) const { return Base::template minus<Vec3>(v); }
+    __hostdev__ constexpr Vec3  operator*(const Vec3& v) const { return Base::template mul<Vec3>(v); }
+    __hostdev__ constexpr Vec3  operator/(const Vec3& v) const { return Base::template div<Vec3>(v); }
+    __hostdev__ constexpr Vec3& operator+=(const Vec3& v)     { Base::addAssign(v); return *this; }
+    __hostdev__ constexpr Vec3& operator-=(const Vec3& v)     { Base::subAssign(v); return *this; }
 
     // ---- mixed Vec3 / Coord (3D) ----
-    __hostdev__ Vec3  operator+(const Coord& ijk) const { return Vec3(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1], this->mVec[2] + ijk[2]); }
-    __hostdev__ Vec3  operator-(const Coord& ijk) const { return Vec3(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1], this->mVec[2] - ijk[2]); }
-    __hostdev__ Vec3& operator+=(const Coord& ijk) {
+    __hostdev__ constexpr Vec3  operator+(const Coord& ijk) const { return Vec3(this->mVec[0] + ijk[0], this->mVec[1] + ijk[1], this->mVec[2] + ijk[2]); }
+    __hostdev__ constexpr Vec3  operator-(const Coord& ijk) const { return Vec3(this->mVec[0] - ijk[0], this->mVec[1] - ijk[1], this->mVec[2] - ijk[2]); }
+    __hostdev__ constexpr Vec3& operator+=(const Coord& ijk) {
         this->mVec[0] += T(ijk[0]); this->mVec[1] += T(ijk[1]); this->mVec[2] += T(ijk[2]);
         return *this;
     }
-    __hostdev__ Vec3& operator-=(const Coord& ijk) {
+    __hostdev__ constexpr Vec3& operator-=(const Coord& ijk) {
         this->mVec[0] -= T(ijk[0]); this->mVec[1] -= T(ijk[1]); this->mVec[2] -= T(ijk[2]);
         return *this;
     }
 
     // ---- scalar ----
-    __hostdev__ Vec3  operator*(const T& s) const   { return Base::template scale<Vec3>(s); }
-    __hostdev__ Vec3  operator/(const T& s) const   { return Base::template divideBy<Vec3>(s); }
-    __hostdev__ Vec3& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
-    __hostdev__ Vec3& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
+    __hostdev__ constexpr Vec3  operator*(const T& s) const   { return Base::template scale<Vec3>(s); }
+    __hostdev__ constexpr Vec3  operator/(const T& s) const   { return Base::template divideBy<Vec3>(s); }
+    __hostdev__ constexpr Vec3& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Vec3& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
+    // Not constexpr — depends on length() which calls std::sqrt.
     __hostdev__ Vec3& normalize()                   { return (*this) /= this->length(); }
 
     // ---- equality ----
-    __hostdev__ bool operator==(const Vec3& rhs) const { return Base::equals(rhs); }
-    __hostdev__ bool operator!=(const Vec3& rhs) const { return !Base::equals(rhs); }
+    __hostdev__ constexpr bool operator==(const Vec3& rhs) const { return Base::equals(rhs); }
+    __hostdev__ constexpr bool operator!=(const Vec3& rhs) const { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
-    __hostdev__ Vec3& minComponent(const Vec3& other) { Base::mergeMin(other); return *this; }
-    __hostdev__ Vec3& maxComponent(const Vec3& other) { Base::mergeMax(other); return *this; }
+    __hostdev__ constexpr Vec3& minComponent(const Vec3& other) { Base::mergeMin(other); return *this; }
+    __hostdev__ constexpr Vec3& maxComponent(const Vec3& other) { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
-    __hostdev__ ValueType min() const { return Base::smallestComponent(); }
+    __hostdev__ constexpr ValueType min() const { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ ValueType max() const { return Base::largestComponent(); }
+    __hostdev__ constexpr ValueType max() const { return Base::largestComponent(); }
 
     /// @brief Round each component down (toward negative infinity)
     /// @return integer Coord
-    __hostdev__ Coord floor() const { return Base::template floorAs<Coord>(); }
+    /// @note Only constexpr for integer @c T (floorAs uses non-constexpr math::Floor for floating point).
+    __hostdev__ constexpr Coord floor() const { return Base::template floorAs<Coord>(); }
     /// @brief Round each component up (toward positive infinity)
     /// @return integer Coord
-    __hostdev__ Coord ceil()  const { return Base::template ceilAs<Coord>(); }
+    /// @note Only constexpr for integer @c T (ceilAs uses non-constexpr math::Ceil for floating point).
+    __hostdev__ constexpr Coord ceil()  const { return Base::template ceilAs<Coord>(); }
     /// @brief Round each component to its closest integer value
     /// @return integer Coord
-    __hostdev__ Coord round() const { return Base::template roundAs<Coord>(); }
+    /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
+    __hostdev__ constexpr Coord round() const { return Base::template roundAs<Coord>(); }
 
     // ---- 3D-specific ----
 
     /// @brief cross product with another 3-vector
     template<typename Vec3T>
-    __hostdev__ Vec3 cross(const Vec3T& v) const {
+    __hostdev__ constexpr Vec3 cross(const Vec3T& v) const {
         return Vec3(this->mVec[1] * v[2] - this->mVec[2] * v[1],
                     this->mVec[2] * v[0] - this->mVec[0] * v[2],
                     this->mVec[0] * v[1] - this->mVec[1] * v[0]);
@@ -1684,7 +1708,7 @@ public:
 
     /// @brief Outer product of a 3x1 vector and a 1x3 vector, result is a 3x3 matrix
     template<typename Vec3T>
-    __hostdev__ Mat3<ValueType> outer(const Vec3T& v) const {
+    __hostdev__ constexpr Mat3<ValueType> outer(const Vec3T& v) const {
         return Mat3<ValueType>(this->mVec[0] * v[0], this->mVec[0] * v[1], this->mVec[0] * v[2],
                                this->mVec[1] * v[0], this->mVec[1] * v[1], this->mVec[1] * v[2],
                                this->mVec[2] * v[0], this->mVec[2] * v[1], this->mVec[2] * v[2]);
@@ -1692,24 +1716,24 @@ public:
 }; // Vec3<T>
 
 template<typename T1, typename T2>
-__hostdev__ inline Vec3<T2> operator*(T1 scalar, const Vec3<T2>& vec)
+__hostdev__ inline constexpr Vec3<T2> operator*(T1 scalar, const Vec3<T2>& vec)
 {
     return Vec3<T2>(scalar * vec[0], scalar * vec[1], scalar * vec[2]);
 }
 template<typename T1, typename T2>
-__hostdev__ inline Vec3<T2> operator/(T1 scalar, const Vec3<T2>& vec)
+__hostdev__ inline constexpr Vec3<T2> operator/(T1 scalar, const Vec3<T2>& vec)
 {
     return Vec3<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2]);
 }
 
 /// @brief Return a single precision floating-point vector of this coordinate
-__hostdev__ inline Vec3<float> Coord::asVec3s() const
+__hostdev__ inline constexpr Vec3<float> Coord::asVec3s() const
 {
     return Vec3<float>(float(mVec[0]), float(mVec[1]), float(mVec[2]));
 }
 
 /// @brief Return a double precision floating-point vector of this coordinate
-__hostdev__ inline Vec3<double> Coord::asVec3d() const
+__hostdev__ inline constexpr Vec3<double> Coord::asVec3d() const
 {
     return Vec3<double>(double(mVec[0]), double(mVec[1]), double(mVec[2]));
 }
@@ -1727,72 +1751,76 @@ public:
     static constexpr int size = 4; // openvdb::math::Tuple-compat alias of SIZE
 
     Vec4() = default;
-    __hostdev__ explicit Vec4(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; this->mVec[3] = x; }
-    __hostdev__ Vec4(T x, T y, T z, T w)      { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; this->mVec[3] = w; }
+    __hostdev__ explicit constexpr Vec4(T x)            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; this->mVec[3] = x; }
+    __hostdev__ constexpr Vec4(T x, T y, T z, T w)      { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; this->mVec[3] = w; }
 
     template<typename T2>
-    __hostdev__ explicit Vec4(const Vec4<T2>& v) {
+    __hostdev__ explicit constexpr Vec4(const Vec4<T2>& v) {
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]); this->mVec[3] = T(v[3]);
     }
     template<template<class> class Vec4T, class T2>
-    __hostdev__ Vec4(const Vec4T<T2>& v) {
+    __hostdev__ constexpr Vec4(const Vec4T<T2>& v) {
         static_assert(Vec4T<T2>::size == 4, "expected Vec4T::size==4!");
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]); this->mVec[3] = T(v[3]);
     }
     template<template<class> class Vec4T, class T2>
-    __hostdev__ Vec4& operator=(const Vec4T<T2>& rhs) {
+    __hostdev__ constexpr Vec4& operator=(const Vec4T<T2>& rhs) {
         static_assert(Vec4T<T2>::size == 4, "expected Vec4T::size==4!");
         this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1]; this->mVec[2] = rhs[2]; this->mVec[3] = rhs[3];
         return *this;
     }
 
     // ---- element-wise (Vec & Vec) ----
-    __hostdev__ Vec4  operator-() const             { return Base::template negate<Vec4>(); }
-    __hostdev__ Vec4  operator+(const Vec4& v) const { return Base::template plus<Vec4>(v); }
-    __hostdev__ Vec4  operator-(const Vec4& v) const { return Base::template minus<Vec4>(v); }
-    __hostdev__ Vec4  operator*(const Vec4& v) const { return Base::template mul<Vec4>(v); }
-    __hostdev__ Vec4  operator/(const Vec4& v) const { return Base::template div<Vec4>(v); }
-    __hostdev__ Vec4& operator+=(const Vec4& v)     { Base::addAssign(v); return *this; }
-    __hostdev__ Vec4& operator-=(const Vec4& v)     { Base::subAssign(v); return *this; }
+    __hostdev__ constexpr Vec4  operator-() const             { return Base::template negate<Vec4>(); }
+    __hostdev__ constexpr Vec4  operator+(const Vec4& v) const { return Base::template plus<Vec4>(v); }
+    __hostdev__ constexpr Vec4  operator-(const Vec4& v) const { return Base::template minus<Vec4>(v); }
+    __hostdev__ constexpr Vec4  operator*(const Vec4& v) const { return Base::template mul<Vec4>(v); }
+    __hostdev__ constexpr Vec4  operator/(const Vec4& v) const { return Base::template div<Vec4>(v); }
+    __hostdev__ constexpr Vec4& operator+=(const Vec4& v)     { Base::addAssign(v); return *this; }
+    __hostdev__ constexpr Vec4& operator-=(const Vec4& v)     { Base::subAssign(v); return *this; }
 
     // ---- scalar ----
-    __hostdev__ Vec4  operator*(const T& s) const   { return Base::template scale<Vec4>(s); }
-    __hostdev__ Vec4  operator/(const T& s) const   { return Base::template divideBy<Vec4>(s); }
-    __hostdev__ Vec4& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
-    __hostdev__ Vec4& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
+    __hostdev__ constexpr Vec4  operator*(const T& s) const   { return Base::template scale<Vec4>(s); }
+    __hostdev__ constexpr Vec4  operator/(const T& s) const   { return Base::template divideBy<Vec4>(s); }
+    __hostdev__ constexpr Vec4& operator*=(const T& s)        { Base::scaleAssign(s); return *this; }
+    __hostdev__ constexpr Vec4& operator/=(const T& s)        { Base::divideAssignScalar(s); return *this; }
+    // Not constexpr — depends on length() which calls std::sqrt.
     __hostdev__ Vec4& normalize()                   { return (*this) /= this->length(); }
 
     // ---- equality ----
-    __hostdev__ bool operator==(const Vec4& rhs) const { return Base::equals(rhs); }
-    __hostdev__ bool operator!=(const Vec4& rhs) const { return !Base::equals(rhs); }
+    __hostdev__ constexpr bool operator==(const Vec4& rhs) const { return Base::equals(rhs); }
+    __hostdev__ constexpr bool operator!=(const Vec4& rhs) const { return !Base::equals(rhs); }
 
     // ---- component-wise min/max ----
-    __hostdev__ Vec4& minComponent(const Vec4& other) { Base::mergeMin(other); return *this; }
-    __hostdev__ Vec4& maxComponent(const Vec4& other) { Base::mergeMax(other); return *this; }
+    __hostdev__ constexpr Vec4& minComponent(const Vec4& other) { Base::mergeMin(other); return *this; }
+    __hostdev__ constexpr Vec4& maxComponent(const Vec4& other) { Base::mergeMax(other); return *this; }
 
     /// @brief Return the smallest vector component
-    __hostdev__ ValueType min() const { return Base::smallestComponent(); }
+    __hostdev__ constexpr ValueType min() const { return Base::smallestComponent(); }
     /// @brief Return the largest vector component
-    __hostdev__ ValueType max() const { return Base::largestComponent(); }
+    __hostdev__ constexpr ValueType max() const { return Base::largestComponent(); }
 
     /// @brief Round each component down (toward negative infinity)
     /// @return Vec4<int32_t> (NanoVDB has no Coord4)
-    __hostdev__ Vec4<int32_t> floor() const { return Base::template floorAs<Vec4<int32_t>>(); }
+    /// @note Only constexpr for integer @c T (floorAs uses non-constexpr math::Floor for floating point).
+    __hostdev__ constexpr Vec4<int32_t> floor() const { return Base::template floorAs<Vec4<int32_t>>(); }
     /// @brief Round each component up (toward positive infinity)
     /// @return Vec4<int32_t>
-    __hostdev__ Vec4<int32_t> ceil()  const { return Base::template ceilAs<Vec4<int32_t>>(); }
+    /// @note Only constexpr for integer @c T (ceilAs uses non-constexpr math::Ceil for floating point).
+    __hostdev__ constexpr Vec4<int32_t> ceil()  const { return Base::template ceilAs<Vec4<int32_t>>(); }
     /// @brief Round each component to its closest integer value
     /// @return Vec4<int32_t>
-    __hostdev__ Vec4<int32_t> round() const { return Base::template roundAs<Vec4<int32_t>>(); }
+    /// @note Only constexpr for integer @c T (roundAs uses non-constexpr math::Floor for floating point).
+    __hostdev__ constexpr Vec4<int32_t> round() const { return Base::template roundAs<Vec4<int32_t>>(); }
 }; // Vec4<T>
 
 template<typename T1, typename T2>
-__hostdev__ inline Vec4<T2> operator*(T1 scalar, const Vec4<T2>& vec)
+__hostdev__ inline constexpr Vec4<T2> operator*(T1 scalar, const Vec4<T2>& vec)
 {
     return Vec4<T2>(scalar * vec[0], scalar * vec[1], scalar * vec[2], scalar * vec[3]);
 }
 template<typename T1, typename T2>
-__hostdev__ inline Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
+__hostdev__ inline constexpr Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
 {
     return Vec4<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2], scalar / vec[3]);
 }
@@ -1907,22 +1935,22 @@ template<typename Vec3T>
 struct BaseBBox
 {
     Vec3T                    mCoord[2];
-    __hostdev__ bool         operator==(const BaseBBox& rhs) const { return mCoord[0] == rhs.mCoord[0] && mCoord[1] == rhs.mCoord[1]; };
-    __hostdev__ bool         operator!=(const BaseBBox& rhs) const { return mCoord[0] != rhs.mCoord[0] || mCoord[1] != rhs.mCoord[1]; };
-    __hostdev__ const Vec3T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
-    __hostdev__ Vec3T&       operator[](int i) { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
-    __hostdev__ Vec3T&       min() { return mCoord[0]; }
-    __hostdev__ Vec3T&       max() { return mCoord[1]; }
-    __hostdev__ const Vec3T& min() const { return mCoord[0]; }
-    __hostdev__ const Vec3T& max() const { return mCoord[1]; }
-    __hostdev__ BaseBBox&    translate(const Vec3T& xyz)
+    __hostdev__ constexpr bool         operator==(const BaseBBox& rhs) const { return mCoord[0] == rhs.mCoord[0] && mCoord[1] == rhs.mCoord[1]; };
+    __hostdev__ constexpr bool         operator!=(const BaseBBox& rhs) const { return mCoord[0] != rhs.mCoord[0] || mCoord[1] != rhs.mCoord[1]; };
+    __hostdev__ constexpr const Vec3T& operator[](int i) const { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
+    __hostdev__ constexpr Vec3T&       operator[](int i) { NANOVDB_ASSERT(i >= 0 && i < 2); return mCoord[i]; }
+    __hostdev__ constexpr Vec3T&       min() { return mCoord[0]; }
+    __hostdev__ constexpr Vec3T&       max() { return mCoord[1]; }
+    __hostdev__ constexpr const Vec3T& min() const { return mCoord[0]; }
+    __hostdev__ constexpr const Vec3T& max() const { return mCoord[1]; }
+    __hostdev__ constexpr BaseBBox&    translate(const Vec3T& xyz)
     {
         mCoord[0] += xyz;
         mCoord[1] += xyz;
         return *this;
     }
     /// @brief Expand this bounding box to enclose point @c xyz.
-    __hostdev__ BaseBBox& expand(const Vec3T& xyz)
+    __hostdev__ constexpr BaseBBox& expand(const Vec3T& xyz)
     {
         mCoord[0].minComponent(xyz);
         mCoord[1].maxComponent(xyz);
@@ -1930,7 +1958,7 @@ struct BaseBBox
     }
 
     /// @brief Expand this bounding box to enclose the given bounding box.
-    __hostdev__ BaseBBox& expand(const BaseBBox& bbox)
+    __hostdev__ constexpr BaseBBox& expand(const BaseBBox& bbox)
     {
         mCoord[0].minComponent(bbox[0]);
         mCoord[1].maxComponent(bbox[1]);
@@ -1938,7 +1966,7 @@ struct BaseBBox
     }
 
     /// @brief Intersect this bounding box with the given bounding box.
-    __hostdev__ BaseBBox& intersect(const BaseBBox& bbox)
+    __hostdev__ constexpr BaseBBox& intersect(const BaseBBox& bbox)
     {
         mCoord[0].maxComponent(bbox[0]);
         mCoord[1].minComponent(bbox[1]);
@@ -1949,7 +1977,7 @@ struct BaseBBox
 //    {
 //        return BaseBBox(mCoord[0].offsetBy(-padding),mCoord[1].offsetBy(padding));
 //    }
-    __hostdev__ bool isInside(const Vec3T& xyz)
+    __hostdev__ constexpr bool isInside(const Vec3T& xyz)
     {
         if (xyz[0] < mCoord[0][0] || xyz[1] < mCoord[0][1] || xyz[2] < mCoord[0][2])
             return false;
@@ -1959,8 +1987,8 @@ struct BaseBBox
     }
 
 protected:
-    __hostdev__ BaseBBox() {}
-    __hostdev__ BaseBBox(const Vec3T& min, const Vec3T& max)
+    __hostdev__ constexpr BaseBBox() {}
+    __hostdev__ constexpr BaseBBox(const Vec3T& min, const Vec3T& max)
         : mCoord{min, max}
     {
     }
@@ -1982,37 +2010,37 @@ struct BBox<Vec3T, true> : public BaseBBox<Vec3T>
     using BaseT = BaseBBox<Vec3T>;
     using BaseT::mCoord;
     /// @brief Default construction sets BBox to an empty bbox
-    __hostdev__ BBox()
+    __hostdev__ constexpr BBox()
         : BaseT(Vec3T( Maximum<typename Vec3T::ValueType>::value()),
                 Vec3T(-Maximum<typename Vec3T::ValueType>::value()))
     {
     }
-    __hostdev__ BBox(const Vec3T& min, const Vec3T& max)
+    __hostdev__ constexpr BBox(const Vec3T& min, const Vec3T& max)
         : BaseT(min, max)
     {
     }
-    __hostdev__ BBox(const Coord& min, const Coord& max)
+    __hostdev__ constexpr BBox(const Coord& min, const Coord& max)
         : BaseT(Vec3T(ValueType(min[0]), ValueType(min[1]), ValueType(min[2])),
                 Vec3T(ValueType(max[0] + 1), ValueType(max[1] + 1), ValueType(max[2] + 1)))
     {
     }
-    __hostdev__ static BBox createCube(const Coord& min, typename Coord::ValueType dim)
+    __hostdev__ static constexpr BBox createCube(const Coord& min, typename Coord::ValueType dim)
     {
         return BBox(min, min.offsetBy(dim));
     }
 
-    __hostdev__ BBox(const BaseBBox<Coord>& bbox)
+    __hostdev__ constexpr BBox(const BaseBBox<Coord>& bbox)
         : BBox(bbox[0], bbox[1])
     {
     }
-    __hostdev__ bool  empty() const { return mCoord[0][0] >= mCoord[1][0] ||
+    __hostdev__ constexpr bool  empty() const { return mCoord[0][0] >= mCoord[1][0] ||
                                              mCoord[0][1] >= mCoord[1][1] ||
                                              mCoord[0][2] >= mCoord[1][2]; }
-    __hostdev__ operator bool() const { return mCoord[0][0] < mCoord[1][0] &&
+    __hostdev__ constexpr operator bool() const { return mCoord[0][0] < mCoord[1][0] &&
                                                mCoord[0][1] < mCoord[1][1] &&
                                                mCoord[0][2] < mCoord[1][2]; }
-    __hostdev__ Vec3T dim() const { return *this ? this->max() - this->min() : Vec3T(0); }
-    __hostdev__ bool  isInside(const Vec3T& p) const
+    __hostdev__ constexpr Vec3T dim() const { return *this ? this->max() - this->min() : Vec3T(0); }
+    __hostdev__ constexpr bool  isInside(const Vec3T& p) const
     {
         return p[0] > mCoord[0][0] && p[1] > mCoord[0][1] && p[2] > mCoord[0][2] &&
                p[0] < mCoord[1][0] && p[1] < mCoord[1][1] && p[2] < mCoord[1][2];
@@ -2038,17 +2066,17 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
         CoordT      mPos;
 
     public:
-        __hostdev__ Iterator(const BBox& b)
+        __hostdev__ constexpr Iterator(const BBox& b)
             : mBBox(b)
             , mPos(b.min())
         {
         }
-        __hostdev__ Iterator(const BBox& b, const Coord& p)
+        __hostdev__ constexpr Iterator(const BBox& b, const Coord& p)
             : mBBox(b)
             , mPos(p)
         {
         }
-        __hostdev__ Iterator& operator++()
+        __hostdev__ constexpr Iterator& operator++()
         {
             if (mPos[2] < mBBox[1][2]) { // this is the most common case
                 ++mPos[2];// increment z
@@ -2062,49 +2090,49 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
             }
             return *this;
         }
-        __hostdev__ Iterator operator++(int)
+        __hostdev__ constexpr Iterator operator++(int)
         {
             auto tmp = *this;
             ++(*this);
             return tmp;
         }
-        __hostdev__ bool operator==(const Iterator& rhs) const
+        __hostdev__ constexpr bool operator==(const Iterator& rhs) const
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos == rhs.mPos;
         }
-        __hostdev__ bool operator!=(const Iterator& rhs) const
+        __hostdev__ constexpr bool operator!=(const Iterator& rhs) const
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos != rhs.mPos;
         }
-        __hostdev__ bool operator<(const Iterator& rhs) const
+        __hostdev__ constexpr bool operator<(const Iterator& rhs) const
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos < rhs.mPos;
         }
-        __hostdev__ bool operator<=(const Iterator& rhs) const
+        __hostdev__ constexpr bool operator<=(const Iterator& rhs) const
         {
             NANOVDB_ASSERT(mBBox == rhs.mBBox);
             return mPos <= rhs.mPos;
         }
         /// @brief Return @c true if the iterator still points to a valid coordinate.
-        __hostdev__ operator bool() const { return mPos <= mBBox[1]; }
-        __hostdev__ const CoordT& operator*() const { return mPos; }
+        __hostdev__ constexpr operator bool() const { return mPos <= mBBox[1]; }
+        __hostdev__ constexpr const CoordT& operator*() const { return mPos; }
     }; // Iterator
-    __hostdev__ Iterator begin() const { return Iterator{*this}; }
-    __hostdev__ Iterator end()   const { return Iterator{*this, CoordT(mCoord[1][0]+1, mCoord[0][1], mCoord[0][2])}; }
-    __hostdev__          BBox()
+    __hostdev__ constexpr Iterator begin() const { return Iterator{*this}; }
+    __hostdev__ constexpr Iterator end()   const { return Iterator{*this, CoordT(mCoord[1][0]+1, mCoord[0][1], mCoord[0][2])}; }
+    __hostdev__ constexpr BBox()
         : BaseT(CoordT::max(), CoordT::min())
     {
     }
-    __hostdev__ BBox(const CoordT& min, const CoordT& max)
+    __hostdev__ constexpr BBox(const CoordT& min, const CoordT& max)
         : BaseT(min, max)
     {
     }
 
     template<typename SplitT>
-    __hostdev__ BBox(BBox& other, const SplitT&)
+    __hostdev__ constexpr BBox(BBox& other, const SplitT&)
         : BaseT(other.mCoord[0], other.mCoord[1])
     {
         NANOVDB_ASSERT(this->is_divisible());
@@ -2113,56 +2141,56 @@ struct BBox<CoordT, false> : public BaseBBox<CoordT>
         other.mCoord[0][n] = mCoord[1][n] + 1;
     }
 
-    __hostdev__ static BBox createCube(const CoordT& min, typename CoordT::ValueType dim)
+    __hostdev__ static constexpr BBox createCube(const CoordT& min, typename CoordT::ValueType dim)
     {
         return BBox(min, min.offsetBy(dim - 1));
     }
 
-    __hostdev__ static BBox createCube(typename CoordT::ValueType min, typename CoordT::ValueType max)
+    __hostdev__ static constexpr BBox createCube(typename CoordT::ValueType min, typename CoordT::ValueType max)
     {
         return BBox(CoordT(min), CoordT(max));
     }
 
-    __hostdev__ bool is_divisible() const { return mCoord[0][0] < mCoord[1][0] &&
+    __hostdev__ constexpr bool is_divisible() const { return mCoord[0][0] < mCoord[1][0] &&
                                                    mCoord[0][1] < mCoord[1][1] &&
                                                    mCoord[0][2] < mCoord[1][2]; }
     /// @brief Return true if this bounding box is empty, e.g. uninitialized
-    __hostdev__ bool     empty() const { return mCoord[0][0] > mCoord[1][0] ||
+    __hostdev__ constexpr bool     empty() const { return mCoord[0][0] > mCoord[1][0] ||
                                                 mCoord[0][1] > mCoord[1][1] ||
                                                 mCoord[0][2] > mCoord[1][2]; }
     /// @brief Convert this BBox to boolean true if it is not empty
-    __hostdev__ operator bool() const { return mCoord[0][0] <= mCoord[1][0] &&
+    __hostdev__ constexpr operator bool() const { return mCoord[0][0] <= mCoord[1][0] &&
                                                mCoord[0][1] <= mCoord[1][1] &&
                                                mCoord[0][2] <= mCoord[1][2]; }
-    __hostdev__ CoordT   dim() const { return *this ? this->max() - this->min() + Coord(1) : Coord(0); }
-    __hostdev__ uint64_t volume() const
+    __hostdev__ constexpr CoordT   dim() const { return *this ? this->max() - this->min() + Coord(1) : Coord(0); }
+    __hostdev__ constexpr uint64_t volume() const
     {
         auto d = this->dim();
         return uint64_t(d[0]) * uint64_t(d[1]) * uint64_t(d[2]);
     }
-    __hostdev__ bool isInside(const CoordT& p) const { return !(CoordT::lessThan(p, this->min()) || CoordT::lessThan(this->max(), p)); }
+    __hostdev__ constexpr bool isInside(const CoordT& p) const { return !(CoordT::lessThan(p, this->min()) || CoordT::lessThan(this->max(), p)); }
     /// @brief Return @c true if the given bounding box is inside this bounding box.
-    __hostdev__ bool isInside(const BBox& b) const
+    __hostdev__ constexpr bool isInside(const BBox& b) const
     {
         return !(CoordT::lessThan(b.min(), this->min()) || CoordT::lessThan(this->max(), b.max()));
     }
 
     /// @brief Return @c true if the given bounding box overlaps with this bounding box.
-    __hostdev__ bool hasOverlap(const BBox& b) const
+    __hostdev__ constexpr bool hasOverlap(const BBox& b) const
     {
         return !(CoordT::lessThan(this->max(), b.min()) || CoordT::lessThan(b.max(), this->min()));
     }
 
     /// @warning This converts a CoordBBox into a floating-point bounding box which implies that max += 1 !
     template<typename RealT = double>
-    __hostdev__ BBox<Vec3<RealT>> asReal() const
+    __hostdev__ constexpr BBox<Vec3<RealT>> asReal() const
     {
         static_assert(util::is_floating_point<RealT>::value, "CoordBBox::asReal: Expected a floating point coordinate");
         return BBox<Vec3<RealT>>(Vec3<RealT>(RealT(mCoord[0][0]), RealT(mCoord[0][1]), RealT(mCoord[0][2])),
                                  Vec3<RealT>(RealT(mCoord[1][0] + 1), RealT(mCoord[1][1] + 1), RealT(mCoord[1][2] + 1)));
     }
     /// @brief Return a new instance that is expanded by the specified padding.
-    __hostdev__ BBox expandBy(typename CoordT::ValueType padding) const
+    __hostdev__ constexpr BBox expandBy(typename CoordT::ValueType padding) const
     {
         return BBox(mCoord[0].offsetBy(-padding), mCoord[1].offsetBy(padding));
     }
@@ -2238,7 +2266,7 @@ public:
     Rgba8&      operator=(const Rgba8&) = default;
 
     /// @brief Default ctor initializes all channels to zero
-    __hostdev__ Rgba8()
+    __hostdev__ constexpr Rgba8()
         : mData{{0, 0, 0, 0}}
     {
         static_assert(sizeof(uint32_t) == sizeof(Rgba8), "Unexpected sizeof");
@@ -2246,21 +2274,21 @@ public:
 
     /// @brief integer r,g,b,a ctor where alpha channel defaults to opaque
     /// @note all values should be in the range 0u to 255u
-    __hostdev__ Rgba8(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255u)
+    __hostdev__ constexpr Rgba8(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255u)
         : mData{{r, g, b, a}}
     {
     }
 
     /// @brief  @brief ctor where all channels are initialized to the same value
     /// @note value should be in the range 0u to 255u
-    explicit __hostdev__ Rgba8(uint8_t v)
+    explicit __hostdev__ constexpr Rgba8(uint8_t v)
         : mData{{v, v, v, v}}
     {
     }
 
     /// @brief floating-point r,g,b,a ctor where alpha channel defaults to opaque
     /// @note all values should be in the range 0.0f to 1.0f
-    __hostdev__ Rgba8(float r, float g, float b, float a = 1.0f)
+    __hostdev__ constexpr Rgba8(float r, float g, float b, float a = 1.0f)
         : mData{{static_cast<uint8_t>(0.5f + r * 255.0f), // round floats to nearest integers
                  static_cast<uint8_t>(0.5f + g * 255.0f), // double {{}} is needed due to union
                  static_cast<uint8_t>(0.5f + b * 255.0f),
@@ -2270,45 +2298,52 @@ public:
 
     /// @brief Vec3f r,g,b ctor (alpha channel it set to 1)
     /// @note all values should be in the range 0.0f to 1.0f
-    __hostdev__ Rgba8(const Vec3<float>& rgb)
+    __hostdev__ constexpr Rgba8(const Vec3<float>& rgb)
         : Rgba8(rgb[0], rgb[1], rgb[2])
     {
     }
 
     /// @brief Vec4f r,g,b,a ctor
     /// @note all values should be in the range 0.0f to 1.0f
-    __hostdev__ Rgba8(const Vec4<float>& rgba)
+    __hostdev__ constexpr Rgba8(const Vec4<float>& rgba)
         : Rgba8(rgba[0], rgba[1], rgba[2], rgba[3])
     {
     }
 
-    __hostdev__ bool  operator< (const Rgba8& rhs) const { return mData.packed < rhs.mData.packed; }
-    __hostdev__ bool  operator==(const Rgba8& rhs) const { return mData.packed == rhs.mData.packed; }
-    __hostdev__ float lengthSqr() const
+    // Not usable as a constant expression for instances constructed via the
+    // {{r,g,b,a}} brace-init form (active union member is @c c, not @c packed);
+    // marking constexpr is still valid since a copy from a @c packed()-mutated
+    // instance could in principle be evaluated.
+    __hostdev__ constexpr bool  operator< (const Rgba8& rhs) const { return mData.packed < rhs.mData.packed; }
+    __hostdev__ constexpr bool  operator==(const Rgba8& rhs) const { return mData.packed == rhs.mData.packed; }
+    __hostdev__ constexpr float lengthSqr() const
     {
         return 0.0000153787005f * (float(mData.c[0]) * mData.c[0] +
                                    float(mData.c[1]) * mData.c[1] +
                                    float(mData.c[2]) * mData.c[2]); //1/255^2
     }
+    // Not constexpr — sqrtf isn't constexpr until C++26.
     __hostdev__ float           length() const { return sqrtf(this->lengthSqr()); }
     /// @brief return n'th color channel as a float in the range 0 to 1
-    __hostdev__ float           asFloat(int n) const { return 0.003921569f*float(mData.c[n]); }// divide by 255
-    __hostdev__ const uint8_t&  operator[](int n) const { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
-    __hostdev__ uint8_t&        operator[](int n) { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
-    __hostdev__ const uint32_t& packed() const { return mData.packed; }
-    __hostdev__ uint32_t&       packed() { return mData.packed; }
-    __hostdev__ const uint8_t&  r() const { return mData.c[0]; }
-    __hostdev__ const uint8_t&  g() const { return mData.c[1]; }
-    __hostdev__ const uint8_t&  b() const { return mData.c[2]; }
-    __hostdev__ const uint8_t&  a() const { return mData.c[3]; }
-    __hostdev__ uint8_t&        r() { return mData.c[0]; }
-    __hostdev__ uint8_t&        g() { return mData.c[1]; }
-    __hostdev__ uint8_t&        b() { return mData.c[2]; }
-    __hostdev__ uint8_t&        a() { return mData.c[3]; }
-    __hostdev__                 operator Vec3<float>() const {
+    __hostdev__ constexpr float           asFloat(int n) const { return 0.003921569f*float(mData.c[n]); }// divide by 255
+    __hostdev__ constexpr const uint8_t&  operator[](int n) const { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
+    __hostdev__ constexpr uint8_t&        operator[](int n) { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
+    // See note above operator< — only usable as a constant expression for
+    // instances whose active union member is @c packed.
+    __hostdev__ constexpr const uint32_t& packed() const { return mData.packed; }
+    __hostdev__ constexpr uint32_t&       packed() { return mData.packed; }
+    __hostdev__ constexpr const uint8_t&  r() const { return mData.c[0]; }
+    __hostdev__ constexpr const uint8_t&  g() const { return mData.c[1]; }
+    __hostdev__ constexpr const uint8_t&  b() const { return mData.c[2]; }
+    __hostdev__ constexpr const uint8_t&  a() const { return mData.c[3]; }
+    __hostdev__ constexpr uint8_t&        r() { return mData.c[0]; }
+    __hostdev__ constexpr uint8_t&        g() { return mData.c[1]; }
+    __hostdev__ constexpr uint8_t&        b() { return mData.c[2]; }
+    __hostdev__ constexpr uint8_t&        a() { return mData.c[3]; }
+    __hostdev__ constexpr           operator Vec3<float>() const {
         return Vec3<float>(this->asFloat(0), this->asFloat(1), this->asFloat(2));
     }
-    __hostdev__                 operator Vec4<float>() const {
+    __hostdev__ constexpr           operator Vec4<float>() const {
         return Vec4<float>(this->asFloat(0), this->asFloat(1), this->asFloat(2), this->asFloat(3));
     }
 }; // Rgba8

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -838,6 +838,18 @@ public:
 
     VecBase() noexcept = default;
 
+protected:
+    /// @brief Variadic component-init ctor — used only by derived ctors
+    /// (`Vec2(T x, T y) : Base(x, y) {}`). The member-init list directly
+    /// initializes @c mVec, avoiding the default-construct-then-assign that
+    /// a body-assignment ctor would impose on a non-fundamental @c T.
+    template<typename... Args>
+    __hostdev__ explicit constexpr VecBase(Args... args) noexcept : mVec{T(args)...}
+    {
+        static_assert(sizeof...(Args) == N, "VecBase: wrong number of constructor arguments");
+    }
+
+public:
     /// @brief Indexed element access. Asserts 0 <= i < N in debug builds.
     __hostdev__ constexpr const T& operator[](int i) const noexcept { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
     __hostdev__ constexpr T&       operator[](int i) noexcept       { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
@@ -1054,21 +1066,17 @@ public:
     static constexpr int size = 2; // openvdb::math::Tuple-compat alias of SIZE
 
     Vec2() noexcept = default;
-    __hostdev__ explicit constexpr Vec2(T x) noexcept            { this->mVec[0] = x;    this->mVec[1] = x;    }
-    __hostdev__ constexpr Vec2(T x, T y) noexcept                { this->mVec[0] = x;    this->mVec[1] = y;    }
+    __hostdev__ explicit constexpr Vec2(T x) noexcept            : Base(x, x) {}
+    __hostdev__ constexpr Vec2(T x, T y) noexcept                : Base(x, y) {}
 
     template<template<class> class Vec2T, class T2>
-    __hostdev__ explicit constexpr Vec2(const Vec2T<T2>& v) noexcept {
+    __hostdev__ explicit constexpr Vec2(const Vec2T<T2>& v) noexcept : Base(v[0], v[1])
+    {
         static_assert(Vec2T<T2>::size == 2, "expected Vec2T::size==2!");
-        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]);
     }
     template<typename T2>
-    __hostdev__ explicit constexpr Vec2(const Vec2<T2>& v) noexcept {
-        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]);
-    }
-    __hostdev__ explicit constexpr Vec2(const Coord2& ijk) noexcept {
-        this->mVec[0] = T(ijk[0]); this->mVec[1] = T(ijk[1]);
-    }
+    __hostdev__ explicit constexpr Vec2(const Vec2<T2>& v) noexcept : Base(v[0], v[1]) {}
+    __hostdev__ explicit constexpr Vec2(const Coord2& ijk) noexcept : Base(ijk[0], ijk[1]) {}
 
     template<template<class> class Vec2T, class T2>
     __hostdev__ constexpr Vec2& operator=(const Vec2T<T2>& rhs) noexcept {
@@ -1180,6 +1188,20 @@ public:
             mData[i] = static_cast<T>(array[i]);
         }
     }
+
+protected:
+    /// @brief Variadic component-init ctor — used only by derived ctors
+    /// (`Mat2(T a, T b, T c, T d) : Base(a, b, c, d) {}`). The member-init
+    /// list directly initializes @c mData, avoiding the default-construct-
+    /// then-assign that a body-assignment ctor would impose on a
+    /// non-fundamental @c T.
+    template<typename... Args>
+    __hostdev__ explicit constexpr MatBase(Args... args) noexcept : mData{T(args)...}
+    {
+        static_assert(sizeof...(Args) == ROWS * COLS, "MatBase: wrong number of constructor arguments");
+    }
+
+public:
 
     // 2D array access. Returns a row pointer; the caller is responsible
     // for the column bound (0 <= col < COLS).
@@ -1341,10 +1363,7 @@ public:
         a b
         c d
         @endverbatim */
-    __hostdev__ constexpr Mat2(T a, T b, T c, T d) noexcept {
-        this->mData[0] = a; this->mData[1] = b;
-        this->mData[2] = c; this->mData[3] = d;
-    }
+    __hostdev__ constexpr Mat2(T a, T b, T c, T d) noexcept : Base(a, b, c, d) {}
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
@@ -1405,10 +1424,7 @@ public:
         a b c
         d e f
         @endverbatim */
-    __hostdev__ constexpr Mat2x3(T a, T b, T c, T d, T e, T f) noexcept {
-        this->mData[0] = a; this->mData[1] = b; this->mData[2] = c;
-        this->mData[3] = d; this->mData[4] = e; this->mData[5] = f;
-    }
+    __hostdev__ constexpr Mat2x3(T a, T b, T c, T d, T e, T f) noexcept : Base(a, b, c, d, e, f) {}
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
@@ -1460,12 +1476,7 @@ public:
         c d
         e f
         @endverbatim */
-    __hostdev__ constexpr Mat3x2(T a, T b, T c, T d, T e, T f) noexcept
-    {
-        this->mData[0] = a; this->mData[1] = b;
-        this->mData[2] = c; this->mData[3] = d;
-        this->mData[4] = e; this->mData[5] = f;
-    }
+    __hostdev__ constexpr Mat3x2(T a, T b, T c, T d, T e, T f) noexcept : Base(a, b, c, d, e, f) {}
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
@@ -1518,12 +1529,7 @@ public:
         @endverbatim */
     __hostdev__ constexpr Mat3(T a, T b, T c,
                                T d, T e, T f,
-                               T g, T h, T i) noexcept
-    {
-        this->mData[0] = a; this->mData[1] = b; this->mData[2] = c;
-        this->mData[3] = d; this->mData[4] = e; this->mData[5] = f;
-        this->mData[6] = g; this->mData[7] = h; this->mData[8] = i;
-    }
+                               T g, T h, T i) noexcept : Base(a, b, c, d, e, f, g, h, i) {}
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
@@ -1585,12 +1591,7 @@ public:
                                T e, T f, T g, T h,
                                T i, T j, T k, T l,
                                T m, T n, T o, T p) noexcept
-    {
-        this->mData[0] = a; this->mData[1] = b; this->mData[2] = c; this->mData[3] = d;
-        this->mData[4] = e; this->mData[5] = f; this->mData[6] = g; this->mData[7] = h;
-        this->mData[8] = i; this->mData[9] = j; this->mData[10] = k; this->mData[11] = l;
-        this->mData[12] = m; this->mData[13] = n; this->mData[14] = o; this->mData[15] = p;
-    }
+        : Base(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {}
 
     /// @brief Constructor given array of elements, the ordering is in row major form
     template<typename Source>
@@ -1677,21 +1678,17 @@ public:
     static constexpr int size = 3; // openvdb::math::Tuple-compat alias of SIZE
 
     Vec3() noexcept = default;
-    __hostdev__ explicit constexpr Vec3(T x) noexcept            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; }
-    __hostdev__ constexpr Vec3(T x, T y, T z) noexcept           { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; }
+    __hostdev__ explicit constexpr Vec3(T x) noexcept            : Base(x, x, x) {}
+    __hostdev__ constexpr Vec3(T x, T y, T z) noexcept           : Base(x, y, z) {}
 
     template<template<class> class Vec3T, class T2>
-    __hostdev__ explicit constexpr Vec3(const Vec3T<T2>& v) noexcept {
+    __hostdev__ explicit constexpr Vec3(const Vec3T<T2>& v) noexcept : Base(v[0], v[1], v[2])
+    {
         static_assert(Vec3T<T2>::size == 3, "expected Vec3T::size==3!");
-        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]);
     }
     template<typename T2>
-    __hostdev__ explicit constexpr Vec3(const Vec3<T2>& v) noexcept {
-        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]);
-    }
-    __hostdev__ explicit constexpr Vec3(const Coord& ijk) noexcept {
-        this->mVec[0] = T(ijk[0]); this->mVec[1] = T(ijk[1]); this->mVec[2] = T(ijk[2]);
-    }
+    __hostdev__ explicit constexpr Vec3(const Vec3<T2>& v) noexcept : Base(v[0], v[1], v[2]) {}
+    __hostdev__ explicit constexpr Vec3(const Coord& ijk) noexcept : Base(ijk[0], ijk[1], ijk[2]) {}
 
     template<template<class> class Vec3T, class T2>
     __hostdev__ constexpr Vec3& operator=(const Vec3T<T2>& rhs) noexcept {
@@ -1817,17 +1814,15 @@ public:
     static constexpr int size = 4; // openvdb::math::Tuple-compat alias of SIZE
 
     Vec4() noexcept = default;
-    __hostdev__ explicit constexpr Vec4(T x) noexcept            { this->mVec[0] = x; this->mVec[1] = x; this->mVec[2] = x; this->mVec[3] = x; }
-    __hostdev__ constexpr Vec4(T x, T y, T z, T w) noexcept      { this->mVec[0] = x; this->mVec[1] = y; this->mVec[2] = z; this->mVec[3] = w; }
+    __hostdev__ explicit constexpr Vec4(T x) noexcept            : Base(x, x, x, x) {}
+    __hostdev__ constexpr Vec4(T x, T y, T z, T w) noexcept      : Base(x, y, z, w) {}
 
     template<typename T2>
-    __hostdev__ explicit constexpr Vec4(const Vec4<T2>& v) noexcept {
-        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]); this->mVec[3] = T(v[3]);
-    }
+    __hostdev__ explicit constexpr Vec4(const Vec4<T2>& v) noexcept : Base(v[0], v[1], v[2], v[3]) {}
     template<template<class> class Vec4T, class T2>
-    __hostdev__ explicit constexpr Vec4(const Vec4T<T2>& v) noexcept {
+    __hostdev__ explicit constexpr Vec4(const Vec4T<T2>& v) noexcept : Base(v[0], v[1], v[2], v[3])
+    {
         static_assert(Vec4T<T2>::size == 4, "expected Vec4T::size==4!");
-        this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]); this->mVec[3] = T(v[3]);
     }
     template<template<class> class Vec4T, class T2>
     __hostdev__ constexpr Vec4& operator=(const Vec4T<T2>& rhs) noexcept {

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -2310,12 +2310,13 @@ public:
     {
     }
 
-    // Not usable as a constant expression for instances constructed via the
-    // {{r,g,b,a}} brace-init form (active union member is @c c, not @c packed);
-    // marking constexpr is still valid since a copy from a @c packed()-mutated
-    // instance could in principle be evaluated.
-    __hostdev__ constexpr bool  operator< (const Rgba8& rhs) const { return mData.packed < rhs.mData.packed; }
-    __hostdev__ constexpr bool  operator==(const Rgba8& rhs) const { return mData.packed == rhs.mData.packed; }
+    // Not constexpr — every Rgba8 ctor initialises @c mData.c[4] (the first
+    // union member), so reading @c mData.packed is undefined behaviour at
+    // constant evaluation in C++17 / C++20. (C++20 relaxes the rule only
+    // for layout-compatible types sharing a "common initial sequence",
+    // which doesn't apply to uint8_t[4] vs uint32_t.)
+    __hostdev__ bool  operator< (const Rgba8& rhs) const { return mData.packed < rhs.mData.packed; }
+    __hostdev__ bool  operator==(const Rgba8& rhs) const { return mData.packed == rhs.mData.packed; }
     __hostdev__ constexpr float lengthSqr() const
     {
         return 0.0000153787005f * (float(mData.c[0]) * mData.c[0] +
@@ -2328,10 +2329,9 @@ public:
     __hostdev__ constexpr float           asFloat(int n) const { return 0.003921569f*float(mData.c[n]); }// divide by 255
     __hostdev__ constexpr const uint8_t&  operator[](int n) const { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
     __hostdev__ constexpr uint8_t&        operator[](int n) { NANOVDB_ASSERT(n >= 0 && n < 4); return mData.c[n]; }
-    // See note above operator< — only usable as a constant expression for
-    // instances whose active union member is @c packed.
-    __hostdev__ constexpr const uint32_t& packed() const { return mData.packed; }
-    __hostdev__ constexpr uint32_t&       packed() { return mData.packed; }
+    // Not constexpr — see note above operator<.
+    __hostdev__ const uint32_t& packed() const { return mData.packed; }
+    __hostdev__ uint32_t&       packed() { return mData.packed; }
     __hostdev__ constexpr const uint8_t&  r() const { return mData.c[0]; }
     __hostdev__ constexpr const uint8_t&  g() const { return mData.c[1]; }
     __hostdev__ constexpr const uint8_t&  b() const { return mData.c[2]; }

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -1012,7 +1012,7 @@ public:
 
     template<template<class> class Vec2T, class T2>
     __hostdev__ Vec2(const Vec2T<T2>& v) {
-        static_assert(Vec2T<T2>::SIZE == 2, "expected Vec2T::SIZE==2!");
+        static_assert(Vec2T<T2>::size == 2, "expected Vec2T::size==2!");
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]);
     }
     template<typename T2>
@@ -1025,7 +1025,7 @@ public:
 
     template<template<class> class Vec2T, class T2>
     __hostdev__ Vec2& operator=(const Vec2T<T2>& rhs) {
-        static_assert(Vec2T<T2>::SIZE == 2, "expected Vec2T::SIZE==2!");
+        static_assert(Vec2T<T2>::size == 2, "expected Vec2T::size==2!");
         this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1];
         return *this;
     }
@@ -1587,7 +1587,7 @@ public:
 
     template<template<class> class Vec3T, class T2>
     __hostdev__ Vec3(const Vec3T<T2>& v) {
-        static_assert(Vec3T<T2>::SIZE == 3, "expected Vec3T::SIZE==3!");
+        static_assert(Vec3T<T2>::size == 3, "expected Vec3T::size==3!");
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]);
     }
     template<typename T2>
@@ -1600,7 +1600,7 @@ public:
 
     template<template<class> class Vec3T, class T2>
     __hostdev__ Vec3& operator=(const Vec3T<T2>& rhs) {
-        static_assert(Vec3T<T2>::SIZE == 3, "expected Vec3T::SIZE==3!");
+        static_assert(Vec3T<T2>::size == 3, "expected Vec3T::size==3!");
         this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1]; this->mVec[2] = rhs[2];
         return *this;
     }
@@ -1720,12 +1720,12 @@ public:
     }
     template<template<class> class Vec4T, class T2>
     __hostdev__ Vec4(const Vec4T<T2>& v) {
-        static_assert(Vec4T<T2>::SIZE == 4, "expected Vec4T::SIZE==4!");
+        static_assert(Vec4T<T2>::size == 4, "expected Vec4T::size==4!");
         this->mVec[0] = T(v[0]); this->mVec[1] = T(v[1]); this->mVec[2] = T(v[2]); this->mVec[3] = T(v[3]);
     }
     template<template<class> class Vec4T, class T2>
     __hostdev__ Vec4& operator=(const Vec4T<T2>& rhs) {
-        static_assert(Vec4T<T2>::SIZE == 4, "expected Vec4T::SIZE==4!");
+        static_assert(Vec4T<T2>::size == 4, "expected Vec4T::size==4!");
         this->mVec[0] = rhs[0]; this->mVec[1] = rhs[1]; this->mVec[2] = rhs[2]; this->mVec[3] = rhs[3];
         return *this;
     }

--- a/nanovdb/nanovdb/math/Math.h
+++ b/nanovdb/nanovdb/math/Math.h
@@ -157,8 +157,6 @@ __hostdev__ [[nodiscard]] inline constexpr bool isApproxZero(const Type& x) noex
 }
 
 /// @brief Same-type minimum (the primary template).
-/// @note Float/double overloads below use @c fminf/fmin for NaN handling and are
-/// therefore not @c constexpr.
 template<typename Type>
 __hostdev__ [[nodiscard]] inline constexpr Type Min(Type a, Type b) noexcept
 {
@@ -176,19 +174,15 @@ __hostdev__ [[nodiscard]] inline constexpr uint32_t Min(uint32_t a, uint32_t b) 
 {
     return a < b ? a : b;
 }
-// Not constexpr — fminf/fmin aren't constexpr until C++23.
 __hostdev__ [[nodiscard]] inline float Min(float a, float b) noexcept
 {
     return fminf(a, b);
 }
-// Not constexpr — fminf/fmin aren't constexpr until C++23.
 __hostdev__ [[nodiscard]] inline double Min(double a, double b) noexcept
 {
     return fmin(a, b);
 }
 /// @brief Same-type maximum (the primary template).
-/// @note Float/double overloads below use @c fmaxf/fmax for NaN handling and
-/// are therefore not @c constexpr.
 template<typename Type>
 __hostdev__ [[nodiscard]] inline constexpr Type Max(Type a, Type b) noexcept
 {
@@ -203,19 +197,16 @@ __hostdev__ [[nodiscard]] inline constexpr uint32_t Max(uint32_t a, uint32_t b) 
 {
     return a > b ? a : b;
 }
-// Not constexpr — fmaxf/fmax aren't constexpr until C++23.
 __hostdev__ [[nodiscard]] inline float Max(float a, float b) noexcept
 {
     return fmaxf(a, b);
 }
-// Not constexpr — fmaxf/fmax aren't constexpr until C++23.
 __hostdev__ [[nodiscard]] inline double Max(double a, double b) noexcept
 {
     return fmax(a, b);
 }
 //@{
 /// @brief Clamp @c x to the closed interval [@c a, @c b].
-/// @note Not @c constexpr — relies on the non-constexpr float/double @c Min/@c Max overloads.
 __hostdev__ [[nodiscard]] inline float Clamp(float x, float a, float b) noexcept
 {
     return Max(Min(x, b), a);
@@ -284,28 +275,24 @@ __hostdev__ [[nodiscard]] inline constexpr T Pow4(T x) noexcept
 }
 /// @brief Absolute value (generic primary template, branchless for arithmetic types).
 /// @note The @c float / @c double / @c int specializations below are not
-/// @c constexpr because @c fabsf / @c fabs / @c abs are not @c constexpr until C++23.
 template<typename T>
 __hostdev__ [[nodiscard]] inline constexpr T Abs(T x) noexcept
 {
     return x < 0 ? -x : x;
 }
 
-// Not constexpr — fabsf isn't constexpr until C++23.
 template<>
 __hostdev__ [[nodiscard]] inline float Abs(float x) noexcept
 {
     return fabsf(x);
 }
 
-// Not constexpr — fabs isn't constexpr until C++23.
 template<>
 __hostdev__ [[nodiscard]] inline double Abs(double x) noexcept
 {
     return fabs(x);
 }
 
-// Not constexpr — std::abs(int) isn't constexpr until C++23.
 template<>
 __hostdev__ [[nodiscard]] inline int Abs(int x) noexcept
 {
@@ -660,7 +647,6 @@ public:
 
     /// @brief Return the largest integer coordinates that are not greater
     /// than @a xyz (node centered conversion).
-    // Not constexpr — math::Floor uses floorf/floor which aren't constexpr until C++23.
     template<typename Vec3T>
     __hostdev__ [[nodiscard]] static Coord Floor(const Vec3T& xyz) noexcept { return Coord(math::Floor(xyz[0]), math::Floor(xyz[1]), math::Floor(xyz[2])); }
 
@@ -673,7 +659,6 @@ public:
     __hostdev__ [[nodiscard]] constexpr uint32_t hash() const noexcept { return ((1 << Log2N) - 1) & (mVec[0] * 73856093 ^ mVec[1] * 19349669 ^ mVec[2] * 83492791); }
 
     /// @brief Return the octant of this Coord
-    //__hostdev__ size_t octant() const { return (uint32_t(mVec[0])>>31) | ((uint32_t(mVec[1])>>31)<<1) | ((uint32_t(mVec[2])>>31)<<2); }
     __hostdev__ [[nodiscard]] constexpr uint8_t octant() const noexcept { return (uint8_t(bool(mVec[0] & (1u << 31)))) |
                                                 (uint8_t(bool(mVec[1] & (1u << 31))) << 1) |
                                                 (uint8_t(bool(mVec[2] & (1u << 31))) << 2); }
@@ -913,7 +898,6 @@ public:
 
     /// @brief Return the largest integer coordinates that are not greater
     /// than @a xyz (node centered conversion).
-    // Not constexpr — math::Floor uses floorf/floor which aren't constexpr until C++23.
     template<typename Vec2T>
     __hostdev__ [[nodiscard]] static Coord2 Floor(const Vec2T& xy) noexcept { return Coord2(math::Floor(xy[0]), math::Floor(xy[1])); }
 
@@ -963,10 +947,6 @@ public:
     __hostdev__ constexpr const T& operator[](int i) const noexcept { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
     __hostdev__ constexpr T&       operator[](int i) noexcept       { NANOVDB_ASSERT(i >= 0 && i < N); return mVec[i]; }
 
-    /// @brief Named component accessors. Available based on dimensionality:
-    /// x() requires N >= 1, y() requires N >= 2, z() requires N >= 3, w()
-    /// requires N >= 4. A call on a Vec too small for the requested component
-    /// triggers a clear compile-time static_assert at the call site.
     __hostdev__ constexpr const T& x() const noexcept { return mVec[0]; }
     __hostdev__ constexpr       T& x() noexcept       { return mVec[0]; }
     __hostdev__ constexpr const T& y() const noexcept { static_assert(N >= 2, "VecBase::y() requires N >= 2"); return mVec[1]; }
@@ -1121,16 +1101,6 @@ public:
 
     // ---- integer rounding (toward -inf / +inf / nearest) ----
     //
-    // We test against `std::is_floating_point<T>` rather than
-    // `util::is_floating_point<T>` because the latter only matches `float`
-    // and `double` whereas the former (correctly) also matches
-    // `long double`. Without the broader predicate, `Vec<long double>`
-    // would silently truncate via `static_cast<int32_t>` instead of using
-    // the floor/ceil/round rounding rules. The inner `math::Floor` /
-    // `math::Ceil` only have float/double overloads, so `long double`
-    // implicitly converts to `double` at the call site — matching the
-    // pre-refactor behaviour of `Vec*::round()` which routed `long
-    // double` through the same `Floor(x + 0.5)` path.
 
     /// @brief floor-rounded components into the @c Result type (whose @c [i]
     /// must accept int32_t). For integer @c T the value is passed through.
@@ -1184,9 +1154,7 @@ public:
 /// @brief A simple vector class with two components, similar to openvdb::math::Vec2
 ///
 /// Aligned to 2*alignof(T) so the whole class fits in one SIMD-friendly
-/// chunk (e.g. 8 bytes for Vec2<float>, 16 bytes for Vec2<double>),
-/// without any tail padding because the byte size is already a power-of-2
-/// multiple of alignof(T).
+/// chunk (e.g. 8 bytes for Vec2<float>, 16 bytes for Vec2<double>)
 template<typename T>
 class alignas(alignof(T) * 2) Vec2 final : public VecBase<T, 2>
 {
@@ -1301,13 +1269,13 @@ public:
     // ---- scalar * Vec / scalar / Vec (hidden friends — found only via ADL on Vec2,
     // never participate in unrelated namespace-scope overload sets) ----
 
-    /// @brief Scalar-on-the-left multiplication (hidden friend; found only via ADL on @c Vec2).
+    /// @brief Scalar-on-the-left multiplication (hidden friend).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec2 operator*(T1 scalar, const Vec2& vec) noexcept
     {
         return Vec2(scalar * vec[0], scalar * vec[1]);
     }
-    /// @brief Scalar-on-the-left division (hidden friend; found only via ADL on @c Vec2).
+    /// @brief Scalar-on-the-left division (hidden friend).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec2 operator/(T1 scalar, const Vec2& vec) noexcept
     {
@@ -1760,8 +1728,7 @@ public:
 /// for @c Mat4<double>) is heavy compared to row-alignment (4*alignof(T))
 /// but matches the per-class "align to full size" rule used for @c Vec2 /
 /// @c Vec4 / @c Mat2 above and lets a @c Mat4<float> load with a single
-/// AVX-512 instruction. Drop to @c alignas(alignof(T) * 4) here if the
-/// over-aligned constraint causes friction with downstream allocators.
+/// AVX-512 instruction.
 template <typename T>
 class alignas(alignof(T) * 16) Mat4 final : public MatBase<T, 4, 4> {
     using Base = MatBase<T, 4, 4>;
@@ -1854,9 +1821,7 @@ __hostdev__ [[nodiscard]] constexpr Mat3x2<T> operator*(const Mat3<T>& lhs, cons
 /// Vec3 is intentionally NOT alignas-elevated: its byte size
 /// (3*sizeof(T)) is not a power-of-2 multiple of alignof(T), so any
 /// alignas(N > alignof(T)) would force tail padding and break
-/// packed-array layout plus on-disk format compatibility. An opt-in
-/// over-aligned Vec3 wrapper (e.g. for CUDA-coalesced loads) is best
-/// added as a separate type rather than changing Vec3 itself.
+/// packed-array layout plus on-disk format compatibility.
 template<typename T>
 class Vec3 final : public VecBase<T, 3>
 {
@@ -1989,13 +1954,13 @@ public:
     // ---- scalar * Vec / scalar / Vec (hidden friends — found only via ADL on Vec3,
     // never participate in unrelated namespace-scope overload sets) ----
 
-    /// @brief Scalar-on-the-left multiplication (hidden friend; found only via ADL on @c Vec3).
+    /// @brief Scalar-on-the-left multiplication (hidden friend).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec3 operator*(T1 scalar, const Vec3& vec) noexcept
     {
         return Vec3(scalar * vec[0], scalar * vec[1], scalar * vec[2]);
     }
-    /// @brief Scalar-on-the-left division (hidden friend; found only via ADL on @c Vec3).
+    /// @brief Scalar-on-the-left division (hidden friend).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec3 operator/(T1 scalar, const Vec3& vec) noexcept
     {
@@ -2118,13 +2083,13 @@ public:
     // ---- scalar * Vec / scalar / Vec (hidden friends — found only via ADL on Vec4,
     // never participate in unrelated namespace-scope overload sets) ----
 
-    /// @brief Scalar-on-the-left multiplication (hidden friend; found only via ADL on @c Vec4).
+    /// @brief Scalar-on-the-left multiplication (hidden friend).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec4 operator*(T1 scalar, const Vec4& vec) noexcept
     {
         return Vec4(scalar * vec[0], scalar * vec[1], scalar * vec[2], scalar * vec[3]);
     }
-    /// @brief Scalar-on-the-left division (hidden friend; found only via ADL on @c Vec4).
+    /// @brief Scalar-on-the-left division (hidden friend).
     template<typename T1>
     __hostdev__ [[nodiscard]] friend constexpr Vec4 operator/(T1 scalar, const Vec4& vec) noexcept
     {
@@ -2336,10 +2301,6 @@ struct BaseBBox
         return *this;
     }
 
-//    __hostdev__ BaseBBox expandBy(typename Vec3T::ValueType padding) const
-//    {
-//        return BaseBBox(mCoord[0].offsetBy(-padding),mCoord[1].offsetBy(padding));
-//    }
     /// @brief Return @c true iff @a xyz lies in the closed box (each component
     /// satisfies @c min[i] <= @c xyz[i] <= @c max[i]).
     __hostdev__ [[nodiscard]] constexpr bool isInside(const Vec3T& xyz) const noexcept

--- a/nanovdb/nanovdb/python/cuda/PySampleFromVoxels.cu
+++ b/nanovdb/nanovdb/python/cuda/PySampleFromVoxels.cu
@@ -40,7 +40,9 @@ __global__ void sampleFromVoxels(unsigned int numPoints, const BuildT* points, c
         math::SampleFromVoxels<TreeT, 1, false> sampler(d_grid->tree());
         values[i] = sampler(indexPos);
 
-        Vec3T inv2Dx = (BuildT).5 / d_grid->voxelSize();
+        // voxelSize() returns Vec3d; explicit conversion to Vec3T preserves the existing
+        // "compute reciprocal in double, then narrow to BuildT" semantics.
+        Vec3T inv2Dx = Vec3T((BuildT).5 / d_grid->voxelSize());
         Vec3T gradient = Vec3T(sampler(indexPos + Vec3T(1, 0, 0)) - sampler(indexPos - Vec3T(1, 0, 0)),
                                sampler(indexPos + Vec3T(0, 1, 0)) - sampler(indexPos - Vec3T(0, 1, 0)),
                                sampler(indexPos + Vec3T(0, 0, 1)) - sampler(indexPos - Vec3T(0, 0, 1))) *

--- a/nanovdb/nanovdb/tools/cuda/PointsToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/PointsToGrid.cuh
@@ -196,7 +196,7 @@ struct pointer_traits {
 template<typename Vec3T>
 __hostdev__ inline static void worldToVoxel(Vec3u8 &voxel, const Vec3T &world, const Map &indexToWorld)
 {
-    const Vec3d ijk = indexToWorld.applyInverseMap(world);// world -> index
+    const Vec3d ijk = Vec3d(indexToWorld.applyInverseMap(world));// world -> index
     static constexpr double encode = double((1<<8) - 1);
     voxel[0] = uint8_t( encode*(ijk[0] - math::Floor(ijk[0] + 0.5) + 0.5) );
     voxel[1] = uint8_t( encode*(ijk[1] - math::Floor(ijk[1] + 0.5) + 0.5) );
@@ -211,7 +211,7 @@ __hostdev__ inline static void worldToVoxel(Vec3u8 &voxel, const Vec3T &world, c
 template<typename Vec3T>
 __hostdev__ inline static void worldToVoxel(Vec3u16 &voxel, const Vec3T &world, const Map &indexToWorld)
 {
-    const Vec3d ijk = indexToWorld.applyInverseMap(world);// world -> index
+    const Vec3d ijk = Vec3d(indexToWorld.applyInverseMap(world));// world -> index
     static constexpr double encode = double((1<<16) - 1);
     voxel[0] = uint16_t( encode*(ijk[0] - math::Floor(ijk[0] + 0.5) + 0.5) );
     voxel[1] = uint16_t( encode*(ijk[1] - math::Floor(ijk[1] + 0.5) + 0.5) );
@@ -226,7 +226,7 @@ __hostdev__ inline static void worldToVoxel(Vec3u16 &voxel, const Vec3T &world, 
 template<typename Vec3T>
 __hostdev__ inline static void worldToVoxel(Vec3f &voxel, const Vec3T &world, const Map &indexToWorld)
 {
-    const Vec3d ijk = indexToWorld.applyInverseMap(world);// world -> index
+    const Vec3d ijk = Vec3d(indexToWorld.applyInverseMap(world));// world -> index
     voxel[0] = float( ijk[0] - math::Floor(ijk[0] + 0.5) );
     voxel[1] = float( ijk[1] - math::Floor(ijk[1] + 0.5) );
     voxel[2] = float( ijk[2] - math::Floor(ijk[2] + 0.5) );

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cc
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cc
@@ -1351,6 +1351,648 @@ TEST_F(TestNanoVDB, Vec4)
     EXPECT_NE(nanovdb::Vec4f(1, 2, 3, 4), nanovdb::Vec4f(1, 2, 3, 5));
 }// Vec4
 
+// ===========================> Math.h refactor tests <===========================
+// The tests below cover behaviour added/changed by the MatBase/VecBase refactors:
+//   - integer Min/Max precision (no fminf/fmaxf trap)
+//   - math::Round float/double parity at half-integers
+//   - Vec2 (no prior test) plus extended Vec3/Vec4 operator coverage
+//   - All five matrix classes' constructors/operators/transpose/inverse
+//   - Cross-shape matrix products (Mat2x3*Mat3x2, Mat3*Mat3x2, Mat4*Mat4, ...)
+//   - Public shape/value introspection on MatBase and VecBase
+
+TEST_F(TestNanoVDB, IntegerMinMax)
+{
+    // 2^24 + 1 cannot be represented exactly as float; the old fminf-based
+    // overload would round both inputs to the same float and return a value
+    // that is neither of the inputs.
+    const int32_t a32 = 16777217; // 2^24 + 1
+    const int32_t b32 = 16777218; // 2^24 + 2
+    EXPECT_EQ(a32, nanovdb::math::Min(a32, b32));
+    EXPECT_EQ(b32, nanovdb::math::Max(a32, b32));
+
+    // INT32_MAX through float can round up to 2^31 and convert back to INT_MIN
+    // (UB on x86). The ternary path returns the correct value.
+    const int32_t hi = (std::numeric_limits<int32_t>::max)();
+    EXPECT_EQ(hi, nanovdb::math::Max(hi, 0));
+    EXPECT_EQ(0,  nanovdb::math::Min(hi, 0));
+
+    // Same risk on the unsigned side: float(UINT_MAX) rounds to 2^32.
+    const uint32_t uhi = (std::numeric_limits<uint32_t>::max)();
+    EXPECT_EQ(uhi, nanovdb::math::Max(uhi, 0u));
+    EXPECT_EQ(0u,  nanovdb::math::Min(uhi, 0u));
+
+    // Sanity: float/double overloads still work.
+    EXPECT_EQ(1.0f, nanovdb::math::Min(1.0f, 2.0f));
+    EXPECT_EQ(2.0,  nanovdb::math::Max(1.0, 2.0));
+}// IntegerMinMax
+
+TEST_F(TestNanoVDB, Round)
+{
+    // math::Round(Vec3<float>) used rintf (round-half-to-even) while the
+    // double overload used floor(x + 0.5). They disagreed at -1.5:
+    //   rintf(-1.5) -> -2,  floor(-1) -> -1.
+    // After the unification both use floor(x + 0.5).
+    nanovdb::Vec3f vf(-1.5f, -0.5f, 1.5f);
+    nanovdb::Vec3d vd(-1.5,  -0.5,  1.5);
+
+    const auto rf = nanovdb::math::Round<nanovdb::Coord>(vf);
+    const auto rd = nanovdb::math::Round<nanovdb::Coord>(vd);
+
+    EXPECT_EQ(rf[0], rd[0]);
+    EXPECT_EQ(rf[1], rd[1]);
+    EXPECT_EQ(rf[2], rd[2]);
+
+    // floor(x + 0.5): -1.5 -> -1, -0.5 -> 0, 1.5 -> 2
+    EXPECT_EQ(-1, rf[0]);
+    EXPECT_EQ( 0, rf[1]);
+    EXPECT_EQ( 2, rf[2]);
+}// Round
+
+TEST_F(TestNanoVDB, Vec2)
+{
+    using Vec2d  = nanovdb::math::Vec2<double>;
+    using Vec2i  = nanovdb::math::Vec2<int>;
+    using Coord2 = nanovdb::math::Coord2;
+
+    EXPECT_EQ(2, Vec2d::SIZE);
+    EXPECT_EQ(2, Vec2d::size); // openvdb::math::Tuple-compat alias
+    bool tt = nanovdb::util::is_same<double, Vec2d::ValueType>::value;
+    EXPECT_TRUE(tt);
+
+    Vec2d a(1.0, 2.0);
+    EXPECT_EQ(1.0, a[0]);
+    EXPECT_EQ(2.0, a[1]);
+
+    // construction from single scalar
+    EXPECT_EQ(Vec2d(5.0, 5.0), Vec2d(5.0));
+
+    // copy from Coord2
+    Coord2 c(3, 4);
+    Vec2d  fromC(c);
+    EXPECT_EQ(3.0, fromC[0]);
+    EXPECT_EQ(4.0, fromC[1]);
+
+    // equality
+    EXPECT_EQ(Vec2d(1, 2), Vec2d(1, 2));
+    EXPECT_NE(Vec2d(1, 2), Vec2d(1, 3));
+
+    // arithmetic
+    Vec2d b(3.0, 4.0);
+    EXPECT_EQ(Vec2d(4, 6),     a + b);
+    EXPECT_EQ(Vec2d(-2, -2),   a - b);
+    EXPECT_EQ(Vec2d(3, 8),     a * b);
+    EXPECT_EQ(Vec2d(2, 2),     b / Vec2d(1.5, 2.0));
+    EXPECT_EQ(Vec2d(-1, -2),   -a);
+    EXPECT_EQ(Vec2d(2, 4),     a * 2.0);
+    EXPECT_EQ(Vec2d(0.5, 1.0), a / 2.0);
+
+    Vec2d acc = a; acc += b;       EXPECT_EQ(Vec2d(4, 6), acc);
+    acc = a; acc -= b;             EXPECT_EQ(Vec2d(-2, -2), acc);
+    acc = a; acc *= 3.0;           EXPECT_EQ(Vec2d(3, 6), acc);
+    acc = Vec2d(8, 4); acc /= 2.0; EXPECT_EQ(Vec2d(4, 2), acc);
+
+    // mixed Vec2 / Coord2 (these used to take a 3D Coord -- bug #2)
+    EXPECT_EQ(Vec2d(4, 6),  a + c);
+    EXPECT_EQ(Vec2d(-2, -2), a - c);
+    acc = a; acc += c; EXPECT_EQ(Vec2d(4, 6), acc);
+    acc = a; acc -= c; EXPECT_EQ(Vec2d(-2, -2), acc);
+
+    // scalar*Vec free function
+    EXPECT_EQ(Vec2d(2, 4), 2.0 * a);
+
+    // dot/length
+    EXPECT_EQ(1.0 + 4.0,         a.lengthSqr());
+    EXPECT_EQ(std::sqrt(5.0),    a.length());
+    EXPECT_EQ(1.0*3.0 + 2.0*4.0, a.dot(b));
+
+    // min/max scalar reductions
+    EXPECT_EQ(1.0, a.min());
+    EXPECT_EQ(2.0, a.max());
+
+    // minComponent / maxComponent (mutating)
+    Vec2d p(5.0, 1.0);
+    Vec2d q(2.0, 7.0);
+    Vec2d mn = p; mn.minComponent(q); EXPECT_EQ(Vec2d(2, 1), mn);
+    Vec2d mx = p; mx.maxComponent(q); EXPECT_EQ(Vec2d(5, 7), mx);
+
+    // floor / ceil / round
+    Vec2d r(-0.5, 1.5);
+    EXPECT_EQ(Coord2(-1, 1), r.floor());
+    EXPECT_EQ(Coord2( 0, 2), r.ceil());
+    // floor(x + 0.5): -0.5 -> 0, 1.5 -> 2
+    EXPECT_EQ(Coord2( 0, 2), r.round());
+
+    // asPointer
+    Vec2d u(7.0, 9.0);
+    EXPECT_EQ(7.0, u.asPointer()[0]);
+    EXPECT_EQ(9.0, u.asPointer()[1]);
+
+    // integer-T division must be per-element (not 1/s, which would give 0)
+    Vec2i vi(6, 8);
+    EXPECT_EQ(Vec2i(3, 4), vi / 2);
+    Vec2i vid = vi; vid /= 2;
+    EXPECT_EQ(Vec2i(3, 4), vid);
+}// Vec2
+
+TEST_F(TestNanoVDB, Vec3Ops)
+{
+    using Vec3d = nanovdb::math::Vec3<double>;
+    using Vec3i = nanovdb::math::Vec3<int>;
+
+    Vec3d a(1.0, 2.0, 3.0);
+    Vec3d b(4.0, 5.0, 6.0);
+
+    EXPECT_EQ(Vec3d(5,7,9),  a + b);
+    EXPECT_EQ(Vec3d(3,3,3),  b - a);
+    EXPECT_EQ(Vec3d(4,10,18), a * b);
+    EXPECT_EQ(Vec3d(2,1,1),  b / Vec3d(2.0, 5.0, 6.0));
+    EXPECT_EQ(Vec3d(-1,-2,-3), -a);
+    EXPECT_EQ(Vec3d(2,4,6),  a * 2.0);
+    EXPECT_EQ(Vec3d(0.5,1,1.5), a / 2.0);
+    EXPECT_EQ(Vec3d(2,4,6),  2.0 * a);
+
+    Vec3d acc = a; acc += b; EXPECT_EQ(Vec3d(5,7,9), acc);
+    acc = b; acc -= a;       EXPECT_EQ(Vec3d(3,3,3), acc);
+    acc = a; acc *= 2.0;     EXPECT_EQ(Vec3d(2,4,6), acc);
+    acc = Vec3d(8,4,2); acc /= 2.0; EXPECT_EQ(Vec3d(4,2,1), acc);
+
+    EXPECT_EQ(1.0*4 + 2*5 + 3*6, a.dot(b));
+
+    // cross and outer (3D-only)
+    Vec3d ex(1,0,0), ey(0,1,0);
+    EXPECT_EQ(Vec3d(0,0,1), ex.cross(ey));
+    auto M = ex.outer(ey);
+    EXPECT_EQ(0.0, M[0][0]);
+    EXPECT_EQ(1.0, M[0][1]);
+    EXPECT_EQ(0.0, M[2][2]);
+
+    // min/max scalar reductions
+    Vec3d p(3, 1, 4);
+    EXPECT_EQ(1.0, p.min());
+    EXPECT_EQ(4.0, p.max());
+
+    // minComponent / maxComponent
+    Vec3d q(2, 7, 1);
+    Vec3d mn = p; mn.minComponent(q); EXPECT_EQ(Vec3d(2,1,1), mn);
+    Vec3d mx = p; mx.maxComponent(q); EXPECT_EQ(Vec3d(3,7,4), mx);
+
+    // floor / ceil
+    Vec3d r(-1.4, 2.7, 3.0);
+    EXPECT_EQ(nanovdb::Coord(-2, 2, 3), r.floor());
+    EXPECT_EQ(nanovdb::Coord(-1, 3, 3), r.ceil());
+    // floor(x + 0.5)
+    Vec3d s(-1.5, -0.5, 1.5);
+    EXPECT_EQ(nanovdb::Coord(-1, 0, 2), s.round());
+
+    // mixed Vec3/Coord (3D Coord is correct here)
+    nanovdb::Coord ijk(1, 2, 3);
+    EXPECT_EQ(Vec3d(2, 4, 6), a + ijk);
+    EXPECT_EQ(Vec3d(0, 0, 0), a - ijk);
+    Vec3d acc2 = a; acc2 += ijk; EXPECT_EQ(Vec3d(2, 4, 6), acc2);
+    acc2 = a; acc2 -= ijk;       EXPECT_EQ(Vec3d(0, 0, 0), acc2);
+
+    // asPointer
+    const double* dp = a.asPointer();
+    EXPECT_EQ(1.0, dp[0]);
+    EXPECT_EQ(3.0, dp[2]);
+
+    // integer-T division per-element
+    Vec3i vi(6, 8, 10);
+    EXPECT_EQ(Vec3i(3, 4, 5), vi / 2);
+
+    // normalize
+    Vec3d n(3, 0, 4);
+    n.normalize();
+    EXPECT_NEAR(1.0, n.length(), 1e-12);
+}// Vec3Ops
+
+TEST_F(TestNanoVDB, Vec4Ops)
+{
+    using Vec4d = nanovdb::math::Vec4<double>;
+    using Vec4i = nanovdb::math::Vec4<int>;
+
+    Vec4d a(1, 2, 3, 4);
+    Vec4d b(4, 5, 6, 7);
+
+    EXPECT_EQ(Vec4d(5,7,9,11),  a + b);
+    EXPECT_EQ(Vec4d(3,3,3,3),   b - a);
+    EXPECT_EQ(Vec4d(4,10,18,28), a * b);
+    EXPECT_EQ(Vec4d(-1,-2,-3,-4), -a);
+    EXPECT_EQ(Vec4d(2,4,6,8),    a * 2.0);
+    EXPECT_EQ(Vec4d(0.5,1,1.5,2), a / 2.0);
+    EXPECT_EQ(Vec4d(2,4,6,8),    2.0 * a);
+
+    Vec4d acc = a; acc += b; EXPECT_EQ(Vec4d(5,7,9,11), acc);
+    acc = b; acc -= a;       EXPECT_EQ(Vec4d(3,3,3,3),  acc);
+    acc = a; acc *= 2.0;     EXPECT_EQ(Vec4d(2,4,6,8),  acc);
+    acc = Vec4d(8,4,2,1); acc /= 2.0; EXPECT_EQ(Vec4d(4,2,1,0.5), acc);
+
+    // ---- Vec4 API gaps that the refactor closed ----
+
+    // min / max scalar reductions (Vec4 did not have these before)
+    Vec4d p(3, 1, 4, 1);
+    EXPECT_EQ(1.0, p.min());
+    EXPECT_EQ(4.0, p.max());
+
+    // asPointer (was missing on Vec4)
+    const double* dp = a.asPointer();
+    EXPECT_EQ(1.0, dp[0]);
+    EXPECT_EQ(4.0, dp[3]);
+
+    // floor / ceil / round (was missing on Vec4) -> Vec4<int32_t>
+    Vec4d r(-1.4, 2.7, 3.0, 0.5);
+    EXPECT_EQ(nanovdb::math::Vec4<int32_t>(-2, 2, 3, 0), r.floor());
+    EXPECT_EQ(nanovdb::math::Vec4<int32_t>(-1, 3, 3, 1), r.ceil());
+    // floor(x + 0.5)
+    EXPECT_EQ(nanovdb::math::Vec4<int32_t>(-1, 3, 3, 1), r.round());
+
+    // integer-T per-element division
+    Vec4i vi(6, 8, 10, 12);
+    EXPECT_EQ(Vec4i(3, 4, 5, 6), vi / 2);
+
+    // normalize
+    Vec4d n(1, 0, 0, 0);
+    n.normalize();
+    EXPECT_NEAR(1.0, n.length(), 1e-12);
+}// Vec4Ops
+
+TEST_F(TestNanoVDB, Mat2)
+{
+    using Mat2d = nanovdb::math::Mat2<double>;
+
+    EXPECT_EQ(2, Mat2d::rows());
+    EXPECT_EQ(2, Mat2d::cols());
+    EXPECT_EQ(4, Mat2d::size());
+
+    Mat2d a(1, 2,
+            3, 4);
+    EXPECT_EQ(1.0, a[0][0]); EXPECT_EQ(2.0, a[0][1]);
+    EXPECT_EQ(3.0, a[1][0]); EXPECT_EQ(4.0, a[1][1]);
+
+    // negation, transpose, equality
+    Mat2d neg = -a;
+    EXPECT_EQ(-1.0, neg[0][0]);
+    EXPECT_EQ(-4.0, neg[1][1]);
+
+    Mat2d t = a.transpose();
+    EXPECT_EQ(1.0, t[0][0]); EXPECT_EQ(3.0, t[0][1]);
+    EXPECT_EQ(2.0, t[1][0]); EXPECT_EQ(4.0, t[1][1]);
+
+    EXPECT_TRUE (a == Mat2d(1, 2, 3, 4));
+    EXPECT_FALSE(a == Mat2d(1, 2, 3, 5));
+    EXPECT_TRUE (a != Mat2d(0, 0, 0, 0));
+
+    // arithmetic
+    Mat2d b(5, 6, 7, 8);
+    Mat2d sum = a + b;  EXPECT_EQ(Mat2d(6, 8, 10, 12), sum);
+    Mat2d dif = b - a;  EXPECT_EQ(Mat2d(4, 4, 4, 4),  dif);
+    Mat2d ac = a; ac += b; EXPECT_EQ(Mat2d(6, 8, 10, 12), ac);
+    ac = b; ac -= a;       EXPECT_EQ(Mat2d(4, 4, 4, 4),  ac);
+
+    // scalar
+    Mat2d twoA = a * 2.0;       EXPECT_EQ(Mat2d(2, 4, 6, 8),   twoA);
+    Mat2d twoA2 = 2.0 * a;      EXPECT_EQ(Mat2d(2, 4, 6, 8),   twoA2);
+    Mat2d halfA = a / 2.0;      EXPECT_EQ(Mat2d(0.5, 1, 1.5, 2), halfA);
+    Mat2d ac2 = a; ac2 *= 0.5;  EXPECT_EQ(Mat2d(0.5, 1, 1.5, 2), ac2);
+    Mat2d ac3 = a; ac3 /= 2.0;  EXPECT_EQ(Mat2d(0.5, 1, 1.5, 2), ac3);
+
+    // Mat2 * Mat2
+    // [1 2][5 6] = [1*5+2*7 1*6+2*8] = [19 22]
+    // [3 4][7 8]   [3*5+4*7 3*6+4*8]   [43 50]
+    Mat2d prod = a * b;
+    EXPECT_EQ(Mat2d(19, 22, 43, 50), prod);
+
+    // Mat2 * Vec2  (newly added member)
+    nanovdb::math::Vec2<double> v(1, 2);
+    nanovdb::math::Vec2<double> mv = a * v;
+    // [1 2][1] = [5]
+    // [3 4][2]   [11]
+    EXPECT_EQ(nanovdb::math::Vec2<double>(5, 11), mv);
+
+    // inverse: non-singular roundtrip + singular returns explicit zero
+    Mat2d inv = a.inverse();
+    // det(a) = 1*4 - 2*3 = -2; invDet = -0.5
+    // [a^-1] = [-2  1; 1.5 -0.5]
+    EXPECT_EQ(Mat2d(-2.0, 1.0, 1.5, -0.5), inv);
+
+    Mat2d singular(1, 1, 1, 1);
+    Mat2d zinv = singular.inverse();
+    EXPECT_EQ(Mat2d(0, 0, 0, 0), zinv);
+}// Mat2
+
+TEST_F(TestNanoVDB, Mat3)
+{
+    using Mat3d = nanovdb::math::Mat3<double>;
+    using Vec3d = nanovdb::math::Vec3<double>;
+
+    EXPECT_EQ(3, Mat3d::rows());
+    EXPECT_EQ(3, Mat3d::cols());
+    EXPECT_EQ(9, Mat3d::size());
+
+    // Mixed-literal construction now works (Source->T unification)
+    Mat3d m(1, 2.0, 3,
+            4.0, 5, 6.0,
+            7, 8.0, 9);
+    EXPECT_EQ(1.0, m[0][0]);
+    EXPECT_EQ(5.0, m[1][1]);
+    EXPECT_EQ(9.0, m[2][2]);
+
+    // transpose
+    Mat3d mt = m.transpose();
+    EXPECT_EQ(1.0, mt[0][0]); EXPECT_EQ(4.0, mt[0][1]); EXPECT_EQ(7.0, mt[0][2]);
+    EXPECT_EQ(2.0, mt[1][0]); EXPECT_EQ(5.0, mt[1][1]); EXPECT_EQ(8.0, mt[1][2]);
+
+    // ==, !=, +/-, scalar, +=, -=, *=, /=
+    EXPECT_TRUE (m == m);
+    EXPECT_FALSE(m != m);
+
+    Mat3d twoM = m * 2.0;
+    EXPECT_EQ(2.0,  twoM[0][0]);
+    EXPECT_EQ(18.0, twoM[2][2]);
+
+    Mat3d sum = m + m;
+    EXPECT_EQ(twoM, sum);
+
+    Mat3d dif = sum - m;
+    EXPECT_EQ(m, dif);
+
+    Mat3d acc = m; acc += m; EXPECT_EQ(twoM, acc);
+    acc = sum; acc -= m;     EXPECT_EQ(m, acc);
+    acc = m; acc *= 2.0;     EXPECT_EQ(twoM, acc);
+    acc = twoM; acc /= 2.0;  EXPECT_EQ(m, acc);
+
+    Mat3d neg = -m;
+    EXPECT_EQ(-1.0, neg[0][0]);
+    EXPECT_EQ(-9.0, neg[2][2]);
+
+    // scalar*Mat free function
+    EXPECT_EQ(twoM, 2.0 * m);
+
+    // Mat3 * Mat3
+    Mat3d id(1, 0, 0, 0, 1, 0, 0, 0, 1);
+    EXPECT_EQ(m, m * id);
+    Mat3d sq = m * m;
+    // Row 0, col 0: 1*1 + 2*4 + 3*7 = 30
+    EXPECT_EQ(30.0, sq[0][0]);
+
+    // Mat3 * Vec3
+    Vec3d v(1, 2, 3);
+    Vec3d r = m * v;
+    // Row 0: 1+4+9 = 14, Row 1: 4+10+18 = 32, Row 2: 7+16+27 = 50
+    EXPECT_EQ(Vec3d(14, 32, 50), r);
+}// Mat3
+
+TEST_F(TestNanoVDB, Mat4)
+{
+    using Mat4d = nanovdb::math::Mat4<double>;
+    using Vec4d = nanovdb::math::Vec4<double>;
+
+    EXPECT_EQ(4,  Mat4d::rows());
+    EXPECT_EQ(4,  Mat4d::cols());
+    EXPECT_EQ(16, Mat4d::size());
+
+    // Mixed-literal construction (Source->T unification)
+    Mat4d m( 1,  2.0,  3,  4.0,
+             5,  6.0,  7,  8.0,
+             9, 10.0, 11, 12.0,
+            13, 14.0, 15, 16.0);
+    EXPECT_EQ(1.0,  m[0][0]);
+    EXPECT_EQ(16.0, m[3][3]);
+
+    // transpose
+    Mat4d mt = m.transpose();
+    EXPECT_EQ(1.0,  mt[0][0]); EXPECT_EQ(5.0,  mt[0][1]);
+    EXPECT_EQ(4.0,  mt[3][0]); EXPECT_EQ(16.0, mt[3][3]);
+
+    // ==/!=, +/-, +=, -=, scalar, *=, /=, unary minus
+    EXPECT_TRUE(m == m);
+    EXPECT_TRUE(m != Mat4d(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1));
+    Mat4d twoM = m * 2.0;
+    EXPECT_EQ(32.0, twoM[3][3]);
+    EXPECT_EQ(twoM, 2.0 * m);
+    Mat4d sum = m + m; EXPECT_EQ(twoM, sum);
+    Mat4d dif = sum - m; EXPECT_EQ(m, dif);
+    Mat4d acc = m; acc += m; EXPECT_EQ(twoM, acc);
+    acc = sum; acc -= m;     EXPECT_EQ(m, acc);
+    acc = m; acc *= 2.0;     EXPECT_EQ(twoM, acc);
+    acc = twoM; acc /= 2.0;  EXPECT_EQ(m, acc);
+
+    Mat4d neg = -m;
+    EXPECT_EQ(-1.0, neg[0][0]);
+
+    // Mat4 * Mat4 (newly added)
+    Mat4d id(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1);
+    EXPECT_EQ(m, m * id);
+    Mat4d sq = m * m;
+    // Row 0, col 0: 1*1 + 2*5 + 3*9 + 4*13 = 1 + 10 + 27 + 52 = 90
+    EXPECT_EQ(90.0, sq[0][0]);
+
+    // Mat4 * Vec4 (now a member, replacing the old standalone)
+    Vec4d v(1, 2, 3, 4);
+    Vec4d r = m * v;
+    // Row 0: 1+4+9+16 = 30
+    // Row 1: 5+12+21+32 = 70
+    // Row 2: 9+20+33+48 = 110
+    // Row 3: 13+28+45+64 = 150
+    EXPECT_EQ(Vec4d(30, 70, 110, 150), r);
+}// Mat4
+
+TEST_F(TestNanoVDB, Mat2x3_Mat3x2)
+{
+    using Mat2x3d = nanovdb::math::Mat2x3<double>;
+    using Mat3x2d = nanovdb::math::Mat3x2<double>;
+    using Vec2d   = nanovdb::math::Vec2<double>;
+    using Vec3d   = nanovdb::math::Vec3<double>;
+
+    EXPECT_EQ(2, Mat2x3d::rows()); EXPECT_EQ(3, Mat2x3d::cols()); EXPECT_EQ(6, Mat2x3d::size());
+    EXPECT_EQ(3, Mat3x2d::rows()); EXPECT_EQ(2, Mat3x2d::cols()); EXPECT_EQ(6, Mat3x2d::size());
+
+    Mat2x3d a(1, 2, 3,
+              4, 5, 6);
+    Mat3x2d b(1, 2,
+              3, 4,
+              5, 6);
+
+    // transpose round-trip between the two shapes
+    Mat3x2d at = a.transpose();
+    EXPECT_EQ(1.0, at[0][0]); EXPECT_EQ(4.0, at[0][1]);
+    EXPECT_EQ(2.0, at[1][0]); EXPECT_EQ(5.0, at[1][1]);
+    EXPECT_EQ(3.0, at[2][0]); EXPECT_EQ(6.0, at[2][1]);
+    EXPECT_TRUE(a == at.transpose());
+
+    Mat2x3d bt = b.transpose();
+    EXPECT_EQ(1.0, bt[0][0]); EXPECT_EQ(3.0, bt[0][1]); EXPECT_EQ(5.0, bt[0][2]);
+    EXPECT_EQ(2.0, bt[1][0]); EXPECT_EQ(4.0, bt[1][1]); EXPECT_EQ(6.0, bt[1][2]);
+
+    // element-wise (only Mat2x3 had + and += previously; Mat3x2 now has them too)
+    Mat2x3d a2 = a + a; EXPECT_EQ(Mat2x3d(2,4,6,8,10,12), a2);
+    Mat2x3d ac = a; ac += a; EXPECT_EQ(a2, ac);
+    Mat2x3d ad = a; ad -= a; EXPECT_EQ(Mat2x3d(0,0,0,0,0,0), ad);
+
+    Mat3x2d b2 = b + b; EXPECT_EQ(Mat3x2d(2,4,6,8,10,12), b2);
+    Mat3x2d bc = b; bc += b; EXPECT_EQ(b2, bc);
+    Mat3x2d bd = b; bd -= b; EXPECT_EQ(Mat3x2d(0,0,0,0,0,0), bd);
+
+    // scalar
+    EXPECT_EQ(Mat2x3d(2,4,6,8,10,12), a * 2.0);
+    EXPECT_EQ(Mat2x3d(2,4,6,8,10,12), 2.0 * a);
+    EXPECT_EQ(a, (a * 2.0) / 2.0);
+
+    EXPECT_EQ(Mat3x2d(2,4,6,8,10,12), b * 2.0);
+    EXPECT_EQ(Mat3x2d(2,4,6,8,10,12), 2.0 * b);
+
+    // unary minus
+    EXPECT_EQ(Mat2x3d(-1,-2,-3,-4,-5,-6), -a);
+    EXPECT_EQ(Mat3x2d(-1,-2,-3,-4,-5,-6), -b);
+
+    // ==, !=
+    EXPECT_TRUE(a == Mat2x3d(1,2,3,4,5,6));
+    EXPECT_TRUE(a != Mat2x3d(1,2,3,4,5,7));
+
+    // Mat2x3 * Vec3 (newly added member) -> Vec2
+    Vec3d v3(1, 2, 3);
+    Vec2d r1 = a * v3;
+    // Row 0: 1+4+9 = 14, Row 1: 4+10+18 = 32
+    EXPECT_EQ(Vec2d(14, 32), r1);
+
+    // Mat3x2 * Vec2 (newly added member) -> Vec3
+    Vec2d v2(1, 2);
+    Vec3d r2 = b * v2;
+    // Row 0: 1+4 = 5, Row 1: 3+8 = 11, Row 2: 5+12 = 17
+    EXPECT_EQ(Vec3d(5, 11, 17), r2);
+}// Mat2x3_Mat3x2
+
+TEST_F(TestNanoVDB, MatMul)
+{
+    using namespace nanovdb::math;
+    using Mat2d   = Mat2<double>;
+    using Mat3d   = Mat3<double>;
+    using Mat4d   = Mat4<double>;
+    using Mat2x3d = Mat2x3<double>;
+    using Mat3x2d = Mat3x2<double>;
+
+    Mat2d   m22(1, 2, 3, 4);
+    Mat3d   m33(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    Mat4d   m44(1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16);
+    Mat2x3d m23(1, 2, 3,
+                4, 5, 6);
+    Mat3x2d m32(1, 2,
+                3, 4,
+                5, 6);
+
+    // Square * Square (member form)
+    EXPECT_EQ(Mat2d(7, 10, 15, 22), m22 * m22);
+    // [1 2 3][1 2 3]   [30 36 42]
+    // [4 5 6][4 5 6] = [66 81 96]
+    // [7 8 9][7 8 9]   [102 126 150]
+    Mat3d m33sq = m33 * m33;
+    EXPECT_EQ(30.0,  m33sq[0][0]);
+    EXPECT_EQ(150.0, m33sq[2][2]);
+
+    Mat4d m44sq = m44 * m44;
+    EXPECT_EQ(90.0,  m44sq[0][0]);  // 1+10+27+52
+    EXPECT_EQ(600.0, m44sq[3][3]);  // 13*4 + 14*8 + 15*12 + 16*16
+
+    // Rectangular: Mat2x3 * Mat3x2 -> Mat2
+    // [1 2 3][1 2]   [22 28]
+    // [4 5 6][3 4] = [49 64]
+    //        [5 6]
+    EXPECT_EQ(Mat2d(22, 28, 49, 64), m23 * m32);
+
+    // Mat3x2 * Mat2x3 -> Mat3
+    // Each entry: lhs.row[i] dotted with rhs.col[j]
+    // Row 0, col 0: 1*1 + 2*4 = 9
+    Mat3d m32x23 = m32 * m23;
+    EXPECT_EQ(9.0,  m32x23[0][0]);
+    EXPECT_EQ(51.0, m32x23[2][2]);  // 5*3 + 6*6 = 51
+
+    // Mat2 * Mat2x3 -> Mat2x3 (identity-passes test)
+    Mat2d id2(1, 0, 0, 1);
+    EXPECT_EQ(m23, id2 * m23);
+
+    // Mat3x2 * Mat2 -> Mat3x2
+    EXPECT_EQ(m32, m32 * id2);
+
+    // Mat2x3 * Mat3 -> Mat2x3
+    Mat3d id3(1, 0, 0, 0, 1, 0, 0, 0, 1);
+    EXPECT_EQ(m23, m23 * id3);
+
+    // Mat3 * Mat3x2 -> Mat3x2  (the consistency-pass addition)
+    Mat3x2d r = m33 * m32;
+    // Row 0: [1*1+2*3+3*5 1*2+2*4+3*6] = [22 28]
+    EXPECT_EQ(22.0, r[0][0]); EXPECT_EQ(28.0, r[0][1]);
+    EXPECT_EQ(49.0, r[1][0]); EXPECT_EQ(64.0, r[1][1]);
+    EXPECT_EQ(76.0, r[2][0]); EXPECT_EQ(100.0, r[2][1]);
+
+    // identity-on-the-left passes through for the rectangular shapes too
+    EXPECT_EQ(m32, id3 * m32);
+
+    // Mat3 * Vec3 (member)
+    Vec3<double> v3(1, 2, 3);
+    EXPECT_EQ(Vec3<double>(14, 32, 50), m33 * v3);
+
+    // Mat4 * Vec4 (member after the consistency pass)
+    Vec4<double> v4(1, 2, 3, 4);
+    EXPECT_EQ(Vec4<double>(30, 70, 110, 150), m44 * v4);
+
+    // Mat2 * Vec2 (member, new)
+    EXPECT_EQ(Vec2<double>(5, 11), m22 * Vec2<double>(1, 2));
+
+    // Mat2x3 * Vec3 (member, new) -> Vec2
+    EXPECT_EQ(Vec2<double>(14, 32), m23 * v3);
+
+    // Mat3x2 * Vec2 (member, new) -> Vec3
+    EXPECT_EQ(Vec3<double>(5, 11, 17), m32 * Vec2<double>(1, 2));
+}// MatMul
+
+TEST_F(TestNanoVDB, MatVecIntrospection)
+{
+    using namespace nanovdb::math;
+
+    // MatBase / Mat* shape and type introspection (public after refactor)
+    static_assert(Mat2<float>::rows()   == 2,  "");
+    static_assert(Mat2<float>::cols()   == 2,  "");
+    static_assert(Mat2<float>::size()   == 4,  "");
+    static_assert(Mat3<float>::rows()   == 3,  "");
+    static_assert(Mat3<float>::cols()   == 3,  "");
+    static_assert(Mat3<float>::size()   == 9,  "");
+    static_assert(Mat4<float>::rows()   == 4,  "");
+    static_assert(Mat4<float>::cols()   == 4,  "");
+    static_assert(Mat4<float>::size()   == 16, "");
+    static_assert(Mat2x3<float>::rows() == 2,  "");
+    static_assert(Mat2x3<float>::cols() == 3,  "");
+    static_assert(Mat3x2<float>::rows() == 3,  "");
+    static_assert(Mat3x2<float>::cols() == 2,  "");
+
+    bool tm = nanovdb::util::is_same<float, Mat3<float>::ValueType>::value;
+    EXPECT_TRUE(tm);
+    tm = nanovdb::util::is_same<double, Mat4<double>::ValueType>::value;
+    EXPECT_TRUE(tm);
+
+    // VecBase / Vec* shape and type introspection
+    static_assert(Vec2<float>::SIZE == 2, "");
+    static_assert(Vec3<float>::SIZE == 3, "");
+    static_assert(Vec4<float>::SIZE == 4, "");
+    // openvdb::math::Tuple-compat lowercase alias
+    static_assert(Vec3<float>::size == 3, "");
+
+    bool tv = nanovdb::util::is_same<double, Vec3<double>::ValueType>::value;
+    EXPECT_TRUE(tv);
+    tv = nanovdb::util::is_same<float,  Vec4<float>::ValueType>::value;
+    EXPECT_TRUE(tv);
+
+    // data() on Mat lays out row-major
+    Mat3<double> m(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    EXPECT_EQ(1.0, m.data()[0]);
+    EXPECT_EQ(5.0, m.data()[4]);
+    EXPECT_EQ(9.0, m.data()[8]);
+
+    // asPointer() on Vec lays out left-to-right
+    Vec4<double> v(10, 20, 30, 40);
+    EXPECT_EQ(10.0, v.asPointer()[0]);
+    EXPECT_EQ(40.0, v.asPointer()[3]);
+}// MatVecIntrospection
+
 TEST_F(TestNanoVDB, Map)
 {
     EXPECT_EQ(264u, sizeof(nanovdb::Map));

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cc
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cc
@@ -1414,8 +1414,8 @@ TEST_F(TestNanoVDB, Vec2)
     using Vec2i  = nanovdb::math::Vec2<int>;
     using Coord2 = nanovdb::math::Coord2;
 
-    EXPECT_EQ(2, Vec2d::SIZE);
-    EXPECT_EQ(2, Vec2d::size); // openvdb::math::Tuple-compat alias
+    static_assert(Vec2d::SIZE == 2, "");
+    static_assert(Vec2d::size == 2, ""); // openvdb::math::Tuple-compat alias
     bool tt = nanovdb::util::is_same<double, Vec2d::ValueType>::value;
     EXPECT_TRUE(tt);
 

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cc
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cc
@@ -1465,6 +1465,11 @@ TEST_F(TestNanoVDB, Vec2)
     EXPECT_EQ(std::sqrt(5.0),    a.length());
     EXPECT_EQ(1.0*3.0 + 2.0*4.0, a.dot(b));
 
+    // normalized() — const, non-mutating, unit length
+    const Vec2d e(3, 4);
+    EXPECT_NEAR(1.0, e.normalized().length(), 1e-12);
+    EXPECT_EQ(Vec2d(3, 4), e);// source unchanged
+
     // min/max scalar reductions
     EXPECT_EQ(1.0, a.min());
     EXPECT_EQ(2.0, a.max());
@@ -1564,6 +1569,15 @@ TEST_F(TestNanoVDB, Vec3Ops)
     Vec3d n(3, 0, 4);
     n.normalize();
     EXPECT_NEAR(1.0, n.length(), 1e-12);
+
+    // normalized() — const, non-mutating counterpart; callable on a const vector
+    const Vec3d c(3, 0, 4);
+    const Vec3d u = c.normalized();
+    EXPECT_NEAR(1.0, u.length(), 1e-12);
+    EXPECT_NEAR(0.6, u[0], 1e-12);
+    EXPECT_NEAR(0.0, u[1], 1e-12);
+    EXPECT_NEAR(0.8, u[2], 1e-12);
+    EXPECT_EQ(Vec3d(3, 0, 4), c);// source unchanged
 }// Vec3Ops
 
 TEST_F(TestNanoVDB, Vec4Ops)
@@ -1614,6 +1628,12 @@ TEST_F(TestNanoVDB, Vec4Ops)
     Vec4d n(1, 0, 0, 0);
     n.normalize();
     EXPECT_NEAR(1.0, n.length(), 1e-12);
+
+    // normalized() — const, non-mutating counterpart; callable on a const vector
+    const Vec4d c(0, 3, 0, 4);
+    const Vec4d u = c.normalized();
+    EXPECT_NEAR(1.0, u.length(), 1e-12);
+    EXPECT_EQ(Vec4d(0, 3, 0, 4), c);// source unchanged
 }// Vec4Ops
 
 TEST_F(TestNanoVDB, Mat2)

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cc
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cc
@@ -1991,6 +1991,43 @@ TEST_F(TestNanoVDB, MatVecIntrospection)
     Vec4<double> v(10, 20, 30, 40);
     EXPECT_EQ(10.0, v.asPointer()[0]);
     EXPECT_EQ(40.0, v.asPointer()[3]);
+
+    // Named component accessors x()/y()/z()/w(). x() is available on every
+    // Vec*; y() requires N >= 2; z() requires N >= 3; w() requires N >= 4.
+    // Each is exercised here at compile time (constexpr) and at runtime
+    // (read + write through the non-const overload).
+    {
+        constexpr Vec2<int> v2(11, 22);
+        static_assert(v2.x() == 11, "");
+        static_assert(v2.y() == 22, "");
+    }
+    {
+        constexpr Vec3<int> v3(31, 32, 33);
+        static_assert(v3.x() == 31, "");
+        static_assert(v3.y() == 32, "");
+        static_assert(v3.z() == 33, "");
+    }
+    {
+        constexpr Vec4<int> v4(41, 42, 43, 44);
+        static_assert(v4.x() == 41, "");
+        static_assert(v4.y() == 42, "");
+        static_assert(v4.z() == 43, "");
+        static_assert(v4.w() == 44, "");
+    }
+    {
+        // Non-const overloads return mutable references.
+        Vec4<double> vw(0.0, 0.0, 0.0, 0.0);
+        vw.x() = 1.0; vw.y() = 2.0; vw.z() = 3.0; vw.w() = 4.0;
+        EXPECT_EQ(1.0, vw[0]);
+        EXPECT_EQ(2.0, vw[1]);
+        EXPECT_EQ(3.0, vw[2]);
+        EXPECT_EQ(4.0, vw[3]);
+    }
+    // The static_asserts in the bodies of y()/z()/w() guarantee that calling
+    // e.g. Vec2<T>::w() fails with a clear compile-time error
+    // ("VecBase::w() requires N >= 4"); we don't exercise the negative
+    // case here because there's no way to assert "must fail to compile"
+    // inside a gtest TU.
 }// MatVecIntrospection
 
 TEST_F(TestNanoVDB, Map)

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -2075,7 +2075,7 @@ TEST(TestNanoVDBCUDA, Sphere_CudaPointsToGrid_Voxel32)
                 EXPECT_LE(voxel[0],  0.5f);
                 EXPECT_LE(voxel[1],  0.5f);
                 EXPECT_LE(voxel[2],  0.5f);
-                test = (begin[i] - nanovdb::voxelToWorld(voxel, ijk, grid->map())).length() < 1e-9;
+                test = (begin[i] - nanovdb::voxelToWorld<Vec3T>(voxel, ijk, grid->map())).length() < 1e-9;
             }
             EXPECT_TRUE(test);
         }
@@ -2202,7 +2202,7 @@ TEST(TestNanoVDBCUDA, Sphere_CudaPointsToGrid_Voxel16)
             EXPECT_LE(count, maxPointsPerVoxel);
             bool test = false;
             for (uint64_t j=0; test == false && j<count; ++j) {
-                test = (begin[i] - nanovdb::voxelToWorld(start[j], ijk, grid->map())).length() < 1e-6;
+                test = (begin[i] - nanovdb::voxelToWorld<Vec3T>(start[j], ijk, grid->map())).length() < 1e-6;
             }
         }
     });
@@ -2331,7 +2331,7 @@ TEST(TestNanoVDBCUDA, Sphere_CudaPointsToGrid_Voxel8)
             EXPECT_LE(count, maxPointsPerVoxel);
             bool test = false;
             for (uint64_t j=0; test == false && j<count; ++j) {
-                test = (begin[i] - nanovdb::voxelToWorld(start[j], ijk, grid->map())).length() < 1e-2;
+                test = (begin[i] - nanovdb::voxelToWorld<Vec3T>(start[j], ijk, grid->map())).length() < 1e-2;
             }
             EXPECT_TRUE(test);
         }

--- a/nanovdb/nanovdb/unittest/TestOpenVDB.cc
+++ b/nanovdb/nanovdb/unittest/TestOpenVDB.cc
@@ -2243,9 +2243,9 @@ TEST_F(TestOpenVDB, NanoToOpenVDB_ValueOnIndex_Vec3f_SideCar)
         EXPECT_EQ("vec3s", openGrid->valueType());
         EXPECT_EQ(2u, openGrid->activeVoxelCount());
         auto openAcc = openGrid->getAccessor();
-        EXPECT_EQ(nanovdb::Vec3f(0.0f), openAcc.getValue(openvdb::Coord(0,  0, 0)));
-        EXPECT_EQ(nanovdb::Vec3f(1.0f), openAcc.getValue(openvdb::Coord(1,  2, 3)));
-        EXPECT_EQ(nanovdb::Vec3f(2.0f), openAcc.getValue(openvdb::Coord(2, -2, 9)));
+        EXPECT_EQ(nanovdb::Vec3f(0.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(0,  0, 0))));
+        EXPECT_EQ(nanovdb::Vec3f(1.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(1,  2, 3))));
+        EXPECT_EQ(nanovdb::Vec3f(2.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(2, -2, 9))));
 
         const auto nanoBBox = idxGrid->indexBBox();
         const auto openBBox = openGrid->evalActiveVoxelBoundingBox();
@@ -2263,9 +2263,9 @@ TEST_F(TestOpenVDB, NanoToOpenVDB_ValueOnIndex_Vec3f_SideCar)
         EXPECT_EQ("vec3s", openGrid->valueType());
         EXPECT_EQ(2u, openGrid->activeVoxelCount());
         auto openAcc = openGrid->getAccessor();
-        EXPECT_EQ(nanovdb::Vec3f(0.0f), openAcc.getValue(openvdb::Coord(0,  0, 0)));
-        EXPECT_EQ(nanovdb::Vec3f(1.0f), openAcc.getValue(openvdb::Coord(1,  2, 3)));
-        EXPECT_EQ(nanovdb::Vec3f(2.0f), openAcc.getValue(openvdb::Coord(2, -2, 9)));
+        EXPECT_EQ(nanovdb::Vec3f(0.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(0,  0, 0))));
+        EXPECT_EQ(nanovdb::Vec3f(1.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(1,  2, 3))));
+        EXPECT_EQ(nanovdb::Vec3f(2.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(2, -2, 9))));
 
         const auto nanoBBox = idxGrid->indexBBox();
         const auto openBBox = openGrid->evalActiveVoxelBoundingBox();
@@ -2323,9 +2323,9 @@ TEST_F(TestOpenVDB, NanoToOpenVDB_ValueIndex_Vec3f_SideCar)
         EXPECT_EQ("vec3s", openGrid->valueType());
         EXPECT_EQ(2u, openGrid->activeVoxelCount());
         auto openAcc = openGrid->getAccessor();
-        EXPECT_EQ(nanovdb::Vec3f(0.0f), openAcc.getValue(openvdb::Coord(0,  0, 0)));
-        EXPECT_EQ(nanovdb::Vec3f(1.0f), openAcc.getValue(openvdb::Coord(1,  2, 3)));
-        EXPECT_EQ(nanovdb::Vec3f(2.0f), openAcc.getValue(openvdb::Coord(2, -2, 9)));
+        EXPECT_EQ(nanovdb::Vec3f(0.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(0,  0, 0))));
+        EXPECT_EQ(nanovdb::Vec3f(1.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(1,  2, 3))));
+        EXPECT_EQ(nanovdb::Vec3f(2.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(2, -2, 9))));
 
         const auto nanoBBox = idxGrid->indexBBox();
         const auto openBBox = openGrid->evalActiveVoxelBoundingBox();
@@ -2343,9 +2343,9 @@ TEST_F(TestOpenVDB, NanoToOpenVDB_ValueIndex_Vec3f_SideCar)
         EXPECT_EQ("vec3s", openGrid->valueType());
         EXPECT_EQ(2u, openGrid->activeVoxelCount());
         auto openAcc = openGrid->getAccessor();
-        EXPECT_EQ(nanovdb::Vec3f(0.0f), openAcc.getValue(openvdb::Coord(0,  0, 0)));
-        EXPECT_EQ(nanovdb::Vec3f(1.0f), openAcc.getValue(openvdb::Coord(1,  2, 3)));
-        EXPECT_EQ(nanovdb::Vec3f(2.0f), openAcc.getValue(openvdb::Coord(2, -2, 9)));
+        EXPECT_EQ(nanovdb::Vec3f(0.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(0,  0, 0))));
+        EXPECT_EQ(nanovdb::Vec3f(1.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(1,  2, 3))));
+        EXPECT_EQ(nanovdb::Vec3f(2.0f), nanovdb::Vec3f(openAcc.getValue(openvdb::Coord(2, -2, 9))));
 
         const auto nanoBBox = idxGrid->indexBBox();
         const auto openBBox = openGrid->evalActiveVoxelBoundingBox();

--- a/pendingchanges/nanovdbmath.txt
+++ b/pendingchanges/nanovdbmath.txt
@@ -1,0 +1,20 @@
+NanoVDB:
+  Improvements:
+  - Refactored the math::Mat and math::Vec classes onto shared base classes
+    (MatBase and the new VecBase), giving every Mat/Vec type a complete and
+    consistent operator surface, bounds-checked element access, and constexpr
+    evaluation throughout Math.h and the Map API in NanoVDB.h. The
+    cross-template Vec conversion constructors are now explicit, so downstream
+    code relying on implicit Vec type conversions may need a one-line cast.
+
+  Bug Fixes:
+  - Fixed math::Min/Max for 32-bit integers routing through fminf/fmaxf, which
+    lost precision above 2^24 and could overflow near INT_MAX.
+  - Fixed integer division in the Vec and Mat scalar operator/, which previously
+    computed a reciprocal first, so e.g. Vec3i(6,8,10) / 2 returned (0,0,0).
+  - Fixed Mat2::inverse returning uninitialized values on singular input; it now
+    returns zero.
+  - Fixed Vec2 arithmetic against Coord silently dropping the z component; the
+    overloads now take Coord2.
+  - Fixed math::Round(Vec3<float>) disagreeing with the double overload at
+    half-integers; both now use floor(x + 0.5).


### PR DESCRIPTION
Consolidates `nanovdb/math/Math.h` by lifting Mat / Vec arithmetic onto two shared base classes (`MatBase<T, R, C>` and a new `VecBase<T, N>`). The five Mat and three Vec derived classes become thin delegating wrappers. The pass also fixes several long-standing correctness bugs and fills inconsistent / partial APIs.

**Files changed**: `Math.h` (the refactor), `NanoVDB.h` (`Map` API now constexpr — depends on the `matMult` rework), `tools/cuda/PointsToGrid.cuh` (three call-site casts from the `explicit` ctor tightening), and three test files (additive: 11 new `TEST_F` blocks plus mechanical cast updates), and one python-binding kernel.

## Bug fixes

- `math::Min` / `Max` for `int32_t` / `uint32_t` no longer route through `fminf` / `fmaxf` — old form lost precision above 2^24 and could be UB near `INT_MAX`. Heavily used by `HDDA.h`.
- Removed dimensionally-invalid `operator*(Mat3, Mat2x3) -> Mat2x3`. No callers in the tree.
- `Mat2::inverse()` now returns an explicit zero on singular input (was uninitialised) and uses `T(1)/det` for `T=double`.
- `Vec*::operator/(T)` and `Mat*::operator/(T)` now per-element-divide. The old `(T(1)/s) * (*this)` did integer division for integer `T`, so `Vec3i(6,8,10) / 2` returned `(0,0,0)`.
- `Vec2`'s `operator+`/`-`/`+=`/`-=` against `Coord` now take `Coord2`. Old signature silently dropped `z`.
- `math::Round(Vec3<float>)` and `Round(Vec3<double>)` both use `floor(x + 0.5)` now. The `float` overload previously used `rintf` (round-half-to-even), so the two disagreed at half-integers.
- Corrected `floor()` / `ceil()` doc swap on `Vec2` / `Vec3`. Implementations were always right.

## Refactor

- **`MatBase<T, R, C>`**: shared element-wise / scalar / equality / transpose / mat*mat / mat*vec implementations, all `__hostdev__ constexpr`. `rows()` / `cols()` / `size()` promoted public.
- **`VecBase<T, N>`** (new): shared element-wise / scalar / equality / reductions / mutating min/max / integer rounding. `floorAs<Result>` / `ceilAs<Result>` / `roundAs<Result>` unify `Round` semantics across `float` / `double` / `long double`.
- All five Mat and three Vec classes become thin wrappers: ctors + per-type extras (`Mat2::inverse`, `Vec3::cross`/`outer`) + one-line operators delegating to the base.
- `Mat3` / `Mat3x2` / `Mat4` scalar ctors switched from `template<typename Source>` to `T`, matching `Mat2` / `Mat2x3`. Mixed-literal construction (`Mat3<double>(1, 2.0, 3, ...)`) now works uniformly. Array ctors keep `template<typename Source>` for cross-type interop.

## API completeness

- Every Mat type has the same operator surface: unary `-`, binary `+` / `-`, `+=` / `-=`, `*(T)` / `/(T)`, `*=(T)` / `/=(T)`, `==` / `!=`. Previously scattered.
- New mat*mat: `Mat3 * Mat3x2` standalone, `Mat4 * Mat4` member.
- New mat*vec members: `Mat2 * Vec2`, `Mat2x3 * Vec3 -> Vec2`, `Mat3x2 * Vec2 -> Vec3`. `Mat4 * Vec4` promoted to member.
- New `scalar * MatN` standalones for `Mat2x3` / `Mat3x2` / `Mat3` / `Mat4`.
- `Vec4` gains parity with `Vec3`: `min`, `max`, `asPointer`, `floor`, `ceil`, `round` (returns `Vec4<int32_t>` — no `Coord4`).

## `constexpr` sweep

Every function in `Math.h` and the `Map` API in `NanoVDB.h` that C++17 allows is now `constexpr`. Carve-outs: `length` / `normalize` (`std::sqrt`, C++26), the `float` / `double` overloads of `Min` / `Max` / `Floor` / `Ceil` / `Round` / `Abs` (C++23), and CUDA-device-only `*Atomic` helpers.

Rewriting `matMult` / `matMultT` from `fma(a, b, c)` to `a * b + c` was required (fma isn't constexpr until C++23, P1383R2). **GPU codegen unchanged** — nvcc `-fmad=true` contracts back to hardware FMA. **Host codegen unchanged** under default `-ffp-contract=on`. Only compile-time `constexpr` evaluation observes the double-rounded result. Worst-case ≤1 ulp drift, well below NanoVDB's geometric precision.

## Other quality passes

- **Bounds checks** on every `operator[]` in `Math.h` via `NANOVDB_ASSERT` (twelve sites). No-op under `NDEBUG`; const-index accesses fold at compile time even in debug.
- **Doxygen sweep**: every previously-undocumented public method gains an `@brief`; several `// @brief` typos (missing leading slash — silently invisible to Doxygen) fixed.
- **Hidden friends**: `scalar*Vec` / `scalar/Vec` / `scalar*Mat` converted from namespace-scope free templates to in-class `friend` definitions — ADL-found only, no longer pollute the enclosing namespace.

## Tests

Eleven additive `TEST_F` blocks in `TestNanoVDB.cc`:

| Test | Covers |
|---|---|
| `IntegerMinMax` | `2^24+1` precision; `INT_MAX` / `UINT_MAX` overflow safety. |
| `Round` | Half-integer agreement between `float` and `double` (especially `-1.5`). |
| `Vec2` / `Vec3Ops` / `Vec4Ops` | Full operator coverage; new `Vec4` methods; integer-T division. |
| `Mat2` / `Mat3` / `Mat4` / `Mat2x3_Mat3x2` | Constructors, every operator, transpose, mat*mat, mat*vec; `Mat2::inverse` non-singular roundtrip + singular-returns-zero; mixed-literal construction. |
| `MatMul` | Every dimensionally-valid mat*mat plus every member mat*vec across the five matrix types. |
| `MatVecIntrospection` | `static_assert`s for `rows`/`cols`/`size`/`SIZE`/`ValueType`; `data()`/`asPointer()` ordering. |

## Risk and compatibility

- **Behaviour preserved** for every previously-correct code path.
- **Behaviour changes** are exactly the bug fixes above — each moves an incorrect / undefined output to a defined, correct one.
- **`matMult` rounding**: ≤1 ulp drift only in pure abstract-machine evaluation. GPU and host codegen identical to before.
- **API additions are pure**. The only removed overload is the broken `Mat3 * Mat2x3` (no callers).
- **One signature tightening**: `Vec2`'s `Coord` overloads now require `Coord2`. Code passing a 3D `Coord` to `Vec2` will fail to compile — but it was silently dropping `z`.
- **Cross-template ctor tightened to `explicit`**: `Vec*(const Vec*T<T2>&)` now matches the same-class ctor's convention. Audit found 18 affected sites across the nanovdb + openvdb trees, all updated here (3 in `PointsToGrid.cuh`, 3 in `TestNanoVDB.cu`, 12 in `TestOpenVDB.cc`, 1 in `PySampleFromVoxels.cu`). All mechanical and value-preserving. **Downstream consumers that relied on the implicit conversion will need the same one-line cast** — typically `nanovdb::Vec3f(yourVec)` or an explicit template argument to a returning helper.
