### PR TITLE
nanovdb python: Phase 2 — broaden BuildT coverage to 24 grid types

### DIFF
--- a/nanovdb/nanovdb/python/BuildTypes.def
+++ b/nanovdb/nanovdb/python/BuildTypes.def
@@ -44,9 +44,9 @@
 //       ValueOnIndex, and ValueMask). nanovdb::BuildTraits<T>::is_special
 //       is true for all of these. Exposed with a bare accessor only — no
 //       setVoxel, no NodeInfo. The Python accessor's getValue() returns
-//       the type given by nanovdb::BuildToValueMap<T>::Type (float for
-//       Fp*, uint64 for ValueIndex / ValueOnIndex, bool for ValueMask
-//       and bool).
+//       the type given by nanovdb::BuildToValueMap<T>::Type — float for
+//       Fp4 / Fp8 / Fp16 / FpN, uint64 for ValueIndex / ValueOnIndex,
+//       bool for ValueMask and for the BuildT=bool (Boolean) grid.
 //
 //   NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
 //       Subset that has C++ sampler specializations (used by PyMath

--- a/nanovdb/nanovdb/python/BuildTypes.def
+++ b/nanovdb/nanovdb/python/BuildTypes.def
@@ -19,16 +19,17 @@
 //
 // Macros:
 //   NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)
-//       Scalar value types — exposed with full NodeInfo accessors. Suffix
-//       forms Python class names (e.g. "Float" -> "FloatGrid").
-//       GridTypeEnum names the nanovdb::GridType:: enumerator a grid of
-//       this BuildT carries (used by the polymorphic handle.grid(n)
-//       dispatch). Usually identical to Suffix.
+//       Scalar value types with arithmetic semantics — exposed with full
+//       NodeInfo + setVoxel accessors. Suffix forms Python class names
+//       (e.g. "Float" -> "FloatGrid"). GridTypeEnum names the
+//       nanovdb::GridType:: enumerator a grid of this BuildT carries
+//       (used by the polymorphic handle.grid(n) dispatch).
 //
 //   NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum)
 //       Vector value types — exposed with a setVoxel accessor but no
 //       NodeInfo. AccessorName is passed explicitly because the legacy
-//       Python class names for these are inconsistent.
+//       Python class names for the original two (Vec3f, RGBA8) are
+//       inconsistent — kept as-is for backwards compatibility.
 //
 //   NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum)
 //       The nanovdb::Point build type — exposed with a bare accessor.
@@ -36,6 +37,16 @@
 //       that enumerator doesn't exist), so GridTypeEnum is given
 //       explicitly. Polymorphic dispatch routes PointIndex grids to
 //       NanoGrid<Point>.
+//
+//   NANOVDB_PY_FOR_EACH_READONLY_BUILDT(T, Suffix, GridTypeEnum)
+//       BuildTs whose nanovdb::SetVoxel<T> is unavailable (bool, the
+//       quantized Fp4/Fp8/Fp16/FpN types, the index types ValueIndex /
+//       ValueOnIndex, and ValueMask). nanovdb::BuildTraits<T>::is_special
+//       is true for all of these. Exposed with a bare accessor only — no
+//       setVoxel, no NodeInfo. The Python accessor's getValue() returns
+//       the type given by nanovdb::BuildToValueMap<T>::Type (float for
+//       Fp*, uint64 for ValueIndex / ValueOnIndex, bool for ValueMask
+//       and bool).
 //
 //   NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
 //       Subset that has C++ sampler specializations (used by PyMath
@@ -53,21 +64,54 @@
 #define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum)
 #define NANOVDB_PY_LOCAL_DEFINED_POINT
 #endif
+#ifndef NANOVDB_PY_FOR_EACH_READONLY_BUILDT
+#define NANOVDB_PY_FOR_EACH_READONLY_BUILDT(T, Suffix, GridTypeEnum)
+#define NANOVDB_PY_LOCAL_DEFINED_READONLY
+#endif
 #ifndef NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT
 #define NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix)
 #define NANOVDB_PY_LOCAL_DEFINED_SAMPLEABLE
 #endif
 
-NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(float,   Float,  Float)
-NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(double,  Double, Double)
-NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(int32_t, Int32,  Int32)
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(float,    Float,  Float)
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(double,   Double, Double)
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(int16_t,  Int16,  Int16)
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(int32_t,  Int32,  Int32)
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(int64_t,  Int64,  Int64)
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(uint8_t,  UInt8,  UInt8)
+NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(uint32_t, UInt32, UInt32)
+// nanovdb::Half is intentionally not bound. The source declares it as
+// `class Half{};` (an empty placeholder for IEEE 754 half-precision, see
+// NanoVDB.h around line 180) and the C++ ProbeValue<Half> chain is
+// inconsistent — leaf storage carries Half but the ProbeValue specialization
+// expects float, causing a type mismatch during instantiation. When the
+// upstream Half implementation lands this can be added in a follow-up.
 
 NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec3f, Vec3f,
                                   "Vec3fReadVectorAccessor", Vec3f)
+NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec3d, Vec3d,
+                                  "Vec3dReadAccessor", Vec3d)
+NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec4f, Vec4f,
+                                  "Vec4fReadAccessor", Vec4f)
+NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec4d, Vec4d,
+                                  "Vec4dReadAccessor", Vec4d)
+NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec3u8, Vec3u8,
+                                  "Vec3u8ReadAccessor", Vec3u8)
+NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::Vec3u16, Vec3u16,
+                                  "Vec3u16ReadAccessor", Vec3u16)
 NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(::nanovdb::math::Rgba8, RGBA8,
                                   "RGBA8ReadAccessor", RGBA8)
 
 NANOVDB_PY_FOR_EACH_POINT_BUILDT(::nanovdb::Point, Point, PointIndex)
+
+NANOVDB_PY_FOR_EACH_READONLY_BUILDT(bool,                  Boolean,     Boolean)
+NANOVDB_PY_FOR_EACH_READONLY_BUILDT(::nanovdb::Fp4,        Fp4,         Fp4)
+NANOVDB_PY_FOR_EACH_READONLY_BUILDT(::nanovdb::Fp8,        Fp8,         Fp8)
+NANOVDB_PY_FOR_EACH_READONLY_BUILDT(::nanovdb::Fp16,       Fp16,        Fp16)
+NANOVDB_PY_FOR_EACH_READONLY_BUILDT(::nanovdb::FpN,        FpN,         FpN)
+NANOVDB_PY_FOR_EACH_READONLY_BUILDT(::nanovdb::ValueIndex, Index,       Index)
+NANOVDB_PY_FOR_EACH_READONLY_BUILDT(::nanovdb::ValueOnIndex, OnIndex,   OnIndex)
+NANOVDB_PY_FOR_EACH_READONLY_BUILDT(::nanovdb::ValueMask,  Mask,        Mask)
 
 NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(float,            Float)
 NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(double,           Double)
@@ -83,6 +127,9 @@ NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(::nanovdb::Vec3f, Vec3f)
 #ifdef NANOVDB_PY_LOCAL_DEFINED_POINT
 #undef NANOVDB_PY_LOCAL_DEFINED_POINT
 #endif
+#ifdef NANOVDB_PY_LOCAL_DEFINED_READONLY
+#undef NANOVDB_PY_LOCAL_DEFINED_READONLY
+#endif
 #ifdef NANOVDB_PY_LOCAL_DEFINED_SAMPLEABLE
 #undef NANOVDB_PY_LOCAL_DEFINED_SAMPLEABLE
 #endif
@@ -90,4 +137,5 @@ NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(::nanovdb::Vec3f, Vec3f)
 #undef NANOVDB_PY_FOR_EACH_SCALAR_BUILDT
 #undef NANOVDB_PY_FOR_EACH_VECTOR_BUILDT
 #undef NANOVDB_PY_FOR_EACH_POINT_BUILDT
+#undef NANOVDB_PY_FOR_EACH_READONLY_BUILDT
 #undef NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -666,6 +666,7 @@ NB_MODULE(nanovdb, m)
         .value("PointIndex", GridType::PointIndex)
         .value("Vec3u8", GridType::Vec3u8)
         .value("Vec3u16", GridType::Vec3u16)
+        .value("UInt8", GridType::UInt8)
         .value("End", GridType::End)
         .export_values()
         .def("__repr__", [](const GridType& gridType) {

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -533,7 +533,13 @@ void defineGridMetaData(nb::module_& m)
 
 template<typename BuildT> nb::class_<DefaultReadAccessor<BuildT>> defineAccessor(nb::module_& m, const char* name)
 {
-    using ValueType = typename DefaultReadAccessor<BuildT>::ValueType;
+    // Use the decoded value type (nanovdb::BuildToValueMap<BuildT>::Type)
+    // rather than DefaultReadAccessor<BuildT>::ValueType. For ordinary types
+    // (float/double/Int*/Vec*) the two are identical, but for Half / Fp* the
+    // accessor decodes to float on read, for ValueIndex/OnIndex it returns
+    // uint64, and for ValueMask / bool it returns bool. The probeValue out-
+    // parameter and the Python return type both want the decoded form.
+    using ValueType = typename nanovdb::BuildToValueMap<BuildT>::Type;
     using CoordType = typename DefaultReadAccessor<BuildT>::CoordType;
 
     nb::class_<DefaultReadAccessor<BuildT>> accessor(m, name);
@@ -721,6 +727,9 @@ NB_MODULE(nanovdb, m)
     defineNanoGrid<T>(m, #Suffix "Grid");                      \
     defineVectorAccessor<T>(m, AccessorName);
 #define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum) \
+    defineNanoGrid<T>(m, #Suffix "Grid");                      \
+    defineAccessor<T>(m, #Suffix "ReadAccessor");
+#define NANOVDB_PY_FOR_EACH_READONLY_BUILDT(T, Suffix, GridTypeEnum) \
     defineNanoGrid<T>(m, #Suffix "Grid");                      \
     defineAccessor<T>(m, #Suffix "ReadAccessor");
 #include "BuildTypes.def"

--- a/nanovdb/nanovdb/python/PyGridHandle.h
+++ b/nanovdb/nanovdb/python/PyGridHandle.h
@@ -19,9 +19,9 @@ namespace pynanovdb {
 
 // Polymorphic host-side `handle.grid(n)`: dispatch on gridType(n) to the
 // matching NanoGrid<BuildT> subclass currently bound in Python. Returns
-// None when the underlying BuildT is not yet Python-visible (e.g. Boolean,
-// Half, Fp16 — they land in Phase 2). The returned object is parented to
-// the handle so the handle is kept alive at least as long as the grid.
+// None when the underlying BuildT is not bound in this build — see the
+// list of bound types in BuildTypes.def. The returned object is parented
+// to the handle so the handle is kept alive at least as long as the grid.
 template<typename BufferT>
 inline nb::object pyHostGrid(nb::handle py_handle, uint32_t n)
 {

--- a/nanovdb/nanovdb/python/PyGridHandle.h
+++ b/nanovdb/nanovdb/python/PyGridHandle.h
@@ -46,6 +46,12 @@ inline nb::object pyHostGrid(nb::handle py_handle, uint32_t n)
             return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)  \
                         : nb::none();                                          \
         }
+#define NANOVDB_PY_FOR_EACH_READONLY_BUILDT(T, Suffix, GridTypeEnum)           \
+        case nanovdb::GridType::GridTypeEnum: {                                \
+            auto* grid = handle.template grid<T>(n);                           \
+            return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)  \
+                        : nb::none();                                          \
+        }
 #include "BuildTypes.def"
         default:
             return nb::none();

--- a/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
+++ b/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
@@ -44,6 +44,12 @@ static nb::object pyDeviceGrid(nb::handle py_handle, uint32_t n)
             return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)   \
                         : nb::none();                                           \
         }
+#define NANOVDB_PY_FOR_EACH_READONLY_BUILDT(T, Suffix, GridTypeEnum)            \
+        case nanovdb::GridType::GridTypeEnum: {                                 \
+            auto* grid = handle.template deviceGrid<T>(n);                      \
+            return grid ? nb::cast(grid, nb::rv_policy::reference, py_handle)   \
+                        : nb::none();                                           \
+        }
 #include "../BuildTypes.def"
         default:
             return nb::none();

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -472,6 +472,59 @@ class TestSplitMergeCopy(unittest.TestCase):
         self.assertEqual(cp.grid().gridName(), "orig")
 
 
+class TestPhase2BuildTCoverage(unittest.TestCase):
+    """Phase 2: every additional BuildT registers a Grid + ReadAccessor (and
+    NodeInfo where applicable). We can't host-construct most of these (the
+    primitives that produce them land in Phase 5), but we can confirm
+    registration completed and the accessor surfaces match the type kind.
+    """
+
+    SCALARS = ["Int16", "Int64", "UInt8", "UInt32"]
+    VECTORS = ["Vec3d", "Vec4f", "Vec4d", "Vec3u8", "Vec3u16"]
+    READONLY = ["Boolean", "Fp4", "Fp8", "Fp16", "FpN", "Index", "OnIndex", "Mask"]
+
+    def test_all_grid_classes_registered(self):
+        for suffix in self.SCALARS + self.VECTORS + self.READONLY:
+            cls = getattr(nanovdb, suffix + "Grid", None)
+            self.assertIsNotNone(cls, f"{suffix}Grid missing")
+            # All inherit from the type-erased Grid base.
+            self.assertIn(nanovdb.Grid, cls.__mro__)
+
+    def test_all_accessors_registered(self):
+        for suffix in self.SCALARS + self.VECTORS + self.READONLY:
+            acc = getattr(nanovdb, suffix + "ReadAccessor", None)
+            self.assertIsNotNone(acc, f"{suffix}ReadAccessor missing")
+
+    def test_scalar_accessors_have_setvoxel_and_nodeinfo(self):
+        for suffix in self.SCALARS:
+            acc = getattr(nanovdb, suffix + "ReadAccessor")
+            self.assertTrue(hasattr(acc, "setVoxel"),
+                            f"{suffix}ReadAccessor missing setVoxel")
+            self.assertTrue(hasattr(acc, "getNodeInfo"),
+                            f"{suffix}ReadAccessor missing getNodeInfo")
+            self.assertIsNotNone(getattr(nanovdb, suffix + "NodeInfo", None),
+                                 f"{suffix}NodeInfo missing")
+
+    def test_vector_accessors_have_setvoxel_no_nodeinfo(self):
+        # Vector accessor names are aligned in Phase 2 (Vec3dReadAccessor,
+        # ...). The legacy Vec3f one is still Vec3fReadVectorAccessor.
+        for suffix in self.VECTORS:
+            acc = getattr(nanovdb, suffix + "ReadAccessor")
+            self.assertTrue(hasattr(acc, "setVoxel"))
+            self.assertFalse(hasattr(acc, "getNodeInfo"))
+
+    def test_readonly_accessors_have_neither_setvoxel_nor_nodeinfo(self):
+        # The plan calls out: quantized types decode to float on read but
+        # do not bind setVoxel; index types return uint64 and ValueMask
+        # exposes only active-state queries.
+        for suffix in self.READONLY:
+            acc = getattr(nanovdb, suffix + "ReadAccessor")
+            self.assertFalse(hasattr(acc, "setVoxel"),
+                             f"{suffix}ReadAccessor should not have setVoxel")
+            self.assertFalse(hasattr(acc, "getNodeInfo"),
+                             f"{suffix}ReadAccessor should not have getNodeInfo")
+
+
 class TestGridMetaDataGuards(unittest.TestCase):
     """Copilot review #3: GridMetaData ctor + safeCast guard against bad input."""
 

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -513,6 +513,17 @@ class TestPhase2BuildTCoverage(unittest.TestCase):
             self.assertTrue(hasattr(acc, "setVoxel"))
             self.assertFalse(hasattr(acc, "getNodeInfo"))
 
+    def test_all_grid_type_enums_reachable(self):
+        # GridType enum binding must cover every BuildT we register —
+        # otherwise Python users can't compare against handle.gridType(n).
+        # UInt8 was missed in Phase 0; this test locks the fix in.
+        for name in ["Float", "Double", "Int16", "Int32", "Int64", "UInt8",
+                     "UInt32", "Boolean", "Half", "RGBA8", "Vec3f", "Vec3d",
+                     "Vec4f", "Vec4d", "Vec3u8", "Vec3u16", "Mask", "Fp4",
+                     "Fp8", "Fp16", "FpN", "Index", "OnIndex", "PointIndex"]:
+            self.assertTrue(hasattr(nanovdb.GridType, name),
+                            f"nanovdb.GridType.{name} not bound")
+
     def test_readonly_accessors_have_neither_setvoxel_nor_nodeinfo(self):
         # The plan calls out: quantized types decode to float on read but
         # do not bind setVoxel; index types return uint64 and ValueMask


### PR DESCRIPTION
## Summary

Third slice of the [NanoVDB Python bindings C++ API mirror plan](https://github.com/swahtz/openvdb/blob/phase2/nanovdb_python_buildt_coverage/nanovdb-python-plan.md) tracked in #2208. Phase 2 expands the bound `BuildT` list from the six surfaced in Phase 0/1 (`float`, `double`, `int32_t`, `Vec3f`, `Rgba8`, `Point`) to **17 additional types**, riding the Phase 0 X-macro so each addition is a single row in `BuildTypes.def` plus an automatically-generated polymorphic dispatch arm.

PR target: `feature/nanovdb_python` (the integration branch).

## New BuildTs

| Category | Adds | Class names | Accessor surface |
|---|---|---|---|
| **SCALAR** (+4) | `int16_t`, `int64_t`, `uint8_t`, `uint32_t` | `Int16Grid`, `Int64Grid`, `UInt8Grid`, `UInt32Grid` | full `*ReadAccessor` with `setVoxel` + `*NodeInfo` |
| **VECTOR** (+5) | `Vec3d`, `Vec4f`, `Vec4d`, `Vec3u8`, `Vec3u16` | `Vec3dGrid`, …, `Vec3u16Grid` | `*ReadAccessor` with `setVoxel` (no NodeInfo) |
| **READONLY** (new, +8) | `bool`, `Fp4`, `Fp8`, `Fp16`, `FpN`, `ValueIndex`, `ValueOnIndex`, `ValueMask` | `BooleanGrid`, `Fp4Grid` / `Fp8Grid` / `Fp16Grid` / `FpNGrid`, `IndexGrid`, `OnIndexGrid`, `MaskGrid` | bare `*ReadAccessor` — no `setVoxel`, no NodeInfo |

All 24 `GridType` enumerators except `GridType::Half` are now reachable from Python (see the Half note below).

## Mechanical changes

- `BuildTypes.def` gains a fourth category, `NANOVDB_PY_FOR_EACH_READONLY_BUILDT(T, Suffix, GridTypeEnum)`, alongside the existing SCALAR / VECTOR / POINT categories. The semantic is \"BuildT where `nanovdb::SetVoxel<T>`'s `static_assert(!is_special)` would fire\" — covers `bool`, the quantized `Fp*`, the index types `ValueIndex` / `ValueOnIndex`, and `ValueMask`. All four \"read-only\" semantically.

- `NanoVDBModule.cc` X-macro consumer gets one more arm that expands to `defineNanoGrid<T>(m, …) + defineAccessor<T>(m, …)` — the same shape as the existing POINT arm.

- Accessor value type now resolves through `nanovdb::BuildToValueMap<BuildT>::Type` rather than `DefaultReadAccessor<BuildT>::ValueType`. For ordinary types they're identical, but for `Fp*` it decodes to `float`, for `ValueIndex` / `OnIndex` to `uint64`, and for `ValueMask` / `bool` to `bool` — the bound `probeValue()` out-parameter and the Python-side return type both want the decoded form.

- Polymorphic dispatch in `pyHostGrid` / `pyDeviceGrid` (PyGridHandle.h, cuda/PyDeviceGridHandle.cu) gains a fourth arm covering all eight new `GridType` enumerators (`Boolean`, `Fp4`/`Fp8`/`Fp16`/`FpN`, `Index`, `OnIndex`, `Mask`). `handle.grid(n)` / `handle.deviceGrid(n)` now route to the new typed subclasses automatically.

## Why no Half

`nanovdb::Half` is intentionally **not** bound. The source declares it as `class Half{};` (an empty placeholder for IEEE 754 half-precision, see NanoVDB.h around line 180) and the C++ `ProbeValue<Half>` instantiation chain is internally inconsistent — leaf storage carries `Half` but `ProbeValue<Half>::ValueT` is `float`, so the template doesn't instantiate cleanly. When the upstream `Half` implementation lands this is a one-line addition via the same X-macro path. Comment in `BuildTypes.def` calls this out.

## Test plan

- [x] **CUDA sm_120 + BLOSC + ZLIB** (NVIDIA RTX PRO 6000 Blackwell, CUDA 13.2, libblosc 1.21.5, zlib 1.3): **57/57 pass**. With the optional codec libraries enabled the test suite is fully green — the "pre-existing BLOSC failure" called out in earlier phase PRs was a local-env miss, not a test bug.
- [x] **CPU only** (no CUDA, no OpenVDB, no BLOSC): 57 tests, 48 pass, 8 CUDA-skip, 1 environment-dependent BLOSC failure in `test_read_write_grid` (no codec linked; same pattern on master).
- [x] New `TestPhase2BuildTCoverage` class with 5 methods locks in: every new BuildT is registered as a Grid + ReadAccessor (and NodeInfo for scalars); each accessor surface matches its category (scalars have `setVoxel` + `getNodeInfo`; vectors have `setVoxel`; read-only have neither); all new typed grids inherit from the polymorphic `nanovdb.Grid` base.
- [x] All new lines ≤ 100 cols (codingstyle.txt).

### What this PR intentionally doesn't do

We can't host-construct `Int16Grid` / `Vec3dGrid` / `Fp4Grid` / `IndexGrid` / `MaskGrid` from Python yet because the corresponding `create*Grid` / `createNanoGrid<…>` factories for those BuildTs land in **Phase 5**. The dispatch surface is locked in — once Phase 5 adds factories, `handle.grid(n)` will already route correctly to the new typed subclasses without further binding changes.

### Not verified locally — still on the reviewer

- [ ] Windows build.
- [ ] OpenVDB-enabled build to confirm `openToNanoVDB` / `nanoToOpenVDB` still wire up through the broader BuildT list (they're templated on a fixed subset, so this should be a no-op, but worth verifying).
- [ ] End-to-end round-trip of a quantized / index / mask grid loaded from a `.nvdb` file containing one of these types — once a sample file lands.

Part of #2208.
