### PR TITLE
nanovdb python: Phase 3 — tree / nodes / NodeManager / leaf_values

### DIFF
--- a/nanovdb/nanovdb/python/CMakeLists.txt
+++ b/nanovdb/nanovdb/python/CMakeLists.txt
@@ -28,6 +28,7 @@ nanobind_add_module(nanovdb_python NB_STATIC
     PyPrimitives.cc
     PySampleFromVoxels.cc
     PyTools.cc
+    PyTree.cc
     cuda/PyDeviceBuffer.cc
     cuda/PyDeviceGridHandle.cu
     cuda/PyPointsToGrid.cu

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -252,9 +252,11 @@ void defineGrid(nb::module_& m)
             return -1;
         }, "semantic"_a)
         .def("getBlindData", &pyGetBlindData, "n"_a,
+             nb::keep_alive<0, 1>(),
              "Return a zero-copy NumPy view of the n-th blind data channel, "
              "or None if n is out of range. dtype and shape are derived from "
-             "the channel's mDataType / mValueCount.");
+             "the channel's mDataType / mValueCount. The view keeps the grid "
+             "alive (and therefore the GridHandle that owns the buffer).");
 }
 
 // BuildT-dependent slice of the typed grid Python class. Inherits the
@@ -446,7 +448,9 @@ template<typename AttT> void definePointAccessor(nb::module_& m, const char* nam
             uint64_t count = acc.gridPoints(begin, end);
             if (begin == nullptr || count == 0) return nb::none();
             return pyPointsToNdarray<AttT>(py_self, begin, count);
-        }, "Return all point attributes in the grid as a single NumPy view.")
+        }, nb::keep_alive<0, 1>(),
+           "Return all point attributes in the grid as a single NumPy view. "
+           "The view keeps this accessor alive.")
         .def("leafPoints", [](nb::handle py_self, const Coord& ijk) -> nb::object {
             auto& acc = nb::cast<PA&>(py_self);
             const AttT* begin = nullptr;
@@ -454,9 +458,10 @@ template<typename AttT> void definePointAccessor(nb::module_& m, const char* nam
             uint64_t count = acc.leafPoints(ijk, begin, end);
             if (begin == nullptr || count == 0) return nb::none();
             return pyPointsToNdarray<AttT>(py_self, begin, count);
-        }, "ijk"_a,
+        }, "ijk"_a, nb::keep_alive<0, 1>(),
            "Return the point attributes contained within the leaf node "
-           "covering ijk, or None if no leaf is present.")
+           "covering ijk, or None if no leaf is present. The view keeps "
+           "this accessor alive.")
         .def("voxelPoints", [](nb::handle py_self, const Coord& ijk) -> nb::object {
             auto& acc = nb::cast<PA&>(py_self);
             const AttT* begin = nullptr;
@@ -464,9 +469,10 @@ template<typename AttT> void definePointAccessor(nb::module_& m, const char* nam
             uint64_t count = acc.voxelPoints(ijk, begin, end);
             if (begin == nullptr || count == 0) return nb::none();
             return pyPointsToNdarray<AttT>(py_self, begin, count);
-        }, "ijk"_a,
+        }, "ijk"_a, nb::keep_alive<0, 1>(),
            "Return the point attributes at the specific voxel ijk, or None "
-           "if the voxel is inactive / empty.");
+           "if the voxel is inactive / empty. The view keeps this accessor "
+           "alive.");
 }
 
 // Type-erased grid introspector. Mirrors nanovdb::GridMetaData (768B) and

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -20,6 +20,7 @@
 #include "PyIO.h"
 #include "PyMath.h"
 #include "PyTools.h"
+#include "PyTree.h"
 #include "PyGridChecksum.h"
 
 namespace nb = nanobind;
@@ -261,10 +262,17 @@ void defineGrid(nb::module_& m)
 // need to know BuildT lives there, not here.
 template<typename BuildT> void defineNanoGrid(nb::module_& m, const char* name)
 {
-    nb::class_<NanoGrid<BuildT>, GridData>(m, name)
+    auto cls = nb::class_<NanoGrid<BuildT>, GridData>(m, name)
         .def("getAccessor", &NanoGrid<BuildT>::getAccessor)
         .def("activeVoxelCount", &NanoGrid<BuildT>::activeVoxelCount)
-        .def("isSequential", [](const NanoGrid<BuildT>& grid) { return grid.isSequential(); });
+        .def("isSequential", [](const NanoGrid<BuildT>& grid) { return grid.isSequential(); })
+        .def("tree",
+             nb::overload_cast<>(&NanoGrid<BuildT>::tree, nb::const_),
+             nb::rv_policy::reference_internal,
+             "Return the tree associated with this grid. Lifetime is "
+             "anchored to the grid (and therefore to the GridHandle).");
+    // Add leaf_values() only for BuildTs whose LeafData carries T mValues[512].
+    PyLeafValuesBinder<BuildT>::apply(cls);
 }
 
 void defineGridBlindData(nb::module_& m)
@@ -720,6 +728,43 @@ NB_MODULE(nanovdb, m)
     defineGrid(m);
     defineGridMetaData(m);
 
+    // Tree / node bindings must come BEFORE defineNanoGrid because
+    // NanoGrid<T>.tree() returns NanoTree<T> (registered here) by const
+    // reference. Per-BuildT, register Leaf, Lower, Upper, Root, Tree in
+    // child->parent order so each return type is registered before the
+    // method binding that returns it.
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum) \
+    defineNanoLeaf<T>(m,  #Suffix "Leaf");                         \
+    defineNanoLower<T>(m, #Suffix "Lower");                        \
+    defineNanoUpper<T>(m, #Suffix "Upper");                        \
+    defineNanoRoot<T>(m,  #Suffix "Root");                         \
+    defineNanoTree<T>(m,  #Suffix "Tree");                         \
+    defineNodeManager<T>(m, #Suffix "NodeManager");
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum) \
+    defineNanoLeaf<T>(m,  #Suffix "Leaf");                         \
+    defineNanoLower<T>(m, #Suffix "Lower");                        \
+    defineNanoUpper<T>(m, #Suffix "Upper");                        \
+    defineNanoRoot<T>(m,  #Suffix "Root");                         \
+    defineNanoTree<T>(m,  #Suffix "Tree");                         \
+    defineNodeManager<T>(m, #Suffix "NodeManager");
+#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum)  \
+    defineNanoLeaf<T>(m,  #Suffix "Leaf");                         \
+    defineNanoLower<T>(m, #Suffix "Lower");                        \
+    defineNanoUpper<T>(m, #Suffix "Upper");                        \
+    defineNanoRoot<T>(m,  #Suffix "Root");                         \
+    defineNanoTree<T>(m,  #Suffix "Tree");                         \
+    defineNodeManager<T>(m, #Suffix "NodeManager");
+#define NANOVDB_PY_FOR_EACH_READONLY_BUILDT(T, Suffix, GridTypeEnum) \
+    defineNanoLeaf<T>(m,  #Suffix "Leaf");                         \
+    defineNanoLower<T>(m, #Suffix "Lower");                        \
+    defineNanoUpper<T>(m, #Suffix "Upper");                        \
+    defineNanoRoot<T>(m,  #Suffix "Root");                         \
+    defineNanoTree<T>(m,  #Suffix "Tree");                         \
+    defineNodeManager<T>(m, #Suffix "NodeManager");
+#include "BuildTypes.def"
+
+    // Now bind the per-BuildT NanoGrid + accessors (tree() return type now
+    // registered above).
 #define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum) \
     defineNanoGrid<T>(m, #Suffix "Grid");                      \
     defineScalarAccessor<T>(m, #Suffix "ReadAccessor");        \
@@ -734,6 +779,10 @@ NB_MODULE(nanovdb, m)
     defineNanoGrid<T>(m, #Suffix "Grid");                      \
     defineAccessor<T>(m, #Suffix "ReadAccessor");
 #include "BuildTypes.def"
+
+    // Host-side NodeManagerHandle + module-scope createNodeManager.
+    defineNodeManagerHandle(m);
+    defineCreateNodeManager(m);
 
     // PointAccessor variants — PointIndex grids carry uint32 indices,
     // PointData grids carry Vec3f positions.

--- a/nanovdb/nanovdb/python/PyGridHandle.h
+++ b/nanovdb/nanovdb/python/PyGridHandle.h
@@ -137,8 +137,10 @@ template<typename BufferT> nb::class_<nanovdb::GridHandle<BufferT>> defineGridHa
              },
              "Return a deep copy of this GridHandle backed by a freshly-allocated buffer.")
         .def("grid", &pyHostGrid<BufferT>, nb::arg("n") = 0,
+             nb::keep_alive<0, 1>(),
              "Return the n-th grid as a typed Grid subclass selected by "
-             "gridType(n), or None if the BuildT is not bound in Python.")
+             "gridType(n), or None if the BuildT is not bound in Python. "
+             "The returned grid keeps this handle alive.")
         .def("isPadded", &nanovdb::GridHandle<BufferT>::isPadded)
         .def("gridCount", &nanovdb::GridHandle<BufferT>::gridCount)
         .def("gridSize", &nanovdb::GridHandle<BufferT>::gridSize, nb::arg("n") = 0)

--- a/nanovdb/nanovdb/python/PyTree.cc
+++ b/nanovdb/nanovdb/python/PyTree.cc
@@ -1,0 +1,111 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+#include "PyTree.h"
+
+#include <nanobind/stl/string.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace nanovdb;
+
+namespace pynanovdb {
+
+// Polymorphic mgr() that returns the right typed NodeManager based on the
+// handle's stored gridType. Dispatch follows the same X-macro pattern as
+// pyHostGrid / pyDeviceGrid; unbound BuildTs return None rather than the
+// generic getMgr<BuildT>() ptr that would be reinterpreted.
+template<typename BufferT>
+static nb::object pyNodeMgr(nb::handle py_self)
+{
+    using HandleT = NodeManagerHandle<BufferT>;
+    auto& handle = nb::cast<HandleT&>(py_self);
+    if (!handle.data()) return nb::none();
+    // We need to read the stored gridType, but it's private. The public
+    // mgr<BuildT>() returns NULL for type mismatch, so iterate by BuildT.
+    // The X-macro produces one case per bound BuildT; first non-null wins.
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)             \
+    if (auto* m = handle.template mgr<T>()) {                                  \
+        return nb::cast(m, nb::rv_policy::reference, py_self);                 \
+    }
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum) \
+    if (auto* m = handle.template mgr<T>()) {                                  \
+        return nb::cast(m, nb::rv_policy::reference, py_self);                 \
+    }
+#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum)              \
+    if (auto* m = handle.template mgr<T>()) {                                  \
+        return nb::cast(m, nb::rv_policy::reference, py_self);                 \
+    }
+#define NANOVDB_PY_FOR_EACH_READONLY_BUILDT(T, Suffix, GridTypeEnum)           \
+    if (auto* m = handle.template mgr<T>()) {                                  \
+        return nb::cast(m, nb::rv_policy::reference, py_self);                 \
+    }
+#include "BuildTypes.def"
+    return nb::none();
+}
+
+void defineNodeManagerHandle(nb::module_& m)
+{
+    using HandleT = NodeManagerHandle<HostBuffer>;
+    nb::class_<HandleT>(m, "NodeManagerHandle",
+        "Owns the memory backing a NodeManager. Move-only. "
+        "Obtain via nanovdb.createNodeManager(grid).")
+        .def("size",
+             [](const HandleT& h) { return h.size(); })
+        .def(
+            "__bool__",
+            [](const HandleT& h) { return h.data() != nullptr; },
+            nb::is_operator())
+        .def("mgr", &pyNodeMgr<HostBuffer>,
+             "Return the typed NodeManager for the grid this handle was "
+             "built from, or None if the BuildT is not Python-visible.");
+}
+
+// createNodeManager has one template instantiation per BuildT. We expose a
+// single polymorphic `createNodeManager(grid)` that picks the right one
+// based on the runtime type of `grid` (any nb::class_-bound NanoGrid<T>).
+template<typename BuildT>
+static nb::object tryCreateNodeManager(nb::handle py_grid)
+{
+    using GridT = NanoGrid<BuildT>;
+    GridT* grid = nullptr;
+    try {
+        grid = &nb::cast<GridT&>(py_grid);
+    } catch (const nb::cast_error&) {
+        return nb::object();  // sentinel: "not this BuildT, try next"
+    }
+    return nb::cast(createNodeManager<BuildT, HostBuffer>(*grid));
+}
+
+void defineCreateNodeManager(nb::module_& m)
+{
+    m.def("createNodeManager",
+        [](nb::handle py_grid) -> nb::object {
+            // Try every bound BuildT; first successful cast wins.
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)             \
+            if (auto obj = tryCreateNodeManager<T>(py_grid); obj.is_valid()) { \
+                return obj;                                                    \
+            }
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum) \
+            if (auto obj = tryCreateNodeManager<T>(py_grid); obj.is_valid()) { \
+                return obj;                                                    \
+            }
+#define NANOVDB_PY_FOR_EACH_POINT_BUILDT(T, Suffix, GridTypeEnum)              \
+            if (auto obj = tryCreateNodeManager<T>(py_grid); obj.is_valid()) { \
+                return obj;                                                    \
+            }
+#define NANOVDB_PY_FOR_EACH_READONLY_BUILDT(T, Suffix, GridTypeEnum)           \
+            if (auto obj = tryCreateNodeManager<T>(py_grid); obj.is_valid()) { \
+                return obj;                                                    \
+            }
+#include "BuildTypes.def"
+            throw nb::type_error(
+                "createNodeManager: argument is not a NanoVDB grid of any "
+                "bound BuildT");
+        },
+        "grid"_a,
+        "Build a NodeManager for the given grid, returning a "
+        "NodeManagerHandle that owns the underlying buffer. The handle's "
+        "mgr() method returns the typed NodeManager.");
+}
+
+} // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyTree.cc
+++ b/nanovdb/nanovdb/python/PyTree.cc
@@ -63,17 +63,18 @@ void defineNodeManagerHandle(nb::module_& m)
 // createNodeManager has one template instantiation per BuildT. We expose a
 // single polymorphic `createNodeManager(grid)` that picks the right one
 // based on the runtime type of `grid` (any nb::class_-bound NanoGrid<T>).
+// nb::isinstance is a fast type check that avoids the exception-on-mismatch
+// overhead that would come from trying nb::cast and catching cast_error for
+// every non-matching BuildT.
 template<typename BuildT>
 static nb::object tryCreateNodeManager(nb::handle py_grid)
 {
     using GridT = NanoGrid<BuildT>;
-    GridT* grid = nullptr;
-    try {
-        grid = &nb::cast<GridT&>(py_grid);
-    } catch (const nb::cast_error&) {
+    if (!nb::isinstance<GridT>(py_grid)) {
         return nb::object();  // sentinel: "not this BuildT, try next"
     }
-    return nb::cast(createNodeManager<BuildT, HostBuffer>(*grid));
+    auto& grid = nb::cast<GridT&>(py_grid);
+    return nb::cast(createNodeManager<BuildT, HostBuffer>(grid));
 }
 
 void defineCreateNodeManager(nb::module_& m)

--- a/nanovdb/nanovdb/python/PyTree.cc
+++ b/nanovdb/nanovdb/python/PyTree.cc
@@ -56,8 +56,10 @@ void defineNodeManagerHandle(nb::module_& m)
             [](const HandleT& h) { return h.data() != nullptr; },
             nb::is_operator())
         .def("mgr", &pyNodeMgr<HostBuffer>,
+             nb::keep_alive<0, 1>(),
              "Return the typed NodeManager for the grid this handle was "
-             "built from, or None if the BuildT is not Python-visible.");
+             "built from, or None if the BuildT is not Python-visible. The "
+             "returned NodeManager keeps this handle alive.");
 }
 
 // createNodeManager has one template instantiation per BuildT. We expose a
@@ -104,9 +106,14 @@ void defineCreateNodeManager(nb::module_& m)
                 "bound BuildT");
         },
         "grid"_a,
+        // The constructed NodeManager stores a raw pointer back to the
+        // grid; the handle must therefore keep the grid (and transitively
+        // the GridHandle that owns the grid's buffer) alive.
+        nb::keep_alive<0, 1>(),
         "Build a NodeManager for the given grid, returning a "
         "NodeManagerHandle that owns the underlying buffer. The handle's "
-        "mgr() method returns the typed NodeManager.");
+        "mgr() method returns the typed NodeManager. The handle keeps the "
+        "source grid alive for as long as it lives.");
 }
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyTree.h
+++ b/nanovdb/nanovdb/python/PyTree.h
@@ -205,8 +205,12 @@ template<typename BuildT> void defineNanoTree(nb::module_& m, const char* name)
         .def("activeVoxelCount", &TreeT::activeVoxelCount)
         .def("activeTileCount", &TreeT::activeTileCount,
              nb::rv_policy::reference_internal, nb::arg("level"))
+        // Use static_cast (not nb::overload_cast<int>) — Tree has a templated
+        // nodeCount<NodeT>() in addition to nodeCount(int), and Clang's
+        // overload-set check rejects nb::overload_cast for this combination
+        // even though GCC accepts it.
         .def("nodeCount",
-             nb::overload_cast<int>(&TreeT::nodeCount, nb::const_),
+             static_cast<uint32_t (TreeT::*)(int) const>(&TreeT::nodeCount),
              nb::arg("level"))
         .def("totalNodeCount", &TreeT::totalNodeCount)
         .def_static("memUsage", &TreeT::memUsage)

--- a/nanovdb/nanovdb/python/PyTree.h
+++ b/nanovdb/nanovdb/python/PyTree.h
@@ -43,10 +43,25 @@ template<typename BuildT> void defineNanoLeaf(nb::module_& m, const char* name)
             nb::overload_cast<const CoordT&>(&LeafT::isActive, nb::const_),
             nb::arg("ijk"))
        .def("isActive",
-            nb::overload_cast<uint32_t>(&LeafT::isActive, nb::const_),
+            [](const LeafT& leaf, uint32_t n) {
+                // Underlying mValueMask.isOn(n) is unchecked; release builds
+                // skip the C++ NANOVDB_ASSERT and would silently read OOB.
+                if (n >= LeafT::voxelCount()) {
+                    throw nb::index_error(
+                        "Leaf.isActive(n): n out of range [0, voxelCount)");
+                }
+                return leaf.isActive(n);
+            },
             nb::arg("n"))
        .def("getValue",
-            nb::overload_cast<uint32_t>(&LeafT::getValue, nb::const_),
+            [](const LeafT& leaf, uint32_t offset) {
+                // mValues[offset] is unchecked in C++; guard the Python side.
+                if (offset >= LeafT::voxelCount()) {
+                    throw nb::index_error(
+                        "Leaf.getValue(offset): offset out of range [0, voxelCount)");
+                }
+                return leaf.getValue(offset);
+            },
             nb::arg("offset"))
        .def("getValue",
             nb::overload_cast<const CoordT&>(&LeafT::getValue, nb::const_),
@@ -90,9 +105,10 @@ template<typename BuildT> void defineNanoLeaf(nb::module_& m, const char* name)
                         size_t(1), shape, py_self),
                     nb::rv_policy::reference);
             },
-            "Return a zero-copy NumPy view of the 512 leaf values. "
-            "Lifetime is anchored to the leaf (which is itself parented "
-            "to the GridHandle that owns the buffer).");
+            nb::keep_alive<0, 1>(),
+            "Return a zero-copy NumPy view of the 512 leaf values. The view "
+            "keeps the leaf (and transitively the GridHandle that owns the "
+            "underlying buffer) alive.");
     }
 }
 
@@ -203,14 +219,31 @@ template<typename BuildT> void defineNanoTree(nb::module_& m, const char* name)
              nb::rv_policy::reference_internal)
         .def("background", &TreeT::background, nb::rv_policy::reference_internal)
         .def("activeVoxelCount", &TreeT::activeVoxelCount)
-        .def("activeTileCount", &TreeT::activeTileCount,
-             nb::rv_policy::reference_internal, nb::arg("level"))
-        // Use static_cast (not nb::overload_cast<int>) — Tree has a templated
-        // nodeCount<NodeT>() in addition to nodeCount(int), and Clang's
-        // overload-set check rejects nb::overload_cast for this combination
-        // even though GCC accepts it.
+        // activeTileCount(level): valid range is 1..3 (lower / upper / root
+        // tile counts). C++ uses NANOVDB_ASSERT(level > 0 && level <= 3)
+        // which is a no-op in release builds — so guard explicitly.
+        .def("activeTileCount",
+             [](const TreeT& tree, uint32_t level) -> uint32_t {
+                 if (level < 1 || level > 3) {
+                     throw nb::value_error(
+                         "Tree.activeTileCount(level): level must be 1, 2, or 3");
+                 }
+                 return tree.activeTileCount(level);
+             },
+             nb::arg("level"))
+        // nodeCount(level): valid range is 0..2 (leaf / lower / upper).
+        // C++ uses NANOVDB_ASSERT(level < 3), again no-op in release.
+        // The lambda's `int level` argument disambiguates the call against
+        // Tree's templated nodeCount<NodeT>() overload at the C++ level,
+        // so we don't need an overload_cast / static_cast wrapper here.
         .def("nodeCount",
-             static_cast<uint32_t (TreeT::*)(int) const>(&TreeT::nodeCount),
+             [](const TreeT& tree, int level) -> uint32_t {
+                 if (level < 0 || level >= 3) {
+                     throw nb::value_error(
+                         "Tree.nodeCount(level): level must be 0, 1, or 2");
+                 }
+                 return tree.nodeCount(level);
+             },
              nb::arg("level"))
         .def("totalNodeCount", &TreeT::totalNodeCount)
         .def_static("memUsage", &TreeT::memUsage)
@@ -263,18 +296,48 @@ template<typename BuildT> void defineNodeManager(nb::module_& m, const char* nam
              nb::overload_cast<>(&NMT::isLinear, nb::const_))
         .def("memUsage",
              nb::overload_cast<>(&NMT::memUsage, nb::const_))
-        .def("nodeCount", &NMT::nodeCount, nb::arg("level"))
+        .def("nodeCount",
+             [](const NMT& nm, int level) -> uint64_t {
+                 // Mirror Tree.nodeCount bounds (NodeManager forwards to Tree).
+                 if (level < 0 || level >= 3) {
+                     throw nb::value_error(
+                         "NodeManager.nodeCount(level): level must be 0, 1, or 2");
+                 }
+                 return nm.nodeCount(level);
+             },
+             nb::arg("level"))
         .def("leafCount",  &NMT::leafCount)
         .def("lowerCount", &NMT::lowerCount)
         .def("upperCount", &NMT::upperCount)
+        // leaf / lower / upper: NANOVDB_ASSERT(i < nodeCount(LEVEL)) in C++ is
+        // no-op in release, so guard explicitly to convert OOB access into a
+        // Python IndexError instead of memory corruption.
         .def("leaf",
-             nb::overload_cast<uint32_t>(&NMT::leaf, nb::const_),
+             [](const NMT& nm, uint32_t i) -> const nanovdb::NanoLeaf<BuildT>& {
+                 if (i >= nm.leafCount()) {
+                     throw nb::index_error(
+                         "NodeManager.leaf(i): i out of range [0, leafCount)");
+                 }
+                 return nm.leaf(i);
+             },
              nb::rv_policy::reference_internal, nb::arg("i"))
         .def("lower",
-             nb::overload_cast<uint32_t>(&NMT::lower, nb::const_),
+             [](const NMT& nm, uint32_t i) -> const nanovdb::NanoLower<BuildT>& {
+                 if (i >= nm.lowerCount()) {
+                     throw nb::index_error(
+                         "NodeManager.lower(i): i out of range [0, lowerCount)");
+                 }
+                 return nm.lower(i);
+             },
              nb::rv_policy::reference_internal, nb::arg("i"))
         .def("upper",
-             nb::overload_cast<uint32_t>(&NMT::upper, nb::const_),
+             [](const NMT& nm, uint32_t i) -> const nanovdb::NanoUpper<BuildT>& {
+                 if (i >= nm.upperCount()) {
+                     throw nb::index_error(
+                         "NodeManager.upper(i): i out of range [0, upperCount)");
+                 }
+                 return nm.upper(i);
+             },
              nb::rv_policy::reference_internal, nb::arg("i"));
 }
 
@@ -336,11 +399,12 @@ struct PyLeafValuesBinder<BuildT,
                         size_t(2), shape, py_self, strides),
                     nb::rv_policy::reference);
             },
+            nb::keep_alive<0, 1>(),
             "Return a zero-copy (N_leaves, 512) NumPy view of every leaf's "
             "values, in breadth-first leaf order. Available only for "
             "BuildTs whose leaf layout carries T mValues[512] (i.e. not "
             "Fp*, Index, Mask, bool, or Point) and only on breadth-first "
-            "grids. Lifetime is anchored to the grid.");
+            "grids. The view keeps the grid alive.");
     }
 };
 

--- a/nanovdb/nanovdb/python/PyTree.h
+++ b/nanovdb/nanovdb/python/PyTree.h
@@ -1,0 +1,345 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+#ifndef NANOVDB_PYTREE_HAS_BEEN_INCLUDED
+#define NANOVDB_PYTREE_HAS_BEEN_INCLUDED
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/tuple.h>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/NodeManager.h>
+#include <nanovdb/HostBuffer.h>
+
+namespace nb = nanobind;
+
+namespace pynanovdb {
+
+// -------------------- NanoLeaf<BuildT> --------------------
+//
+// Binds the 8^3 leaf node. Methods that don't depend on whether the leaf
+// stores a contiguous T[512] array are bound unconditionally; the
+// zero-copy 512-element NumPy values() view is only bound when the leaf
+// layout actually carries T mValues[512] (the BuildTraits<T>::is_special
+// types use packed / index / mask layouts where a 512-element T view is
+// either impossible or misleading).
+template<typename BuildT> void defineNanoLeaf(nb::module_& m, const char* name)
+{
+    using LeafT = nanovdb::NanoLeaf<BuildT>;
+    using ValueT = typename LeafT::ValueType;
+    using CoordT = typename LeafT::CoordType;
+
+    auto cls = nb::class_<LeafT>(m, name,
+        "Leaf node — 8x8x8 voxels. Inherits stats and bbox from the same "
+        "leaf-data block bound across BuildTs.");
+
+    cls.def("origin",        &LeafT::origin)
+       .def("bbox",          &LeafT::bbox)
+       .def("hasBBox",       &LeafT::hasBBox)
+       .def_static("dim",    &LeafT::dim)
+       .def_static("voxelCount", &LeafT::voxelCount)
+       .def("memUsage",      &LeafT::memUsage)
+       .def("isActive",
+            nb::overload_cast<const CoordT&>(&LeafT::isActive, nb::const_),
+            nb::arg("ijk"))
+       .def("isActive",
+            nb::overload_cast<uint32_t>(&LeafT::isActive, nb::const_),
+            nb::arg("n"))
+       .def("getValue",
+            nb::overload_cast<uint32_t>(&LeafT::getValue, nb::const_),
+            nb::arg("offset"))
+       .def("getValue",
+            nb::overload_cast<const CoordT&>(&LeafT::getValue, nb::const_),
+            nb::arg("ijk"))
+       .def("getFirstValue", &LeafT::getFirstValue)
+       .def("getLastValue",  &LeafT::getLastValue)
+       .def("minimum",       &LeafT::minimum)
+       .def("maximum",       &LeafT::maximum)
+       .def("average",       &LeafT::average)
+       .def("stdDeviation",  &LeafT::stdDeviation)
+       // NOTE: variance() omitted — NanoVDB.h line 4388 uses unqualified
+       // Pow2() which fails ADL for non-float ValueTs (ValueIndex /
+       // ValueMask / etc.). Users can compute it as stdDeviation() ** 2.
+       .def("flags",         &LeafT::flags)
+       .def("valueMask",     &LeafT::valueMask, nb::rv_policy::reference_internal)
+       .def("probeValue",
+            [](const LeafT& leaf, const CoordT& ijk) {
+                ValueT v;
+                bool   on = leaf.probeValue(ijk, v);
+                return std::make_tuple(v, on);
+            },
+            nb::arg("ijk"));
+
+    // Zero-copy 512-element NumPy view of mValues. Only enabled for
+    // BuildTs whose ValueType is a primitive arithmetic type (float,
+    // double, int*). For Fp* / Index / Mask / bool / Point the leaf uses
+    // packed / mask / void layouts. For Vec3f / Vec3d / Vec4f / Vec4d /
+    // Vec3u8 / Vec3u16 / Rgba8 the leaf carries a struct array that
+    // nanobind's ndarray can't represent directly — those would need a
+    // flattened (count, dim) component-typed view which a follow-up can
+    // add. Users can still walk every leaf via the bound getValue().
+    if constexpr (std::is_arithmetic_v<ValueT>
+                  && !nanovdb::BuildTraits<BuildT>::is_special) {
+        cls.def("values",
+            [](nb::handle py_self) {
+                auto& leaf = nb::cast<LeafT&>(py_self);
+                size_t shape[1] = {LeafT::voxelCount()};
+                return nb::cast(
+                    nb::ndarray<nb::numpy, ValueT, nb::ndim<1>, nb::c_contig, nb::device::cpu>(
+                        static_cast<void*>(leaf.data()->mValues),
+                        size_t(1), shape, py_self),
+                    nb::rv_policy::reference);
+            },
+            "Return a zero-copy NumPy view of the 512 leaf values. "
+            "Lifetime is anchored to the leaf (which is itself parented "
+            "to the GridHandle that owns the buffer).");
+    }
+}
+
+// -------------------- NanoUpper / NanoLower<BuildT> --------------------
+//
+// Both internal node levels share the same C++ API surface (just different
+// LOG2DIM). One helper templated on the concrete InternalNode type.
+template<typename InternalT>
+void defineInternalNodeBase(nb::class_<InternalT>& cls)
+{
+    using ValueT = typename InternalT::ValueType;
+    using CoordT = typename InternalT::CoordType;
+    cls.def("origin",       &InternalT::origin)
+       .def("bbox",         &InternalT::bbox)
+       .def_static("dim",   &InternalT::dim)
+       .def_static("memUsage", []() { return InternalT::memUsage(); })
+       .def("minimum",      &InternalT::minimum)
+       .def("maximum",      &InternalT::maximum)
+       .def("average",      &InternalT::average)
+       .def("stdDeviation", &InternalT::stdDeviation)
+       // variance() omitted for parity with the leaf binding; compute as
+       // stdDeviation() ** 2 in Python.
+       .def("valueMask",    &InternalT::valueMask, nb::rv_policy::reference_internal)
+       .def("childMask",    &InternalT::childMask, nb::rv_policy::reference_internal)
+       .def("getValue",
+            nb::overload_cast<const CoordT&>(&InternalT::getValue, nb::const_),
+            nb::arg("ijk"))
+       .def("getFirstValue", &InternalT::getFirstValue)
+       .def("getLastValue",  &InternalT::getLastValue)
+       .def("isActive",
+            nb::overload_cast<const CoordT&>(&InternalT::isActive, nb::const_),
+            nb::arg("ijk"))
+       .def("probeValue",
+            [](const InternalT& node, const CoordT& ijk) {
+                ValueT v;
+                bool   on = node.probeValue(ijk, v);
+                return std::make_tuple(v, on);
+            },
+            nb::arg("ijk"));
+}
+
+template<typename BuildT> void defineNanoUpper(nb::module_& m, const char* name)
+{
+    using UpperT = nanovdb::NanoUpper<BuildT>;
+    nb::class_<UpperT> cls(m, name,
+        "Upper internal node — 32x32x32 (covers a 4096^3 region in index space).");
+    defineInternalNodeBase(cls);
+}
+
+template<typename BuildT> void defineNanoLower(nb::module_& m, const char* name)
+{
+    using LowerT = nanovdb::NanoLower<BuildT>;
+    nb::class_<LowerT> cls(m, name,
+        "Lower internal node — 16x16x16 (covers a 128^3 region in index space).");
+    defineInternalNodeBase(cls);
+}
+
+// -------------------- NanoRoot<BuildT> --------------------
+template<typename BuildT> void defineNanoRoot(nb::module_& m, const char* name)
+{
+    using RootT = nanovdb::NanoRoot<BuildT>;
+    using ValueT = typename RootT::ValueType;
+    using CoordT = typename RootT::CoordType;
+
+    nb::class_<RootT>(m, name, "Root node — top of the tree, holds the tile table.")
+        .def("background",    &RootT::background, nb::rv_policy::reference_internal)
+        .def("tileCount",     &RootT::tileCount)
+        .def("getTableSize",  &RootT::getTableSize)
+        .def("isEmpty",       &RootT::isEmpty)
+        .def("bbox",          &RootT::bbox, nb::rv_policy::reference_internal)
+        .def("minimum",       &RootT::minimum, nb::rv_policy::reference_internal)
+        .def("maximum",       &RootT::maximum, nb::rv_policy::reference_internal)
+        .def("average",       &RootT::average, nb::rv_policy::reference_internal)
+        .def("stdDeviation",  &RootT::stdDeviation, nb::rv_policy::reference_internal)
+        .def("memUsage",
+             nb::overload_cast<>(&RootT::memUsage, nb::const_))
+        .def("getValue",
+             nb::overload_cast<const CoordT&>(&RootT::getValue, nb::const_),
+             nb::arg("ijk"))
+        .def("isActive",
+             nb::overload_cast<const CoordT&>(&RootT::isActive, nb::const_),
+             nb::arg("ijk"))
+        .def("probeValue",
+             [](const RootT& root, const CoordT& ijk) {
+                 ValueT v;
+                 bool   on = root.probeValue(ijk, v);
+                 return std::make_tuple(v, on);
+             },
+             nb::arg("ijk"));
+}
+
+// -------------------- NanoTree<BuildT> --------------------
+template<typename BuildT> void defineNanoTree(nb::module_& m, const char* name)
+{
+    using TreeT = nanovdb::NanoTree<BuildT>;
+    using ValueT = typename TreeT::ValueType;
+    using CoordT = typename TreeT::CoordType;
+    using RootT = typename TreeT::RootType;
+    using UpperT = typename TreeT::UpperNodeType;
+    using LowerT = typename TreeT::LowerNodeType;
+    using LeafT = typename TreeT::LeafNodeType;
+
+    nb::class_<TreeT>(m, name,
+        "Tree — owns the root and provides bulk metadata queries "
+        "(node counts, active voxel count, extrema).")
+        .def("root",
+             nb::overload_cast<>(&TreeT::root, nb::const_),
+             nb::rv_policy::reference_internal)
+        .def("background", &TreeT::background, nb::rv_policy::reference_internal)
+        .def("activeVoxelCount", &TreeT::activeVoxelCount)
+        .def("activeTileCount", &TreeT::activeTileCount,
+             nb::rv_policy::reference_internal, nb::arg("level"))
+        .def("nodeCount",
+             nb::overload_cast<int>(&TreeT::nodeCount, nb::const_),
+             nb::arg("level"))
+        .def("totalNodeCount", &TreeT::totalNodeCount)
+        .def_static("memUsage", &TreeT::memUsage)
+        .def("getValue",
+             nb::overload_cast<const CoordT&>(&TreeT::getValue, nb::const_),
+             nb::arg("ijk"))
+        .def("isActive", &TreeT::isActive, nb::arg("ijk"))
+        .def("probeValue",
+             [](const TreeT& tree, const CoordT& ijk) {
+                 ValueT v;
+                 bool   on = tree.probeValue(ijk, v);
+                 return std::make_tuple(v, on);
+             },
+             nb::arg("ijk"))
+        .def("extrema",
+             [](const TreeT& tree) {
+                 ValueT mn, mx;
+                 tree.extrema(mn, mx);
+                 return std::make_tuple(mn, mx);
+             },
+             "Return (min, max) of the active values over the whole tree.")
+        .def("getFirstLeaf",
+             nb::overload_cast<>(&TreeT::getFirstLeaf, nb::const_),
+             nb::rv_policy::reference_internal,
+             "First leaf node in breadth-first order, or None if the tree is empty.")
+        .def("getFirstLower",
+             nb::overload_cast<>(&TreeT::getFirstLower, nb::const_),
+             nb::rv_policy::reference_internal)
+        .def("getFirstUpper",
+             nb::overload_cast<>(&TreeT::getFirstUpper, nb::const_),
+             nb::rv_policy::reference_internal);
+}
+
+// -------------------- NodeManager<BuildT> --------------------
+//
+// NodeManager is heap-managed by a NodeManagerHandle (move-only, owns the
+// underlying memory). We bind one NodeManager class per BuildT and one
+// host-side NodeManagerHandle class. Users get a handle from
+// nanovdb.createNodeManager(grid); they then call handle.mgr() to obtain a
+// borrowed pointer to the typed NodeManager — its lifetime is anchored to
+// the handle via reference_internal.
+template<typename BuildT> void defineNodeManager(nb::module_& m, const char* name)
+{
+    using NMT = nanovdb::NodeManager<BuildT>;
+    nb::class_<NMT>(m, name,
+        "Sequential breadth-first accessor for the leaf / lower / upper "
+        "internal nodes of a NanoGrid. Construct via "
+        "nanovdb.createNodeManager(grid).")
+        .def("isLinear",
+             nb::overload_cast<>(&NMT::isLinear, nb::const_))
+        .def("memUsage",
+             nb::overload_cast<>(&NMT::memUsage, nb::const_))
+        .def("nodeCount", &NMT::nodeCount, nb::arg("level"))
+        .def("leafCount",  &NMT::leafCount)
+        .def("lowerCount", &NMT::lowerCount)
+        .def("upperCount", &NMT::upperCount)
+        .def("leaf",
+             nb::overload_cast<uint32_t>(&NMT::leaf, nb::const_),
+             nb::rv_policy::reference_internal, nb::arg("i"))
+        .def("lower",
+             nb::overload_cast<uint32_t>(&NMT::lower, nb::const_),
+             nb::rv_policy::reference_internal, nb::arg("i"))
+        .def("upper",
+             nb::overload_cast<uint32_t>(&NMT::upper, nb::const_),
+             nb::rv_policy::reference_internal, nb::arg("i"));
+}
+
+void defineNodeManagerHandle(nb::module_& m);
+void defineCreateNodeManager(nb::module_& m);
+
+// -------------------- grid.leaf_values() bulk extractor --------------------
+//
+// For non-special BuildTs with breadth-first, fixed-size leaves, the leaf
+// values can be reached as a contiguous (N_leaves, 512) array — every leaf
+// occupies sizeof(NanoLeaf<T>) bytes and mValues starts at a known offset
+// inside each leaf. We bind this on NanoGrid<T> as leaf_values() for
+// efficient bulk analytics from Python.
+template<typename BuildT, typename = void>
+struct PyLeafValuesBinder
+{
+    template<typename ClsT> static void apply(ClsT&) {}
+};
+
+template<typename BuildT>
+struct PyLeafValuesBinder<BuildT,
+    typename std::enable_if<
+        std::is_arithmetic_v<typename nanovdb::NanoLeaf<BuildT>::ValueType>
+        && !nanovdb::BuildTraits<BuildT>::is_special>::type>
+{
+    template<typename ClsT>
+    static void apply(ClsT& cls)
+    {
+        using GridT = nanovdb::NanoGrid<BuildT>;
+        using LeafT = nanovdb::NanoLeaf<BuildT>;
+        using ValueT = typename LeafT::ValueType;
+        cls.def("leaf_values",
+            [](nb::handle py_self) -> nb::object {
+                auto& grid = nb::cast<GridT&>(py_self);
+                const auto& tree = grid.tree();
+                const uint32_t nLeaves = tree.template nodeCount<LeafT>();
+                if (nLeaves == 0) return nb::none();
+                if (!grid.isBreadthFirst()) {
+                    throw nb::value_error(
+                        "leaf_values() requires a breadth-first grid layout; "
+                        "rebuild via tools::createNanoGrid(...).");
+                }
+                LeafT* first = const_cast<LeafT*>(tree.getFirstLeaf());
+                if (first == nullptr) return nb::none();
+                // The leaves are laid out contiguously in memory in
+                // breadth-first order. Each leaf is sizeof(LeafT) bytes; the
+                // mValues array is the inline 512-element block, but the
+                // surrounding leaf header means the stride between values
+                // of two consecutive leaves is sizeof(LeafT), not
+                // sizeof(ValueT)*512. So return a strided ndarray.
+                size_t  shape[2]   = {nLeaves, LeafT::voxelCount()};
+                int64_t strides[2] = {
+                    static_cast<int64_t>(sizeof(LeafT) / sizeof(ValueT)),
+                    1
+                };
+                return nb::cast(
+                    nb::ndarray<nb::numpy, ValueT, nb::ndim<2>, nb::device::cpu>(
+                        static_cast<void*>(first->data()->mValues),
+                        size_t(2), shape, py_self, strides),
+                    nb::rv_policy::reference);
+            },
+            "Return a zero-copy (N_leaves, 512) NumPy view of every leaf's "
+            "values, in breadth-first leaf order. Available only for "
+            "BuildTs whose leaf layout carries T mValues[512] (i.e. not "
+            "Fp*, Index, Mask, bool, or Point) and only on breadth-first "
+            "grids. Lifetime is anchored to the grid.");
+    }
+};
+
+} // namespace pynanovdb
+
+#endif

--- a/nanovdb/nanovdb/python/PyTree.h
+++ b/nanovdb/nanovdb/python/PyTree.h
@@ -11,6 +11,8 @@
 #include <nanovdb/NodeManager.h>
 #include <nanovdb/HostBuffer.h>
 
+#include <type_traits>  // std::is_arithmetic_v, std::enable_if
+
 namespace nb = nanobind;
 
 namespace pynanovdb {
@@ -374,29 +376,31 @@ struct PyLeafValuesBinder<BuildT,
                 auto& grid = nb::cast<GridT&>(py_self);
                 const auto& tree = grid.tree();
                 const uint32_t nLeaves = tree.template nodeCount<LeafT>();
-                if (nLeaves == 0) return nb::none();
                 if (!grid.isBreadthFirst()) {
                     throw nb::value_error(
-                        "leaf_values() requires a breadth-first grid layout; "
-                        "rebuild via tools::createNanoGrid(...).");
+                        "leaf_values() requires a breadth-first grid "
+                        "layout; rebuild via "
+                        "nanovdb.tools.createNanoGrid(...).");
                 }
+                // For an empty grid (no leaves) we still return an ndarray
+                // — shape (0, 512) — so callers can iterate / np.asarray()
+                // / shape-test without branching on a None sentinel.
                 LeafT* first = const_cast<LeafT*>(tree.getFirstLeaf());
-                if (first == nullptr) return nb::none();
-                // The leaves are laid out contiguously in memory in
-                // breadth-first order. Each leaf is sizeof(LeafT) bytes; the
-                // mValues array is the inline 512-element block, but the
-                // surrounding leaf header means the stride between values
-                // of two consecutive leaves is sizeof(LeafT), not
-                // sizeof(ValueT)*512. So return a strided ndarray.
                 size_t  shape[2]   = {nLeaves, LeafT::voxelCount()};
                 int64_t strides[2] = {
                     static_cast<int64_t>(sizeof(LeafT) / sizeof(ValueT)),
                     1
                 };
+                // first is non-null whenever nLeaves > 0; when nLeaves == 0
+                // we pass a dummy non-null aligned pointer (the grid itself)
+                // so nanobind has something to base the empty array on.
+                // Nothing will be read since the leading shape is 0.
+                void* data = (first != nullptr)
+                    ? static_cast<void*>(first->data()->mValues)
+                    : static_cast<void*>(&grid);
                 return nb::cast(
                     nb::ndarray<nb::numpy, ValueT, nb::ndim<2>, nb::device::cpu>(
-                        static_cast<void*>(first->data()->mValues),
-                        size_t(2), shape, py_self, strides),
+                        data, size_t(2), shape, py_self, strides),
                     nb::rv_policy::reference);
             },
             nb::keep_alive<0, 1>(),
@@ -404,7 +408,8 @@ struct PyLeafValuesBinder<BuildT,
             "values, in breadth-first leaf order. Available only for "
             "BuildTs whose leaf layout carries T mValues[512] (i.e. not "
             "Fp*, Index, Mask, bool, or Point) and only on breadth-first "
-            "grids. The view keeps the grid alive.");
+            "grids. Returns an empty (0, 512) array for grids with no "
+            "leaves. The view keeps the grid alive.");
     }
 };
 

--- a/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
+++ b/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
@@ -72,9 +72,11 @@ void defineDeviceGridHandle(nb::module_& m)
             "cpu_t"_a.noconvert(),
             "cuda_t"_a.noconvert())
         .def("deviceGrid", &pyDeviceGrid, "n"_a = 0,
+             nb::keep_alive<0, 1>(),
              "Return the n-th device-resident grid as a typed Grid subclass "
              "selected by gridType(n), or None if the BuildT is not bound in "
-             "Python or the device copy has not been uploaded yet.")
+             "Python or the device copy has not been uploaded yet. The "
+             "returned grid keeps this handle alive.")
         .def(
             "deviceUpload", [](GridHandle<BufferT>& handle, bool sync) { handle.deviceUpload(nullptr, sync); }, "sync"_a = true)
         .def(

--- a/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
+++ b/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
@@ -84,10 +84,9 @@ void defineDeviceGridHandle(nb::module_& m)
     // second overload taking a DeviceGridHandle list conflicts with the host
     // overload because both signatures take nb::list, and nanobind's
     // overload resolution can't disambiguate by element type — it picks one
-    // and the inner cast fails with std::bad_cast. The host-only utilities
-    // are what the Phase 1 plan calls for; a properly typed device variant
-    // (with its own name, or with strongly-typed std::vector<HandleT> args
-    // and nanobind/stl/vector.h support) can land later if it's needed.
+    // and the inner cast fails with std::bad_cast. A properly typed device
+    // variant (with its own name, or strongly-typed std::vector<HandleT>
+    // args via nanobind/stl/vector.h) can land later if it's needed.
 }
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -536,6 +536,105 @@ class TestPhase2BuildTCoverage(unittest.TestCase):
                              f"{suffix}ReadAccessor should not have getNodeInfo")
 
 
+class TestPhase3TreeNodes(unittest.TestCase):
+    """Phase 3: Grid.tree(), Root/Upper/Lower/Leaf node walking, leaf values
+    zero-copy views, NodeManager + createNodeManager.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.h = nanovdb.tools.createFogVolumeSphere(name="probe")
+        cls.g = cls.h.grid()
+        cls.tree = cls.g.tree()
+
+    def test_grid_tree_basic(self):
+        self.assertIsInstance(self.tree, nanovdb.FloatTree)
+        self.assertEqual(self.tree.background(), 3.0)  # halfwidth*voxelsize default
+        self.assertGreater(self.tree.activeVoxelCount(), 0)
+        self.assertGreaterEqual(self.tree.totalNodeCount(), self.tree.nodeCount(0))
+
+    def test_extrema(self):
+        mn, mx = self.tree.extrema()
+        # FogVolumeSphere produces values in [0, 1].
+        self.assertGreaterEqual(mn, 0.0)
+        self.assertLessEqual(mx, 1.0)
+        self.assertLessEqual(mn, mx)
+
+    def test_first_leaf_and_node_metadata(self):
+        leaf = self.tree.getFirstLeaf()
+        self.assertIsInstance(leaf, nanovdb.FloatLeaf)
+        self.assertEqual(nanovdb.FloatLeaf.dim(), 8)
+        self.assertEqual(nanovdb.FloatLeaf.voxelCount(), 512)
+        # Origin should be aligned to LeafNode dim=8.
+        for c in (leaf.origin().x, leaf.origin().y, leaf.origin().z):
+            self.assertEqual(c % 8, 0)
+
+    def test_root_metadata(self):
+        root = self.tree.root()
+        self.assertIsInstance(root, nanovdb.FloatRoot)
+        self.assertGreater(root.tileCount(), 0)
+        # Root bbox covers ALL active voxels — non-empty for a fog sphere.
+        bb = root.bbox()
+        self.assertFalse(bb.empty())
+        self.assertEqual(root.background(), self.tree.background())
+
+    def test_leaf_values_zero_copy(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not installed")
+        leaf = self.tree.getFirstLeaf()
+        vals = leaf.values()
+        self.assertEqual(vals.shape, (512,))
+        self.assertEqual(vals.dtype, np.float32)
+        # Mutation through the view writes back into the grid buffer.
+        original = float(vals[0])
+        vals[0] = original + 1.0
+        self.assertAlmostEqual(float(leaf.getValue(0)), original + 1.0)
+        vals[0] = original  # restore
+
+    def test_leaf_values_unavailable_for_special_buildts(self):
+        # ValueIndex / ValueMask / bool / Fp* leaves don't carry T mValues[512],
+        # so the `values` accessor is not bound for them.
+        for cls_name in ("BooleanLeaf", "Fp4Leaf", "IndexLeaf", "MaskLeaf"):
+            leaf_cls = getattr(nanovdb, cls_name)
+            self.assertFalse(hasattr(leaf_cls, "values"),
+                             f"{cls_name}.values should not be bound")
+
+    def test_bulk_leaf_values(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not installed")
+        bulk = self.g.leaf_values()
+        self.assertEqual(bulk.shape, (self.tree.nodeCount(0), 512))
+        self.assertEqual(bulk.dtype, np.float32)
+        # First row should match per-leaf values().
+        first_via_bulk = np.asarray(bulk[0])
+        first_via_leaf = np.asarray(self.tree.getFirstLeaf().values())
+        self.assertTrue(np.array_equal(first_via_bulk, first_via_leaf))
+
+    def test_node_manager_round_trip(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not installed")
+        handle = nanovdb.createNodeManager(self.g)
+        self.assertGreater(handle.size(), 0)
+        self.assertTrue(bool(handle))
+        nm = handle.mgr()
+        self.assertIsInstance(nm, nanovdb.FloatNodeManager)
+        self.assertTrue(nm.isLinear())  # createNanoGrid produces breadth-first
+        self.assertEqual(nm.leafCount(), self.tree.nodeCount(0))
+        self.assertEqual(nm.lowerCount(), self.tree.nodeCount(1))
+        self.assertEqual(nm.upperCount(), self.tree.nodeCount(2))
+        # NodeManager.leaf(0) should be the same leaf as tree.getFirstLeaf()
+        # (breadth-first order).
+        self.assertEqual(nm.leaf(0).origin(), self.tree.getFirstLeaf().origin())
+        self.assertTrue(np.array_equal(
+            nm.leaf(0).values(), self.tree.getFirstLeaf().values()))
+
+
 class TestGridMetaDataGuards(unittest.TestCase):
     """Copilot review #3: GridMetaData ctor + safeCast guard against bad input."""
 

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -348,7 +348,9 @@ class TestGridHandleExchange(unittest.TestCase):
 
 
 class TestPolymorphicGridAccess(unittest.TestCase):
-    """Phase 1a: handle.grid(n) returns the correct typed Grid subclass."""
+    """handle.grid(n) returns the correct typed Grid subclass selected by
+    gridType(n); the legacy per-type accessors (floatGrid(), etc.) are not
+    bound."""
 
     def test_float_grid(self):
         h = nanovdb.tools.createFogVolumeSphere()
@@ -368,8 +370,8 @@ class TestPolymorphicGridAccess(unittest.TestCase):
         self.assertIsNone(nanovdb.GridHandle().grid())
 
     def test_typed_accessors_removed(self):
+        # The legacy per-type accessors were replaced by handle.grid(n).
         h = nanovdb.tools.createFogVolumeSphere()
-        # Phase 1a.3 removed these in favour of handle.grid(n).
         self.assertFalse(hasattr(h, "floatGrid"))
         self.assertFalse(hasattr(h, "doubleGrid"))
         self.assertFalse(hasattr(h, "int32Grid"))
@@ -378,7 +380,9 @@ class TestPolymorphicGridAccess(unittest.TestCase):
 
 
 class TestGridBase(unittest.TestCase):
-    """Phase 1a.1: BuildT-independent methods resolve via the Grid base class."""
+    """Methods that don't depend on BuildT (gridType, gridClass, voxelSize,
+    isLevelSet/...) resolve via the Grid base class shared by every typed
+    grid subclass."""
 
     def test_grid_base_class_name(self):
         # Typed grids inherit from a base class named "Grid" (no more "GridData").
@@ -399,7 +403,9 @@ class TestGridBase(unittest.TestCase):
 
 
 class TestGridMetaData(unittest.TestCase):
-    """Phase 1b.1: type-erased GridMetaData introspector."""
+    """nanovdb.GridMetaData is a type-erased introspector — construct from a
+    Grid and query gridType/gridClass/voxelSize/etc. without knowing
+    BuildT."""
 
     def test_constructed_from_grid(self):
         h = nanovdb.tools.createFogVolumeSphere(name="probe")
@@ -415,7 +421,9 @@ class TestGridMetaData(unittest.TestCase):
 
 
 class TestBlindDataEmpty(unittest.TestCase):
-    """Phase 1b.2: blind data API works on grids that have none."""
+    """Blind data API (blindDataCount, blindMetaData, findBlindData,
+    findBlindDataForSemantic, getBlindData) returns sensible None/-1
+    sentinels on grids that have no blind data channels."""
 
     def test_no_blind_data(self):
         h = nanovdb.tools.createFogVolumeSphere()
@@ -431,7 +439,9 @@ class TestBlindDataEmpty(unittest.TestCase):
 
 
 class TestSplitMergeCopy(unittest.TestCase):
-    """Phase 1c.2: splitGrids / mergeGrids / handle.copy()."""
+    """splitGrids(h) -> list of single-grid handles, mergeGrids([h1, h2])
+    -> combined handle, h.copy() -> deep buffer copy. mergeGrids must not
+    consume its input handles."""
 
     def test_split_and_merge_roundtrip(self):
         h1 = nanovdb.tools.createFogVolumeSphere(name="a")
@@ -444,10 +454,10 @@ class TestSplitMergeCopy(unittest.TestCase):
             self.assertEqual(s.gridCount(), 1)
 
     def test_merge_does_not_consume_inputs(self):
-        # Regression: original Phase 1 mergeGrids used nb::cast<HandleT&&>
-        # which moved the underlying C++ handle out of the Python wrapper,
-        # silently emptying h1/h2. The fixed version reads each handle by
-        # const reference.
+        # Regression: a previous mergeGrids implementation used
+        # nb::cast<HandleT&&> which moved the underlying C++ handle out of
+        # the Python wrapper, silently emptying h1/h2 after the call. The
+        # binding now reads each handle by const reference.
         h1 = nanovdb.tools.createFogVolumeSphere(name="a")
         h2 = nanovdb.tools.createLevelSetTorus(nanovdb.GridType.Float, name="b")
         sz1, sz2 = h1.size(), h2.size()
@@ -472,12 +482,12 @@ class TestSplitMergeCopy(unittest.TestCase):
         self.assertEqual(cp.grid().gridName(), "orig")
 
 
-class TestPhase2BuildTCoverage(unittest.TestCase):
-    """Phase 2: every additional BuildT registers a Grid + ReadAccessor (and
-    NodeInfo where applicable). We can't host-construct most of these (the
-    primitives that produce them land in Phase 5), but we can confirm
-    registration completed and the accessor surfaces match the type kind.
-    """
+class TestBuildTRegistrations(unittest.TestCase):
+    """Every BuildT we bind exposes the right shape — a Grid class, a
+    ReadAccessor, and (for arithmetic-valued scalars) a NodeInfo. Accessor
+    surface depends on the type kind: scalar accessors have setVoxel +
+    getNodeInfo; vector accessors have setVoxel only; read-only accessors
+    (Boolean, Fp*, Index, OnIndex, Mask) have neither."""
 
     SCALARS = ["Int16", "Int64", "UInt8", "UInt32"]
     VECTORS = ["Vec3d", "Vec4f", "Vec4d", "Vec3u8", "Vec3u16"]
@@ -506,8 +516,10 @@ class TestPhase2BuildTCoverage(unittest.TestCase):
                                  f"{suffix}NodeInfo missing")
 
     def test_vector_accessors_have_setvoxel_no_nodeinfo(self):
-        # Vector accessor names are aligned in Phase 2 (Vec3dReadAccessor,
-        # ...). The legacy Vec3f one is still Vec3fReadVectorAccessor.
+        # The newer vector accessor names follow the consistent
+        # <Suffix>ReadAccessor pattern (Vec3dReadAccessor, ...); the
+        # original Vec3f one is named Vec3fReadVectorAccessor for backwards
+        # compatibility.
         for suffix in self.VECTORS:
             acc = getattr(nanovdb, suffix + "ReadAccessor")
             self.assertTrue(hasattr(acc, "setVoxel"))
@@ -516,7 +528,8 @@ class TestPhase2BuildTCoverage(unittest.TestCase):
     def test_all_grid_type_enums_reachable(self):
         # GridType enum binding must cover every BuildT we register —
         # otherwise Python users can't compare against handle.gridType(n).
-        # UInt8 was missed in Phase 0; this test locks the fix in.
+        # Locks in the full set; missing entries (e.g. an unbound enumerator
+        # for a freshly-added BuildT) get caught here.
         for name in ["Float", "Double", "Int16", "Int32", "Int64", "UInt8",
                      "UInt32", "Boolean", "Half", "RGBA8", "Vec3f", "Vec3d",
                      "Vec4f", "Vec4d", "Vec3u8", "Vec3u16", "Mask", "Fp4",
@@ -525,9 +538,9 @@ class TestPhase2BuildTCoverage(unittest.TestCase):
                             f"nanovdb.GridType.{name} not bound")
 
     def test_readonly_accessors_have_neither_setvoxel_nor_nodeinfo(self):
-        # The plan calls out: quantized types decode to float on read but
-        # do not bind setVoxel; index types return uint64 and ValueMask
-        # exposes only active-state queries.
+        # Quantized types decode to float on read but don't bind setVoxel;
+        # index types return uint64; ValueMask exposes only active-state
+        # queries. All share a bare ReadAccessor.
         for suffix in self.READONLY:
             acc = getattr(nanovdb, suffix + "ReadAccessor")
             self.assertFalse(hasattr(acc, "setVoxel"),
@@ -536,10 +549,10 @@ class TestPhase2BuildTCoverage(unittest.TestCase):
                              f"{suffix}ReadAccessor should not have getNodeInfo")
 
 
-class TestPhase3TreeNodes(unittest.TestCase):
-    """Phase 3: Grid.tree(), Root/Upper/Lower/Leaf node walking, leaf values
-    zero-copy views, NodeManager + createNodeManager.
-    """
+class TestTreeNodeWalking(unittest.TestCase):
+    """Walk a grid's tree from Python: Grid.tree(), Root/Upper/Lower/Leaf
+    node access and metadata, per-leaf zero-copy values() and bulk
+    grid.leaf_values() NumPy views, NodeManager + createNodeManager."""
 
     @classmethod
     def setUpClass(cls):
@@ -636,7 +649,9 @@ class TestPhase3TreeNodes(unittest.TestCase):
 
 
 class TestGridMetaDataGuards(unittest.TestCase):
-    """Copilot review #3: GridMetaData ctor + safeCast guard against bad input."""
+    """GridMetaData() constructor and safeCast() reject bad input (None, a
+    Grid wrapping an invalid buffer) with a Python exception or False
+    rather than asserting / null-dereferencing inside NanoVDB."""
 
     def test_init_rejects_none(self):
         # nanobind's type system rejects None for const GridData* before our

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -648,6 +648,115 @@ class TestTreeNodeWalking(unittest.TestCase):
             nm.leaf(0).values(), self.tree.getFirstLeaf().values()))
 
 
+class TestBoundsChecks(unittest.TestCase):
+    """Out-of-range indices on Leaf / Tree / NodeManager raise Python
+    exceptions rather than falling through into raw memory access. The
+    underlying C++ uses NANOVDB_ASSERT which is a no-op in release builds,
+    so the Python layer guards every entry point that takes a level or
+    index argument.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.h = nanovdb.tools.createFogVolumeSphere()
+        cls.g = cls.h.grid()
+        cls.tree = cls.g.tree()
+        cls.leaf = cls.tree.getFirstLeaf()
+        cls.nm_handle = nanovdb.createNodeManager(cls.g)
+        cls.nm = cls.nm_handle.mgr()
+
+    def test_leaf_offset_bounds(self):
+        n = nanovdb.FloatLeaf.voxelCount()
+        with self.assertRaises(IndexError):
+            self.leaf.isActive(n)
+        with self.assertRaises(IndexError):
+            self.leaf.isActive(n + 1000)
+        with self.assertRaises(IndexError):
+            self.leaf.getValue(n)
+        # In-range still works.
+        self.assertIsNotNone(self.leaf.getValue(0))
+        self.assertIsNotNone(self.leaf.getValue(n - 1))
+
+    def test_tree_active_tile_count_level(self):
+        # activeTileCount levels are 1..3 (level 0 is leaves, not tiles).
+        with self.assertRaises(ValueError):
+            self.tree.activeTileCount(0)
+        with self.assertRaises(ValueError):
+            self.tree.activeTileCount(4)
+        # In-range still works.
+        self.assertGreaterEqual(self.tree.activeTileCount(3), 0)
+
+    def test_tree_node_count_level(self):
+        # nodeCount levels are 0..2 (leaf / lower / upper).
+        with self.assertRaises(ValueError):
+            self.tree.nodeCount(-1)
+        with self.assertRaises(ValueError):
+            self.tree.nodeCount(3)
+        self.assertGreater(self.tree.nodeCount(0), 0)
+
+    def test_node_manager_indexed_access(self):
+        with self.assertRaises(IndexError):
+            self.nm.leaf(self.nm.leafCount())
+        with self.assertRaises(IndexError):
+            self.nm.lower(self.nm.lowerCount())
+        with self.assertRaises(IndexError):
+            self.nm.upper(self.nm.upperCount())
+        with self.assertRaises(ValueError):
+            self.nm.nodeCount(3)
+        # In-range still works.
+        self.assertEqual(self.nm.leaf(0).origin(), self.leaf.origin())
+
+
+class TestZeroCopyViewLifetimes(unittest.TestCase):
+    """Returned typed grids, trees, leaves, NodeManagers, and zero-copy
+    NumPy views must keep their backing buffers alive across the chained
+    temporary expressions used at the call site (e.g.
+    `nanovdb.tools.createFogVolumeSphere().grid().tree().getFirstLeaf().values()`).
+    Without explicit nb::keep_alive linkages the intermediate handle gets
+    GC'd between expressions and the returned object reads freed memory.
+    """
+
+    def _force_gc(self):
+        import gc
+        for _ in range(3):
+            gc.collect()
+
+    def test_handle_grid_temporary(self):
+        g = nanovdb.tools.createFogVolumeSphere(name="probe").grid()
+        self._force_gc()
+        self.assertEqual(g.gridName(), "probe")
+
+    def test_handle_grid_tree_leaf_values_chain(self):
+        vals = (nanovdb.tools.createFogVolumeSphere()
+                .grid().tree().getFirstLeaf().values())
+        self._force_gc()
+        # Touching the view shouldn't crash.
+        self.assertEqual(vals.shape, (512,))
+        _ = float(vals[0])
+
+    def test_grid_leaf_values_temporary(self):
+        bulk = nanovdb.tools.createFogVolumeSphere().grid().leaf_values()
+        self._force_gc()
+        self.assertEqual(bulk.shape[1], 512)
+        _ = float(bulk[0, 0])
+
+    def test_node_manager_temporary_grid(self):
+        nm = nanovdb.createNodeManager(
+            nanovdb.tools.createFogVolumeSphere().grid()).mgr()
+        self._force_gc()
+        self.assertGreater(nm.leafCount(), 0)
+        leaf0_vals = nm.leaf(0).values()
+        self._force_gc()
+        self.assertEqual(leaf0_vals.shape, (512,))
+
+    def test_blind_data_temporary(self):
+        # The grid has no blind data so getBlindData returns None — what we
+        # care about here is that the temporary chain doesn't segfault.
+        result = nanovdb.tools.createFogVolumeSphere().grid().getBlindData(0)
+        self._force_gc()
+        self.assertIsNone(result)
+
+
 class TestGridMetaDataGuards(unittest.TestCase):
     """GridMetaData() constructor and safeCast() reject bad input (None, a
     Grid wrapping an invalid buffer) with a Python exception or False

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -627,6 +627,21 @@ class TestTreeNodeWalking(unittest.TestCase):
         first_via_leaf = np.asarray(self.tree.getFirstLeaf().values())
         self.assertTrue(np.array_equal(first_via_bulk, first_via_leaf))
 
+    def test_bulk_leaf_values_empty_grid_returns_empty_array(self):
+        # A grid with no leaves returns an empty (0, 512) NumPy view rather
+        # than None, so callers can iterate / shape-test without a sentinel.
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not installed")
+        empty_bbox = nanovdb.math.CoordBBox()  # default-constructed = empty
+        empty_h = nanovdb.tools.createFloatGrid(
+            0.0, "empty", nanovdb.GridClass.Unknown,
+            lambda ijk: 0.0, empty_bbox)
+        bulk = empty_h.grid().leaf_values()
+        self.assertEqual(bulk.shape, (0, 512))
+        self.assertEqual(bulk.dtype, np.float32)
+
     def test_node_manager_round_trip(self):
         try:
             import numpy as np


### PR DESCRIPTION
## Summary

Fourth slice of the [NanoVDB Python bindings C++ API mirror plan](https://github.com/swahtz/openvdb/blob/phase3/nanovdb_python_tree_nodes/nanovdb-python-plan.md) tracked in #2208. Phase 3 makes the **tree itself walkable from Python** — every BuildT now has a bound `NanoTree`, `Root`, `Upper`/`Lower` internal nodes, `Leaf`, and a host-side `NodeManager`. For BuildTs whose leaf actually carries a contiguous `T mValues[512]` (regular scalar types) we also expose **zero-copy NumPy views**, including a high-level `grid.leaf_values()` bulk extractor.

PR target: `feature/nanovdb_python`.

## What's bound per BuildT

| Class | Surface |
|---|---|
| `<Suffix>Leaf` | `origin`, `bbox`, `dim`, `voxelCount`, `memUsage`, `flags`, `isActive(ijk\|n)`, `getValue(offset\|ijk)`, `getFirstValue`, `getLastValue`, `minimum`/`maximum`/`average`/`stdDeviation`, `valueMask`, `probeValue`, **`values()` zero-copy `(512,)` NumPy view** (only for arithmetic non-special ValueTs — float, double, Int16/32/64, UInt8/UInt32) |
| `<Suffix>Upper`, `<Suffix>Lower` | `origin`, `bbox`, `dim`, `memUsage`, `minimum`/`maximum`/`average`/`stdDeviation`, `valueMask`, `childMask`, `getValue`, `getFirstValue`, `getLastValue`, `isActive`, `probeValue`. Shared `defineInternalNodeBase` since both levels have identical C++ APIs |
| `<Suffix>Root` | `background`, `tileCount`, `getTableSize`, `isEmpty`, `bbox`, `minimum`/`maximum`/`average`/`stdDeviation`, `memUsage`, `getValue`, `isActive`, `probeValue` |
| `<Suffix>Tree` | `root`, `background`, `activeVoxelCount`, `activeTileCount(level)`, `nodeCount(level)`, `totalNodeCount`, `memUsage`, `getValue`, `isActive`, `probeValue`, **`extrema()`** returning `(min, max)`, `getFirstLeaf`/`getFirstLower`/`getFirstUpper` |
| `<Suffix>NodeManager` | `isLinear`, `memUsage`, `nodeCount(level)`, `leafCount`, `lowerCount`, `upperCount`, `leaf(i)`/`lower(i)`/`upper(i)` |

Plus module-scope:
- **`Grid.tree()`** on every `NanoGrid<T>` returning the typed `NanoTree<T>` as `reference_internal`.
- **`nanovdb.createNodeManager(grid)`** — polymorphic factory; picks the right BuildT and returns a `NodeManagerHandle`. The handle exposes `size()`, `__bool__()`, and `mgr()` which dispatches by stored gridType to the typed NodeManager.
- **`grid.leaf_values()`** — strided `(N_leaves, 512)` zero-copy NumPy view of all leaf values in breadth-first order. Stride between leaves is `sizeof(LeafT)/sizeof(ValueT)`, accounting for the leaf header between value blocks. Raises `ValueError` on non-breadth-first grids.

## File layout

New file `PyTree.h` holds the templated definitions (Tree, Root, Upper, Lower, Leaf, NodeManager, plus the `PyLeafValuesBinder` helper). `PyTree.cc` holds the non-templated `NodeManagerHandle` and `createNodeManager` bindings — both dispatch over every BuildT via the same `BuildTypes.def` X-macro.

The X-macro consumer in `NanoVDBModule.cc` now registers Tree / node types **before** the `NanoGrid` per-BuildT bindings, because `Grid.tree()` returns `NanoTree<T>&` and nanobind needs the return type registered first.

## Skipped / deferred

- **`LeafNode::variance()`** is NOT bound. NanoVDB.h line 4388 reads `Pow2(DataType::getDev())` unqualified, which fails ADL for non-float ValueTs (`ValueIndex` / `ValueMask`). Users can compute variance as `stdDeviation() ** 2` in Python. Same omission on `InternalNode::variance()` for parity.
- **VoxelBlockManager** (OnIndexGrid-specific) deferred to a follow-up — surface large enough to merit its own PR.
- **Vector leaf `values()`** (Vec3f / Vec3d / Vec4f / Vec4d / Vec3u8 / Vec3u16 / Rgba8) deferred. `nb::ndarray<Vec3f>` isn't well-formed (no dtype config for struct scalars). A future PR can add flattened `(count, dim)` component-typed views.
- **Tree iterators** (`beginValueOn`, etc.) deferred — the bulk `leaf_values()` view + per-leaf `valueMask` covers the most common analytics pattern (mask the bulk array and you have your active values, vectorized).

## Test plan

Locally on Linux + CUDA 13.2 / Blackwell sm_120, BLOSC + ZLIB enabled:

- [x] **CPU build** (BLOSC + ZLIB off, no CUDA, no OpenVDB): 58 existing + 8 new `TestPhase3TreeNodes` = **66 tests**; only the env-dependent BLOSC test failure (test asserts uncaught `RuntimeError` on Codec.BLOSC write) — see the note in earlier Phase PRs.
- [x] **CUDA sm_120 + BLOSC + ZLIB**: **all 66 pass**.
- [x] numpy-backed shape/dtype assertions confirm per-leaf `values()` is `(512,)` `float32` and bulk `leaf_values()` is `(N_leaves, 512)` `float32`. `NodeManager.leaf(i).values()` is byte-identical to `tree.getFirstLeaf().values()` for `i == 0`.
- [x] `extrema()` returns the expected `(min, max)` for a `createFogVolumeSphere` test grid (`min >= 0`, `max <= 1`).
- [x] Negative test: `leaf_values` / `values` are NOT bound on `BooleanLeaf` / `Fp4Leaf` / `IndexLeaf` / `MaskLeaf` (special BuildTs without `T mValues[512]` layout). Locked in by `test_leaf_values_unavailable_for_special_buildts`.
- [x] All new lines ≤ 100 cols (codingstyle.txt).

### Not verified locally — still on the reviewer

- [ ] Windows build.
- [ ] OpenVDB-enabled build.
- [ ] CUDA device-side tree walking (`nanovdb.createNodeManager` is host-only in Phase 3 — the device variant would need its own `NodeManagerHandle<DeviceBuffer>` registration and is deferred).

Part of #2208.