### PR TITLE
nanovdb python: Phase 0 foundation for C++ API mirror

### DIFF
--- a/nanovdb/nanovdb/python/BuildTypes.def
+++ b/nanovdb/nanovdb/python/BuildTypes.def
@@ -3,78 +3,90 @@
 //
 // X-macro list of NanoVDB BuildT types currently exposed to Python.
 //
+// NanoVDB coding style says "avoid macro functions; use inline and templates
+// instead" (docs/codingstyle.txt). This file is a deliberate exception: it
+// must emit top-level template instantiations and binding registrations into
+// several translation units from one canonical list, which a C++ template
+// cannot do. The pattern is contained to this file plus the matching
+// per-consumer macro definitions; no runtime behavior is hidden behind a
+// macro function.
+//
 // Consumers define one or more of the kind-specific macros below before
 // including this file. Each macro is invoked once per matching type; any
-// macro the consumer does not define is treated as a no-op and reset
-// after the file is processed. This is the single point that must be
-// edited when adding (or removing) a Python-visible BuildT.
+// macro the consumer does not define is treated as a no-op and reset after
+// the file is processed. This is the single point that must be edited when
+// adding (or removing) a Python-visible BuildT.
 //
 // Macros:
-//   NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod)
-//       Scalar value types — exposed with full NodeInfo accessors.
-//       Suffix forms Python class names (e.g. "Float" -> "FloatGrid").
-//       HandleMethod / DeviceHandleMethod are the legacy lower-camel-case
-//       method names on GridHandle / DeviceGridHandle (e.g. "floatGrid").
+//   NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod)
+//       Scalar value types — exposed with full NodeInfo accessors. Suffix
+//       forms Python class names (e.g. "Float" -> "FloatGrid"). HandleMethod
+//       and DeviceMethod are the legacy lower-camel-case method names
+//       on GridHandle / DeviceGridHandle (e.g. "floatGrid").
 //
-//   NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod)
+//   NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod)
 //       Vector value types — exposed with a setVoxel accessor but no
 //       NodeInfo. AccessorName is passed explicitly because the legacy
 //       Python class names for these are inconsistent.
 //
-//   NVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)
-//       The nanovdb::Point build type — exposed with a bare accessor and
-//       no GridHandle method (Point is not currently surfaced through
+//   NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)
+//       The nanovdb::Point build type — exposed with a bare accessor and no
+//       GridHandle method (Point is not currently surfaced through
 //       handle.*Grid()).
 //
-//   NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
-//       Subset that has C++ sampler specializations (used by PyMath
-//       samplers and PyCreateNanoGrid create*Grid factories).
+//   NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
+//       Subset that has C++ sampler specializations (used by PyMath samplers
+//       and PyCreateNanoGrid create*Grid factories).
 
-#ifndef NVDB_PY_FOR_EACH_SCALAR_BUILDT
-#define NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod)
-#define NVDB_PY_LOCAL_DEFINED_SCALAR
+#ifndef NANOVDB_PY_FOR_EACH_SCALAR_BUILDT
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod)
+#define NANOVDB_PY_LOCAL_DEFINED_SCALAR
 #endif
-#ifndef NVDB_PY_FOR_EACH_VECTOR_BUILDT
-#define NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod)
-#define NVDB_PY_LOCAL_DEFINED_VECTOR
+#ifndef NANOVDB_PY_FOR_EACH_VECTOR_BUILDT
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod)
+#define NANOVDB_PY_LOCAL_DEFINED_VECTOR
 #endif
-#ifndef NVDB_PY_FOR_EACH_POINT_BUILDT
-#define NVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)
-#define NVDB_PY_LOCAL_DEFINED_POINT
+#ifndef NANOVDB_PY_FOR_EACH_POINT_BUILDT
+#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)
+#define NANOVDB_PY_LOCAL_DEFINED_POINT
 #endif
-#ifndef NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT
-#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
-#define NVDB_PY_LOCAL_DEFINED_SAMPLEABLE
-#endif
-
-NVDB_PY_FOR_EACH_SCALAR_BUILDT(float,   Float, "floatGrid",  "deviceFloatGrid")
-NVDB_PY_FOR_EACH_SCALAR_BUILDT(double,  Double, "doubleGrid", "deviceDoubleGrid")
-NVDB_PY_FOR_EACH_SCALAR_BUILDT(int32_t, Int32, "int32Grid",  "deviceInt32Grid")
-
-NVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec3f,       Vec3f, "Vec3fReadVectorAccessor", "vec3fGrid", "deviceVec3fGrid")
-NVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::math::Rgba8, RGBA8, "RGBA8ReadAccessor",       "rgba8Grid", "deviceRGBA8Grid")
-
-NVDB_PY_FOR_EACH_POINT_BUILDT(::nanovdb::Point, Point)
-
-NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(float,             Float)
-NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(double,            Double)
-NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(int32_t,           Int32)
-NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(::nanovdb::Vec3f,  Vec3f)
-
-#ifdef NVDB_PY_LOCAL_DEFINED_SCALAR
-#undef NVDB_PY_LOCAL_DEFINED_SCALAR
-#endif
-#ifdef NVDB_PY_LOCAL_DEFINED_VECTOR
-#undef NVDB_PY_LOCAL_DEFINED_VECTOR
-#endif
-#ifdef NVDB_PY_LOCAL_DEFINED_POINT
-#undef NVDB_PY_LOCAL_DEFINED_POINT
-#endif
-#ifdef NVDB_PY_LOCAL_DEFINED_SAMPLEABLE
-#undef NVDB_PY_LOCAL_DEFINED_SAMPLEABLE
+#ifndef NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT
+#define NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
+#define NANOVDB_PY_LOCAL_DEFINED_SAMPLEABLE
 #endif
 
-#undef NVDB_PY_FOR_EACH_SCALAR_BUILDT
-#undef NVDB_PY_FOR_EACH_VECTOR_BUILDT
-#undef NVDB_PY_FOR_EACH_POINT_BUILDT
-#undef NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(float,   Float,  "floatGrid",  "deviceFloatGrid")
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(double,  Double, "doubleGrid", "deviceDoubleGrid")
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(int32_t, Int32,  "int32Grid",  "deviceInt32Grid")
+
+NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec3f, Vec3f,
+                                  "Vec3fReadVectorAccessor",
+                                  "vec3fGrid", "deviceVec3fGrid")
+NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::math::Rgba8, RGBA8,
+                                  "RGBA8ReadAccessor",
+                                  "rgba8Grid", "deviceRGBA8Grid")
+
+NANOVDB_PY_FOR_EACH_POINT_BUILDT(::nanovdb::Point, Point)
+
+NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(float,            Float)
+NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(double,           Double)
+NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(int32_t,          Int32)
+NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(::nanovdb::Vec3f, Vec3f)
+
+#ifdef NANOVDB_PY_LOCAL_DEFINED_SCALAR
+#undef NANOVDB_PY_LOCAL_DEFINED_SCALAR
+#endif
+#ifdef NANOVDB_PY_LOCAL_DEFINED_VECTOR
+#undef NANOVDB_PY_LOCAL_DEFINED_VECTOR
+#endif
+#ifdef NANOVDB_PY_LOCAL_DEFINED_POINT
+#undef NANOVDB_PY_LOCAL_DEFINED_POINT
+#endif
+#ifdef NANOVDB_PY_LOCAL_DEFINED_SAMPLEABLE
+#undef NANOVDB_PY_LOCAL_DEFINED_SAMPLEABLE
+#endif
+
+#undef NANOVDB_PY_FOR_EACH_SCALAR_BUILDT
+#undef NANOVDB_PY_FOR_EACH_VECTOR_BUILDT
+#undef NANOVDB_PY_FOR_EACH_POINT_BUILDT
+#undef NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT

--- a/nanovdb/nanovdb/python/BuildTypes.def
+++ b/nanovdb/nanovdb/python/BuildTypes.def
@@ -1,0 +1,80 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// X-macro list of NanoVDB BuildT types currently exposed to Python.
+//
+// Consumers define one or more of the kind-specific macros below before
+// including this file. Each macro is invoked once per matching type; any
+// macro the consumer does not define is treated as a no-op and reset
+// after the file is processed. This is the single point that must be
+// edited when adding (or removing) a Python-visible BuildT.
+//
+// Macros:
+//   NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod)
+//       Scalar value types — exposed with full NodeInfo accessors.
+//       Suffix forms Python class names (e.g. "Float" -> "FloatGrid").
+//       HandleMethod / DeviceHandleMethod are the legacy lower-camel-case
+//       method names on GridHandle / DeviceGridHandle (e.g. "floatGrid").
+//
+//   NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod)
+//       Vector value types — exposed with a setVoxel accessor but no
+//       NodeInfo. AccessorName is passed explicitly because the legacy
+//       Python class names for these are inconsistent.
+//
+//   NVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)
+//       The nanovdb::Point build type — exposed with a bare accessor and
+//       no GridHandle method (Point is not currently surfaced through
+//       handle.*Grid()).
+//
+//   NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
+//       Subset that has C++ sampler specializations (used by PyMath
+//       samplers and PyCreateNanoGrid create*Grid factories).
+
+#ifndef NVDB_PY_FOR_EACH_SCALAR_BUILDT
+#define NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod)
+#define NVDB_PY_LOCAL_DEFINED_SCALAR
+#endif
+#ifndef NVDB_PY_FOR_EACH_VECTOR_BUILDT
+#define NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod)
+#define NVDB_PY_LOCAL_DEFINED_VECTOR
+#endif
+#ifndef NVDB_PY_FOR_EACH_POINT_BUILDT
+#define NVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)
+#define NVDB_PY_LOCAL_DEFINED_POINT
+#endif
+#ifndef NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT
+#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
+#define NVDB_PY_LOCAL_DEFINED_SAMPLEABLE
+#endif
+
+NVDB_PY_FOR_EACH_SCALAR_BUILDT(float,   Float, "floatGrid",  "deviceFloatGrid")
+NVDB_PY_FOR_EACH_SCALAR_BUILDT(double,  Double, "doubleGrid", "deviceDoubleGrid")
+NVDB_PY_FOR_EACH_SCALAR_BUILDT(int32_t, Int32, "int32Grid",  "deviceInt32Grid")
+
+NVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec3f,       Vec3f, "Vec3fReadVectorAccessor", "vec3fGrid", "deviceVec3fGrid")
+NVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::math::Rgba8, RGBA8, "RGBA8ReadAccessor",       "rgba8Grid", "deviceRGBA8Grid")
+
+NVDB_PY_FOR_EACH_POINT_BUILDT(::nanovdb::Point, Point)
+
+NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(float,             Float)
+NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(double,            Double)
+NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(int32_t,           Int32)
+NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(::nanovdb::Vec3f,  Vec3f)
+
+#ifdef NVDB_PY_LOCAL_DEFINED_SCALAR
+#undef NVDB_PY_LOCAL_DEFINED_SCALAR
+#endif
+#ifdef NVDB_PY_LOCAL_DEFINED_VECTOR
+#undef NVDB_PY_LOCAL_DEFINED_VECTOR
+#endif
+#ifdef NVDB_PY_LOCAL_DEFINED_POINT
+#undef NVDB_PY_LOCAL_DEFINED_POINT
+#endif
+#ifdef NVDB_PY_LOCAL_DEFINED_SAMPLEABLE
+#undef NVDB_PY_LOCAL_DEFINED_SAMPLEABLE
+#endif
+
+#undef NVDB_PY_FOR_EACH_SCALAR_BUILDT
+#undef NVDB_PY_FOR_EACH_VECTOR_BUILDT
+#undef NVDB_PY_FOR_EACH_POINT_BUILDT
+#undef NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT

--- a/nanovdb/nanovdb/python/CMakeLists.txt
+++ b/nanovdb/nanovdb/python/CMakeLists.txt
@@ -4,9 +4,15 @@ option(NANOVDB_BUILD_PYTHON_UNITTESTS [=[
   "Include the NanoVDB Python unit test. Requires a python interpreter]=]
 ${NANOVDB_BUILD_UNITTESTS})
 
+# Stubs are only consumed from an installed wheel (they ship next to the .so
+# in nanovdb/), so default ON only when SKBUILD is driving the build. In an
+# in-source dev / OpenVDB-CI build the .pyi is not used and stub generation
+# can be skipped — which also dodges the macOS CI's sanitizer-runtime
+# DYLD_INSERT_LIBRARIES wrapper, under which Python dlopen'ing the .so
+# triggers TSan "Interceptors are not working" and aborts stubgen.
 option(NANOVDB_BUILD_PYTHON_STUBS
   "Generate .pyi type stubs for the nanovdb Python module (requires nanobind 2.x or newer)."
-  ON)
+  ${SKBUILD})
 
 nanobind_add_module(nanovdb_python NB_STATIC
     NanoVDBModule.cc

--- a/nanovdb/nanovdb/python/CMakeLists.txt
+++ b/nanovdb/nanovdb/python/CMakeLists.txt
@@ -4,6 +4,10 @@ option(NANOVDB_BUILD_PYTHON_UNITTESTS [=[
   "Include the NanoVDB Python unit test. Requires a python interpreter]=]
 ${NANOVDB_BUILD_UNITTESTS})
 
+option(NANOVDB_BUILD_PYTHON_STUBS
+  "Generate .pyi type stubs for the nanovdb Python module (requires nanobind 2.x or newer)."
+  ON)
+
 nanobind_add_module(nanovdb_python NB_STATIC
     NanoVDBModule.cc
     PyCreateNanoGrid.cc
@@ -33,8 +37,45 @@ if(SKBUILD)
   set_target_properties(nanovdb_python PROPERTIES INSTALL_RPATH "$ORIGIN/../../openvdb/lib")
   install(TARGETS nanovdb_python DESTINATION ${NANOVDB_INSTALL_LIBDIR})
   install(FILES __init__.py DESTINATION nanovdb)
+  # Ship the nanovdb C/C++ headers inside the Python wheel so downstream
+  # extension authors can compile against the same NanoVDB the wheel was
+  # built with. nanovdb.get_include() resolves to this directory at runtime.
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../
+          DESTINATION nanovdb/include/nanovdb
+          FILES_MATCHING
+            PATTERN "*.h"
+            PATTERN "*.cuh"
+            PATTERN "python" EXCLUDE
+            PATTERN "examples" EXCLUDE
+            PATTERN "unittest" EXCLUDE
+            PATTERN "cmd" EXCLUDE
+            PATTERN "docs" EXCLUDE)
 else()
   install(TARGETS nanovdb_python DESTINATION ${VDB_PYTHON_INSTALL_DIRECTORY})
+endif()
+
+# .pyi type stubs for IDE / type-checker support. Driven by the CMake helper
+# that ships with nanobind 2.x; silently skipped on older nanobind where the
+# helper does not exist.
+if(NANOVDB_BUILD_PYTHON_STUBS AND COMMAND nanobind_add_stub)
+  set(NANOVDB_STUB_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+  nanobind_add_stub(nanovdb_python_stub
+    MODULE nanovdb
+    OUTPUT "${NANOVDB_STUB_OUTPUT_DIR}/nanovdb.pyi"
+    PYTHON_PATH $<TARGET_FILE_DIR:nanovdb_python>
+    DEPENDS nanovdb_python
+    MARKER_FILE "${NANOVDB_STUB_OUTPUT_DIR}/py.typed"
+    INCLUDE_PRIVATE)
+  if(SKBUILD)
+    install(FILES
+        "${NANOVDB_STUB_OUTPUT_DIR}/nanovdb.pyi"
+        "${NANOVDB_STUB_OUTPUT_DIR}/py.typed"
+      DESTINATION nanovdb)
+  endif()
+elseif(NANOVDB_BUILD_PYTHON_STUBS)
+  message(STATUS
+    "NANOVDB_BUILD_PYTHON_STUBS is ON but nanobind_add_stub is unavailable "
+    "(nanobind >= 2.0 required). Skipping stub generation.")
 endif()
 
 # pytest

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -343,12 +343,12 @@ NB_MODULE(nanovdb, m)
         .value("Vec3u8", GridType::Vec3u8)
         .value("Vec3u16", GridType::Vec3u16)
         .value("End", GridType::End)
-        .export_values();
-        // .def("__repr__", [](const GridType& gridType) {
-        //     char str[strlen<GridType>()];
-        //     toStr(str, gridType);
-        //     return std::string(str);
-        // });
+        .export_values()
+        .def("__repr__", [](const GridType& gridType) {
+            char str[strlen<GridType>()];
+            toStr(str, gridType);
+            return std::string(str);
+        });
 
     nb::enum_<GridClass>(m, "GridClass")
         .value("Unknown", GridClass::Unknown)
@@ -362,12 +362,12 @@ NB_MODULE(nanovdb, m)
         .value("IndexGrid", GridClass::IndexGrid)
         .value("TensorGrid", GridClass::TensorGrid)
         .value("End", GridClass::End)
-        .export_values();
-        // .def("__repr__", [](const GridClass& gridClass) {
-        //     char str[strlen<GridClass>()];
-        //     toStr(str, gridClass);
-        //     return std::string(str);
-        // });
+        .export_values()
+        .def("__repr__", [](const GridClass& gridClass) {
+            char str[strlen<GridClass>()];
+            toStr(str, gridClass);
+            return std::string(str);
+        });
 
     defineVersion(m);
 
@@ -385,26 +385,17 @@ NB_MODULE(nanovdb, m)
 
     defineGridData(m);
 
-    defineGrid<float>(m, "FloatGrid");
-    defineScalarAccessor<float>(m, "FloatReadAccessor");
-    defineNodeInfo<float>(m, "FloatNodeInfo");
-
-    defineGrid<double>(m, "DoubleGrid");
-    defineScalarAccessor<double>(m, "DoubleReadAccessor");
-    defineNodeInfo<double>(m, "DoubleNodeInfo");
-
-    defineGrid<int32_t>(m, "Int32Grid");
-    defineScalarAccessor<int32_t>(m, "Int32ReadAccessor");
-    defineNodeInfo<int32_t>(m, "Int32NodeInfo");
-
-    defineGrid<Vec3f>(m, "Vec3fGrid");
-    defineVectorAccessor<Vec3f>(m, "Vec3fReadVectorAccessor");
-
-    defineGrid<math::Rgba8>(m, "RGBA8Grid");
-    defineVectorAccessor<math::Rgba8>(m, "RGBA8ReadAccessor");
-
-    defineGrid<Point>(m, "PointGrid");
-    defineAccessor<Point>(m, "PointReadAccessor");
+#define NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod) \
+    defineGrid<T>(m, #Suffix "Grid");                          \
+    defineScalarAccessor<T>(m, #Suffix "ReadAccessor");        \
+    defineNodeInfo<T>(m, #Suffix "NodeInfo");
+#define NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod) \
+    defineGrid<T>(m, #Suffix "Grid");                          \
+    defineVectorAccessor<T>(m, AccessorName);
+#define NVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)               \
+    defineGrid<T>(m, #Suffix "Grid");                          \
+    defineAccessor<T>(m, #Suffix "ReadAccessor");
+#include "BuildTypes.def"
 
     defineHostBuffer(m);
     defineHostGridHandle(m);

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -385,14 +385,14 @@ NB_MODULE(nanovdb, m)
 
     defineGridData(m);
 
-#define NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod) \
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod) \
     defineGrid<T>(m, #Suffix "Grid");                          \
     defineScalarAccessor<T>(m, #Suffix "ReadAccessor");        \
     defineNodeInfo<T>(m, #Suffix "NodeInfo");
-#define NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod) \
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod) \
     defineGrid<T>(m, #Suffix "Grid");                          \
     defineVectorAccessor<T>(m, AccessorName);
-#define NVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)               \
+#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)               \
     defineGrid<T>(m, #Suffix "Grid");                          \
     defineAccessor<T>(m, #Suffix "ReadAccessor");
 #include "BuildTypes.def"

--- a/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
+++ b/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
@@ -45,10 +45,9 @@ template<typename BufferT> void defineOpenToNanoVDB(nb::module_& m)
 #endif
 }
 
-template void defineCreateNanoGrid<float>(nb::module_&, const char*);
-template void defineCreateNanoGrid<double>(nb::module_&, const char*);
-template void defineCreateNanoGrid<int32_t>(nb::module_&, const char*);
-template void defineCreateNanoGrid<Vec3f>(nb::module_&, const char*);
+#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix) \
+    template void defineCreateNanoGrid<T>(nb::module_&, const char*);
+#include "BuildTypes.def"
 
 template void defineOpenToNanoVDB<HostBuffer>(nb::module_&);
 

--- a/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
+++ b/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
@@ -45,7 +45,7 @@ template<typename BufferT> void defineOpenToNanoVDB(nb::module_& m)
 #endif
 }
 
-#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix) \
+#define NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix) \
     template void defineCreateNanoGrid<T>(nb::module_&, const char*);
 #include "BuildTypes.def"
 

--- a/nanovdb/nanovdb/python/PyGridHandle.h
+++ b/nanovdb/nanovdb/python/PyGridHandle.h
@@ -21,14 +21,16 @@ template<typename BufferT> nb::class_<nanovdb::GridHandle<BufferT>> defineGridHa
         .def("isEmpty", &nanovdb::GridHandle<BufferT>::isEmpty)
         .def("empty", &nanovdb::GridHandle<BufferT>::empty)
         .def(
-            "__bool__", [](const nanovdb::GridHandle<BufferT>& handle) { return !handle.empty(); }, nb::is_operator());
+            "__bool__",
+            [](const nanovdb::GridHandle<BufferT>& handle) { return !handle.empty(); },
+            nb::is_operator());
 
-#define NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod) \
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod) \
     cls.def(HandleMethod,                                               \
             nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<T>), \
             nb::arg("n") = 0,                                           \
             nb::rv_policy::reference_internal);
-#define NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod) \
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod) \
     cls.def(HandleMethod,                                               \
             nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<T>), \
             nb::arg("n") = 0,                                           \

--- a/nanovdb/nanovdb/python/PyGridHandle.h
+++ b/nanovdb/nanovdb/python/PyGridHandle.h
@@ -14,31 +14,28 @@ namespace pynanovdb {
 
 template<typename BufferT> nb::class_<nanovdb::GridHandle<BufferT>> defineGridHandle(nb::module_& m, const char* name)
 {
-    return nb::class_<nanovdb::GridHandle<BufferT>>(m, name)
+    auto cls = nb::class_<nanovdb::GridHandle<BufferT>>(m, name)
         .def(nb::init<>())
         .def("reset", &nanovdb::GridHandle<BufferT>::reset)
         .def("size", &nanovdb::GridHandle<BufferT>::bufferSize)
         .def("isEmpty", &nanovdb::GridHandle<BufferT>::isEmpty)
         .def("empty", &nanovdb::GridHandle<BufferT>::empty)
         .def(
-            "__bool__", [](const nanovdb::GridHandle<BufferT>& handle) { handle.empty(); }, nb::is_operator())
-        .def("floatGrid", nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<float>), nb::arg("n") = 0, nb::rv_policy::reference_internal)
-        .def("doubleGrid",
-             nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<double>),
-             nb::arg("n") = 0,
-             nb::rv_policy::reference_internal)
-        .def("int32Grid",
-             nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<int32_t>),
-             nb::arg("n") = 0,
-             nb::rv_policy::reference_internal)
-        .def("vec3fGrid",
-             nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<nanovdb::Vec3f>),
-             nb::arg("n") = 0,
-             nb::rv_policy::reference_internal)
-        .def("rgba8Grid",
-             nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<nanovdb::math::Rgba8>),
-             nb::arg("n") = 0,
-             nb::rv_policy::reference_internal)
+            "__bool__", [](const nanovdb::GridHandle<BufferT>& handle) { return !handle.empty(); }, nb::is_operator());
+
+#define NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod) \
+    cls.def(HandleMethod,                                               \
+            nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<T>), \
+            nb::arg("n") = 0,                                           \
+            nb::rv_policy::reference_internal);
+#define NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod) \
+    cls.def(HandleMethod,                                               \
+            nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<T>), \
+            nb::arg("n") = 0,                                           \
+            nb::rv_policy::reference_internal);
+#include "BuildTypes.def"
+
+    return cls
         .def("isPadded", &nanovdb::GridHandle<BufferT>::isPadded)
         .def("gridCount", &nanovdb::GridHandle<BufferT>::gridCount)
         .def("gridSize", &nanovdb::GridHandle<BufferT>::gridSize, nb::arg("n") = 0)

--- a/nanovdb/nanovdb/python/PyIO.cc
+++ b/nanovdb/nanovdb/python/PyIO.cc
@@ -138,12 +138,12 @@ void defineIOModule(nb::module_& m)
         .value("NONE", io::Codec::NONE)
         .value("ZIP", io::Codec::ZIP)
         .value("BLOSC", io::Codec::BLOSC)
-        .export_values();
-        // .def("__repr__", [](const io::Codec& codec) {
-        //     char str[strlen<io::Codec>()];
-        //     toStr(str, codec);
-        //     return std::string(str);
-        // });
+        .export_values()
+        .def("__repr__", [](const io::Codec& codec) {
+            char str[strlen<io::Codec>()];
+            toStr(str, codec);
+            return std::string(str);
+        });
 
     defineFileGridMetaData(m);
     defineHostReadWriteGrid(m);

--- a/nanovdb/nanovdb/python/PyMath.cc
+++ b/nanovdb/nanovdb/python/PyMath.cc
@@ -11,7 +11,6 @@
 #include <nanobind/stl/bind_vector.h>
 
 #include "PySampleFromVoxels.h"
-#include "cuda/PySampleFromVoxels.h"
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -377,33 +376,12 @@ void defineMathModule(nb::module_& m)
     defineBaseBBox<math::Coord>(m, "CoordBaseBBox");
     defineBBoxInteger<math::Coord>(m, "CoordBBox", "Bounding box for Coord minimum and maximum");
 
-    defineNearestNeighborSampler<float>(m, "FloatNearestNeighborSampler");
-    defineTrilinearSampler<float>(m, "FloatTrilinearSampler");
-    defineTriquadraticSampler<float>(m, "FloatTriquadraticSampler");
-    defineTricubicSampler<float>(m, "FloatTricubicSampler");
-
-    defineNearestNeighborSampler<double>(m, "DoubleNearestNeighborSampler");
-    defineTrilinearSampler<double>(m, "DoubleTrilinearSampler");
-    defineTriquadraticSampler<double>(m, "DoubleTriquadraticSampler");
-    defineTricubicSampler<double>(m, "DoubleTricubicSampler");
-
-    defineNearestNeighborSampler<int32_t>(m, "Int32NearestNeighborSampler");
-    defineTrilinearSampler<int32_t>(m, "Int32TrilinearSampler");
-    defineTriquadraticSampler<int32_t>(m, "Int32TriquadraticSampler");
-    defineTricubicSampler<int32_t>(m, "Int32TricubicSampler");
-
-    defineNearestNeighborSampler<Vec3f>(m, "Vec3fNearestNeighborSampler");
-    defineTrilinearSampler<Vec3f>(m, "Vec3fTrilinearSampler");
-    defineTriquadraticSampler<Vec3f>(m, "Vec3fTriquadraticSampler");
-    defineTricubicSampler<Vec3f>(m, "Vec3fTricubicSampler");
-
-#ifdef NANOVDB_USE_CUDA
-    nb::module_ cudaModule = m.def_submodule("cuda");
-    cudaModule.doc() = "A submodule that implements CUDA-accelerated math functions";
-
-    defineSampleFromVoxels<float>(cudaModule, "sampleFromVoxels");
-    defineSampleFromVoxels<double>(cudaModule, "sampleFromVoxels");
-#endif
+#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)               \
+    defineNearestNeighborSampler<T>(m, #Suffix "NearestNeighborSampler"); \
+    defineTrilinearSampler<T>(m, #Suffix "TrilinearSampler");       \
+    defineTriquadraticSampler<T>(m, #Suffix "TriquadraticSampler"); \
+    defineTricubicSampler<T>(m, #Suffix "TricubicSampler");
+#include "BuildTypes.def"
 }
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyMath.cc
+++ b/nanovdb/nanovdb/python/PyMath.cc
@@ -376,7 +376,7 @@ void defineMathModule(nb::module_& m)
     defineBaseBBox<math::Coord>(m, "CoordBaseBBox");
     defineBBoxInteger<math::Coord>(m, "CoordBBox", "Bounding box for Coord minimum and maximum");
 
-#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)               \
+#define NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)               \
     defineNearestNeighborSampler<T>(m, #Suffix "NearestNeighborSampler"); \
     defineTrilinearSampler<T>(m, #Suffix "TrilinearSampler");       \
     defineTriquadraticSampler<T>(m, #Suffix "TriquadraticSampler"); \

--- a/nanovdb/nanovdb/python/PySampleFromVoxels.cc
+++ b/nanovdb/nanovdb/python/PySampleFromVoxels.cc
@@ -65,24 +65,11 @@ template<typename BuildT> void defineTricubicSampler(nb::module_& m, const char*
     defineCreateSampler<TreeT, 3>(m, "createTricubicSampler");
 }
 
-template void defineNearestNeighborSampler<float>(nb::module_&, const char*);
-template void defineTrilinearSampler<float>(nb::module_&, const char*);
-template void defineTriquadraticSampler<float>(nb::module_&, const char*);
-template void defineTricubicSampler<float>(nb::module_&, const char*);
-
-template void defineNearestNeighborSampler<double>(nb::module_&, const char*);
-template void defineTrilinearSampler<double>(nb::module_&, const char*);
-template void defineTriquadraticSampler<double>(nb::module_&, const char*);
-template void defineTricubicSampler<double>(nb::module_&, const char*);
-
-template void defineNearestNeighborSampler<int32_t>(nb::module_&, const char*);
-template void defineTrilinearSampler<int32_t>(nb::module_&, const char*);
-template void defineTriquadraticSampler<int32_t>(nb::module_&, const char*);
-template void defineTricubicSampler<int32_t>(nb::module_&, const char*);
-
-template void defineNearestNeighborSampler<Vec3f>(nb::module_&, const char*);
-template void defineTrilinearSampler<Vec3f>(nb::module_&, const char*);
-template void defineTriquadraticSampler<Vec3f>(nb::module_&, const char*);
-template void defineTricubicSampler<Vec3f>(nb::module_&, const char*);
+#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)            \
+    template void defineNearestNeighborSampler<T>(nb::module_&, const char*); \
+    template void defineTrilinearSampler<T>(nb::module_&, const char*);       \
+    template void defineTriquadraticSampler<T>(nb::module_&, const char*);    \
+    template void defineTricubicSampler<T>(nb::module_&, const char*);
+#include "BuildTypes.def"
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PySampleFromVoxels.cc
+++ b/nanovdb/nanovdb/python/PySampleFromVoxels.cc
@@ -65,7 +65,7 @@ template<typename BuildT> void defineTricubicSampler(nb::module_& m, const char*
     defineCreateSampler<TreeT, 3>(m, "createTricubicSampler");
 }
 
-#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)            \
+#define NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)            \
     template void defineNearestNeighborSampler<T>(nb::module_&, const char*); \
     template void defineTrilinearSampler<T>(nb::module_&, const char*);       \
     template void defineTriquadraticSampler<T>(nb::module_&, const char*);    \

--- a/nanovdb/nanovdb/python/PyTools.cc
+++ b/nanovdb/nanovdb/python/PyTools.cc
@@ -34,7 +34,7 @@ void defineToolsModule(nb::module_& m)
 
     definePrimitives<HostBuffer>(m);
 
-#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix) \
+#define NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix) \
     defineCreateNanoGrid<T>(m, "create" #Suffix "Grid");
 #include "BuildTypes.def"
 

--- a/nanovdb/nanovdb/python/PyTools.cc
+++ b/nanovdb/nanovdb/python/PyTools.cc
@@ -16,6 +16,7 @@
 #include "PyNanoToOpenVDB.h"
 #ifdef NANOVDB_USE_CUDA
 #include "cuda/PyPointsToGrid.h"
+#include "cuda/PySampleFromVoxels.h"
 #include "cuda/PySignedFloodFill.h"
 #endif
 
@@ -33,10 +34,9 @@ void defineToolsModule(nb::module_& m)
 
     definePrimitives<HostBuffer>(m);
 
-    defineCreateNanoGrid<float>(m, "createFloatGrid");
-    defineCreateNanoGrid<double>(m, "createDoubleGrid");
-    defineCreateNanoGrid<int32_t>(m, "createInt32Grid");
-    defineCreateNanoGrid<Vec3f>(m, "createVec3fGrid");
+#define NVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix) \
+    defineCreateNanoGrid<T>(m, "create" #Suffix "Grid");
+#include "BuildTypes.def"
 
 #ifdef NANOVDB_USE_OPENVDB
     defineOpenToNanoVDB<HostBuffer>(m);
@@ -55,6 +55,9 @@ void defineToolsModule(nb::module_& m)
     defineSignedFloodFill<double>(cudaModule, "signedFloodFill");
 
     definePointsToGrid<math::Rgba8>(cudaModule, "pointsToRGBA8Grid");
+
+    defineSampleFromVoxels<float>(cudaModule, "sampleFromVoxels");
+    defineSampleFromVoxels<double>(cudaModule, "sampleFromVoxels");
 #endif
 }
 

--- a/nanovdb/nanovdb/python/__init__.py
+++ b/nanovdb/nanovdb/python/__init__.py
@@ -1,9 +1,26 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
+import os
 import sys
-if sys.platform == "win32":
-    import os
-    openvdb_dll_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir, 'openvdb', 'lib')
-    os.add_dll_directory(directory)
 
-from .lib.nanovdb import *
+if sys.platform == "win32":
+    _openvdb_dll_directory = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), os.pardir, "openvdb", "lib"
+    )
+    if os.path.isdir(_openvdb_dll_directory):
+        os.add_dll_directory(_openvdb_dll_directory)
+
+
+def get_include():
+    """Return the absolute path to the bundled NanoVDB C/C++ include directory.
+
+    Use this from a downstream Python extension's build system so the extension
+    compiles against the same NanoVDB headers the installed wheel was built with::
+
+        import nanovdb
+        ext_kwargs = dict(include_dirs=[nanovdb.get_include()])
+    """
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "include")
+
+
+from .lib.nanovdb import *  # noqa: E402,F401,F403

--- a/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
+++ b/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
@@ -16,7 +16,7 @@ namespace pynanovdb {
 void defineDeviceGridHandle(nb::module_& m)
 {
     using BufferT = nanovdb::cuda::DeviceBuffer;
-    defineGridHandle<BufferT>(m, "DeviceGridHandle")
+    auto cls = defineGridHandle<BufferT>(m, "DeviceGridHandle")
         .def(
             "__init__",
             [](GridHandle<BufferT>&                                 handle,
@@ -27,16 +27,21 @@ void defineDeviceGridHandle(nb::module_& m)
                 new (&handle) GridHandle<BufferT>(std::move(buffer));
             },
             "cpu_t"_a.noconvert(),
-            "cuda_t"_a.noconvert())
-        .def("deviceFloatGrid", nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<float>), "n"_a = 0, nb::rv_policy::reference_internal)
-        .def("deviceDoubleGrid", nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<double>), "n"_a = 0, nb::rv_policy::reference_internal)
-        .def("deviceInt32Grid", nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<int32_t>), "n"_a = 0, nb::rv_policy::reference_internal)
-        .def("deviceVec3fGrid", nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<Vec3f>), "n"_a = 0, nb::rv_policy::reference_internal)
-        .def("deviceRGBA8Grid",
-             nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<math::Rgba8>),
-             "n"_a = 0,
-             nb::rv_policy::reference_internal)
-        .def(
+            "cuda_t"_a.noconvert());
+
+#define NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod) \
+    cls.def(DeviceHandleMethod,                                        \
+            nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<T>), \
+            "n"_a = 0,                                                 \
+            nb::rv_policy::reference_internal);
+#define NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod) \
+    cls.def(DeviceHandleMethod,                                        \
+            nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<T>), \
+            "n"_a = 0,                                                 \
+            nb::rv_policy::reference_internal);
+#include "../BuildTypes.def"
+
+    cls.def(
             "deviceUpload", [](GridHandle<BufferT>& handle, bool sync) { handle.deviceUpload(nullptr, sync); }, "sync"_a = true)
         .def(
             "deviceDownload", [](GridHandle<BufferT>& handle, bool sync) { handle.deviceDownload(nullptr, sync); }, "sync"_a = true);

--- a/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
+++ b/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
@@ -29,13 +29,13 @@ void defineDeviceGridHandle(nb::module_& m)
             "cpu_t"_a.noconvert(),
             "cuda_t"_a.noconvert());
 
-#define NVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceHandleMethod) \
-    cls.def(DeviceHandleMethod,                                        \
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod) \
+    cls.def(DeviceMethod,                                        \
             nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<T>), \
             "n"_a = 0,                                                 \
             nb::rv_policy::reference_internal);
-#define NVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceHandleMethod) \
-    cls.def(DeviceHandleMethod,                                        \
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod) \
+    cls.def(DeviceMethod,                                        \
             nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<T>), \
             "n"_a = 0,                                                 \
             nb::rv_policy::reference_internal);

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -663,7 +663,7 @@ class TestSampleFromPoints(unittest.TestCase):
                 dtype=torch.float32,
                 device=torch.device("cuda", 0),
             )
-            nanovdb.math.cuda.sampleFromVoxels(points, grid, values, gradients)
+            nanovdb.tools.cuda.sampleFromVoxels(points, grid, values, gradients)
             for i in range(5):
                 self.assertEqual(values[i], expected_values[i])
             for i in range(5):
@@ -710,7 +710,7 @@ class TestSampleFromPoints(unittest.TestCase):
             expected_values = torch.tensor(
                 [-value, 0.0, -1.0, 1.0, value], dtype=torch.float64
             )
-            nanovdb.math.cuda.sampleFromVoxels(points, grid, values)
+            nanovdb.tools.cuda.sampleFromVoxels(points, grid, values)
             for i in range(5):
                 self.assertEqual(values[i], expected_values[i])
 


### PR DESCRIPTION
## Summary

First slice of the **NanoVDB Python bindings C++ API mirror** plan (see [nanovdb-python-plan.md](https://github.com/swahtz/openvdb/blob/phase0/nanovdb_python_foundation/nanovdb-python-plan.md) and #2208). This is the mechanical groundwork the rest of the plan builds on — no new user-facing features, no new grid types, but a single point where new `BuildT`s can be added (Phase 2 onward) and a number of pre-existing observable bugs fixed.

PR target: `feature/nanovdb_python` (the integration branch tracking the multi-phase rollout).

### What's in this PR

- **`BuildTypes.def`** — single X-macro list of currently-bound `BuildT` types (scalar / vector / point / sampleable). `NanoVDBModule.cc`, `PyMath.cc`, `PySampleFromVoxels.cc`, `PyCreateNanoGrid.cc`, `PyTools.cc`, `PyGridHandle.h` and `cuda/PyDeviceGridHandle.cu` now drive their per-type instantiations from this one file. Adding a `BuildT` in Phase 2 becomes one line.

- **`CMakeLists.txt`** —
  - Under `SKBUILD`, ship the `nanovdb/` headers inside the Python wheel at `nanovdb/include/nanovdb/` so downstream extension authors can compile against the same headers the wheel was built with.
  - Wire `nanobind_add_stub` so a `nanovdb.pyi` (and `py.typed` marker) is emitted into the wheel for IDE / type-checker support. Gated behind `NANOVDB_BUILD_PYTHON_STUBS` and silently skipped on older nanobind.

- **`__init__.py`** —
  - Add `nanovdb.get_include()` returning the bundled include dir.
  - Fix the Windows DLL shim, which referenced an undefined `directory` variable instead of the local `openvdb_dll_directory`.

- **Relocate `sampleFromVoxels`** from the phantom `nanovdb.math.cuda` submodule (which has no C++ counterpart) to `nanovdb.tools.cuda`, alongside the existing `signedFloodFill` and `pointsToRGBA8Grid` kernels. The `math.cuda` submodule is no longer registered. `TestNanoVDB.py` updated to match.

- **Pre-existing observable bug fixes**:
  - `GridHandle.__bool__` returned `None` (lambda was missing `return`); it now returns `!handle.empty()` as intended.
  - `__repr__` enabled on `GridType`, `GridClass` and `io::Codec` via the existing `nanovdb::toStr` / `strlen<>` helpers — previously commented out.

### Departures from existing API

- `nanovdb.math.cuda` no longer exists. The only function it ever exposed (`sampleFromVoxels`) moves to `nanovdb.tools.cuda`. Pre-1.0 break, called out in the plan.
- `repr(nanovdb.GridType.Float)` is now `\"float\"` rather than nanobind's default `\"GridType.Float\"`-with-value. Same for `GridClass` and `Codec`.

The bigger polymorphic-`grid(n)` API switch is intentionally **not** in this PR — it lands in Phase 1.

## Test plan

CPU-only verification done locally in this devcontainer (no CUDA, no OpenVDB, no BLOSC):

- [x] CMake configures clean with `NANOVDB_BUILD_PYTHON_MODULE=ON`.
- [x] `nanovdb_python` target builds without warnings.
- [x] `nanovdb_python_stub` target builds and emits `nanovdb.pyi` (28 kB, includes `GridHandle`, `GridType`, `GridClass`, `floatGrid`, etc.).
- [x] `TestNanoVDB.py`: 28 tests pass, 8 CUDA tests skip cleanly, 1 pre-existing `test_read_write_grid` BLOSC failure unrelated to this PR (test doesn't wrap the optional codec call in try/except like its sibling does — exists on master too).
- [x] Simulated SKBUILD install: wheel layout has `nanovdb/__init__.py`, `nanovdb/lib/nanovdb.*.so`, `nanovdb/include/nanovdb/NanoVDB.h`, `nanovdb/nanovdb.pyi`, `nanovdb/py.typed`. `nanovdb.get_include()` resolves to the bundled headers; `NanoVDB.h` is present at that path.
- [x] Behavioral spot-checks after install:
  - `repr(nanovdb.GridType.Float) == \"float\"`
  - `repr(nanovdb.GridClass.LevelSet) == \"SDF\"`
  - `repr(nanovdb.io.Codec.NONE) == \"NONE\"`
  - `bool(empty_handle) is False`, `bool(populated_handle) is True`
  - `nanovdb.math.cuda` no longer exists

Still needs reviewer verification:
- [x] Full CUDA build + CUDA-enabled `TestNanoVDB.py` (especially `TestSampleFromPoints`, which now exercises `nanovdb.tools.cuda.sampleFromVoxels`).
- [ ] Windows build to confirm the `__init__.py` DLL-shim fix.
- [x] OpenVDB-enabled build to confirm `openToNanoVDB` / `nanoToOpenVDB` still wire up through the X-macro path.

Part of #2208.

