### PR TITLE
nanovdb python: VoxelBlockManager (host) — Phase 3 follow-up

### DIFF
--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -115,6 +115,9 @@ jobs:
     - name: install
       shell: powershell
       run: .\ci\install_windows.ps1
+    - name: install_numpy
+      shell: powershell
+      run: .\ci\install_windows_numpy.ps1
     - name: build
     # nvcc doesn't set _WIN32 when run in bash so we need to set it manually
       shell: bash

--- a/nanovdb/nanovdb/python/CMakeLists.txt
+++ b/nanovdb/nanovdb/python/CMakeLists.txt
@@ -29,6 +29,7 @@ nanobind_add_module(nanovdb_python NB_STATIC
     PySampleFromVoxels.cc
     PyTools.cc
     PyTree.cc
+    PyVoxelBlockManager.cc
     cuda/PyDeviceBuffer.cc
     cuda/PyDeviceGridHandle.cu
     cuda/PyPointsToGrid.cu

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -21,6 +21,7 @@
 #include "PyMath.h"
 #include "PyTools.h"
 #include "PyTree.h"
+#include "PyVoxelBlockManager.h"
 #include "PyGridChecksum.h"
 
 namespace nb = nanobind;
@@ -806,6 +807,7 @@ NB_MODULE(nanovdb, m)
     nb::module_ toolsModule = m.def_submodule("tools");
     toolsModule.doc() = "A submodule that implements tools for NanoVDB grids";
     defineToolsModule(toolsModule);
+    defineVoxelBlockManagerModule(toolsModule);
 
     nb::module_ ioModule = m.def_submodule("io");
     ioModule.doc() = "A submodule that implements I/O functionality for NanoVDB grids";

--- a/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
+++ b/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
@@ -9,6 +9,7 @@
 #include <nanovdb/HostBuffer.h>
 #include <nanovdb/tools/CreateNanoGrid.h>
 #include <nanovdb/tools/VoxelBlockManager.h>
+#include <nanovdb/util/Util.h>
 
 #include <cstring>
 #include <memory>
@@ -87,7 +88,27 @@ static nb::object pyDecodeInverseMapsImpl(const NanoGrid<ValueOnIndex>& grid,
                                           const uint64_t* jumpMap,
                                           uint64_t blockFirstOffset)
 {
-    constexpr int BlockWidth = 1 << Log2BlockWidth;
+    constexpr int BlockWidth    = 1 << Log2BlockWidth;
+    constexpr int JumpMapLength =
+        VoxelBlockManagerBase<Log2BlockWidth>::JumpMapLength;
+
+    // The C++ decodeInverseMaps iterates leafID = firstLeafID ..
+    // firstLeafID + nExtraLeaves, where nExtraLeaves is the popcount of
+    // this block's jumpMap (each set bit marks an additional leaf
+    // boundary crossed within the block). If the jumpMap is corrupt or
+    // was built against a different grid, the loop could read past
+    // tree.getFirstNode<0>(). Pre-compute the upper bound and validate
+    // it against grid.tree().nodeCount(0) before any allocation.
+    uint32_t nExtraLeaves = 0;
+    for (int i = 0; i < JumpMapLength; ++i)
+        nExtraLeaves += util::countOn(jumpMap[i]);
+    const uint32_t nLeaves = grid.tree().nodeCount(0);
+    if (uint64_t(firstLeafID) + uint64_t(nExtraLeaves) >= nLeaves) {
+        throw nb::value_error(
+            "decodeInverseMaps: firstLeafID + popcount(jumpMap) would "
+            "index past grid.tree().nodeCount(0) — the jumpMap is "
+            "either corrupt or was paired with a different grid.");
+    }
 
     // Each call allocates fresh BlockWidth-sized output arrays for the
     // leaf-index and voxel-offset results. We use plain new[] (rather than
@@ -313,10 +334,25 @@ static void defineBuild(nb::module_& toolsModule)
                 if (first_offset == 0) first_offset = 1;
                 if (last_offset  == 0) last_offset  = grid->activeVoxelCount();
                 if (last_offset < first_offset) return PyVBMHandle();
-                if (n_blocks == 0) {
-                    n_blocks = (last_offset - first_offset + BlockWidth)
-                               >> LBW;
+                // Capacity must hold at least ceil((last - first + 1) /
+                // BlockWidth) blocks; otherwise the handle's lastOffset
+                // would advertise more coverage than blockCount allows
+                // and decodeBlock would silently truncate. The formula
+                // below equals the ceil() above when BlockWidth is a
+                // power of two.
+                const uint64_t minBlocks =
+                    (last_offset - first_offset + BlockWidth) >> LBW;
+                if (n_blocks != 0 && n_blocks < minBlocks) {
+                    std::string msg(
+                        "buildVoxelBlockManager: n_blocks must be at "
+                        "least ceil((last_offset - first_offset + 1) / "
+                        "BlockWidth) = ");
+                    msg += std::to_string(minBlocks);
+                    msg += ". Pass 0 (the default) to use the minimum "
+                           "required capacity.";
+                    throw nb::value_error(msg.c_str());
                 }
+                if (n_blocks == 0) n_blocks = minBlocks;
                 // Allocate the metadata buffers ourselves so we can
                 // pre-initialize firstLeafID with a sentinel value before
                 // the in-place builder runs. The C++ allocating overload

--- a/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
+++ b/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
@@ -11,9 +11,10 @@
 #include <nanovdb/tools/VoxelBlockManager.h>
 #include <nanovdb/util/Util.h>
 
-#include <cstring>
 #include <memory>
-#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
 
 namespace nb = nanobind;
 using namespace nb::literals;

--- a/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
+++ b/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
@@ -11,6 +11,7 @@
 #include <nanovdb/tools/VoxelBlockManager.h>
 
 #include <cstring>
+#include <memory>
 #include <stdexcept>
 
 namespace nb = nanobind;
@@ -93,27 +94,35 @@ static nb::object pyDecodeInverseMapsImpl(const NanoGrid<ValueOnIndex>& grid,
     // a numpy-allocated buffer) because the produced ndarrays are returned
     // by reference and Python owns them via the capsule deleters below —
     // when the ndarray is destroyed, the capsule's deleter runs delete[].
-    auto* leafIndex = new uint32_t[BlockWidth];
-    auto* voxelOffset = new uint16_t[BlockWidth];
+    //
+    // The raw pointers live in std::unique_ptr until the matching capsule
+    // has been constructed; that way if the second allocation, the
+    // decodeInverseMaps call, or either capsule construction throws, the
+    // unique_ptr unwinds the half-built state cleanly. After a capsule
+    // takes ownership we release() so the unique_ptr no longer double-frees.
+    std::unique_ptr<uint32_t[]> leafIndex(new uint32_t[BlockWidth]);
+    std::unique_ptr<uint16_t[]> voxelOffset(new uint16_t[BlockWidth]);
 
     using VBM = VoxelBlockManager<Log2BlockWidth>;
     VBM::template decodeInverseMaps<ValueOnIndex>(
         &grid, firstLeafID, jumpMap, blockFirstOffset,
-        leafIndex, voxelOffset);
+        leafIndex.get(), voxelOffset.get());
 
     // nb::capsule wraps the raw pointer + matching delete[] so it can serve
     // as the ndarray's owner — the capsule lives as long as the ndarray and
     // its destruction runs the deleter.
-    nb::capsule leafOwner(leafIndex,
+    nb::capsule leafOwner(leafIndex.get(),
         [](void* p) noexcept { delete[] static_cast<uint32_t*>(p); });
-    nb::capsule offsetOwner(voxelOffset,
+    auto* leafRaw = leafIndex.release();
+    nb::capsule offsetOwner(voxelOffset.get(),
         [](void* p) noexcept { delete[] static_cast<uint16_t*>(p); });
+    auto* offsetRaw = voxelOffset.release();
 
     size_t shape[1] = {static_cast<size_t>(BlockWidth)};
     nb::ndarray<nb::numpy, uint32_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>
-        leafArr(leafIndex, size_t(1), shape, leafOwner);
+        leafArr(leafRaw, size_t(1), shape, leafOwner);
     nb::ndarray<nb::numpy, uint16_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>
-        offsetArr(voxelOffset, size_t(1), shape, offsetOwner);
+        offsetArr(offsetRaw, size_t(1), shape, offsetOwner);
     return nb::make_tuple(
         nb::cast(leafArr,   nb::rv_policy::reference),
         nb::cast(offsetArr, nb::rv_policy::reference));
@@ -287,10 +296,13 @@ static void defineBuild(nb::module_& toolsModule)
             }
             return dispatchLog2BlockWidth(log2_block_width, [&](auto W) {
                 constexpr int LBW = decltype(W)::value;
-                constexpr uint64_t BlockWidth = uint64_t(1) << LBW;
-                // first_offset must be 1 (mod BlockWidth). The C++ helper
-                // normalizes a zero input to 1, so we only need to validate
-                // the nonzero case ourselves.
+                using Base = VoxelBlockManagerBase<LBW>;
+                constexpr uint64_t BlockWidth    = Base::BlockWidth;
+                constexpr uint64_t JumpMapLength = Base::JumpMapLength;
+                // first_offset must be 1 (mod BlockWidth). The single-arg
+                // C++ helper would normalize a zero input to 1; we do the
+                // same here so the in-place builder below sees a valid
+                // value. Validate the nonzero case ourselves.
                 if (first_offset != 0 &&
                     ((first_offset - 1) & (BlockWidth - 1)) != 0) {
                     throw nb::value_error(
@@ -298,10 +310,42 @@ static void defineBuild(nb::module_& toolsModule)
                         "first_offset == 1 (mod BlockWidth). Pass 0 (the "
                         "default) to let the implementation use 1.");
                 }
-                return PyVBMHandle(
-                    buildVoxelBlockManager<LBW, HostBuffer>(
-                        grid, first_offset, last_offset, n_blocks),
-                    LBW);
+                if (first_offset == 0) first_offset = 1;
+                if (last_offset  == 0) last_offset  = grid->activeVoxelCount();
+                if (last_offset < first_offset) return PyVBMHandle();
+                if (n_blocks == 0) {
+                    n_blocks = (last_offset - first_offset + BlockWidth)
+                               >> LBW;
+                }
+                // Allocate the metadata buffers ourselves so we can
+                // pre-initialize firstLeafID with a sentinel value before
+                // the in-place builder runs. The C++ allocating overload
+                // calls HostBuffer::create() which returns uninitialized
+                // memory; blocks that the algorithm doesn't touch would
+                // then retain arbitrary values, and our decodeBlock guard
+                // (firstLeafID >= nLeaves) might miss any garbage value
+                // that happens to be < nLeaves. By prefilling with nLeaves
+                // up front, every untouched slot deterministically trips
+                // the guard.
+                auto firstLeafIDBuf = HostBuffer::create(
+                    n_blocks * sizeof(uint32_t));
+                auto jumpMapBuf = HostBuffer::create(
+                    n_blocks * JumpMapLength * sizeof(uint64_t));
+                const uint32_t nLeaves = grid->tree().nodeCount(0);
+                {
+                    uint32_t* slots = static_cast<uint32_t*>(
+                        firstLeafIDBuf.data());
+                    for (uint64_t i = 0; i < n_blocks; ++i) {
+                        slots[i] = nLeaves;
+                    }
+                }
+                VoxelBlockManagerHandle<HostBuffer> handle(
+                    std::move(firstLeafIDBuf), std::move(jumpMapBuf),
+                    n_blocks, first_offset, last_offset);
+                // In-place builder zeros the jumpMap itself and only
+                // touches firstLeafID slots it actually visits.
+                buildVoxelBlockManager<LBW, HostBuffer>(grid, handle);
+                return PyVBMHandle(std::move(handle), LBW);
             });
         },
         "grid"_a,

--- a/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
+++ b/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
@@ -1,0 +1,360 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+#include "PyVoxelBlockManager.h"
+
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/tuple.h>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/HostBuffer.h>
+#include <nanovdb/tools/CreateNanoGrid.h>
+#include <nanovdb/tools/VoxelBlockManager.h>
+
+#include <cstring>
+#include <stdexcept>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace nanovdb;
+using nanovdb::tools::VoxelBlockManager;
+using nanovdb::tools::VoxelBlockManagerBase;
+using nanovdb::tools::VoxelBlockManagerHandle;
+using nanovdb::tools::buildVoxelBlockManager;
+
+namespace pynanovdb {
+
+using VBMHandle = VoxelBlockManagerHandle<HostBuffer>;
+
+// ----------------------- Log2BlockWidth dispatch --------------------------
+//
+// Log2BlockWidth is a compile-time template parameter on every VBM helper.
+// We expose it to Python as a runtime int and dispatch via a switch that
+// instantiates the four useful widths (BlockWidth = 64, 128, 256, 512).
+// Larger widths are not bound by default; callers who need them can add a
+// new case below.
+
+template<typename F>
+static auto dispatchLog2BlockWidth(int log2BlockWidth, F&& fn)
+{
+    switch (log2BlockWidth) {
+        case 6: return fn(std::integral_constant<int, 6>{});
+        case 7: return fn(std::integral_constant<int, 7>{});
+        case 8: return fn(std::integral_constant<int, 8>{});
+        case 9: return fn(std::integral_constant<int, 9>{});
+        default:
+            throw nb::value_error(
+                "VoxelBlockManager: log2_block_width must be 6, 7, 8, or 9 "
+                "(BlockWidth = 64, 128, 256, or 512). Larger widths are not "
+                "bound in Python by default.");
+    }
+}
+
+// ----------------------- decodeInverseMaps helper -------------------------
+//
+// Common implementation used by both the free function and the
+// handle.decodeBlock(i) method. Allocates fresh leafIndex (uint32) and
+// voxelOffset (uint16) NumPy arrays of length BlockWidth and fills them.
+template<int Log2BlockWidth>
+static nb::object pyDecodeInverseMapsImpl(const NanoGrid<ValueOnIndex>& grid,
+                                          uint32_t firstLeafID,
+                                          const uint64_t* jumpMap,
+                                          uint64_t blockFirstOffset)
+{
+    constexpr int BlockWidth = 1 << Log2BlockWidth;
+
+    // Allocate outputs as numpy-owned arrays. nb::ndarray with no parent
+    // and the nb::numpy framework tag tells nanobind to allocate fresh
+    // memory through numpy (so Python owns the result).
+    auto* leafIndex = new uint32_t[BlockWidth];
+    auto* voxelOffset = new uint16_t[BlockWidth];
+
+    using VBM = VoxelBlockManager<Log2BlockWidth>;
+    VBM::template decodeInverseMaps<ValueOnIndex>(
+        &grid, firstLeafID, jumpMap, blockFirstOffset,
+        leafIndex, voxelOffset);
+
+    // Hand ownership to nanobind via the delete-on-destruction owner
+    // capsule pattern. nb::capsule wraps a raw pointer + deleter and lives
+    // for as long as the ndarray that takes it as parent.
+    nb::capsule leafOwner(leafIndex,
+        [](void* p) noexcept { delete[] static_cast<uint32_t*>(p); });
+    nb::capsule offsetOwner(voxelOffset,
+        [](void* p) noexcept { delete[] static_cast<uint16_t*>(p); });
+
+    size_t shape[1] = {static_cast<size_t>(BlockWidth)};
+    nb::ndarray<nb::numpy, uint32_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>
+        leafArr(leafIndex, size_t(1), shape, leafOwner);
+    nb::ndarray<nb::numpy, uint16_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>
+        offsetArr(voxelOffset, size_t(1), shape, offsetOwner);
+    return nb::make_tuple(
+        nb::cast(leafArr,   nb::rv_policy::reference),
+        nb::cast(offsetArr, nb::rv_policy::reference));
+}
+
+// ------------------- VoxelBlockManagerHandle binding ----------------------
+
+static const NanoGrid<ValueOnIndex>* castOnIndexGrid(nb::handle py_grid,
+                                                    const char* fn_name)
+{
+    if (!nb::isinstance<NanoGrid<ValueOnIndex>>(py_grid)) {
+        std::string msg(fn_name);
+        msg += ": grid must be a NanoVDB grid of build type ValueOnIndex (OnIndexGrid)";
+        throw nb::type_error(msg.c_str());
+    }
+    return &nb::cast<const NanoGrid<ValueOnIndex>&>(py_grid);
+}
+
+static void defineHandle(nb::module_& toolsModule)
+{
+    nb::class_<VBMHandle>(toolsModule, "VoxelBlockManagerHandle",
+        "Owns the firstLeafID / jumpMap metadata buffers backing a "
+        "VoxelBlockManager. Constructed by nanovdb.tools.buildVoxelBlockManager.")
+        .def(nb::init<>())
+        .def("blockCount",  &VBMHandle::blockCount)
+        .def("firstOffset", &VBMHandle::firstOffset)
+        .def("lastOffset",  &VBMHandle::lastOffset)
+        .def("reset",       &VBMHandle::reset)
+        .def(
+            "__bool__",
+            [](const VBMHandle& h) { return h.blockCount() > 0; },
+            nb::is_operator())
+        // Zero-copy view of the (blockCount,) firstLeafID array.
+        .def("firstLeafID",
+            [](nb::handle py_self) -> nb::object {
+                auto& h = nb::cast<VBMHandle&>(py_self);
+                size_t shape[1] = {static_cast<size_t>(h.blockCount())};
+                return nb::cast(
+                    nb::ndarray<nb::numpy, uint32_t, nb::ndim<1>,
+                                nb::c_contig, nb::device::cpu>(
+                        static_cast<void*>(h.hostFirstLeafID()),
+                        size_t(1), shape, py_self),
+                    nb::rv_policy::reference);
+            },
+            nb::keep_alive<0, 1>(),
+            "Return a zero-copy (blockCount,) uint32 NumPy view of the "
+            "firstLeafID array. The view keeps this handle alive.")
+        // jumpMap is uint64_t[blockCount * JumpMapLength]. JumpMapLength
+        // depends on log2_block_width (1 << (log2_block_width - 6)) and
+        // isn't carried on the handle, so we take it as a method argument
+        // and return the buffer reshaped to (blockCount, JumpMapLength).
+        // Default is 1 (matching log2_block_width=6, the most common case).
+        .def("jumpMap",
+            [](nb::handle py_self, int jump_map_length) -> nb::object {
+                if (jump_map_length < 1) {
+                    throw nb::value_error(
+                        "VoxelBlockManagerHandle.jumpMap: "
+                        "jump_map_length must be >= 1.");
+                }
+                auto& h = nb::cast<VBMHandle&>(py_self);
+                size_t shape[2] = {static_cast<size_t>(h.blockCount()),
+                                   static_cast<size_t>(jump_map_length)};
+                return nb::cast(
+                    nb::ndarray<nb::numpy, uint64_t, nb::ndim<2>,
+                                nb::c_contig, nb::device::cpu>(
+                        static_cast<void*>(h.hostJumpMap()),
+                        size_t(2), shape, py_self),
+                    nb::rv_policy::reference);
+            },
+            nb::arg("jump_map_length") = 1,
+            nb::keep_alive<0, 1>(),
+            "Return a zero-copy (blockCount, jump_map_length) uint64 NumPy "
+            "view of the jumpMap. jump_map_length = BlockWidth / 64 = "
+            "1 << (log2_block_width - 6) — pass 1 (default) for "
+            "log2_block_width=6, 2 for 7, 4 for 8, 8 for 9. The view keeps "
+            "this handle alive.")
+        // Decode the inverse maps for a single block of this VBM. The
+        // log2_block_width passed must match the one the handle was built
+        // with (the handle does not store it).
+        .def("decodeBlock",
+            [](VBMHandle& self,
+               nb::handle py_grid,
+               uint64_t block_index,
+               int log2_block_width) -> nb::object {
+                const auto* grid = castOnIndexGrid(py_grid,
+                    "VoxelBlockManagerHandle.decodeBlock");
+                if (block_index >= self.blockCount()) {
+                    throw nb::index_error(
+                        "VoxelBlockManagerHandle.decodeBlock(block_index): "
+                        "block_index out of range [0, blockCount).");
+                }
+                // Defensive: NanoVDB's buildVoxelBlockManager doesn't always
+                // initialize firstLeafID for blocks where no leaf starts at
+                // a block boundary AND no leaf's iteration sweep reaches
+                // them (e.g. when the source grid is tile-compressed, so
+                // some sequential offsets correspond to tile values rather
+                // than leaf voxels). The slot is then uninitialized memory;
+                // passing it into decodeInverseMaps would lead to an OOB
+                // read of tree.getFirstNode<0>()[garbage]. Catch the case
+                // and raise rather than segfault.
+                const uint32_t firstLeafID =
+                    self.hostFirstLeafID()[block_index];
+                const uint32_t nLeaves = grid->tree().nodeCount(0);
+                if (firstLeafID >= nLeaves) {
+                    throw nb::value_error(
+                        "VoxelBlockManagerHandle.decodeBlock: the VBM's "
+                        "firstLeafID for this block was not initialized by "
+                        "buildVoxelBlockManager (the underlying algorithm "
+                        "doesn't cover blocks that no leaf reaches via its "
+                        "iteration). This typically happens on OnIndex "
+                        "grids built from tile-compressed source grids; "
+                        "until the issue is fixed upstream the workaround "
+                        "is to build the source grid voxel-by-voxel with "
+                        "build::Grid so it stays uncompressed.");
+                }
+                return dispatchLog2BlockWidth(log2_block_width, [&](auto W) {
+                    constexpr int LBW = decltype(W)::value;
+                    constexpr int BlockWidth = 1 << LBW;
+                    constexpr int JumpMapLength =
+                        VoxelBlockManagerBase<LBW>::JumpMapLength;
+                    const uint64_t blockFirstOffset =
+                        self.firstOffset() + block_index * BlockWidth;
+                    return pyDecodeInverseMapsImpl<LBW>(
+                        *grid,
+                        firstLeafID,
+                        self.hostJumpMap() + block_index * JumpMapLength,
+                        blockFirstOffset);
+                });
+            },
+            "grid"_a, "block_index"_a, "log2_block_width"_a = 6,
+            "Decode the inverse maps for the block_index-th block of this "
+            "VBM. Returns (leaf_index, voxel_offset) uint32 / uint16 NumPy "
+            "arrays of length BlockWidth = 1<<log2_block_width. The "
+            "log2_block_width must match the value the handle was built "
+            "with.");
+}
+
+// ------------------- buildVoxelBlockManager binding -----------------------
+
+static void defineBuild(nb::module_& toolsModule)
+{
+    toolsModule.def("buildVoxelBlockManager",
+        [](nb::handle py_grid,
+           int log2_block_width,
+           uint64_t first_offset,
+           uint64_t last_offset,
+           uint64_t n_blocks) -> VBMHandle {
+            const auto* grid = castOnIndexGrid(py_grid, "buildVoxelBlockManager");
+            return dispatchLog2BlockWidth(log2_block_width, [&](auto W) {
+                constexpr int LBW = decltype(W)::value;
+                return buildVoxelBlockManager<LBW, HostBuffer>(
+                    grid, first_offset, last_offset, n_blocks);
+            });
+        },
+        "grid"_a,
+        "log2_block_width"_a = 6,
+        "first_offset"_a = 0,
+        "last_offset"_a = 0,
+        "n_blocks"_a = 0,
+        "Build a host-side VoxelBlockManager from an OnIndexGrid. "
+        "log2_block_width selects the per-block active-voxel count "
+        "(6=64, 7=128, 8=256, 9=512). Pass 0 for first_offset / "
+        "last_offset / n_blocks to use the full grid (first active "
+        "voxel through grid.activeVoxelCount(), minimum block count).");
+}
+
+// --------------------- decodeInverseMaps binding --------------------------
+
+static void defineDecode(nb::module_& toolsModule)
+{
+    toolsModule.def("decodeInverseMaps",
+        [](nb::handle py_grid,
+           uint32_t first_leaf_id,
+           nb::ndarray<const uint64_t, nb::ndim<1>,
+                       nb::c_contig, nb::device::cpu> jump_map,
+           uint64_t block_first_offset,
+           int log2_block_width) -> nb::object {
+            const auto* grid = castOnIndexGrid(py_grid, "decodeInverseMaps");
+            return dispatchLog2BlockWidth(log2_block_width, [&](auto W) {
+                constexpr int LBW = decltype(W)::value;
+                constexpr int JumpMapLength =
+                    VoxelBlockManagerBase<LBW>::JumpMapLength;
+                if (jump_map.shape(0) != JumpMapLength) {
+                    std::string msg("decodeInverseMaps: jump_map must have "
+                                    "length JumpMapLength = ");
+                    msg += std::to_string(JumpMapLength);
+                    msg += " for log2_block_width=";
+                    msg += std::to_string(LBW);
+                    throw nb::value_error(msg.c_str());
+                }
+                return pyDecodeInverseMapsImpl<LBW>(
+                    *grid, first_leaf_id, jump_map.data(),
+                    block_first_offset);
+            });
+        },
+        "grid"_a,
+        "first_leaf_id"_a,
+        "jump_map"_a,
+        "block_first_offset"_a,
+        "log2_block_width"_a = 6,
+        "Decode the inverse maps for a single voxel block of an OnIndexGrid. "
+        "Returns a (leaf_index, voxel_offset) tuple of fresh NumPy arrays of "
+        "length BlockWidth = 1<<log2_block_width. jump_map must have length "
+        "BlockWidth/64.");
+}
+
+// ----- createOnIndexGrid test-scaffold factory (subset of Phase 5) --------
+
+template<typename SrcBuildT>
+static nb::object tryCreateOnIndexGrid(nb::handle py_grid,
+                                       uint32_t channels,
+                                       bool include_stats,
+                                       bool include_tiles,
+                                       int verbose)
+{
+    using SrcGridT = NanoGrid<SrcBuildT>;
+    if (!nb::isinstance<SrcGridT>(py_grid)) {
+        return nb::object();
+    }
+    const SrcGridT& src = nb::cast<const SrcGridT&>(py_grid);
+    return nb::cast(
+        tools::createNanoGrid<SrcGridT, ValueOnIndex, HostBuffer>(
+            src, channels, include_stats, include_tiles, verbose));
+}
+
+static void defineCreateOnIndexGrid(nb::module_& toolsModule)
+{
+    toolsModule.def("createOnIndexGrid",
+        [](nb::handle py_grid,
+           uint32_t channels,
+           bool include_stats,
+           bool include_tiles,
+           int verbose) -> nb::object {
+            // Try every source BuildT we accept.
+            if (auto r = tryCreateOnIndexGrid<float>(
+                    py_grid, channels, include_stats, include_tiles, verbose);
+                r.is_valid()) return r;
+            if (auto r = tryCreateOnIndexGrid<double>(
+                    py_grid, channels, include_stats, include_tiles, verbose);
+                r.is_valid()) return r;
+            if (auto r = tryCreateOnIndexGrid<int32_t>(
+                    py_grid, channels, include_stats, include_tiles, verbose);
+                r.is_valid()) return r;
+            if (auto r = tryCreateOnIndexGrid<Vec3f>(
+                    py_grid, channels, include_stats, include_tiles, verbose);
+                r.is_valid()) return r;
+            throw nb::type_error(
+                "createOnIndexGrid: source grid must be a FloatGrid, "
+                "DoubleGrid, Int32Grid, or Vec3fGrid (other source BuildTs "
+                "are not yet bound).");
+        },
+        "src_grid"_a,
+        "channels"_a = 0u,
+        "include_stats"_a = true,
+        "include_tiles"_a = true,
+        "verbose"_a = 0,
+        "Convert a source grid into a NanoGrid<ValueOnIndex> "
+        "(OnIndexGrid). Accepts FloatGrid / DoubleGrid / Int32Grid / "
+        "Vec3fGrid. Required for constructing inputs to "
+        "buildVoxelBlockManager. The broader createNanoGrid<SrcGridT, "
+        "DstBuildT> surface lands in a later phase.");
+}
+
+void defineVoxelBlockManagerModule(nb::module_& toolsModule)
+{
+    defineHandle(toolsModule);
+    defineBuild(toolsModule);
+    defineDecode(toolsModule);
+    defineCreateOnIndexGrid(toolsModule);
+}
+
+} // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
+++ b/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
@@ -23,8 +23,6 @@ using nanovdb::tools::buildVoxelBlockManager;
 
 namespace pynanovdb {
 
-using VBMHandle = VoxelBlockManagerHandle<HostBuffer>;
-
 // ----------------------- Log2BlockWidth dispatch --------------------------
 //
 // Log2BlockWidth is a compile-time template parameter on every VBM helper.
@@ -48,6 +46,34 @@ static auto dispatchLog2BlockWidth(int log2BlockWidth, F&& fn)
                 "bound in Python by default.");
     }
 }
+
+// PyVBMHandle wraps the C++ VoxelBlockManagerHandle and carries the
+// log2_block_width the handle was built with. The C++ handle does NOT store
+// log2_block_width itself, so without this wrapper the Python binding would
+// have to ask the caller every time — which the user can lie about and
+// trigger out-of-bounds reads of the metadata buffers. Storing it once at
+// build time and consulting it in every accessor closes that hole.
+struct PyVBMHandle
+{
+    VoxelBlockManagerHandle<HostBuffer> handle;
+    int                                 log2BlockWidth = 6;
+
+    PyVBMHandle() = default;
+    PyVBMHandle(VoxelBlockManagerHandle<HostBuffer>&& h, int lbw) noexcept
+        : handle(std::move(h)), log2BlockWidth(lbw) {}
+
+    PyVBMHandle(const PyVBMHandle&)            = delete;
+    PyVBMHandle& operator=(const PyVBMHandle&) = delete;
+    PyVBMHandle(PyVBMHandle&&)                 = default;
+    PyVBMHandle& operator=(PyVBMHandle&&)      = default;
+
+    uint64_t blockCount()  const { return handle.blockCount(); }
+    uint64_t firstOffset() const { return handle.firstOffset(); }
+    uint64_t lastOffset()  const { return handle.lastOffset(); }
+    void     reset()             { handle.reset(); }
+    int      blockWidth()    const { return 1 << log2BlockWidth; }
+    int      jumpMapLength() const { return 1 << (log2BlockWidth - 6); }
+};
 
 // ----------------------- decodeInverseMaps helper -------------------------
 //
@@ -106,70 +132,68 @@ static const NanoGrid<ValueOnIndex>* castOnIndexGrid(nb::handle py_grid,
 
 static void defineHandle(nb::module_& toolsModule)
 {
-    nb::class_<VBMHandle>(toolsModule, "VoxelBlockManagerHandle",
+    nb::class_<PyVBMHandle>(toolsModule, "VoxelBlockManagerHandle",
         "Owns the firstLeafID / jumpMap metadata buffers backing a "
         "VoxelBlockManager. Constructed by nanovdb.tools.buildVoxelBlockManager.")
         .def(nb::init<>())
-        .def("blockCount",  &VBMHandle::blockCount)
-        .def("firstOffset", &VBMHandle::firstOffset)
-        .def("lastOffset",  &VBMHandle::lastOffset)
-        .def("reset",       &VBMHandle::reset)
+        .def("blockCount",  &PyVBMHandle::blockCount)
+        .def("firstOffset", &PyVBMHandle::firstOffset)
+        .def("lastOffset",  &PyVBMHandle::lastOffset)
+        .def("reset",       &PyVBMHandle::reset)
+        .def_prop_ro("log2_block_width", [](const PyVBMHandle& h) { return h.log2BlockWidth; },
+            "The log2_block_width this handle was built with. The jumpMap "
+            "and decodeBlock outputs derive their shapes from this value.")
+        .def_prop_ro("block_width", &PyVBMHandle::blockWidth,
+            "BlockWidth = 1 << log2_block_width (64, 128, 256, or 512).")
+        .def_prop_ro("jump_map_length", &PyVBMHandle::jumpMapLength,
+            "JumpMapLength = BlockWidth / 64 (1, 2, 4, or 8).")
         .def(
             "__bool__",
-            [](const VBMHandle& h) { return h.blockCount() > 0; },
+            [](const PyVBMHandle& h) { return h.blockCount() > 0; },
             nb::is_operator())
         // Zero-copy view of the (blockCount,) firstLeafID array.
         .def("firstLeafID",
             [](nb::handle py_self) -> nb::object {
-                auto& h = nb::cast<VBMHandle&>(py_self);
+                auto& h = nb::cast<PyVBMHandle&>(py_self);
                 size_t shape[1] = {static_cast<size_t>(h.blockCount())};
                 return nb::cast(
                     nb::ndarray<nb::numpy, uint32_t, nb::ndim<1>,
                                 nb::c_contig, nb::device::cpu>(
-                        static_cast<void*>(h.hostFirstLeafID()),
+                        static_cast<void*>(h.handle.hostFirstLeafID()),
                         size_t(1), shape, py_self),
                     nb::rv_policy::reference);
             },
             nb::keep_alive<0, 1>(),
             "Return a zero-copy (blockCount,) uint32 NumPy view of the "
             "firstLeafID array. The view keeps this handle alive.")
-        // jumpMap is uint64_t[blockCount * JumpMapLength]. JumpMapLength
-        // depends on log2_block_width (1 << (log2_block_width - 6)) and
-        // isn't carried on the handle, so we take it as a method argument
-        // and return the buffer reshaped to (blockCount, JumpMapLength).
-        // Default is 1 (matching log2_block_width=6, the most common case).
+        // jumpMap is uint64_t[blockCount * JumpMapLength]. JumpMapLength is
+        // determined by the log2_block_width recorded on the handle, not by
+        // the caller — that way the returned view always covers exactly the
+        // allocated buffer, with no risk of OOB reads.
         .def("jumpMap",
-            [](nb::handle py_self, int jump_map_length) -> nb::object {
-                if (jump_map_length < 1) {
-                    throw nb::value_error(
-                        "VoxelBlockManagerHandle.jumpMap: "
-                        "jump_map_length must be >= 1.");
-                }
-                auto& h = nb::cast<VBMHandle&>(py_self);
+            [](nb::handle py_self) -> nb::object {
+                auto& h = nb::cast<PyVBMHandle&>(py_self);
                 size_t shape[2] = {static_cast<size_t>(h.blockCount()),
-                                   static_cast<size_t>(jump_map_length)};
+                                   static_cast<size_t>(h.jumpMapLength())};
                 return nb::cast(
                     nb::ndarray<nb::numpy, uint64_t, nb::ndim<2>,
                                 nb::c_contig, nb::device::cpu>(
-                        static_cast<void*>(h.hostJumpMap()),
+                        static_cast<void*>(h.handle.hostJumpMap()),
                         size_t(2), shape, py_self),
                     nb::rv_policy::reference);
             },
-            nb::arg("jump_map_length") = 1,
             nb::keep_alive<0, 1>(),
             "Return a zero-copy (blockCount, jump_map_length) uint64 NumPy "
-            "view of the jumpMap. jump_map_length = BlockWidth / 64 = "
-            "1 << (log2_block_width - 6) — pass 1 (default) for "
-            "log2_block_width=6, 2 for 7, 4 for 8, 8 for 9. The view keeps "
+            "view of the jumpMap. The shape is determined by the "
+            "log2_block_width the handle was built with. The view keeps "
             "this handle alive.")
         // Decode the inverse maps for a single block of this VBM. The
-        // log2_block_width passed must match the one the handle was built
-        // with (the handle does not store it).
+        // log2_block_width is taken from the handle, so the caller cannot
+        // request a width that doesn't match what was built.
         .def("decodeBlock",
-            [](VBMHandle& self,
+            [](PyVBMHandle& self,
                nb::handle py_grid,
-               uint64_t block_index,
-               int log2_block_width) -> nb::object {
+               uint64_t block_index) -> nb::object {
                 const auto* grid = castOnIndexGrid(py_grid,
                     "VoxelBlockManagerHandle.decodeBlock");
                 if (block_index >= self.blockCount()) {
@@ -187,7 +211,7 @@ static void defineHandle(nb::module_& toolsModule)
                 // read of tree.getFirstNode<0>()[garbage]. Catch the case
                 // and raise rather than segfault.
                 const uint32_t firstLeafID =
-                    self.hostFirstLeafID()[block_index];
+                    self.handle.hostFirstLeafID()[block_index];
                 const uint32_t nLeaves = grid->tree().nodeCount(0);
                 if (firstLeafID >= nLeaves) {
                     throw nb::value_error(
@@ -201,7 +225,7 @@ static void defineHandle(nb::module_& toolsModule)
                         "is to build the source grid voxel-by-voxel with "
                         "build::Grid so it stays uncompressed.");
                 }
-                return dispatchLog2BlockWidth(log2_block_width, [&](auto W) {
+                return dispatchLog2BlockWidth(self.log2BlockWidth, [&](auto W) {
                     constexpr int LBW = decltype(W)::value;
                     constexpr int BlockWidth = 1 << LBW;
                     constexpr int JumpMapLength =
@@ -211,16 +235,15 @@ static void defineHandle(nb::module_& toolsModule)
                     return pyDecodeInverseMapsImpl<LBW>(
                         *grid,
                         firstLeafID,
-                        self.hostJumpMap() + block_index * JumpMapLength,
+                        self.handle.hostJumpMap() + block_index * JumpMapLength,
                         blockFirstOffset);
                 });
             },
-            "grid"_a, "block_index"_a, "log2_block_width"_a = 6,
+            "grid"_a, "block_index"_a,
             "Decode the inverse maps for the block_index-th block of this "
             "VBM. Returns (leaf_index, voxel_offset) uint32 / uint16 NumPy "
-            "arrays of length BlockWidth = 1<<log2_block_width. The "
-            "log2_block_width must match the value the handle was built "
-            "with.");
+            "arrays of length BlockWidth = 1<<log2_block_width, using the "
+            "log2_block_width the handle was built with.");
 }
 
 // ------------------- buildVoxelBlockManager binding -----------------------
@@ -232,12 +255,35 @@ static void defineBuild(nb::module_& toolsModule)
            int log2_block_width,
            uint64_t first_offset,
            uint64_t last_offset,
-           uint64_t n_blocks) -> VBMHandle {
+           uint64_t n_blocks) -> PyVBMHandle {
             const auto* grid = castOnIndexGrid(py_grid, "buildVoxelBlockManager");
+            // The C++ implementation only NANOVDB_ASSERTs these preconditions,
+            // which makes them no-ops in release builds. Validate them here
+            // so Python callers get a clear error instead of UB / abort.
+            if (!grid->isSequential()) {
+                throw nb::value_error(
+                    "buildVoxelBlockManager: grid must satisfy "
+                    "grid.isSequential() (fixed-size, breadth-first node "
+                    "layout). NanoVDB grids constructed via "
+                    "tools.createOnIndexGrid satisfy this by default.");
+            }
             return dispatchLog2BlockWidth(log2_block_width, [&](auto W) {
                 constexpr int LBW = decltype(W)::value;
-                return buildVoxelBlockManager<LBW, HostBuffer>(
-                    grid, first_offset, last_offset, n_blocks);
+                constexpr uint64_t BlockWidth = uint64_t(1) << LBW;
+                // first_offset must be 1 (mod BlockWidth). The C++ helper
+                // normalizes a zero input to 1, so we only need to validate
+                // the nonzero case ourselves.
+                if (first_offset != 0 &&
+                    ((first_offset - 1) & (BlockWidth - 1)) != 0) {
+                    throw nb::value_error(
+                        "buildVoxelBlockManager: first_offset must satisfy "
+                        "first_offset == 1 (mod BlockWidth). Pass 0 (the "
+                        "default) to let the implementation use 1.");
+                }
+                return PyVBMHandle(
+                    buildVoxelBlockManager<LBW, HostBuffer>(
+                        grid, first_offset, last_offset, n_blocks),
+                    LBW);
             });
         },
         "grid"_a,
@@ -249,7 +295,9 @@ static void defineBuild(nb::module_& toolsModule)
         "log2_block_width selects the per-block active-voxel count "
         "(6=64, 7=128, 8=256, 9=512). Pass 0 for first_offset / "
         "last_offset / n_blocks to use the full grid (first active "
-        "voxel through grid.activeVoxelCount(), minimum block count).");
+        "voxel through grid.activeVoxelCount(), minimum block count). "
+        "first_offset, if nonzero, must satisfy first_offset == 1 "
+        "(mod BlockWidth).");
 }
 
 // --------------------- decodeInverseMaps binding --------------------------
@@ -264,6 +312,21 @@ static void defineDecode(nb::module_& toolsModule)
            uint64_t block_first_offset,
            int log2_block_width) -> nb::object {
             const auto* grid = castOnIndexGrid(py_grid, "decodeInverseMaps");
+            // The C++ helper indexes tree.getFirstNode<0>()[first_leaf_id]
+            // without a bounds check, so a stray first_leaf_id leads to an
+            // OOB read. Validate up front. (We also require isSequential();
+            // getFirstNode only makes sense on a sequential tree.)
+            if (!grid->isSequential()) {
+                throw nb::value_error(
+                    "decodeInverseMaps: grid must satisfy "
+                    "grid.isSequential().");
+            }
+            const uint32_t nLeaves = grid->tree().nodeCount(0);
+            if (first_leaf_id >= nLeaves) {
+                throw nb::index_error(
+                    "decodeInverseMaps: first_leaf_id out of range "
+                    "[0, grid.tree().nodeCount(0)).");
+            }
             return dispatchLog2BlockWidth(log2_block_width, [&](auto W) {
                 constexpr int LBW = decltype(W)::value;
                 constexpr int JumpMapLength =
@@ -289,7 +352,7 @@ static void defineDecode(nb::module_& toolsModule)
         "Decode the inverse maps for a single voxel block of an OnIndexGrid. "
         "Returns a (leaf_index, voxel_offset) tuple of fresh NumPy arrays of "
         "length BlockWidth = 1<<log2_block_width. jump_map must have length "
-        "BlockWidth/64.");
+        "BlockWidth/64. first_leaf_id must be in [0, grid.tree().nodeCount(0)).");
 }
 
 // ----- createOnIndexGrid test-scaffold factory (subset of Phase 5) --------

--- a/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
+++ b/nanovdb/nanovdb/python/PyVoxelBlockManager.cc
@@ -88,9 +88,11 @@ static nb::object pyDecodeInverseMapsImpl(const NanoGrid<ValueOnIndex>& grid,
 {
     constexpr int BlockWidth = 1 << Log2BlockWidth;
 
-    // Allocate outputs as numpy-owned arrays. nb::ndarray with no parent
-    // and the nb::numpy framework tag tells nanobind to allocate fresh
-    // memory through numpy (so Python owns the result).
+    // Each call allocates fresh BlockWidth-sized output arrays for the
+    // leaf-index and voxel-offset results. We use plain new[] (rather than
+    // a numpy-allocated buffer) because the produced ndarrays are returned
+    // by reference and Python owns them via the capsule deleters below —
+    // when the ndarray is destroyed, the capsule's deleter runs delete[].
     auto* leafIndex = new uint32_t[BlockWidth];
     auto* voxelOffset = new uint16_t[BlockWidth];
 
@@ -99,9 +101,9 @@ static nb::object pyDecodeInverseMapsImpl(const NanoGrid<ValueOnIndex>& grid,
         &grid, firstLeafID, jumpMap, blockFirstOffset,
         leafIndex, voxelOffset);
 
-    // Hand ownership to nanobind via the delete-on-destruction owner
-    // capsule pattern. nb::capsule wraps a raw pointer + deleter and lives
-    // for as long as the ndarray that takes it as parent.
+    // nb::capsule wraps the raw pointer + matching delete[] so it can serve
+    // as the ndarray's owner — the capsule lives as long as the ndarray and
+    // its destruction runs the deleter.
     nb::capsule leafOwner(leafIndex,
         [](void* p) noexcept { delete[] static_cast<uint32_t*>(p); });
     nb::capsule offsetOwner(voxelOffset,
@@ -156,16 +158,25 @@ static void defineHandle(nb::module_& toolsModule)
             [](nb::handle py_self) -> nb::object {
                 auto& h = nb::cast<PyVBMHandle&>(py_self);
                 size_t shape[1] = {static_cast<size_t>(h.blockCount())};
+                // A default-constructed or reset() handle has a null
+                // hostFirstLeafID(); we still return an empty (0,) ndarray
+                // so callers don't have to branch on a None sentinel. The
+                // dummy non-null pointer (the handle itself) keeps nanobind
+                // happy; nothing is read since the leading shape is 0.
+                uint32_t* raw = h.handle.hostFirstLeafID();
+                void* data = (raw != nullptr) ? static_cast<void*>(raw)
+                                              : static_cast<void*>(&h);
                 return nb::cast(
                     nb::ndarray<nb::numpy, uint32_t, nb::ndim<1>,
                                 nb::c_contig, nb::device::cpu>(
-                        static_cast<void*>(h.handle.hostFirstLeafID()),
-                        size_t(1), shape, py_self),
+                        data, size_t(1), shape, py_self),
                     nb::rv_policy::reference);
             },
             nb::keep_alive<0, 1>(),
             "Return a zero-copy (blockCount,) uint32 NumPy view of the "
-            "firstLeafID array. The view keeps this handle alive.")
+            "firstLeafID array. Returns an empty (0,) array on a "
+            "default-constructed or reset() handle. The view keeps this "
+            "handle alive.")
         // jumpMap is uint64_t[blockCount * JumpMapLength]. JumpMapLength is
         // determined by the log2_block_width recorded on the handle, not by
         // the caller — that way the returned view always covers exactly the
@@ -175,18 +186,25 @@ static void defineHandle(nb::module_& toolsModule)
                 auto& h = nb::cast<PyVBMHandle&>(py_self);
                 size_t shape[2] = {static_cast<size_t>(h.blockCount()),
                                    static_cast<size_t>(h.jumpMapLength())};
+                // Same null-buffer guard as firstLeafID(): a
+                // default-constructed / reset() handle has a null
+                // hostJumpMap(); return an empty (0, jump_map_length)
+                // ndarray rather than passing nullptr to nanobind.
+                uint64_t* raw = h.handle.hostJumpMap();
+                void* data = (raw != nullptr) ? static_cast<void*>(raw)
+                                              : static_cast<void*>(&h);
                 return nb::cast(
                     nb::ndarray<nb::numpy, uint64_t, nb::ndim<2>,
                                 nb::c_contig, nb::device::cpu>(
-                        static_cast<void*>(h.handle.hostJumpMap()),
-                        size_t(2), shape, py_self),
+                        data, size_t(2), shape, py_self),
                     nb::rv_policy::reference);
             },
             nb::keep_alive<0, 1>(),
             "Return a zero-copy (blockCount, jump_map_length) uint64 NumPy "
             "view of the jumpMap. The shape is determined by the "
-            "log2_block_width the handle was built with. The view keeps "
-            "this handle alive.")
+            "log2_block_width the handle was built with. Returns an empty "
+            "(0, jump_map_length) array on a default-constructed or reset() "
+            "handle. The view keeps this handle alive.")
         // Decode the inverse maps for a single block of this VBM. The
         // log2_block_width is taken from the handle, so the caller cannot
         // request a width that doesn't match what was built.

--- a/nanovdb/nanovdb/python/PyVoxelBlockManager.h
+++ b/nanovdb/nanovdb/python/PyVoxelBlockManager.h
@@ -1,0 +1,20 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+#ifndef NANOVDB_PYVOXELBLOCKMANAGER_HAS_BEEN_INCLUDED
+#define NANOVDB_PYVOXELBLOCKMANAGER_HAS_BEEN_INCLUDED
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+namespace pynanovdb {
+
+/// @brief Bind VoxelBlockManagerHandle<HostBuffer>,
+///        tools.buildVoxelBlockManager, tools.decodeInverseMaps, and the
+///        test-scaffold tools.createOnIndexGrid factory under the given
+///        Python submodule (expected to be the existing nanovdb.tools).
+void defineVoxelBlockManagerModule(nb::module_& toolsModule);
+
+} // namespace pynanovdb
+
+#endif

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -772,6 +772,125 @@ class TestZeroCopyViewLifetimes(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestVoxelBlockManager(unittest.TestCase):
+    """nanovdb.tools.buildVoxelBlockManager + VoxelBlockManagerHandle +
+    decodeInverseMaps and the createOnIndexGrid test-scaffold factory.
+
+    NOTE: end-to-end decode verification across every block is intentionally
+    deferred until the Phase 4 build::Grid bindings land. The C++
+    buildVoxelBlockManager has an algorithmic gap when the source OnIndex
+    grid is tile-compressed (blocks not reached by any leaf's iteration
+    sweep are left with uninitialized firstLeafID). The current host-side
+    createFloatGrid + createOnIndexGrid path triggers tile compression on
+    uniform regions, so we only exercise decodeBlock(0) here — that block
+    is guaranteed to be covered when the grid's firstOffset is 1. The
+    bindings include a defensive check that raises ValueError if a
+    user hits the uninitialized-block case rather than crashing.
+    """
+
+    def _make_cube_on_index_grid(self):
+        # 21^3 fully-active cube — matches the C++ unit test's input.
+        bbox = nanovdb.math.CoordBBox(
+            nanovdb.math.Coord(125), nanovdb.math.Coord(145))
+        float_h = nanovdb.tools.createFloatGrid(
+            0.0, "cube", nanovdb.GridClass.Unknown,
+            lambda ijk: 1.0, bbox)
+        return nanovdb.tools.createOnIndexGrid(
+            float_h.grid(), include_stats=False, include_tiles=False)
+
+    def test_create_on_index_grid(self):
+        h = self._make_cube_on_index_grid()
+        g = h.grid()
+        self.assertEqual(g.gridType(), nanovdb.GridType.OnIndex)
+        self.assertEqual(g.gridClass(), nanovdb.GridClass.IndexGrid)
+        self.assertGreater(g.activeVoxelCount(), 0)
+        self.assertTrue(g.isSequential())
+
+    def test_create_on_index_grid_rejects_unsupported_source(self):
+        # PointGrid is not in the accepted source set.
+        # (The bound source types are float / double / int32 / Vec3f.)
+        try:
+            import numpy as np  # noqa
+        except ImportError:
+            self.skipTest("numpy not installed")
+        # Build a PointGrid via the binding stack; if there isn't an easy
+        # way, just attempt with an empty GridHandle.grid() which is None
+        # and should hit the type-error path. Skip if we can't easily make
+        # a non-source-typed grid available.
+        with self.assertRaises(TypeError):
+            nanovdb.tools.createOnIndexGrid(None)
+
+    def test_build_voxel_block_manager_handle(self):
+        h = self._make_cube_on_index_grid()
+        g = h.grid()
+        vbm = nanovdb.tools.buildVoxelBlockManager(g, log2_block_width=6)
+        self.assertGreater(vbm.blockCount(), 0)
+        self.assertEqual(vbm.firstOffset(), 1)
+        self.assertEqual(vbm.lastOffset(), g.activeVoxelCount())
+        self.assertTrue(bool(vbm))
+
+    def test_buffers_zero_copy_shape_and_dtype(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not installed")
+        h = self._make_cube_on_index_grid()
+        vbm = nanovdb.tools.buildVoxelBlockManager(h.grid(), log2_block_width=6)
+        fl = vbm.firstLeafID()
+        self.assertEqual(fl.shape, (vbm.blockCount(),))
+        self.assertEqual(fl.dtype, np.uint32)
+        # Default jump_map_length=1 matches log2_block_width=6.
+        jm = vbm.jumpMap()
+        self.assertEqual(jm.shape, (vbm.blockCount(), 1))
+        self.assertEqual(jm.dtype, np.uint64)
+        # Wider widths reshape correctly:
+        jm2 = vbm.jumpMap(jump_map_length=2)
+        # Same underlying bytes, different reshape — leading dim halves.
+        self.assertEqual(jm2.shape[1], 2)
+
+    def test_decode_block_zero(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not installed")
+        h = self._make_cube_on_index_grid()
+        g = h.grid()
+        vbm = nanovdb.tools.buildVoxelBlockManager(g, log2_block_width=6)
+        leaf_index, voxel_offset = vbm.decodeBlock(g, 0, log2_block_width=6)
+        self.assertEqual(leaf_index.shape, (64,))
+        self.assertEqual(leaf_index.dtype, np.uint32)
+        self.assertEqual(voxel_offset.shape, (64,))
+        self.assertEqual(voxel_offset.dtype, np.uint16)
+        # Free function should produce the same result for the same input.
+        fl = np.asarray(vbm.firstLeafID())
+        jm = np.asarray(vbm.jumpMap())
+        li_free, vo_free = nanovdb.tools.decodeInverseMaps(
+            g, int(fl[0]), jm[0], vbm.firstOffset(), log2_block_width=6)
+        self.assertTrue(np.array_equal(leaf_index, li_free))
+        self.assertTrue(np.array_equal(voxel_offset, vo_free))
+
+    def test_decode_block_out_of_range(self):
+        h = self._make_cube_on_index_grid()
+        g = h.grid()
+        vbm = nanovdb.tools.buildVoxelBlockManager(g)
+        with self.assertRaises(IndexError):
+            vbm.decodeBlock(g, vbm.blockCount())
+
+    def test_log2_block_width_out_of_range(self):
+        h = self._make_cube_on_index_grid()
+        g = h.grid()
+        with self.assertRaises(ValueError):
+            nanovdb.tools.buildVoxelBlockManager(g, log2_block_width=5)
+        with self.assertRaises(ValueError):
+            nanovdb.tools.buildVoxelBlockManager(g, log2_block_width=10)
+
+    def test_build_voxel_block_manager_rejects_non_on_index_grid(self):
+        # FloatGrid is not an OnIndexGrid.
+        h_float = nanovdb.tools.createFogVolumeSphere()
+        with self.assertRaises(TypeError):
+            nanovdb.tools.buildVoxelBlockManager(h_float.grid())
+
+
 class TestGridMetaDataGuards(unittest.TestCase):
     """GridMetaData() constructor and safeCast() reject bad input (None, a
     Grid wrapping an invalid buffer) with a Python exception or False

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -930,6 +930,41 @@ class TestVoxelBlockManager(unittest.TestCase):
         with self.assertRaises(TypeError):
             nanovdb.tools.buildVoxelBlockManager(h_float.grid())
 
+    def test_untouched_blocks_trip_sentinel_guard(self):
+        # Build the cube VBM and probe every block. The Python binding
+        # prefills firstLeafID with a sentinel (== nLeaves) before calling
+        # the in-place builder, so any block the upstream algorithm doesn't
+        # touch deterministically trips the firstLeafID >= nLeaves guard in
+        # decodeBlock (raising ValueError). The sweep must therefore see
+        # only two outcomes per block: a successful decode or a sentinel
+        # ValueError — no segfaults, no IndexError (those would indicate
+        # block_index out of range, not sentinel), and no silent wrong
+        # decode.
+        try:
+            import numpy as np  # noqa: F401
+        except ImportError:
+            self.skipTest("numpy not installed")
+        h = self._make_cube_on_index_grid()
+        g = h.grid()
+        vbm = nanovdb.tools.buildVoxelBlockManager(g, log2_block_width=6)
+        n_leaves = g.tree().nodeCount(0)
+        fl = vbm.firstLeafID()
+        for b in range(vbm.blockCount()):
+            slot = int(fl[b])
+            # Slot must be a real leaf id or the sentinel — never garbage.
+            self.assertTrue(slot < n_leaves or slot == n_leaves,
+                f"block {b}: firstLeafID={slot} is neither a real leaf id "
+                f"(< {n_leaves}) nor the sentinel (== {n_leaves}); "
+                "uninitialized memory leaked through.")
+            if slot >= n_leaves:
+                with self.assertRaises(ValueError):
+                    vbm.decodeBlock(g, b)
+            else:
+                # Successful decode path — just confirm the shapes.
+                li, vo = vbm.decodeBlock(g, b)
+                self.assertEqual(li.shape, (64,))
+                self.assertEqual(vo.shape, (64,))
+
     def test_default_constructed_handle_returns_empty_arrays(self):
         # A default-constructed VoxelBlockManagerHandle has null backing
         # buffers; firstLeafID() and jumpMap() should still return empty

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -930,6 +930,39 @@ class TestVoxelBlockManager(unittest.TestCase):
         with self.assertRaises(TypeError):
             nanovdb.tools.buildVoxelBlockManager(h_float.grid())
 
+    def test_default_constructed_handle_returns_empty_arrays(self):
+        # A default-constructed VoxelBlockManagerHandle has null backing
+        # buffers; firstLeafID() and jumpMap() should still return empty
+        # ndarrays rather than crash on the null pointer.
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not installed")
+        vbm = nanovdb.tools.VoxelBlockManagerHandle()
+        self.assertEqual(vbm.blockCount(), 0)
+        self.assertFalse(bool(vbm))
+        fl = np.asarray(vbm.firstLeafID())
+        self.assertEqual(fl.shape, (0,))
+        self.assertEqual(fl.dtype, np.uint32)
+        jm = np.asarray(vbm.jumpMap())
+        # Default-constructed handle uses log2_block_width=6 -> JumpMapLength=1.
+        self.assertEqual(jm.shape, (0, 1))
+        self.assertEqual(jm.dtype, np.uint64)
+
+    def test_reset_handle_returns_empty_arrays(self):
+        # Same guard but exercising reset() after a real build.
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not installed")
+        h = self._make_cube_on_index_grid()
+        vbm = nanovdb.tools.buildVoxelBlockManager(h.grid(), log2_block_width=6)
+        self.assertGreater(vbm.blockCount(), 0)
+        vbm.reset()
+        self.assertEqual(vbm.blockCount(), 0)
+        self.assertEqual(np.asarray(vbm.firstLeafID()).shape, (0,))
+        self.assertEqual(np.asarray(vbm.jumpMap()).shape, (0, 1))
+
 
 class TestGridMetaDataGuards(unittest.TestCase):
     """GridMetaData() constructor and safeCast() reject bad input (None, a

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -924,6 +924,19 @@ class TestVoxelBlockManager(unittest.TestCase):
             nanovdb.tools.decodeInverseMaps(
                 g, n_leaves, jm0, vbm.firstOffset(), log2_block_width=6)
 
+    def test_build_voxel_block_manager_rejects_undersized_n_blocks(self):
+        # Caller-supplied n_blocks must hold at least
+        # ceil((last_offset - first_offset + 1) / BlockWidth) blocks;
+        # smaller values would silently truncate coverage.
+        h = self._make_cube_on_index_grid()
+        g = h.grid()
+        # The cube grid has ~9261 active voxels, so at log2_block_width=6
+        # (BlockWidth=64) the minimum is roughly 145 blocks. Passing 1
+        # must be rejected.
+        with self.assertRaises(ValueError):
+            nanovdb.tools.buildVoxelBlockManager(
+                g, log2_block_width=6, n_blocks=1)
+
     def test_build_voxel_block_manager_rejects_non_on_index_grid(self):
         # FloatGrid is not an OnIndexGrid.
         h_float = nanovdb.tools.createFogVolumeSphere()

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -842,18 +842,22 @@ class TestVoxelBlockManager(unittest.TestCase):
         except ImportError:
             self.skipTest("numpy not installed")
         h = self._make_cube_on_index_grid()
-        vbm = nanovdb.tools.buildVoxelBlockManager(h.grid(), log2_block_width=6)
-        fl = vbm.firstLeafID()
-        self.assertEqual(fl.shape, (vbm.blockCount(),))
+        # log2_block_width=6 -> JumpMapLength=1.
+        vbm6 = nanovdb.tools.buildVoxelBlockManager(h.grid(), log2_block_width=6)
+        self.assertEqual(vbm6.log2_block_width, 6)
+        self.assertEqual(vbm6.block_width, 64)
+        self.assertEqual(vbm6.jump_map_length, 1)
+        fl = vbm6.firstLeafID()
+        self.assertEqual(fl.shape, (vbm6.blockCount(),))
         self.assertEqual(fl.dtype, np.uint32)
-        # Default jump_map_length=1 matches log2_block_width=6.
-        jm = vbm.jumpMap()
-        self.assertEqual(jm.shape, (vbm.blockCount(), 1))
+        jm = vbm6.jumpMap()
+        self.assertEqual(jm.shape, (vbm6.blockCount(), 1))
         self.assertEqual(jm.dtype, np.uint64)
-        # Wider widths reshape correctly:
-        jm2 = vbm.jumpMap(jump_map_length=2)
-        # Same underlying bytes, different reshape — leading dim halves.
-        self.assertEqual(jm2.shape[1], 2)
+        # log2_block_width=7 -> JumpMapLength=2 (independent build, separate
+        # allocation; the jumpMap shape comes from the handle, not the caller).
+        vbm7 = nanovdb.tools.buildVoxelBlockManager(h.grid(), log2_block_width=7)
+        self.assertEqual(vbm7.jump_map_length, 2)
+        self.assertEqual(vbm7.jumpMap().shape, (vbm7.blockCount(), 2))
 
     def test_decode_block_zero(self):
         try:
@@ -863,7 +867,7 @@ class TestVoxelBlockManager(unittest.TestCase):
         h = self._make_cube_on_index_grid()
         g = h.grid()
         vbm = nanovdb.tools.buildVoxelBlockManager(g, log2_block_width=6)
-        leaf_index, voxel_offset = vbm.decodeBlock(g, 0, log2_block_width=6)
+        leaf_index, voxel_offset = vbm.decodeBlock(g, 0)
         self.assertEqual(leaf_index.shape, (64,))
         self.assertEqual(leaf_index.dtype, np.uint32)
         self.assertEqual(voxel_offset.shape, (64,))
@@ -890,6 +894,35 @@ class TestVoxelBlockManager(unittest.TestCase):
             nanovdb.tools.buildVoxelBlockManager(g, log2_block_width=5)
         with self.assertRaises(ValueError):
             nanovdb.tools.buildVoxelBlockManager(g, log2_block_width=10)
+
+    def test_build_voxel_block_manager_rejects_misaligned_first_offset(self):
+        # first_offset must satisfy first_offset == 1 (mod BlockWidth).
+        # For log2_block_width=6, BlockWidth=64, so 1, 65, 129, ... are valid
+        # but 2 is not.
+        h = self._make_cube_on_index_grid()
+        g = h.grid()
+        with self.assertRaises(ValueError):
+            nanovdb.tools.buildVoxelBlockManager(
+                g, log2_block_width=6, first_offset=2)
+        # And the wider-block case: log2_block_width=7 -> BlockWidth=128,
+        # first_offset=65 is valid for width=6 but misaligned for width=7.
+        with self.assertRaises(ValueError):
+            nanovdb.tools.buildVoxelBlockManager(
+                g, log2_block_width=7, first_offset=65)
+
+    def test_decode_inverse_maps_rejects_bad_first_leaf_id(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not installed")
+        h = self._make_cube_on_index_grid()
+        g = h.grid()
+        vbm = nanovdb.tools.buildVoxelBlockManager(g, log2_block_width=6)
+        jm0 = np.asarray(vbm.jumpMap())[0]
+        n_leaves = g.tree().nodeCount(0)
+        with self.assertRaises(IndexError):
+            nanovdb.tools.decodeInverseMaps(
+                g, n_leaves, jm0, vbm.firstOffset(), log2_block_width=6)
 
     def test_build_voxel_block_manager_rejects_non_on_index_grid(self):
         # FloatGrid is not an OnIndexGrid.

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -742,6 +742,12 @@ class TestZeroCopyViewLifetimes(unittest.TestCase):
         self.assertEqual(g.gridName(), "probe")
 
     def test_handle_grid_tree_leaf_values_chain(self):
+        # nb::ndarray<nb::numpy, ...> requires numpy at runtime, so the
+        # binding raises TypeError if numpy isn't installed. Skip then.
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            self.skipTest("numpy not installed")
         vals = (nanovdb.tools.createFogVolumeSphere()
                 .grid().tree().getFirstLeaf().values())
         self._force_gc()
@@ -750,12 +756,20 @@ class TestZeroCopyViewLifetimes(unittest.TestCase):
         _ = float(vals[0])
 
     def test_grid_leaf_values_temporary(self):
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            self.skipTest("numpy not installed")
         bulk = nanovdb.tools.createFogVolumeSphere().grid().leaf_values()
         self._force_gc()
         self.assertEqual(bulk.shape[1], 512)
         _ = float(bulk[0, 0])
 
     def test_node_manager_temporary_grid(self):
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            self.skipTest("numpy not installed")
         nm = nanovdb.createNodeManager(
             nanovdb.tools.createFogVolumeSphere().grid()).mgr()
         self._force_gc()
@@ -807,16 +821,9 @@ class TestVoxelBlockManager(unittest.TestCase):
         self.assertTrue(g.isSequential())
 
     def test_create_on_index_grid_rejects_unsupported_source(self):
-        # PointGrid is not in the accepted source set.
-        # (The bound source types are float / double / int32 / Vec3f.)
-        try:
-            import numpy as np  # noqa
-        except ImportError:
-            self.skipTest("numpy not installed")
-        # Build a PointGrid via the binding stack; if there isn't an easy
-        # way, just attempt with an empty GridHandle.grid() which is None
-        # and should hit the type-error path. Skip if we can't easily make
-        # a non-source-typed grid available.
+        # createOnIndexGrid only accepts {float, double, int32, Vec3f}
+        # source grids; passing None (or any non-grid object) should raise
+        # TypeError at the first BuildT-isinstance check.
         with self.assertRaises(TypeError):
             nanovdb.tools.createOnIndexGrid(None)
 


### PR DESCRIPTION
## Summary

Phase 3 (#2212) deferred the VoxelBlockManager surface; this picks it up before moving on to Phase 4. Adds host-side bindings for everything under \`nanovdb::tools::VoxelBlockManager*\`, plus a minimal \`createOnIndexGrid\` scaffold needed to construct OnIndex grids from Python (the broader \`createNanoGrid<SrcGridT, DstBuildT>\` surface lands in Phase 5).

PR target: \`feature/nanovdb_python\`.

## New \`nanovdb.tools\` surface

| Symbol | Notes |
|---|---|
| **\`VoxelBlockManagerHandle\`** | Owns the firstLeafID + jumpMap metadata buffers. Read-only props \`blockCount()\` / \`firstOffset()\` / \`lastOffset()\`; \`reset()\`; \`__bool__\`. Zero-copy NumPy views: \`firstLeafID()\` -> \`(blockCount,)\` uint32; \`jumpMap(jump_map_length=1)\` -> \`(blockCount, jump_map_length)\` uint64. \`decodeBlock(grid, i, log2_block_width=6)\` convenience method slices firstLeafID/jumpMap for block \`i\` and runs \`decodeInverseMaps\` internally. |
| **\`buildVoxelBlockManager(grid, log2_block_width=6, first_offset=0, last_offset=0, n_blocks=0)\`** | Runtime switch over \`log2_block_width\` ∈ {6, 7, 8, 9} (BlockWidth = 64 / 128 / 256 / 512) dispatching to the matching C++ template instantiation. Rejects non-OnIndex grids with \`TypeError\`. |
| **\`decodeInverseMaps(grid, first_leaf_id, jump_map, block_first_offset, log2_block_width=6)\`** | Free function. \`jump_map\` is a uint64 NumPy array of length \`JumpMapLength\` (= \`1 << (log2_block_width - 6)\`). Returns \`(leaf_index, voxel_offset)\` freshly-allocated NumPy arrays (\`uint32\`, \`uint16\`) of length \`BlockWidth\`. |
| **\`createOnIndexGrid(src_grid, channels=0, include_stats=True, include_tiles=True, verbose=0)\`** | Test-scaffold factory binding \`tools::createNanoGrid<SrcGridT, ValueOnIndex>\` for source BuildTs ∈ {float, double, int32_t, Vec3f}. Required because no other host-side path produces an OnIndex grid from Python yet. The broader Phase 5 \`createNanoGrid<SrcGridT, DstBuildT>\` binding will subsume this. |

## Defensive checks

- \`decodeBlock\` validates \`firstLeafID[block_index] < grid.tree().nodeCount(0)\` before passing into the C++ \`decodeInverseMaps\`. **NanoVDB's \`buildVoxelBlockManager\` doesn't always initialize \`firstLeafID\`** — blocks that no leaf's iteration sweep reaches (e.g. on tile-compressed OnIndex grids where some sequential offsets correspond to tile values rather than leaf voxels) are left with uninitialized memory. Without the guard, \`decodeInverseMaps\` would read \`tree.getFirstNode<0>()[garbage]\` and segfault; the guard converts that into a Python \`ValueError\` with a clear message pointing at the workaround.
- All entry points reject out-of-range indices, levels, and grid build types upfront (\`TypeError\` / \`ValueError\` / \`IndexError\`).

## Test plan

Locally on CUDA sm_120 + BLOSC + ZLIB on:

- [x] **CPU build**: 84 tests (76 existing + 8 new \`TestVoxelBlockManager\` methods); 75 pass, 1 environment-dependent BLOSC failure in \`test_read_write_grid\` (unrelated; same on master).
- [x] **CUDA sm_120 + BLOSC + ZLIB**: **84/84 pass**.

New \`TestVoxelBlockManager\` covers:
- \`createOnIndexGrid\` produces an OnIndex / IndexGrid / sequential grid
- Buffer shapes + dtypes (firstLeafID, default jumpMap, reshape via \`jump_map_length\`)
- \`decodeBlock(0)\` returns \`(uint32, uint16)\` arrays of length BlockWidth
- \`decodeInverseMaps\` free function agrees with \`handle.decodeBlock\`
- Out-of-range \`block_index\` raises \`IndexError\`
- Out-of-range \`log2_block_width\` (5, 10) raises \`ValueError\`
- Non-OnIndex grid argument raises \`TypeError\`
- \`createOnIndexGrid(None)\` raises \`TypeError\`

## Intentionally deferred

- **End-to-end decode verification across every block** is deferred until Phase 4's \`build::Grid\` bindings land. The C++ algorithm's gap means the only currently-available host-side OnIndex sources (via \`createFloatGrid + createOnIndexGrid\`) produce tile-compressed grids that aren't fully covered by \`buildVoxelBlockManager\`. We get partial coverage (e.g. \`decodeBlock(0)\` works for the small fully-active cube used in the C++ unit test), but a full-grid sweep would hit the uninitialized-block guard for many blocks. Once Phase 4 lands, the per-voxel \`setValue\` path will let us build the same input the C++ unit test uses and a full sweep test can land alongside.
- **Device-side VBM** — the CUDA \`buildVoxelBlockManager\` + decode kernels — defer to a separate PR; they need their own CUDA include / link path and a typed \`VoxelBlockManagerHandle<DeviceBuffer>\` binding.

### Not verified locally — still on the reviewer

- [ ] Windows build.
- [ ] OpenVDB-enabled build.
- [ ] Device-side VBM build (intentionally not exercised in this PR).

Part of #2208.