### PR TITLE
nanovdb python: Phase 1 — polymorphic Grid, GridMetaData, blind data, PointAccessor

### DIFF
--- a/nanovdb/nanovdb/python/BuildTypes.def
+++ b/nanovdb/nanovdb/python/BuildTypes.def
@@ -18,36 +18,39 @@
 // adding (or removing) a Python-visible BuildT.
 //
 // Macros:
-//   NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod)
+//   NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)
 //       Scalar value types — exposed with full NodeInfo accessors. Suffix
-//       forms Python class names (e.g. "Float" -> "FloatGrid"). HandleMethod
-//       and DeviceMethod are the legacy lower-camel-case method names
-//       on GridHandle / DeviceGridHandle (e.g. "floatGrid").
+//       forms Python class names (e.g. "Float" -> "FloatGrid").
+//       GridTypeEnum names the nanovdb::GridType:: enumerator a grid of
+//       this BuildT carries (used by the polymorphic handle.grid(n)
+//       dispatch). Usually identical to Suffix.
 //
-//   NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod)
+//   NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum)
 //       Vector value types — exposed with a setVoxel accessor but no
 //       NodeInfo. AccessorName is passed explicitly because the legacy
 //       Python class names for these are inconsistent.
 //
-//   NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)
-//       The nanovdb::Point build type — exposed with a bare accessor and no
-//       GridHandle method (Point is not currently surfaced through
-//       handle.*Grid()).
+//   NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum)
+//       The nanovdb::Point build type — exposed with a bare accessor.
+//       Point grids carry GridType::PointIndex (NOT a GridType::Point;
+//       that enumerator doesn't exist), so GridTypeEnum is given
+//       explicitly. Polymorphic dispatch routes PointIndex grids to
+//       NanoGrid<Point>.
 //
 //   NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
-//       Subset that has C++ sampler specializations (used by PyMath samplers
-//       and PyCreateNanoGrid create*Grid factories).
+//       Subset that has C++ sampler specializations (used by PyMath
+//       samplers and PyCreateNanoGrid create*Grid factories).
 
 #ifndef NANOVDB_PY_FOR_EACH_SCALAR_BUILDT
-#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod)
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)
 #define NANOVDB_PY_LOCAL_DEFINED_SCALAR
 #endif
 #ifndef NANOVDB_PY_FOR_EACH_VECTOR_BUILDT
-#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod)
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum)
 #define NANOVDB_PY_LOCAL_DEFINED_VECTOR
 #endif
 #ifndef NANOVDB_PY_FOR_EACH_POINT_BUILDT
-#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)
+#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum)
 #define NANOVDB_PY_LOCAL_DEFINED_POINT
 #endif
 #ifndef NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT
@@ -55,18 +58,16 @@
 #define NANOVDB_PY_LOCAL_DEFINED_SAMPLEABLE
 #endif
 
-NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(float,   Float,  "floatGrid",  "deviceFloatGrid")
-NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(double,  Double, "doubleGrid", "deviceDoubleGrid")
-NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(int32_t, Int32,  "int32Grid",  "deviceInt32Grid")
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(float,   Float,  Float)
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(double,  Double, Double)
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(int32_t, Int32,  Int32)
 
 NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec3f, Vec3f,
-                                  "Vec3fReadVectorAccessor",
-                                  "vec3fGrid", "deviceVec3fGrid")
+                                  "Vec3fReadVectorAccessor", Vec3f)
 NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::math::Rgba8, RGBA8,
-                                  "RGBA8ReadAccessor",
-                                  "rgba8Grid", "deviceRGBA8Grid")
+                                  "RGBA8ReadAccessor", RGBA8)
 
-NANOVDB_PY_FOR_EACH_POINT_BUILDT(::nanovdb::Point, Point)
+NANOVDB_PY_FOR_EACH_POINT_BUILDT(::nanovdb::Point, Point, PointIndex)
 
 NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(float,            Float)
 NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(double,           Double)

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -1,6 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 #include <nanobind/operators.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
@@ -137,9 +138,25 @@ void defineMap(nb::module_& m)
         .def("getVoxelSize", &Map::getVoxelSize);
 }
 
-void defineGridData(nb::module_& m)
+// Forward declaration — body lives below defineGridBlindData() so it can
+// reference the enum / class bindings registered there.
+static nb::object pyGetBlindData(nb::handle py_grid, uint32_t n);
+
+// Type-erased Grid base class. nb::class_ is bound to nanovdb::GridData
+// (the 672 B POD prefix present at the start of every NanoGrid<BuildT>),
+// but the Python name is "Grid" to match the C++ class hierarchy where
+// Grid<TreeT> (a.k.a. NanoGrid<BuildT>) is the user-facing type and
+// GridData is the implementation-detail POD.
+//
+// Every BuildT-independent method lives here. The lambdas below read public
+// data members on GridData directly because the accessor methods named
+// version()/gridType()/isLevelSet()/etc. are defined on Grid<TreeT>, not on
+// GridData itself — but they all just forward to a GridData data member,
+// so the same value is reachable from the base.
+void defineGrid(nb::module_& m)
 {
-    nb::class_<GridData>(m, "GridData")
+    nb::class_<GridData>(m, "Grid")
+        // Validation and flag mutators (already member functions on GridData).
         .def("isValid", &GridData::isValid)
         .def("setMinMaxOn", &GridData::setMinMaxOn, "on"_a = true)
         .def("setBBoxOn", &GridData::setBBoxOn, "on"_a = true)
@@ -147,6 +164,7 @@ void defineGridData(nb::module_& m)
         .def("setAverageOn", &GridData::setAverageOn, "on"_a = true)
         .def("setStdDeviationOn", &GridData::setStdDeviationOn, "on"_a = true)
         .def("setGridName", &GridData::setGridName, "src"_a)
+        // Affine transforms (already member functions on GridData).
         .def("applyMap", nb::overload_cast<const Vec3f&>(&GridData::template applyMap<Vec3f>, nb::const_), "xyz"_a)
         .def("applyMap", nb::overload_cast<const Vec3d&>(&GridData::template applyMap<Vec3d>, nb::const_), "xyz"_a)
         .def("applyMapF", nb::overload_cast<const Vec3f&>(&GridData::template applyMapF<Vec3f>, nb::const_), "xyz"_a)
@@ -167,50 +185,307 @@ void defineGridData(nb::module_& m)
         .def("applyIJT", nb::overload_cast<const Vec3d&>(&GridData::template applyIJT<Vec3d>, nb::const_), "xyz"_a)
         .def("applyIJTF", nb::overload_cast<const Vec3f&>(&GridData::template applyIJTF<Vec3f>, nb::const_), "xyz"_a)
         .def("applyIJTF", nb::overload_cast<const Vec3d&>(&GridData::template applyIJTF<Vec3d>, nb::const_), "xyz"_a)
+        // Strings, geometry, layout (already member functions on GridData).
         .def("gridName", &GridData::gridName)
         .def("memUsage", &GridData::memUsage)
         .def("worldBBox", &GridData::worldBBox)
         .def("indexBBox", &GridData::indexBBox)
-        .def("isEmpty", &GridData::isEmpty);
+        .def("isEmpty", &GridData::isEmpty)
+        // Lifted from Grid<TreeT> via direct data-member access.
+        .def("version",         [](const GridData& g) { return g.mVersion; })
+        .def("gridSize",        [](const GridData& g) { return g.mGridSize; })
+        .def("gridIndex",       [](const GridData& g) { return g.mGridIndex; })
+        .def("gridCount",       [](const GridData& g) { return g.mGridCount; })
+        .def("voxelSize",       [](const GridData& g) -> const Vec3d& { return g.mVoxelSize; },
+             nb::rv_policy::reference_internal)
+        .def("map",             [](const GridData& g) -> const Map& { return g.mMap; },
+             nb::rv_policy::reference_internal)
+        .def("gridType",  [](const GridData& g) { return g.mGridType; })
+        .def("gridClass", [](const GridData& g) { return g.mGridClass; })
+        .def("checksum",  [](const GridData& g) { return g.mChecksum; })
+        .def("isLevelSet",   [](const GridData& g) { return g.mGridClass == GridClass::LevelSet; })
+        .def("isFogVolume",  [](const GridData& g) { return g.mGridClass == GridClass::FogVolume; })
+        .def("isStaggered",  [](const GridData& g) { return g.mGridClass == GridClass::Staggered; })
+        .def("isPointIndex",
+             [](const GridData& g) { return g.mGridClass == GridClass::PointIndex; })
+        .def("isGridIndex",  [](const GridData& g) { return g.mGridClass == GridClass::IndexGrid; })
+        .def("isPointData",  [](const GridData& g) { return g.mGridClass == GridClass::PointData; })
+        .def("isMask",       [](const GridData& g) { return g.mGridClass == GridClass::Topology; })
+        .def("isUnknown",    [](const GridData& g) { return g.mGridClass == GridClass::Unknown; })
+        .def("hasMinMax", [](const GridData& g) { return g.mFlags.isMaskOn(GridFlags::HasMinMax); })
+        .def("hasBBox",   [](const GridData& g) { return g.mFlags.isMaskOn(GridFlags::HasBBox); })
+        .def("hasLongGridName",
+             [](const GridData& g) { return g.mFlags.isMaskOn(GridFlags::HasLongGridName); })
+        .def("hasAverage",
+             [](const GridData& g) { return g.mFlags.isMaskOn(GridFlags::HasAverage); })
+        .def("hasStdDeviation",
+             [](const GridData& g) { return g.mFlags.isMaskOn(GridFlags::HasStdDeviation); })
+        .def("isBreadthFirst",
+             [](const GridData& g) { return g.mFlags.isMaskOn(GridFlags::IsBreadthFirst); })
+        .def("shortGridName", [](const GridData& g) { return std::string(g.mGridName); })
+        // Blind data — exposes the sidecar channels that PointGrid and
+        // OnIndexGrid use to carry their actual values, colors, normals, IDs,
+        // etc. blindMetaData(n) returns the descriptor; getBlindData(n)
+        // returns a zero-copy NumPy view onto the underlying bytes typed by
+        // mDataType (Float -> float32 ndarray, Vec3f -> (N, 3) float32, etc.;
+        // unrecognized types fall back to a flat uint8 byte view).
+        .def("blindDataCount",          [](const GridData& g) { return g.mBlindMetadataCount; })
+        .def("blindMetaData",
+             [](const GridData& g, uint32_t n) -> const GridBlindMetaData* {
+                 return n < g.mBlindMetadataCount ? g.blindMetaData(n) : nullptr;
+             },
+             nb::rv_policy::reference_internal, "n"_a)
+        .def("findBlindData",           [](const GridData& g, const std::string& name) -> int {
+            for (uint32_t i = 0; i < g.mBlindMetadataCount; ++i) {
+                const auto* meta = g.blindMetaData(i);
+                if (std::strncmp(meta->mName, name.c_str(), GridBlindMetaData::MaxNameSize) == 0)
+                    return static_cast<int>(i);
+            }
+            return -1;
+        }, "name"_a)
+        .def("findBlindDataForSemantic", [](const GridData& g, GridBlindDataSemantic sem) -> int {
+            for (uint32_t i = 0; i < g.mBlindMetadataCount; ++i) {
+                if (g.blindMetaData(i)->mSemantic == sem)
+                    return static_cast<int>(i);
+            }
+            return -1;
+        }, "semantic"_a)
+        .def("getBlindData", &pyGetBlindData, "n"_a,
+             "Return a zero-copy NumPy view of the n-th blind data channel, "
+             "or None if n is out of range. dtype and shape are derived from "
+             "the channel's mDataType / mValueCount.");
 }
 
-template<typename BuildT> void defineGrid(nb::module_& m, const char* name)
+// BuildT-dependent slice of the typed grid Python class. Inherits the
+// type-erased Grid base bound by defineGrid() above — anything that doesn't
+// need to know BuildT lives there, not here.
+template<typename BuildT> void defineNanoGrid(nb::module_& m, const char* name)
 {
     nb::class_<NanoGrid<BuildT>, GridData>(m, name)
-        .def("version", &NanoGrid<BuildT>::version)
-        .def("memUsage", &NanoGrid<BuildT>::memUsage)
-        .def("gridSize", &NanoGrid<BuildT>::gridSize)
-        .def("gridIndex", &NanoGrid<BuildT>::gridIndex)
-        .def("gridCount", &NanoGrid<BuildT>::gridCount)
         .def("getAccessor", &NanoGrid<BuildT>::getAccessor)
-        .def("voxelSize", &NanoGrid<BuildT>::voxelSize)
-        .def("map", &NanoGrid<BuildT>::map)
-        .def("worldBBox", &NanoGrid<BuildT>::worldBBox)
-        .def("indexBBox", &NanoGrid<BuildT>::indexBBox)
         .def("activeVoxelCount", &NanoGrid<BuildT>::activeVoxelCount)
-        .def("isValid", &NanoGrid<BuildT>::isValid)
-        .def("gridType", &NanoGrid<BuildT>::gridType)
-        .def("gridClass", &NanoGrid<BuildT>::gridClass)
-        .def("isLevelSet", &NanoGrid<BuildT>::isLevelSet)
-        .def("isFogVolume", &NanoGrid<BuildT>::isFogVolume)
-        .def("isStaggered", &NanoGrid<BuildT>::isStaggered)
-        .def("isPointIndex", &NanoGrid<BuildT>::isPointIndex)
-        .def("isGridIndex", &NanoGrid<BuildT>::isGridIndex)
-        .def("isPointData", &NanoGrid<BuildT>::isPointData)
-        .def("isMask", &NanoGrid<BuildT>::isMask)
-        .def("isUnknown", &NanoGrid<BuildT>::isUnknown)
-        .def("hasMinMax", &NanoGrid<BuildT>::hasMinMax)
-        .def("hasBBox", &NanoGrid<BuildT>::hasBBox)
-        .def("hasLongGridName", &NanoGrid<BuildT>::hasLongGridName)
-        .def("hasAverage", &NanoGrid<BuildT>::hasAverage)
-        .def("hasStdDeviation", &NanoGrid<BuildT>::hasStdDeviation)
-        .def("isBreadthFirst", &NanoGrid<BuildT>::isBreadthFirst)
-        // .def("isLexicographic", &NanoGrid<BuildT>::isLexicographic)
-        .def("isSequential", [](const NanoGrid<BuildT>& grid) { return grid.isSequential(); })
-        .def("gridName", &NanoGrid<BuildT>::gridName)
-        .def("shortGridName", &NanoGrid<BuildT>::shortGridName)
-        .def("checksum", &NanoGrid<BuildT>::checksum)
-        .def("isEmpty", &NanoGrid<BuildT>::isEmpty);
+        .def("isSequential", [](const NanoGrid<BuildT>& grid) { return grid.isSequential(); });
+}
+
+void defineGridBlindData(nb::module_& m)
+{
+    nb::enum_<GridBlindDataClass>(m, "GridBlindDataClass")
+        .value("Unknown",        GridBlindDataClass::Unknown)
+        .value("IndexArray",     GridBlindDataClass::IndexArray)
+        .value("AttributeArray", GridBlindDataClass::AttributeArray)
+        .value("GridName",       GridBlindDataClass::GridName)
+        .value("ChannelArray",   GridBlindDataClass::ChannelArray)
+        .value("End",            GridBlindDataClass::End)
+        .export_values();
+
+    nb::enum_<GridBlindDataSemantic>(m, "GridBlindDataSemantic")
+        .value("Unknown",       GridBlindDataSemantic::Unknown)
+        .value("PointPosition", GridBlindDataSemantic::PointPosition)
+        .value("PointColor",    GridBlindDataSemantic::PointColor)
+        .value("PointNormal",   GridBlindDataSemantic::PointNormal)
+        .value("PointRadius",   GridBlindDataSemantic::PointRadius)
+        .value("PointVelocity", GridBlindDataSemantic::PointVelocity)
+        .value("PointId",       GridBlindDataSemantic::PointId)
+        .value("WorldCoords",   GridBlindDataSemantic::WorldCoords)
+        .value("GridCoords",    GridBlindDataSemantic::GridCoords)
+        .value("VoxelCoords",   GridBlindDataSemantic::VoxelCoords)
+        .value("LevelSet",      GridBlindDataSemantic::LevelSet)
+        .value("FogVolume",     GridBlindDataSemantic::FogVolume)
+        .value("Staggered",     GridBlindDataSemantic::Staggered)
+        .value("End",           GridBlindDataSemantic::End)
+        .export_values();
+
+    nb::class_<GridBlindMetaData>(m, "GridBlindMetaData",
+                                  "Sidecar metadata for one blind-data channel attached to a Grid.")
+        .def_ro("valueCount", &GridBlindMetaData::mValueCount)
+        .def_ro("valueSize",  &GridBlindMetaData::mValueSize)
+        .def_ro("semantic",   &GridBlindMetaData::mSemantic)
+        .def_ro("dataClass",  &GridBlindMetaData::mDataClass)
+        .def_ro("dataType",   &GridBlindMetaData::mDataType)
+        .def("name",  [](const GridBlindMetaData& m) { return std::string(m.mName); })
+        .def("isValid", &GridBlindMetaData::isValid)
+        .def("blindDataSize", &GridBlindMetaData::blindDataSize);
+}
+
+// Resolve a blind-data channel into a zero-copy NumPy view. The dtype and
+// shape are derived from the GridBlindMetaData's mDataType / mValueSize.
+// For unrecognized types we fall back to a flat uint8 byte view so callers
+// can still copy out the raw bytes. Falls back to None on a count mismatch
+// between mValueSize and the GridType-implied stride.
+static nb::object pyGetBlindData(nb::handle py_grid, uint32_t n)
+{
+    const auto& grid = nb::cast<const GridData&>(py_grid);
+    if (n >= grid.mBlindMetadataCount) return nb::none();
+    const auto* meta = grid.blindMetaData(n);
+    void* data = const_cast<void*>(static_cast<const void*>(
+        util::PtrAdd<uint8_t>(meta, meta->mDataOffset)));
+    const size_t count = static_cast<size_t>(meta->mValueCount);
+
+    // Helper macro: build a typed 1D or (count, dim) ndarray and cast it,
+    // anchoring the lifetime to the source Grid via py_grid.
+    auto make1D = [&](void* p, size_t n_elems, auto sentinel) -> nb::object {
+        using T = decltype(sentinel);
+        size_t shape[1] = {n_elems};
+        return nb::cast(nb::ndarray<T, nb::ndim<1>, nb::c_contig, nb::device::cpu>(
+                            static_cast<T*>(p), 1, shape, py_grid),
+                        nb::rv_policy::reference);
+    };
+    auto make2D = [&](void* p, size_t n_outer, size_t n_inner, auto sentinel) -> nb::object {
+        using T = decltype(sentinel);
+        size_t shape[2] = {n_outer, n_inner};
+        return nb::cast(nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>(
+                            static_cast<T*>(p), 2, shape, py_grid),
+                        nb::rv_policy::reference);
+    };
+
+    switch (meta->mDataType) {
+        case GridType::Float:   return make1D(data, count, float{});
+        case GridType::Double:  return make1D(data, count, double{});
+        case GridType::Int16:   return make1D(data, count, int16_t{});
+        case GridType::Int32:   return make1D(data, count, int32_t{});
+        case GridType::Int64:   return make1D(data, count, int64_t{});
+        case GridType::UInt8:   return make1D(data, count, uint8_t{});
+        case GridType::UInt32:  return make1D(data, count, uint32_t{});
+        case GridType::Vec3f:   return make2D(data, count, 3, float{});
+        case GridType::Vec3d:   return make2D(data, count, 3, double{});
+        case GridType::Vec4f:   return make2D(data, count, 4, float{});
+        case GridType::Vec4d:   return make2D(data, count, 4, double{});
+        case GridType::Vec3u8:  return make2D(data, count, 3, uint8_t{});
+        case GridType::Vec3u16: return make2D(data, count, 3, uint16_t{});
+        case GridType::RGBA8:   return make2D(data, count, 4, uint8_t{});
+        default:
+            // Fall back to a raw uint8 byte view of mValueCount * mValueSize.
+            return make1D(data, count * meta->mValueSize, uint8_t{});
+    }
+}
+
+// PointAccessor — exposes the per-voxel point attributes that PointGrid
+// carries as blind data. PointIndex grids store uint32 voxel indices;
+// PointData grids store Vec3f positions. Constructor asserts the grid is
+// the right shape; in Python an exception is the result of a mismatch.
+//
+// gridPoints() / leafPoints(ijk) / voxelPoints(ijk) all return a zero-copy
+// NumPy view onto the underlying blind-data buffer, sliced to just the
+// range associated with the call. Lifetime is anchored to the accessor.
+template<typename AttT, int Dim>
+struct PyPointAccessorTraits;
+template<> struct PyPointAccessorTraits<uint32_t, 1> { using Scalar = uint32_t; };
+template<> struct PyPointAccessorTraits<Vec3f, 2>    { using Scalar = float; };
+
+template<typename AttT>
+static nb::object pyPointsToNdarray(nb::handle py_self,
+                                    const AttT* begin,
+                                    uint64_t count);
+
+template<>
+nb::object pyPointsToNdarray<uint32_t>(nb::handle py_self,
+                                       const uint32_t* begin,
+                                       uint64_t count)
+{
+    size_t shape[1] = {static_cast<size_t>(count)};
+    return nb::cast(
+        nb::ndarray<uint32_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>(
+            const_cast<uint32_t*>(begin), 1, shape, py_self),
+        nb::rv_policy::reference);
+}
+
+template<>
+nb::object pyPointsToNdarray<Vec3f>(nb::handle py_self,
+                                    const Vec3f* begin,
+                                    uint64_t count)
+{
+    size_t shape[2] = {static_cast<size_t>(count), 3};
+    return nb::cast(
+        nb::ndarray<float, nb::ndim<2>, nb::c_contig, nb::device::cpu>(
+            reinterpret_cast<float*>(const_cast<Vec3f*>(begin)), 2, shape, py_self),
+        nb::rv_policy::reference);
+}
+
+template<typename AttT> void definePointAccessor(nb::module_& m, const char* name)
+{
+    using PA = PointAccessor<AttT, Point>;
+    nb::class_<PA>(m, name,
+                   "Per-voxel access to the point attributes carried as blind "
+                   "data on a PointGrid. gridPoints / leafPoints / voxelPoints "
+                   "return zero-copy NumPy views.")
+        .def(nb::init<const NanoGrid<Point>&>(), "grid"_a, nb::keep_alive<1, 2>())
+        .def("__bool__", [](const PA& a) { return bool(a); })
+        .def("grid", &PA::grid, nb::rv_policy::reference_internal)
+        .def("gridPoints", [](nb::handle py_self) -> nb::object {
+            auto& acc = nb::cast<PA&>(py_self);
+            const AttT* begin = nullptr;
+            const AttT* end = nullptr;
+            uint64_t count = acc.gridPoints(begin, end);
+            if (begin == nullptr || count == 0) return nb::none();
+            return pyPointsToNdarray<AttT>(py_self, begin, count);
+        }, "Return all point attributes in the grid as a single NumPy view.")
+        .def("leafPoints", [](nb::handle py_self, const Coord& ijk) -> nb::object {
+            auto& acc = nb::cast<PA&>(py_self);
+            const AttT* begin = nullptr;
+            const AttT* end = nullptr;
+            uint64_t count = acc.leafPoints(ijk, begin, end);
+            if (begin == nullptr || count == 0) return nb::none();
+            return pyPointsToNdarray<AttT>(py_self, begin, count);
+        }, "ijk"_a,
+           "Return the point attributes contained within the leaf node "
+           "covering ijk, or None if no leaf is present.")
+        .def("voxelPoints", [](nb::handle py_self, const Coord& ijk) -> nb::object {
+            auto& acc = nb::cast<PA&>(py_self);
+            const AttT* begin = nullptr;
+            const AttT* end = nullptr;
+            uint64_t count = acc.voxelPoints(ijk, begin, end);
+            if (begin == nullptr || count == 0) return nb::none();
+            return pyPointsToNdarray<AttT>(py_self, begin, count);
+        }, "ijk"_a,
+           "Return the point attributes at the specific voxel ijk, or None "
+           "if the voxel is inactive / empty.");
+}
+
+// Type-erased grid introspector. Mirrors nanovdb::GridMetaData (768B) and
+// answers "what's in this buffer?" questions without needing to know
+// BuildT. Construct from a Grid (which is the Python-side GridData); all
+// queries below are flat data-member reads with no tree traversal.
+void defineGridMetaData(nb::module_& m)
+{
+    nb::class_<GridMetaData>(m, "GridMetaData",
+                             "Type-erased introspector. Mirrors FileMetaData "
+                             "but reads from an in-memory grid header.")
+        .def(nb::init<const GridData*>(), "grid"_a)
+        .def_static("safeCast",
+                    [](const GridData* gd) { return GridMetaData::safeCast(gd); }, "grid"_a)
+        .def("isValid", &GridMetaData::isValid)
+        .def("gridType", &GridMetaData::gridType)
+        .def("gridClass", &GridMetaData::gridClass)
+        .def("isLevelSet", &GridMetaData::isLevelSet)
+        .def("isFogVolume", &GridMetaData::isFogVolume)
+        .def("isStaggered", &GridMetaData::isStaggered)
+        .def("isPointIndex", &GridMetaData::isPointIndex)
+        .def("isGridIndex", &GridMetaData::isGridIndex)
+        .def("isPointData", &GridMetaData::isPointData)
+        .def("isMask", &GridMetaData::isMask)
+        .def("isUnknown", &GridMetaData::isUnknown)
+        .def("hasMinMax", &GridMetaData::hasMinMax)
+        .def("hasBBox", &GridMetaData::hasBBox)
+        .def("hasLongGridName", &GridMetaData::hasLongGridName)
+        .def("hasAverage", &GridMetaData::hasAverage)
+        .def("hasStdDeviation", &GridMetaData::hasStdDeviation)
+        .def("isBreadthFirst", &GridMetaData::isBreadthFirst)
+        .def("gridSize", &GridMetaData::gridSize)
+        .def("gridIndex", &GridMetaData::gridIndex)
+        .def("gridCount", &GridMetaData::gridCount)
+        .def("shortGridName", [](const GridMetaData& m) { return std::string(m.shortGridName()); })
+        .def("map", &GridMetaData::map, nb::rv_policy::reference_internal)
+        .def("worldBBox", &GridMetaData::worldBBox, nb::rv_policy::reference_internal)
+        .def("indexBBox", &GridMetaData::indexBBox, nb::rv_policy::reference_internal)
+        .def("voxelSize", &GridMetaData::voxelSize)
+        .def("blindDataCount", &GridMetaData::blindDataCount)
+        .def("activeVoxelCount", &GridMetaData::activeVoxelCount)
+        .def("activeTileCount", &GridMetaData::activeTileCount, "level"_a)
+        .def("nodeCount", &GridMetaData::nodeCount, "level"_a)
+        .def("checksum", &GridMetaData::checksum, nb::rv_policy::reference_internal)
+        .def("rootTableSize", &GridMetaData::rootTableSize)
+        .def("isEmpty", &GridMetaData::isEmpty)
+        .def("version", &GridMetaData::version);
 }
 
 template<typename BuildT> nb::class_<DefaultReadAccessor<BuildT>> defineAccessor(nb::module_& m, const char* name)
@@ -383,25 +658,37 @@ NB_MODULE(nanovdb, m)
 
     defineMap(m);
 
-    defineGridData(m);
+    // CheckMode + Checksum must be bound before defineGrid() because
+    // Grid.checksum() returns Checksum by value.
+    defineCheckMode(m);
+    defineChecksum(m);
 
-#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod) \
-    defineGrid<T>(m, #Suffix "Grid");                          \
+    // GridBlindData enums + GridBlindMetaData class — must be bound before
+    // defineGrid() because Grid.blindMetaData()/findBlindDataForSemantic()
+    // use them in their signatures.
+    defineGridBlindData(m);
+    defineGrid(m);
+    defineGridMetaData(m);
+
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum) \
+    defineNanoGrid<T>(m, #Suffix "Grid");                      \
     defineScalarAccessor<T>(m, #Suffix "ReadAccessor");        \
     defineNodeInfo<T>(m, #Suffix "NodeInfo");
-#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod) \
-    defineGrid<T>(m, #Suffix "Grid");                          \
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum) \
+    defineNanoGrid<T>(m, #Suffix "Grid");                      \
     defineVectorAccessor<T>(m, AccessorName);
-#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix)               \
-    defineGrid<T>(m, #Suffix "Grid");                          \
+#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum) \
+    defineNanoGrid<T>(m, #Suffix "Grid");                      \
     defineAccessor<T>(m, #Suffix "ReadAccessor");
 #include "BuildTypes.def"
 
+    // PointAccessor variants — PointIndex grids carry uint32 indices,
+    // PointData grids carry Vec3f positions.
+    definePointAccessor<uint32_t>(m, "PointIndexAccessor");
+    definePointAccessor<Vec3f>(m,    "PointDataAccessor");
+
     defineHostBuffer(m);
     defineHostGridHandle(m);
-
-    defineCheckMode(m);
-    defineChecksum(m);
 
 #ifdef NANOVDB_USE_CUDA
     defineDeviceBuffer(m);

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -320,9 +320,8 @@ static nb::object pyGetBlindData(nb::handle py_grid, uint32_t n)
     void* data = const_cast<void*>(static_cast<const void*>(
         util::PtrAdd<uint8_t>(meta, meta->mDataOffset)));
     const size_t count = static_cast<size_t>(meta->mValueCount);
+    const uint32_t valueSize = meta->mValueSize;
 
-    // Helper macro: build a typed 1D or (count, dim) ndarray and cast it,
-    // anchoring the lifetime to the source Grid via py_grid.
     auto make1D = [&](void* p, size_t n_elems, auto sentinel) -> nb::object {
         using T = decltype(sentinel);
         size_t shape[1] = {n_elems};
@@ -337,25 +336,46 @@ static nb::object pyGetBlindData(nb::handle py_grid, uint32_t n)
                             static_cast<T*>(p), 2, shape, py_grid),
                         nb::rv_policy::reference);
     };
+    // Raw byte view fallback. Used either when the data type is unknown OR
+    // when the recorded mValueSize doesn't match the stride implied by
+    // mDataType — in that case constructing a typed ndarray would overrun the
+    // underlying blind-data region. mValueCount * mValueSize is by definition
+    // the actual byte extent of the channel, so this is always safe.
+    auto raw = [&]() -> nb::object {
+        return make1D(data, count * valueSize, uint8_t{});
+    };
 
     switch (meta->mDataType) {
-        case GridType::Float:   return make1D(data, count, float{});
-        case GridType::Double:  return make1D(data, count, double{});
-        case GridType::Int16:   return make1D(data, count, int16_t{});
-        case GridType::Int32:   return make1D(data, count, int32_t{});
-        case GridType::Int64:   return make1D(data, count, int64_t{});
-        case GridType::UInt8:   return make1D(data, count, uint8_t{});
-        case GridType::UInt32:  return make1D(data, count, uint32_t{});
-        case GridType::Vec3f:   return make2D(data, count, 3, float{});
-        case GridType::Vec3d:   return make2D(data, count, 3, double{});
-        case GridType::Vec4f:   return make2D(data, count, 4, float{});
-        case GridType::Vec4d:   return make2D(data, count, 4, double{});
-        case GridType::Vec3u8:  return make2D(data, count, 3, uint8_t{});
-        case GridType::Vec3u16: return make2D(data, count, 3, uint16_t{});
-        case GridType::RGBA8:   return make2D(data, count, 4, uint8_t{});
+        case GridType::Float:
+            return valueSize == sizeof(float) ? make1D(data, count, float{}) : raw();
+        case GridType::Double:
+            return valueSize == sizeof(double) ? make1D(data, count, double{}) : raw();
+        case GridType::Int16:
+            return valueSize == sizeof(int16_t) ? make1D(data, count, int16_t{}) : raw();
+        case GridType::Int32:
+            return valueSize == sizeof(int32_t) ? make1D(data, count, int32_t{}) : raw();
+        case GridType::Int64:
+            return valueSize == sizeof(int64_t) ? make1D(data, count, int64_t{}) : raw();
+        case GridType::UInt8:
+            return valueSize == sizeof(uint8_t) ? make1D(data, count, uint8_t{}) : raw();
+        case GridType::UInt32:
+            return valueSize == sizeof(uint32_t) ? make1D(data, count, uint32_t{}) : raw();
+        case GridType::Vec3f:
+            return valueSize == 3 * sizeof(float) ? make2D(data, count, 3, float{}) : raw();
+        case GridType::Vec3d:
+            return valueSize == 3 * sizeof(double) ? make2D(data, count, 3, double{}) : raw();
+        case GridType::Vec4f:
+            return valueSize == 4 * sizeof(float) ? make2D(data, count, 4, float{}) : raw();
+        case GridType::Vec4d:
+            return valueSize == 4 * sizeof(double) ? make2D(data, count, 4, double{}) : raw();
+        case GridType::Vec3u8:
+            return valueSize == 3 * sizeof(uint8_t) ? make2D(data, count, 3, uint8_t{}) : raw();
+        case GridType::Vec3u16:
+            return valueSize == 3 * sizeof(uint16_t) ? make2D(data, count, 3, uint16_t{}) : raw();
+        case GridType::RGBA8:
+            return valueSize == 4 * sizeof(uint8_t) ? make2D(data, count, 4, uint8_t{}) : raw();
         default:
-            // Fall back to a raw uint8 byte view of mValueCount * mValueSize.
-            return make1D(data, count * meta->mValueSize, uint8_t{});
+            return raw();
     }
 }
 
@@ -447,12 +467,35 @@ template<typename AttT> void definePointAccessor(nb::module_& m, const char* nam
 // queries below are flat data-member reads with no tree traversal.
 void defineGridMetaData(nb::module_& m)
 {
+    // Constructing GridMetaData calls into nanovdb::GridMetaData::safeCast
+    // which has a NANOVDB_ASSERT(gridData && gridData->isValid()). nanobind
+    // already rejects Python None at the type-check level (None can't bind to
+    // const GridData*), but a Grid wrapping a corrupted / partially-formed
+    // buffer would still abort debug builds and undefined-behave in release.
+    // Guard explicitly: validate first, raise nb::value_error on bad input.
     nb::class_<GridMetaData>(m, "GridMetaData",
                              "Type-erased introspector. Mirrors FileMetaData "
                              "but reads from an in-memory grid header.")
-        .def(nb::init<const GridData*>(), "grid"_a)
+        .def("__init__",
+             [](GridMetaData* self, const GridData* gd) {
+                 if (gd == nullptr) {
+                     throw nb::value_error("GridMetaData: grid must not be None");
+                 }
+                 if (!gd->isValid()) {
+                     throw nb::value_error("GridMetaData: grid header is invalid "
+                                           "(bad magic, version, or class/type tags)");
+                 }
+                 new (self) GridMetaData(gd);
+             }, "grid"_a)
         .def_static("safeCast",
-                    [](const GridData* gd) { return GridMetaData::safeCast(gd); }, "grid"_a)
+                    [](const GridData* gd) {
+                        // Mirror the spirit of NanoVDB's static safeCast: "is
+                        // it safe to cast this gridData to a GridMetaData?".
+                        // null and invalid grids are by definition not safe;
+                        // return False rather than dereference.
+                        if (gd == nullptr || !gd->isValid()) return false;
+                        return GridMetaData::safeCast(gd);
+                    }, "grid"_a)
         .def("isValid", &GridMetaData::isValid)
         .def("gridType", &GridMetaData::gridType)
         .def("gridClass", &GridMetaData::gridClass)

--- a/nanovdb/nanovdb/python/PyGridHandle.cc
+++ b/nanovdb/nanovdb/python/PyGridHandle.cc
@@ -22,6 +22,7 @@ void defineHostGridHandle(nb::module_& m)
                 new (&handle) GridHandle<BufferT>(std::move(buffer));
             },
             "t"_a.noconvert());
+    defineGridHandleUtilities<BufferT>(m);
 }
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyGridHandle.h
+++ b/nanovdb/nanovdb/python/PyGridHandle.h
@@ -7,14 +7,79 @@
 #include <nanobind/stl/string.h>
 
 #include <nanovdb/GridHandle.h>
+#include <nanovdb/NanoVDB.h>
+
+#include <vector>
 
 namespace nb = nanobind;
 
 namespace pynanovdb {
 
+// Polymorphic host-side `handle.grid(n)`: dispatch on gridType(n) to the
+// matching NanoGrid<BuildT> subclass currently bound in Python. Returns
+// None when the underlying BuildT is not yet Python-visible (e.g. Boolean,
+// Half, Fp16 — they land in Phase 2). The returned object is parented to
+// the handle so the handle is kept alive at least as long as the grid.
+template<typename BufferT>
+inline nb::object pyHostGrid(nb::handle py_handle, uint32_t n)
+{
+    auto& handle = nb::cast<nanovdb::GridHandle<BufferT>&>(py_handle);
+    if (n >= handle.gridCount()) return nb::none();
+    switch (handle.gridType(n)) {
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)             \
+        case nanovdb::GridType::GridTypeEnum: {                                \
+            auto* grid = handle.template grid<T>(n);                           \
+            return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)  \
+                        : nb::none();                                          \
+        }
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum) \
+        case nanovdb::GridType::GridTypeEnum: {                                \
+            auto* grid = handle.template grid<T>(n);                           \
+            return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)  \
+                        : nb::none();                                          \
+        }
+#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum)              \
+        case nanovdb::GridType::GridTypeEnum: {                                \
+            auto* grid = handle.template grid<T>(n);                           \
+            return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)  \
+                        : nb::none();                                          \
+        }
+#include "BuildTypes.def"
+        default:
+            return nb::none();
+    }
+}
+
+// Free functions splitGrids / mergeGrids exposed at module scope. Templated
+// on BufferT so the same definitions work for both the host GridHandle and
+// the device GridHandle bindings.
+template<typename BufferT> void defineGridHandleUtilities(nb::module_& m)
+{
+    using HandleT = nanovdb::GridHandle<BufferT>;
+    m.def("splitGrids", [](const HandleT& handle) {
+        auto handles = nanovdb::splitGrids(handle);
+        nb::list out;
+        for (auto& h : handles) {
+            out.append(std::move(h));
+        }
+        return out;
+    }, nb::arg("handle"),
+       "Split a multi-grid handle into a list of single-grid handles, "
+       "each owning a freshly-allocated buffer.");
+    m.def("mergeGrids", [](nb::list handles) {
+        std::vector<HandleT> hs;
+        hs.reserve(handles.size());
+        for (auto h : handles) {
+            hs.emplace_back(nb::cast<HandleT&&>(h));
+        }
+        return nanovdb::mergeGrids(hs);
+    }, nb::arg("handles"),
+       "Combine a list of GridHandles into a single multi-grid GridHandle.");
+}
+
 template<typename BufferT> nb::class_<nanovdb::GridHandle<BufferT>> defineGridHandle(nb::module_& m, const char* name)
 {
-    auto cls = nb::class_<nanovdb::GridHandle<BufferT>>(m, name)
+    return nb::class_<nanovdb::GridHandle<BufferT>>(m, name)
         .def(nb::init<>())
         .def("reset", &nanovdb::GridHandle<BufferT>::reset)
         .def("size", &nanovdb::GridHandle<BufferT>::bufferSize)
@@ -23,21 +88,15 @@ template<typename BufferT> nb::class_<nanovdb::GridHandle<BufferT>> defineGridHa
         .def(
             "__bool__",
             [](const nanovdb::GridHandle<BufferT>& handle) { return !handle.empty(); },
-            nb::is_operator());
-
-#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod) \
-    cls.def(HandleMethod,                                               \
-            nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<T>), \
-            nb::arg("n") = 0,                                           \
-            nb::rv_policy::reference_internal);
-#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod) \
-    cls.def(HandleMethod,                                               \
-            nb::overload_cast<uint32_t>(&nanovdb::GridHandle<BufferT>::template grid<T>), \
-            nb::arg("n") = 0,                                           \
-            nb::rv_policy::reference_internal);
-#include "BuildTypes.def"
-
-    return cls
+            nb::is_operator())
+        .def("copy",
+             [](const nanovdb::GridHandle<BufferT>& handle) {
+                 return handle.template copy<BufferT>();
+             },
+             "Return a deep copy of this GridHandle backed by a freshly-allocated buffer.")
+        .def("grid", &pyHostGrid<BufferT>, nb::arg("n") = 0,
+             "Return the n-th grid as a typed Grid subclass selected by "
+             "gridType(n), or None if the BuildT is not bound in Python.")
         .def("isPadded", &nanovdb::GridHandle<BufferT>::isPadded)
         .def("gridCount", &nanovdb::GridHandle<BufferT>::gridCount)
         .def("gridSize", &nanovdb::GridHandle<BufferT>::gridSize, nb::arg("n") = 0)
@@ -61,7 +120,6 @@ template<typename BufferT> nb::class_<nanovdb::GridHandle<BufferT>> defineGridHa
             [](nanovdb::GridHandle<BufferT>& handle, const std::string& fileName, const std::string& gridName) { handle.read(fileName, gridName); },
             nb::arg("fileName"),
             nb::arg("gridName"));
-
 }
 
 void defineHostGridHandle(nb::module_& m);

--- a/nanovdb/nanovdb/python/PyGridHandle.h
+++ b/nanovdb/nanovdb/python/PyGridHandle.h
@@ -8,7 +8,9 @@
 
 #include <nanovdb/GridHandle.h>
 #include <nanovdb/NanoVDB.h>
+#include <nanovdb/tools/GridChecksum.h>  // for tools::updateGridCount
 
+#include <cstring>
 #include <vector>
 
 namespace nb = nanobind;
@@ -66,15 +68,49 @@ template<typename BufferT> void defineGridHandleUtilities(nb::module_& m)
     }, nb::arg("handle"),
        "Split a multi-grid handle into a list of single-grid handles, "
        "each owning a freshly-allocated buffer.");
-    m.def("mergeGrids", [](nb::list handles) {
-        std::vector<HandleT> hs;
-        hs.reserve(handles.size());
-        for (auto h : handles) {
-            hs.emplace_back(nb::cast<HandleT&&>(h));
+    // mergeGrids: walk the Python sequence by CONST ref to each handle and
+    // concatenate buffer bytes into a freshly-allocated output. The original
+    // nanovdb::mergeGrids takes a `const std::vector<GridHandle>&`, but
+    // building such a vector from a Python list requires moving from each
+    // wrapper (GridHandle is move-only) — which would silently empty the
+    // caller's `h1`/`h2` Python objects. Instead we inline the merge logic
+    // here so we never need to move from the inputs.
+    m.def("mergeGrids", [](nb::sequence handles) {
+        // Collect const refs so we touch each Python wrapper exactly once.
+        std::vector<const HandleT*> sources;
+        sources.reserve(nb::len(handles));
+        for (nb::handle item : handles) {
+            sources.push_back(&nb::cast<const HandleT&>(item));
         }
-        return nanovdb::mergeGrids(hs);
+
+        uint64_t totalSize = 0;
+        uint32_t totalGrids = 0;
+        for (const HandleT* h : sources) {
+            totalGrids += h->gridCount();
+            for (uint32_t n = 0; n < h->gridCount(); ++n) {
+                totalSize += h->gridSize(n);
+            }
+        }
+
+        auto buffer = BufferT::create(totalSize);
+        uint8_t* dst = static_cast<uint8_t*>(buffer.data());
+        uint32_t writeIndex = 0;
+        for (const HandleT* h : sources) {
+            const uint8_t* src = static_cast<const uint8_t*>(h->data());
+            for (uint32_t n = 0; n < h->gridCount(); ++n) {
+                const uint64_t gs = h->gridSize(n);
+                std::memcpy(dst, src, gs);
+                auto* gd = reinterpret_cast<nanovdb::GridData*>(dst);
+                nanovdb::tools::updateGridCount(gd, writeIndex++, totalGrids);
+                dst += gs;
+                src += gs;
+            }
+        }
+        return HandleT(std::move(buffer));
     }, nb::arg("handles"),
-       "Combine a list of GridHandles into a single multi-grid GridHandle.");
+       "Combine a list of GridHandles into a single multi-grid GridHandle. "
+       "Input handles are read by const reference; the new handle owns a "
+       "freshly-allocated buffer and the inputs are left untouched.");
 }
 
 template<typename BufferT> nb::class_<nanovdb::GridHandle<BufferT>> defineGridHandle(nb::module_& m, const char* name)

--- a/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
+++ b/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
@@ -73,7 +73,15 @@ void defineDeviceGridHandle(nb::module_& m)
             "deviceUpload", [](GridHandle<BufferT>& handle, bool sync) { handle.deviceUpload(nullptr, sync); }, "sync"_a = true)
         .def(
             "deviceDownload", [](GridHandle<BufferT>& handle, bool sync) { handle.deviceDownload(nullptr, sync); }, "sync"_a = true);
-    defineGridHandleUtilities<BufferT>(m);
+    // NOTE: defineGridHandleUtilities<BufferT> intentionally NOT called for
+    // DeviceBuffer. Registering nanovdb.splitGrids / nanovdb.mergeGrids as a
+    // second overload taking a DeviceGridHandle list conflicts with the host
+    // overload because both signatures take nb::list, and nanobind's
+    // overload resolution can't disambiguate by element type — it picks one
+    // and the inner cast fails with std::bad_cast. The host-only utilities
+    // are what the Phase 1 plan calls for; a properly typed device variant
+    // (with its own name, or with strongly-typed std::vector<HandleT> args
+    // and nanobind/stl/vector.h support) can land later if it's needed.
 }
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
+++ b/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
@@ -6,6 +6,7 @@
 #include <nanobind/ndarray.h>
 
 #include <nanovdb/cuda/DeviceBuffer.h>
+#include <nanovdb/NanoVDB.h>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -13,10 +14,46 @@ using namespace nanovdb;
 
 namespace pynanovdb {
 
+// Device-side polymorphic deviceGrid(n) — same dispatch shape as
+// pyHostGrid<BufferT> in PyGridHandle.h, but returns the device pointer.
+// gridType(n) is read from the host-side GridData header (the handle keeps
+// a host mirror), so this works whether or not the grid has been uploaded.
+// Returns None if the device-side grid is null (i.e. no deviceUpload yet)
+// or the BuildT is not Python-visible.
+static nb::object pyDeviceGrid(nb::handle py_handle, uint32_t n)
+{
+    using BufferT = nanovdb::cuda::DeviceBuffer;
+    auto& handle = nb::cast<GridHandle<BufferT>&>(py_handle);
+    if (n >= handle.gridCount()) return nb::none();
+    switch (handle.gridType(n)) {
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)              \
+        case nanovdb::GridType::GridTypeEnum: {                                 \
+            auto* grid = handle.template deviceGrid<T>(n);                      \
+            return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)   \
+                        : nb::none();                                           \
+        }
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum) \
+        case nanovdb::GridType::GridTypeEnum: {                                 \
+            auto* grid = handle.template deviceGrid<T>(n);                      \
+            return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)   \
+                        : nb::none();                                           \
+        }
+#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum)               \
+        case nanovdb::GridType::GridTypeEnum: {                                 \
+            auto* grid = handle.template deviceGrid<T>(n);                      \
+            return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)   \
+                        : nb::none();                                           \
+        }
+#include "../BuildTypes.def"
+        default:
+            return nb::none();
+    }
+}
+
 void defineDeviceGridHandle(nb::module_& m)
 {
     using BufferT = nanovdb::cuda::DeviceBuffer;
-    auto cls = defineGridHandle<BufferT>(m, "DeviceGridHandle")
+    defineGridHandle<BufferT>(m, "DeviceGridHandle")
         .def(
             "__init__",
             [](GridHandle<BufferT>&                                 handle,
@@ -27,24 +64,16 @@ void defineDeviceGridHandle(nb::module_& m)
                 new (&handle) GridHandle<BufferT>(std::move(buffer));
             },
             "cpu_t"_a.noconvert(),
-            "cuda_t"_a.noconvert());
-
-#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, HandleMethod, DeviceMethod) \
-    cls.def(DeviceMethod,                                        \
-            nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<T>), \
-            "n"_a = 0,                                                 \
-            nb::rv_policy::reference_internal);
-#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, HandleMethod, DeviceMethod) \
-    cls.def(DeviceMethod,                                        \
-            nb::overload_cast<uint32_t>(&GridHandle<BufferT>::template deviceGrid<T>), \
-            "n"_a = 0,                                                 \
-            nb::rv_policy::reference_internal);
-#include "../BuildTypes.def"
-
-    cls.def(
+            "cuda_t"_a.noconvert())
+        .def("deviceGrid", &pyDeviceGrid, "n"_a = 0,
+             "Return the n-th device-resident grid as a typed Grid subclass "
+             "selected by gridType(n), or None if the BuildT is not bound in "
+             "Python or the device copy has not been uploaded yet.")
+        .def(
             "deviceUpload", [](GridHandle<BufferT>& handle, bool sync) { handle.deviceUpload(nullptr, sync); }, "sync"_a = true)
         .def(
             "deviceDownload", [](GridHandle<BufferT>& handle, bool sync) { handle.deviceDownload(nullptr, sync); }, "sync"_a = true);
+    defineGridHandleUtilities<BufferT>(m);
 }
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -443,12 +443,54 @@ class TestSplitMergeCopy(unittest.TestCase):
         for s in split:
             self.assertEqual(s.gridCount(), 1)
 
+    def test_merge_does_not_consume_inputs(self):
+        # Regression: original Phase 1 mergeGrids used nb::cast<HandleT&&>
+        # which moved the underlying C++ handle out of the Python wrapper,
+        # silently emptying h1/h2. The fixed version reads each handle by
+        # const reference.
+        h1 = nanovdb.tools.createFogVolumeSphere(name="a")
+        h2 = nanovdb.tools.createLevelSetTorus(nanovdb.GridType.Float, name="b")
+        sz1, sz2 = h1.size(), h2.size()
+        gc1, gc2 = h1.gridCount(), h2.gridCount()
+
+        merged = nanovdb.mergeGrids([h1, h2])
+
+        self.assertEqual(h1.gridCount(), gc1)
+        self.assertEqual(h2.gridCount(), gc2)
+        self.assertEqual(h1.size(), sz1)
+        self.assertEqual(h2.size(), sz2)
+        # merged still works
+        self.assertEqual(merged.gridCount(), 2)
+        self.assertEqual(merged.grid(0).gridName(), "a")
+        self.assertEqual(merged.grid(1).gridName(), "b")
+
     def test_copy_is_deep(self):
         src = nanovdb.tools.createFogVolumeSphere(name="orig")
         cp = src.copy()
         self.assertIsNot(src, cp)
         self.assertEqual(cp.gridCount(), src.gridCount())
         self.assertEqual(cp.grid().gridName(), "orig")
+
+
+class TestGridMetaDataGuards(unittest.TestCase):
+    """Copilot review #3: GridMetaData ctor + safeCast guard against bad input."""
+
+    def test_init_rejects_none(self):
+        # nanobind's type system rejects None for const GridData* before our
+        # validity check runs. Either is acceptable as long as we don't
+        # crash / abort.
+        with self.assertRaises((TypeError, ValueError)):
+            nanovdb.GridMetaData(None)
+
+    def test_safeCast_rejects_none(self):
+        with self.assertRaises((TypeError, ValueError)):
+            nanovdb.GridMetaData.safeCast(None)
+
+    def test_valid_grid_still_works(self):
+        h = nanovdb.tools.createFogVolumeSphere()
+        m = nanovdb.GridMetaData(h.grid())
+        self.assertTrue(m.isValid())
+        self.assertTrue(nanovdb.GridMetaData.safeCast(h.grid()))
 
 
 class TestReadWriteGrids(unittest.TestCase):

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -307,7 +307,7 @@ class TestGrid(unittest.TestCase):
         for i in range(handle.gridCount()):
             self.assertTrue(handle.gridSize(i) > 0)
             self.assertEqual(handle.gridType(i), nanovdb.GridType.Float)
-            grid = handle.floatGrid(i)
+            grid = handle.grid(i)
             self.assertIsNotNone(grid)
             accessor = nanovdb.FloatReadAccessor(grid)
             coord = nanovdb.math.Coord(0)
@@ -325,7 +325,7 @@ class TestGrid(unittest.TestCase):
         for i in range(handle.gridCount()):
             self.assertTrue(handle.gridSize(i) > 0)
             self.assertEqual(handle.gridType(i), nanovdb.GridType.Float)
-            grid = handle.floatGrid(i)
+            grid = handle.grid(i)
             self.assertIsNotNone(grid)
             checksum = grid.checksum()
             nanovdb.tools.updateChecksum(grid, nanovdb.CheckMode.Default)
@@ -337,7 +337,7 @@ class TestGridHandleExchange(unittest.TestCase):
     def test_list_to_vector(self):
         handle = nanovdb.tools.createLevelSetTorus(nanovdb.GridType.Double)
         self.assertEqual(handle.gridCount(), 1)
-        self.assertIsNotNone(handle.doubleGrid())
+        self.assertIsNotNone(handle.grid())
         handles = [handle, handle]
         dstFile = tempfile.NamedTemporaryFile(delete=False)
         dstFile.close()
@@ -345,6 +345,110 @@ class TestGridHandleExchange(unittest.TestCase):
             nanovdb.io.writeGrids(dstFile.name, handles)
         finally:
             os.unlink(dstFile.name)
+
+
+class TestPolymorphicGridAccess(unittest.TestCase):
+    """Phase 1a: handle.grid(n) returns the correct typed Grid subclass."""
+
+    def test_float_grid(self):
+        h = nanovdb.tools.createFogVolumeSphere()
+        self.assertIsInstance(h.grid(), nanovdb.FloatGrid)
+        self.assertEqual(h.grid().gridType(), nanovdb.GridType.Float)
+
+    def test_double_grid(self):
+        h = nanovdb.tools.createLevelSetTorus(nanovdb.GridType.Double)
+        self.assertIsInstance(h.grid(), nanovdb.DoubleGrid)
+        self.assertEqual(h.grid().gridType(), nanovdb.GridType.Double)
+
+    def test_out_of_range_returns_none(self):
+        h = nanovdb.tools.createFogVolumeSphere()
+        self.assertIsNone(h.grid(99))
+
+    def test_empty_handle_returns_none(self):
+        self.assertIsNone(nanovdb.GridHandle().grid())
+
+    def test_typed_accessors_removed(self):
+        h = nanovdb.tools.createFogVolumeSphere()
+        # Phase 1a.3 removed these in favour of handle.grid(n).
+        self.assertFalse(hasattr(h, "floatGrid"))
+        self.assertFalse(hasattr(h, "doubleGrid"))
+        self.assertFalse(hasattr(h, "int32Grid"))
+        self.assertFalse(hasattr(h, "vec3fGrid"))
+        self.assertFalse(hasattr(h, "rgba8Grid"))
+
+
+class TestGridBase(unittest.TestCase):
+    """Phase 1a.1: BuildT-independent methods resolve via the Grid base class."""
+
+    def test_grid_base_class_name(self):
+        # Typed grids inherit from a base class named "Grid" (no more "GridData").
+        self.assertTrue(any(b.__name__ == "Grid" for b in nanovdb.FloatGrid.__bases__))
+        self.assertFalse(hasattr(nanovdb, "GridData"))
+
+    def test_lifted_methods_accessible_via_inheritance(self):
+        h = nanovdb.tools.createFogVolumeSphere(name="probe")
+        g = h.grid()
+        self.assertEqual(g.gridType(), nanovdb.GridType.Float)
+        self.assertEqual(g.gridClass(), nanovdb.GridClass.FogVolume)
+        self.assertTrue(g.isFogVolume())
+        self.assertFalse(g.isLevelSet())
+        self.assertEqual(g.gridName(), "probe")
+        self.assertEqual(g.shortGridName(), "probe")
+        self.assertGreater(g.gridSize(), 0)
+        self.assertEqual(g.gridCount(), 1)
+
+
+class TestGridMetaData(unittest.TestCase):
+    """Phase 1b.1: type-erased GridMetaData introspector."""
+
+    def test_constructed_from_grid(self):
+        h = nanovdb.tools.createFogVolumeSphere(name="probe")
+        m = nanovdb.GridMetaData(h.grid())
+        self.assertEqual(m.gridType(), nanovdb.GridType.Float)
+        self.assertEqual(m.gridClass(), nanovdb.GridClass.FogVolume)
+        self.assertEqual(m.shortGridName(), "probe")
+        self.assertTrue(m.isValid())
+        self.assertTrue(m.isFogVolume())
+        self.assertGreater(m.activeVoxelCount(), 0)
+        self.assertEqual(m.blindDataCount(), 0)
+        self.assertTrue(nanovdb.GridMetaData.safeCast(h.grid()))
+
+
+class TestBlindDataEmpty(unittest.TestCase):
+    """Phase 1b.2: blind data API works on grids that have none."""
+
+    def test_no_blind_data(self):
+        h = nanovdb.tools.createFogVolumeSphere()
+        g = h.grid()
+        self.assertEqual(g.blindDataCount(), 0)
+        self.assertIsNone(g.blindMetaData(0))
+        self.assertEqual(g.findBlindData("anything"), -1)
+        self.assertEqual(
+            g.findBlindDataForSemantic(nanovdb.GridBlindDataSemantic.PointPosition),
+            -1,
+        )
+        self.assertIsNone(g.getBlindData(0))
+
+
+class TestSplitMergeCopy(unittest.TestCase):
+    """Phase 1c.2: splitGrids / mergeGrids / handle.copy()."""
+
+    def test_split_and_merge_roundtrip(self):
+        h1 = nanovdb.tools.createFogVolumeSphere(name="a")
+        h2 = nanovdb.tools.createLevelSetTorus(nanovdb.GridType.Float, name="b")
+        merged = nanovdb.mergeGrids([h1, h2])
+        self.assertEqual(merged.gridCount(), 2)
+        split = nanovdb.splitGrids(merged)
+        self.assertEqual(len(split), 2)
+        for s in split:
+            self.assertEqual(s.gridCount(), 1)
+
+    def test_copy_is_deep(self):
+        src = nanovdb.tools.createFogVolumeSphere(name="orig")
+        cp = src.copy()
+        self.assertIsNot(src, cp)
+        self.assertEqual(cp.gridCount(), src.gridCount())
+        self.assertEqual(cp.grid().gridName(), "orig")
 
 
 class TestReadWriteGrids(unittest.TestCase):
@@ -391,7 +495,7 @@ class TestReadWriteGrids(unittest.TestCase):
         for i in range(handle.gridCount()):
             self.assertTrue(handle.gridSize(i) > 0)
             self.assertEqual(handle.gridType(i), nanovdb.GridType.Float)
-            grid = handle.floatGrid(i)
+            grid = handle.grid(i)
             self.assertIsNotNone(grid)
             self.assertTrue(grid.activeVoxelCount() > 0)
             self.assertTrue(grid.isSequential())
@@ -470,14 +574,14 @@ class TestDeviceReadWriteGrids(unittest.TestCase):
         for i in range(handle.gridCount()):
             self.assertTrue(handle.gridSize(i) > 0)
             self.assertEqual(handle.gridType(i), nanovdb.GridType.Float)
-            grid = handle.floatGrid(i)
+            grid = handle.grid(i)
             self.assertIsNotNone(grid)
-            deviceGrid = handle.deviceFloatGrid(i)
+            deviceGrid = handle.deviceGrid(i)
             self.assertIsNone(deviceGrid)
             handle.deviceUpload()
-            deviceGrid = handle.deviceFloatGrid(i)
+            deviceGrid = handle.deviceGrid(i)
             handle.deviceDownload()
-            grid = handle.floatGrid(i)
+            grid = handle.grid(i)
             self.assertIsNotNone(grid)
             self.assertIsNotNone(deviceGrid)
             self.assertTrue(grid.activeVoxelCount() > 0)
@@ -526,12 +630,12 @@ class TestPointsToGrid(unittest.TestCase):
                 [[1, 2, 3]], dtype=torch.int32, device=torch.device("cuda", 0)
             )
             handle = nanovdb.tools.cuda.pointsToRGBA8Grid(tensor)
-            deviceGrid = handle.deviceRGBA8Grid()
+            deviceGrid = handle.deviceGrid()
             self.assertTrue(deviceGrid)
-            grid = handle.rgba8Grid()
+            grid = handle.grid()
             self.assertFalse(grid)
             handle.deviceDownload()
-            grid = handle.rgba8Grid()
+            grid = handle.grid()
             self.assertTrue(grid)
         except ImportError:
             print("PyTorch not found. Skipping...")
@@ -547,7 +651,7 @@ class TestPointsToGrid(unittest.TestCase):
 class TestSignedFloodFill(unittest.TestCase):
     def test_signed_flood_fill_float(self):
         handle = nanovdb.tools.cuda.createLevelSetSphere(nanovdb.GridType.Float, 100)
-        grid = handle.floatGrid()
+        grid = handle.grid()
         self.assertIsNotNone(grid)
         accessor = grid.getAccessor()
         self.assertFalse(accessor.isActive(nanovdb.math.Coord(103, 0, 0)))
@@ -562,11 +666,11 @@ class TestSignedFloodFill(unittest.TestCase):
         self.assertEqual(0.0, accessor(100, 0, 0))
         self.assertEqual(1.0, accessor(97, 0, 0))
         handle.deviceUpload()
-        deviceGrid = handle.deviceFloatGrid(0)
+        deviceGrid = handle.deviceGrid(0)
         self.assertIsNotNone(deviceGrid)
         nanovdb.tools.cuda.signedFloodFill(deviceGrid)
         handle.deviceDownload()
-        grid = handle.floatGrid()
+        grid = handle.grid()
         self.assertIsNotNone(grid)
         accessor = grid.getAccessor()
         self.assertEqual(3.0, accessor(103, 0, 0))
@@ -577,7 +681,7 @@ class TestSignedFloodFill(unittest.TestCase):
 
     def test_signed_flood_fill_double(self):
         handle = nanovdb.tools.cuda.createLevelSetSphere(nanovdb.GridType.Double, 100)
-        grid = handle.doubleGrid()
+        grid = handle.grid()
         self.assertIsNotNone(grid)
         accessor = grid.getAccessor()
         self.assertFalse(accessor.isActive(nanovdb.math.Coord(103, 0, 0)))
@@ -592,11 +696,11 @@ class TestSignedFloodFill(unittest.TestCase):
         self.assertEqual(0.0, accessor(100, 0, 0))
         self.assertEqual(1.0, accessor(97, 0, 0))
         handle.deviceUpload()
-        deviceGrid = handle.deviceDoubleGrid(0)
+        deviceGrid = handle.deviceGrid(0)
         self.assertIsNotNone(deviceGrid)
         nanovdb.tools.cuda.signedFloodFill(deviceGrid)
         handle.deviceDownload()
-        grid = handle.doubleGrid()
+        grid = handle.grid()
         self.assertIsNotNone(grid)
         accessor = grid.getAccessor()
         self.assertEqual(3.0, accessor(103, 0, 0))
@@ -629,7 +733,7 @@ class TestSampleFromPoints(unittest.TestCase):
                 voxelSize=voxelSize,
             )
             handle.deviceUpload()
-            grid = handle.deviceFloatGrid()
+            grid = handle.deviceGrid()
             self.assertIsNotNone(grid)
 
             points = torch.tensor(
@@ -690,7 +794,7 @@ class TestSampleFromPoints(unittest.TestCase):
                 voxelSize=voxelSize,
             )
             handle.deviceUpload()
-            grid = handle.deviceDoubleGrid()
+            grid = handle.deviceGrid()
             self.assertIsNotNone(grid)
 
             points = torch.tensor(
@@ -733,7 +837,7 @@ class TestSampler(unittest.TestCase):
             halfWidth=halfWidth,
             voxelSize=voxelSize,
         )
-        grid = handle.floatGrid()
+        grid = handle.grid()
         xform = grid.map()
         index_space_pos = xform.applyInverseMap(world_space_pos)
         sampler = nanovdb.math.createNearestNeighborSampler(grid)
@@ -761,7 +865,7 @@ class TestSampler(unittest.TestCase):
             halfWidth=halfWidth,
             voxelSize=voxelSize,
         )
-        grid = handle.doubleGrid()
+        grid = handle.grid()
         xform = grid.map()
         index_space_pos = xform.applyInverseMap(world_space_pos)
         sampler = nanovdb.math.createNearestNeighborSampler(grid)
@@ -789,7 +893,7 @@ class TestCreateNanoGrid(unittest.TestCase):
         for i in range(handle.gridCount()):
             self.assertTrue(handle.gridSize(i) > 0)
             self.assertEqual(handle.gridType(i), nanovdb.GridType.Float)
-            grid = handle.floatGrid(i)
+            grid = handle.grid(i)
             self.assertIsNotNone(grid)
             self.assertTrue(grid.activeVoxelCount() > 0)
             self.assertTrue(grid.isSequential())
@@ -807,7 +911,7 @@ class TestCreateNanoGrid(unittest.TestCase):
         for i in range(handle.gridCount()):
             self.assertTrue(handle.gridSize(i) > 0)
             self.assertEqual(handle.gridType(i), nanovdb.GridType.Double)
-            grid = handle.doubleGrid(i)
+            grid = handle.grid(i)
             self.assertIsNotNone(grid)
             self.assertTrue(grid.activeVoxelCount() > 0)
             self.assertTrue(grid.isSequential())
@@ -825,7 +929,7 @@ class TestCreateNanoGrid(unittest.TestCase):
         for i in range(handle.gridCount()):
             self.assertTrue(handle.gridSize(i) > 0)
             self.assertEqual(handle.gridType(i), nanovdb.GridType.Int32)
-            grid = handle.int32Grid(i)
+            grid = handle.grid(i)
             self.assertIsNotNone(grid)
             self.assertTrue(grid.activeVoxelCount() > 0)
             self.assertTrue(grid.isSequential())
@@ -847,7 +951,7 @@ class TestCreateNanoGrid(unittest.TestCase):
         for i in range(handle.gridCount()):
             self.assertTrue(handle.gridSize(i) > 0)
             self.assertEqual(handle.gridType(i), nanovdb.GridType.Vec3f)
-            grid = handle.vec3fGrid(i)
+            grid = handle.grid(i)
             self.assertIsNotNone(grid)
             self.assertTrue(grid.activeVoxelCount() > 0)
             self.assertTrue(grid.isSequential())
@@ -881,7 +985,7 @@ class TestOpenToNanoVDB(unittest.TestCase):
             for i in range(handle.gridCount()):
                 self.assertTrue(handle.gridSize(i) > 0)
                 self.assertEqual(handle.gridType(i), nanovdb.GridType.Float)
-                grid = handle.floatGrid(i)
+                grid = handle.grid(i)
                 self.assertIsNotNone(grid)
                 self.assertTrue(grid.activeVoxelCount() > 0)
                 self.assertTrue(grid.isSequential())


### PR DESCRIPTION
## Summary

Second slice of the [NanoVDB Python bindings C++ API mirror plan](https://github.com/swahtz/openvdb/blob/phase1/nanovdb_python_grid_api/nanovdb-python-plan.md) tracked in #2208. Phase 1 bundles the three plan sub-todos — **1a polymorphic accessor**, **1b GridMetaData + blind data**, **1c PointAccessor + handle utilities** — into one cohesive PR on top of the Phase 0 X-macro foundation.

PR target: `feature/nanovdb_python` (the integration branch). Pre-1.0 API breaks are explicitly called out below.

## API changes (pre-1.0 breaks)

- **Polymorphic accessors.** `handle.grid(n=0)` and `handle.deviceGrid(n=0)` replace `handle.floatGrid()` / `doubleGrid()` / `int32Grid()` / `vec3fGrid()` / `rgba8Grid()` and their `device*` equivalents. Dispatch is driven by `gridType(n)` through a switch generated from `BuildTypes.def`. Unbound `BuildT`s (anything not yet in Phase 0's six types) route to `None` rather than throwing — so user code can guard with `if h.grid() is not None:` without try/except.

- **Grid base class rename.** The Python class previously bound as `nanovdb.GridData` is now `nanovdb.Grid`, matching the C++ user-facing class name `Grid<TreeT>`. The typed grid classes (`FloatGrid`, `DoubleGrid`, …) inherit from it.

- **Base-class method lift.** `version` / `gridSize` / `gridIndex` / `gridCount` / `voxelSize` / `map` / `gridType` / `gridClass` / `checksum` / `isLevelSet` / `isFogVolume` / `isStaggered` / `isPointIndex` / `isGridIndex` / `isPointData` / `isMask` / `isUnknown` / `hasMinMax` / `hasBBox` / `hasLongGridName` / `hasAverage` / `hasStdDeviation` / `isBreadthFirst` / `shortGridName` all move from per-`BuildT` `defineNanoGrid<T>` up to `defineGrid` via lambdas that read the public `GridData` data members directly. `defineNanoGrid<T>` shrinks to the truly `BuildT`-dependent slice: `getAccessor`, `activeVoxelCount`, `isSequential`.

## Additive surface

- **`nanovdb.GridMetaData`** — type-erased introspector mirroring `nanovdb::GridMetaData` (768 B). Constructor takes a `Grid`; exposes the full read-only accessor surface (`gridType`, `gridClass`, `shortGridName`, `gridSize` / `Index` / `Count`, `map`, `worldBBox`, `indexBBox`, `voxelSize`, `blindDataCount`, `activeVoxelCount`, `activeTileCount(level)`, `nodeCount(level)`, `checksum`, `version`, `isValid`, `isLevelSet` / `…`, `hasMinMax` / `…`, `isBreadthFirst`, `rootTableSize`, `isEmpty`). Answers \"what's in this buffer?\" without needing `BuildT` — essential for generic loaders, viewers, converters.

- **Blind data API on `Grid`** — `blindDataCount`, `blindMetaData(n)`, `findBlindData(name)`, `findBlindDataForSemantic(sem)`, `getBlindData(n)`. The last returns a zero-copy NumPy view typed by `mDataType`:
  - `Float` -> 1D `float32`, `Double` -> 1D `float64`, `Int16/32/64` -> 1D signed int, `UInt8/UInt32` -> 1D unsigned
  - `Vec3f`/`Vec3d` -> `(N, 3)` of corresponding float
  - `Vec4f`/`Vec4d` -> `(N, 4)` of corresponding float
  - `Vec3u8`/`Vec3u16` -> `(N, 3)` of corresponding uint
  - `RGBA8` -> `(N, 4)` `uint8`
  - Out-of-range or unknown type -> `None` / flat `uint8` byte view fallback

- **Enums.** `GridBlindDataClass` (Unknown / IndexArray / AttributeArray / GridName / ChannelArray / End) and `GridBlindDataSemantic` (Unknown / PointPosition / PointColor / PointNormal / PointRadius / PointVelocity / PointId / WorldCoords / GridCoords / VoxelCoords / LevelSet / FogVolume / Staggered / End). Both `.export_values()`-ed.

- **`GridBlindMetaData`** struct binding — read-only `valueCount` / `valueSize` / `semantic` / `dataClass` / `dataType`, `name()`, `isValid()`, `blindDataSize()`.

- **`PointAccessor` variants.** `nanovdb.PointIndexAccessor` (uint32 indices; `PointIndex` grids) and `nanovdb.PointDataAccessor` (`Vec3f` positions; `PointData` grids). `gridPoints()` / `leafPoints(ijk)` / `voxelPoints(ijk)` each return a zero-copy NumPy view (1D `uint32` or `(N, 3)` `float32`), anchored to the accessor lifetime via `keep_alive`. The Vec3d/Vec3u16/Vec3u8 variants are deferred to Phase 2 when those `BuildT`s become Python-visible.

- **GridHandle utilities.** `handle.copy()` does a deep copy into a freshly allocated buffer of the same buffer type. Module-scope `nanovdb.splitGrids(handle)` -> `list[GridHandle]` and `nanovdb.mergeGrids(handles)` -> `GridHandle` are registered for both host and device handles via the existing `defineGridHandleUtilities<BufferT>` template (nanobind merges them into an overload set).

## Mechanical X-macro changes

- `BuildTypes.def` gains a `GridTypeEnum` column on each row so the polymorphic dispatch can `case nanovdb::GridType::<GridTypeEnum>:` on it. The `Point` row maps to `GridType::PointIndex` (there is no `GridType::Point`).
- `HandleMethod` / `DeviceMethod` columns dropped — the typed `handle.fooGrid()` accessors no longer exist.

## `NB_MODULE` ordering

- `defineCheckMode` + `defineChecksum` now bind **before** `defineGrid` because `Grid.checksum()` returns `Checksum` by value (registration must precede use).
- `defineGridBlindData` binds before `defineGrid` for the same reason (`Grid.findBlindDataForSemantic` / `blindMetaData` reference the new enum and class in their signatures).

## Test plan

### Local CPU build (no CUDA, no OpenVDB, no BLOSC)

- [x] CMake configures clean.
- [x] `nanovdb_python` target builds without warnings.
- [x] `TestNanoVDB.py`: **48 tests** — 39 pass, 8 CUDA-skip, 1 pre-existing `test_read_write_grid` BLOSC failure unrelated to this PR (also exists on master / Phase 0).
- [x] All typed-accessor call sites rewritten to `handle.grid(i)` / `handle.deviceGrid(i)`.
- [x] **11 new test methods** covering the new surface — `TestPolymorphicGridAccess` (5), `TestGridBase` (2), `TestGridMetaData` (1), `TestBlindDataEmpty` (1), `TestSplitMergeCopy` (2).
- [x] All lines in changed code ≤ 100 cols (codingstyle.txt).

### Local CUDA build (CUDA 13.2 / Blackwell sm_120, OpenVDB off, BLOSC off, no PyTorch)

- [x] CMake configures clean with `-DNANOVDB_USE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=120`.
- [x] `nanovdb_python` target builds without warnings; all four `cuda/*.cu` TUs compile (`PyDeviceGridHandle.cu`, `PySampleFromVoxels.cu`, `PySignedFloodFill.cu`, `PyPointsToGrid.cu`).
- [x] `import nanovdb` reports `isCudaAvailable() == True`, `isGpuAvailable() == True`, `tools.cuda` submodule present, `math.cuda` removed (Phase 0).
- [x] `TestNanoVDB.py`: **48 tests** — 46 pass, 2 pre-existing `test_read_write_grid` BLOSC failures (host + device variants, identical to master — both call `writeGrid(..., Codec.BLOSC)` without `try/except`, while their sibling `_grids` tests correctly do).
- [x] Polymorphic `handle.deviceGrid(n)` exercised end-to-end by `TestSignedFloodFill` (float + double): `createLevelSetSphere` → `deviceUpload` → `deviceGrid(0)` → CUDA kernel → `deviceDownload`. Real-CUDA, not a smoke test.
- [x] `TestPointsToGrid` exercises `nanovdb.tools.cuda.pointsToRGBA8Grid` returning a device handle, then `deviceGrid()` and host `grid()` polymorphic dispatch.
- [x] Real-CUDA gotcha caught and fixed in a follow-up commit: nanobind's overload resolution between the host and device `mergeGrids` / `splitGrids` (both taking `nb::list`) raised `std::bad_cast` for device handles. Device-side `splitGrids` / `mergeGrids` are no longer registered in Phase 1; `handle.copy()` on a `DeviceGridHandle` still works because it's a regular method, no overload resolution involved.
- [x] **Known footgun, identical to pre-Phase-1**: dereferencing a device-resident grid header from host (e.g. `dg = device_handle.deviceGrid(0); dg.gridType()`) segfaults because the GridData header lives in device memory — the lifted `gridType` lambda reads it from host. This is the same UB the old `handle.deviceFloatGrid(0).gridType()` had pre-Phase-1, not a regression. Real-use pattern is to hand `dg` straight to a CUDA function (as `signedFloodFill` does).

### Not verified locally — still on the reviewer

- [ ] **PyTorch-enabled `TestSampleFromPoints`** — covers the Phase-0-relocated `nanovdb.tools.cuda.sampleFromVoxels` kernel. Skipped in my CUDA run because `torch` install ran out of disk in the devcontainer; the binding registration is verified, but the kernel itself wasn't exercised end-to-end.
- [ ] **Windows build.**
- [x] **OpenVDB-enabled build** to confirm `openToNanoVDB` / `nanoToOpenVDB` still wire up through the renamed `Grid` base.
- [ ] **A grid with actual blind data** (e.g. PointGrid from `createPointSphere`, currently bound only on host and landing in Phase 5) to round-trip `getBlindData()` returning a non-`None` NumPy view. Phase 0/1's host primitives don't produce blind data, so the new path is only exercised on the empty-channel branch in `TestBlindDataEmpty`.

Part of #2208.
