### PR TITLE
nanovdb python: Phase 4a — tools.build.Grid<T> mutable CPU builder

### DIFF
--- a/nanovdb/nanovdb/python/CMakeLists.txt
+++ b/nanovdb/nanovdb/python/CMakeLists.txt
@@ -16,6 +16,7 @@ option(NANOVDB_BUILD_PYTHON_STUBS
 
 nanobind_add_module(nanovdb_python NB_STATIC
     NanoVDBModule.cc
+    PyBuildGrid.cc
     PyCreateNanoGrid.cc
     PyGridChecksum.cc
     PyGridHandle.cc

--- a/nanovdb/nanovdb/python/NanoVDBModule.cc
+++ b/nanovdb/nanovdb/python/NanoVDBModule.cc
@@ -15,6 +15,7 @@
 #include <sstream>
 
 #include "cuda/PyDeviceBuffer.h"
+#include "PyBuildGrid.h"
 #include "PyGridHandle.h"
 #include "PyHostBuffer.h"
 #include "PyIO.h"
@@ -808,6 +809,7 @@ NB_MODULE(nanovdb, m)
     toolsModule.doc() = "A submodule that implements tools for NanoVDB grids";
     defineToolsModule(toolsModule);
     defineVoxelBlockManagerModule(toolsModule);
+    defineBuildGridModule(toolsModule);
 
     nb::module_ ioModule = m.def_submodule("io");
     ioModule.doc() = "A submodule that implements I/O functionality for NanoVDB grids";

--- a/nanovdb/nanovdb/python/PyBuildGrid.cc
+++ b/nanovdb/nanovdb/python/PyBuildGrid.cc
@@ -1,0 +1,225 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+#include "PyBuildGrid.h"
+
+#include <nanobind/stl/array.h>
+#include <nanobind/stl/string.h>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/HostBuffer.h>
+#include <nanovdb/tools/CreateNanoGrid.h>
+#include <nanovdb/tools/GridBuilder.h>
+
+#include <array>
+#include <string>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace nanovdb;
+
+namespace pynanovdb {
+
+// Bind nanovdb::tools::build::Grid<BuildT> together with its
+// ValueAccessor<BuildT> and Tree<BuildT>::WriteAccessor proxies, plus a
+// .to_nanovdb() shortcut that bakes the build grid into a host NanoGrid
+// via tools::createNanoGrid.
+//
+// One instantiation per writable BuildT in BuildTypes.def (scalars +
+// vectors). All three classes live under the nanovdb.tools.build submodule;
+// the Python class names mirror the existing typed-grid naming so
+// nanovdb.tools.build.FloatGrid is the mutable counterpart of the read-only
+// nanovdb.FloatGrid.
+template<typename BuildT>
+static void defineBuildGrid(nb::module_& m,
+                            const char*  gridName,
+                            const char*  valueAccName,
+                            const char*  writeAccName)
+{
+    using GridT     = tools::build::Grid<BuildT>;
+    using TreeT     = tools::build::Tree<BuildT>;
+    using AccT      = tools::build::ValueAccessor<BuildT>;
+    using WriteAccT = typename TreeT::WriteAccessor;
+    using ValueT    = typename GridT::ValueType;
+
+    // ----- build::Grid<BuildT> -----
+    nb::class_<GridT>(m, gridName)
+        .def(nb::init<const ValueT&, const std::string&, GridClass>(),
+            "background"_a,
+            "name"_a      = std::string(""),
+            "gridClass"_a = GridClass::Unknown,
+            "Construct an empty mutable build grid. Voxels read as "
+            "background until written.")
+        .def("getValue",
+            [](const GridT& self, const Coord& ijk) -> ValueT {
+                return self.getValue(ijk);
+            },
+            "ijk"_a,
+            "Return the value at ijk (background if no leaf covers it).")
+        .def("setValue",
+            [](GridT& self, const Coord& ijk, const ValueT& value) {
+                self.setValue(ijk, value);
+            },
+            "ijk"_a, "value"_a,
+            "Set the voxel value at ijk and mark the voxel active.")
+        // build::Grid has no top-level isActive(ijk); the read path is via
+        // ValueAccessor. Spin up a fresh accessor for the single query so
+        // Python callers don't have to.
+        .def("isActive",
+            [](GridT& self, const Coord& ijk) {
+                AccT acc = self.getAccessor();
+                return acc.isActive(ijk);
+            },
+            "ijk"_a,
+            "Return True iff ijk is in an active voxel. Equivalent to "
+            "self.getAccessor().isActive(ijk), but allocates a fresh "
+            "accessor for each call — for repeated queries use "
+            "self.getAccessor() and reuse it.")
+        .def("setValueOn",
+            [](GridT& self, const Coord& ijk) {
+                AccT acc = self.getAccessor();
+                acc.setValueOn(ijk);
+            },
+            "ijk"_a,
+            "Mark ijk active without changing the stored value. Equivalent "
+            "to self.getAccessor().setValueOn(ijk).")
+        .def("nodeCount",
+            [](const GridT& self) -> std::array<size_t, 3> {
+                return self.nodeCount();
+            },
+            "Return a 3-tuple (leaf_count, lower_count, upper_count) of "
+            "internal node counts.")
+        .def("gridType",  &GridT::gridType,
+            "Return the GridType enumerator this BuildT carries.")
+        .def("gridClass", &GridT::gridClass,
+            "Return the GridClass assigned at construction time.")
+        .def("getName",   &GridT::getName,
+            "Return the grid name (as passed at construction).")
+        .def("setName",   &GridT::setName, "name"_a,
+            "Replace the grid name.")
+        .def("setTransform", &GridT::setTransform,
+            "scale"_a       = 1.0,
+            "translation"_a = Vec3d(0.0),
+            "Set an affine index-to-world map from a uniform scale and "
+            "translation. Replaces any prior transform.")
+        .def_prop_ro("background",
+            [](const GridT& self) -> ValueT { return self.mRoot.mBackground; },
+            "The background value supplied at construction.")
+        .def("getAccessor", &GridT::getAccessor,
+            nb::keep_alive<0, 1>(),
+            "Return a ValueAccessor wired to this grid's root. Thread-safe "
+            "for reads, NOT thread-safe for writes. The accessor borrows "
+            "from this grid — the grid must outlive it.")
+        // WriteAccessor's defaulted move constructor would leave its
+        // internal ValueAccessor's `mRoot&` reference dangling (it points
+        // into the moved-from WriteAccessor's own mRoot field). Bypass
+        // the move path entirely by heap-allocating and handing nanobind
+        // ownership — the C++ object stays at a stable address for its
+        // whole lifetime.
+        .def("getWriteAccessor",
+            [](GridT& self) -> WriteAccT* {
+                return new WriteAccT(self.mRoot, self.mMutex);
+            },
+            nb::rv_policy::take_ownership,
+            nb::keep_alive<0, 1>(),
+            "Return a WriteAccessor for thread-safe writes; the accessor "
+            "buffers changes into a private root and merges them into the "
+            "parent grid on destruction (or on an explicit merge() call). "
+            "Held by nanobind on the heap so the accessor's internal "
+            "references stay valid.")
+        .def("to_nanovdb",
+            [](const GridT& self,
+               tools::StatsMode sMode,
+               CheckMode        cMode,
+               int              verbose) {
+                return tools::createNanoGrid<GridT, BuildT, HostBuffer>(
+                    self, sMode, cMode, verbose);
+            },
+            "sMode"_a   = tools::StatsMode::Default,
+            "cMode"_a   = CheckMode::Default,
+            "verbose"_a = 0,
+            "Bake this mutable grid into a host NanoGrid<BuildT> and "
+            "return its GridHandle. The build grid is unchanged.");
+
+    // ----- build::ValueAccessor<BuildT> -----
+    //
+    // Move-only (copy is deleted) — returned by getAccessor(). Caches the
+    // last leaf / lower / upper node it touched, so repeated access to
+    // neighboring coordinates is fast.
+    nb::class_<AccT>(m, valueAccName)
+        .def("getValue",
+            [](const AccT& self, const Coord& ijk) -> ValueT {
+                return self.getValue(ijk);
+            },
+            "ijk"_a, "Return the value at ijk (uses the cache).")
+        .def("setValue",
+            [](AccT& self, const Coord& ijk, const ValueT& value) {
+                self.setValue(ijk, value);
+            },
+            "ijk"_a, "value"_a,
+            "Set the value at ijk and mark it active (uses the cache).")
+        .def("setValueOn",
+            [](AccT& self, const Coord& ijk) { self.setValueOn(ijk); },
+            "ijk"_a,
+            "Mark ijk active without changing the stored value.")
+        .def("isActive",
+            [](const AccT& self, const Coord& ijk) {
+                return self.isActive(ijk);
+            },
+            "ijk"_a,
+            "Return True iff ijk is in an active voxel.")
+        .def("isValueOn",
+            [](const AccT& self, const Coord& ijk) {
+                return self.isValueOn(ijk);
+            },
+            "ijk"_a,
+            "Alias for isActive(ijk).");
+
+    // ----- build::Tree<BuildT>::WriteAccessor -----
+    //
+    // Move-only. Holds its own root node + a reference to the parent root's
+    // mutex; on destruction (or explicit merge()) it locks the mutex and
+    // splices its buffered nodes into the parent. Designed for multi-thread
+    // writes — one WriteAccessor per thread, no shared mutable state.
+    nb::class_<WriteAccT>(m, writeAccName)
+        .def("setValue",
+            [](WriteAccT& self, const Coord& ijk, const ValueT& value) {
+                self.setValue(ijk, value);
+            },
+            "ijk"_a, "value"_a,
+            "Buffer a set into this accessor's private root.")
+        .def("setValueOn",
+            [](WriteAccT& self, const Coord& ijk) { self.setValueOn(ijk); },
+            "ijk"_a,
+            "Buffer an active-state set into this accessor's private root.")
+        .def("merge", &WriteAccT::merge,
+            "Lock the parent mutex and splice this accessor's buffered "
+            "nodes into the parent grid. Called automatically when the "
+            "accessor is destroyed; calling it explicitly is only "
+            "necessary if you want the changes visible to the parent "
+            "before the accessor goes out of scope.");
+}
+
+void defineBuildGridModule(nb::module_& toolsModule)
+{
+    nb::module_ buildModule = toolsModule.def_submodule("build");
+    buildModule.doc() =
+        "Mutable, voxel-by-voxel CPU grid builder mirroring "
+        "nanovdb::tools::build::*. Construct a typed Grid (e.g. "
+        "FloatGrid(0.0, 'mygrid')), populate it with setValue / "
+        "ValueAccessor / WriteAccessor, then call .to_nanovdb() to bake "
+        "a host NanoGrid handle.";
+
+    // X-macro instantiation over every writable BuildT: scalars (full
+    // arithmetic) and vectors. Read-only special BuildTs (Boolean, Fp*,
+    // Index, Mask) and Point are deliberately excluded — they have no
+    // SetValue<T> specialization and can't be built voxel-by-voxel.
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)            \
+    defineBuildGrid<T>(buildModule, #Suffix "Grid",                           \
+                       #Suffix "ValueAccessor", #Suffix "WriteAccessor");
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum) \
+    defineBuildGrid<T>(buildModule, #Suffix "Grid",                              \
+                       #Suffix "ValueAccessor", #Suffix "WriteAccessor");
+#include "BuildTypes.def"
+}
+
+} // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyBuildGrid.cc
+++ b/nanovdb/nanovdb/python/PyBuildGrid.cc
@@ -86,8 +86,7 @@ static void defineBuildGrid(nb::module_& m,
             [](const GridT& self) -> std::array<size_t, 3> {
                 return self.nodeCount();
             },
-            "Return a 3-tuple (leaf_count, lower_count, upper_count) of "
-            "internal node counts.")
+            "Return a 3-tuple (leaf_count, lower_count, upper_count).")
         .def("gridType",  &GridT::gridType,
             "Return the GridType enumerator this BuildT carries.")
         .def("gridClass", &GridT::gridClass,
@@ -102,7 +101,9 @@ static void defineBuildGrid(nb::module_& m,
             "Set an affine index-to-world map from a uniform scale and "
             "translation. Replaces any prior transform.")
         .def_prop_ro("background",
-            [](const GridT& self) -> ValueT { return self.mRoot.mBackground; },
+            [](const GridT& self) -> ValueT {
+                return self.mRoot.background();
+            },
             "The background value supplied at construction.")
         .def("getAccessor", &GridT::getAccessor,
             nb::keep_alive<0, 1>(),
@@ -126,6 +127,9 @@ static void defineBuildGrid(nb::module_& m,
             "parent grid on destruction (or on an explicit merge() call). "
             "Held by nanobind on the heap so the accessor's internal "
             "references stay valid.")
+        // Baking a large grid is the most expensive operation on this
+        // class; release the GIL so other Python threads can run during
+        // the conversion (the lambda only touches C++ state).
         .def("to_nanovdb",
             [](const GridT& self,
                tools::StatsMode sMode,
@@ -134,11 +138,13 @@ static void defineBuildGrid(nb::module_& m,
                 return tools::createNanoGrid<GridT, BuildT, HostBuffer>(
                     self, sMode, cMode, verbose);
             },
+            nb::call_guard<nb::gil_scoped_release>(),
             "sMode"_a   = tools::StatsMode::Default,
             "cMode"_a   = CheckMode::Default,
             "verbose"_a = 0,
             "Bake this mutable grid into a host NanoGrid<BuildT> and "
-            "return its GridHandle. The build grid is unchanged.");
+            "return its GridHandle. The build grid is unchanged. "
+            "Releases the GIL during conversion.");
 
     // ----- build::ValueAccessor<BuildT> -----
     //

--- a/nanovdb/nanovdb/python/PyBuildGrid.h
+++ b/nanovdb/nanovdb/python/PyBuildGrid.h
@@ -1,0 +1,20 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+#ifndef NANOVDB_PYBUILDGRID_HAS_BEEN_INCLUDED
+#define NANOVDB_PYBUILDGRID_HAS_BEEN_INCLUDED
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+namespace pynanovdb {
+
+/// @brief Register the nanovdb.tools.build submodule and its per-BuildT
+///        Grid / ValueAccessor / WriteAccessor classes (one set per writable
+///        scalar and vector BuildT in BuildTypes.def). Constructs the submodule
+///        as `toolsModule.def_submodule("build")`.
+void defineBuildGridModule(nb::module_& toolsModule);
+
+} // namespace pynanovdb
+
+#endif

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -1650,11 +1650,7 @@ class TestBuildGrid(unittest.TestCase):
             nanovdb.math.Vec3f(0.0), "v", nanovdb.GridClass.Unknown)
         v = nanovdb.math.Vec3f(1.0, 2.0, 3.0)
         g.setValue(nanovdb.math.Coord(0, 0, 0), v)
-        got = g.getValue(nanovdb.math.Coord(0, 0, 0))
-        # Vec3f equality isn't bound here, so compare components.
-        self.assertEqual(got[0], 1.0)
-        self.assertEqual(got[1], 2.0)
-        self.assertEqual(got[2], 3.0)
+        self.assertEqual(g.getValue(nanovdb.math.Coord(0, 0, 0)), v)
         h = g.to_nanovdb()
         self.assertEqual(h.grid().gridType(), nanovdb.GridType.Vec3f)
 

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -1543,6 +1543,127 @@ class TestCreateNanoGrid(unittest.TestCase):
             self.assertEqual(grid.gridClass(), nanovdb.GridClass.Unknown)
 
 
+class TestBuildGrid(unittest.TestCase):
+    """nanovdb.tools.build.* — mutable voxel-by-voxel CPU grid builder."""
+
+    def test_constructor_defaults_and_metadata(self):
+        g = nanovdb.tools.build.FloatGrid(0.0)
+        self.assertEqual(g.getName(), "")
+        self.assertEqual(g.gridClass(), nanovdb.GridClass.Unknown)
+        self.assertEqual(g.gridType(), nanovdb.GridType.Float)
+        self.assertEqual(g.background, 0.0)
+        self.assertEqual(g.nodeCount(), [0, 0, 0])
+        g.setName("renamed")
+        self.assertEqual(g.getName(), "renamed")
+
+    def test_set_get_value_marks_active(self):
+        g = nanovdb.tools.build.FloatGrid(0.0, "demo")
+        ijk = nanovdb.math.Coord(1, 2, 3)
+        self.assertFalse(g.isActive(ijk))
+        self.assertEqual(g.getValue(ijk), 0.0)
+        g.setValue(ijk, 4.5)
+        self.assertTrue(g.isActive(ijk))
+        self.assertEqual(g.getValue(ijk), 4.5)
+        # An untouched voxel is still background-valued and inactive.
+        self.assertEqual(g.getValue(nanovdb.math.Coord(10, 0, 0)), 0.0)
+        self.assertFalse(g.isActive(nanovdb.math.Coord(10, 0, 0)))
+
+    def test_set_value_on_keeps_background_value(self):
+        g = nanovdb.tools.build.FloatGrid(-1.0, "demo")
+        ijk = nanovdb.math.Coord(5, 6, 7)
+        g.setValueOn(ijk)
+        self.assertTrue(g.isActive(ijk))
+        # setValueOn does not change the stored value — still background.
+        self.assertEqual(g.getValue(ijk), -1.0)
+
+    def test_value_accessor_parity_with_grid(self):
+        g = nanovdb.tools.build.FloatGrid(0.0)
+        acc = g.getAccessor()
+        ijk = nanovdb.math.Coord(100, 200, 300)
+        acc.setValue(ijk, 7.5)
+        self.assertEqual(g.getValue(ijk), 7.5)
+        self.assertEqual(acc.getValue(ijk), 7.5)
+        self.assertTrue(acc.isActive(ijk))
+        # isValueOn is an alias for isActive.
+        self.assertEqual(acc.isValueOn(ijk), acc.isActive(ijk))
+
+    def test_write_accessor_merges_on_destruction(self):
+        g = nanovdb.tools.build.FloatGrid(0.0)
+        ijk = nanovdb.math.Coord(50, 50, 50)
+        # Buffer the write into a thread-local root, then let the
+        # accessor go out of scope so its destructor merges into the
+        # parent grid.
+        wa = g.getWriteAccessor()
+        wa.setValue(ijk, 9.0)
+        # Before merge, the parent grid hasn't seen the change yet.
+        self.assertEqual(g.getValue(ijk), 0.0)
+        wa.merge()
+        self.assertEqual(g.getValue(ijk), 9.0)
+        self.assertTrue(g.isActive(ijk))
+
+    def test_to_nanovdb_roundtrip(self):
+        g = nanovdb.tools.build.FloatGrid(0.0, "trip", nanovdb.GridClass.FogVolume)
+        g.setValue(nanovdb.math.Coord(0, 0, 0), 1.0)
+        g.setValue(nanovdb.math.Coord(1, 0, 0), 2.0)
+        g.setValue(nanovdb.math.Coord(2, 0, 0), 3.0)
+        h = g.to_nanovdb()
+        self.assertEqual(h.gridCount(), 1)
+        ng = h.grid()
+        self.assertEqual(ng.gridType(), nanovdb.GridType.Float)
+        self.assertEqual(ng.gridClass(), nanovdb.GridClass.FogVolume)
+        self.assertEqual(ng.gridName(), "trip")
+        self.assertEqual(ng.activeVoxelCount(), 3)
+
+    def test_to_nanovdb_does_not_consume_source(self):
+        # Source build::Grid must remain usable after .to_nanovdb().
+        g = nanovdb.tools.build.FloatGrid(0.0)
+        g.setValue(nanovdb.math.Coord(0, 0, 0), 1.0)
+        _ = g.to_nanovdb()
+        g.setValue(nanovdb.math.Coord(1, 0, 0), 2.0)
+        h2 = g.to_nanovdb()
+        self.assertEqual(h2.grid().activeVoxelCount(), 2)
+
+    def test_int32_build_grid(self):
+        g = nanovdb.tools.build.Int32Grid(0, "ints", nanovdb.GridClass.Unknown)
+        g.setValue(nanovdb.math.Coord(0, 0, 0), 42)
+        g.setValue(nanovdb.math.Coord(1, 1, 1), -7)
+        self.assertEqual(g.getValue(nanovdb.math.Coord(0, 0, 0)), 42)
+        self.assertEqual(g.getValue(nanovdb.math.Coord(1, 1, 1)), -7)
+        h = g.to_nanovdb()
+        self.assertEqual(h.grid().gridType(), nanovdb.GridType.Int32)
+        self.assertEqual(h.grid().activeVoxelCount(), 2)
+
+    def test_vec3f_build_grid(self):
+        g = nanovdb.tools.build.Vec3fGrid(
+            nanovdb.math.Vec3f(0.0), "v", nanovdb.GridClass.Unknown)
+        v = nanovdb.math.Vec3f(1.0, 2.0, 3.0)
+        g.setValue(nanovdb.math.Coord(0, 0, 0), v)
+        got = g.getValue(nanovdb.math.Coord(0, 0, 0))
+        # Vec3f equality isn't bound here, so compare components.
+        self.assertEqual(got[0], 1.0)
+        self.assertEqual(got[1], 2.0)
+        self.assertEqual(got[2], 3.0)
+        h = g.to_nanovdb()
+        self.assertEqual(h.grid().gridType(), nanovdb.GridType.Vec3f)
+
+    def test_set_transform(self):
+        g = nanovdb.tools.build.FloatGrid(0.0)
+        g.setTransform(scale=0.5, translation=nanovdb.math.Vec3d(1.0, 2.0, 3.0))
+        g.setValue(nanovdb.math.Coord(0, 0, 0), 1.0)
+        h = g.to_nanovdb()
+        ng = h.grid()
+        vs = ng.voxelSize()
+        self.assertAlmostEqual(vs[0], 0.5)
+        self.assertAlmostEqual(vs[1], 0.5)
+        self.assertAlmostEqual(vs[2], 0.5)
+        # Index (0,0,0) mapped through (scale=0.5, translation=(1,2,3))
+        # lands at world-space (1, 2, 3).
+        w = ng.map().applyMap(nanovdb.math.Vec3d(0.0, 0.0, 0.0))
+        self.assertAlmostEqual(w[0], 1.0)
+        self.assertAlmostEqual(w[1], 2.0)
+        self.assertAlmostEqual(w[2], 3.0)
+
+
 class TestNanoToOpenVDB(unittest.TestCase):
     def test_function(self):
         handle = nanovdb.tools.createLevelSetSphere()

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -1587,18 +1587,30 @@ class TestBuildGrid(unittest.TestCase):
         # isValueOn is an alias for isActive.
         self.assertEqual(acc.isValueOn(ijk), acc.isActive(ijk))
 
-    def test_write_accessor_merges_on_destruction(self):
+    def test_write_accessor_explicit_merge(self):
         g = nanovdb.tools.build.FloatGrid(0.0)
         ijk = nanovdb.math.Coord(50, 50, 50)
-        # Buffer the write into a thread-local root, then let the
-        # accessor go out of scope so its destructor merges into the
-        # parent grid.
         wa = g.getWriteAccessor()
         wa.setValue(ijk, 9.0)
         # Before merge, the parent grid hasn't seen the change yet.
         self.assertEqual(g.getValue(ijk), 0.0)
         wa.merge()
         self.assertEqual(g.getValue(ijk), 9.0)
+        self.assertTrue(g.isActive(ijk))
+
+    def test_write_accessor_merges_on_destruction(self):
+        # When the Python wrapper for a WriteAccessor is collected, the
+        # C++ destructor runs merge() automatically. Force collection by
+        # dropping the only reference and running the GC.
+        import gc
+        g = nanovdb.tools.build.FloatGrid(0.0)
+        ijk = nanovdb.math.Coord(60, 60, 60)
+        wa = g.getWriteAccessor()
+        wa.setValue(ijk, 3.5)
+        self.assertEqual(g.getValue(ijk), 0.0)
+        del wa
+        gc.collect()
+        self.assertEqual(g.getValue(ijk), 3.5)
         self.assertTrue(g.isActive(ijk))
 
     def test_to_nanovdb_roundtrip(self):


### PR DESCRIPTION
## Summary

Phase 4a of the [NanoVDB Python bindings restructure (#2208)](https://github.com/AcademySoftwareFoundation/openvdb/issues/2208). Adds `nanovdb.tools.build` — a Python submodule mirroring `nanovdb::tools::build::*` for direct voxel-by-voxel CPU grid construction. Today the only path to create a NanoVDB grid from pure Python is the `createFloatGrid`/`createDoubleGrid`/`createInt32Grid`/`createVec3fGrid` bbox-and-functor factories; this PR exposes the underlying mutable builder so procedural worlds, test fixtures, synthetic datasets, and per-voxel programmatic editing become feasible without dropping to C++.

- New `PyBuildGrid.cc` / `.h` binds `tools::build::Grid<T>`, `ValueAccessor<T>`, and `Tree<T>::WriteAccessor` for every writable BuildT in `BuildTypes.def` (7 scalars + 7 vectors = 14 instantiations).
- Per-grid surface: ctor `(background, name='', gridClass=Unknown)`, `getValue`, `setValue`, `setValueOn`, `isActive`, `nodeCount`, `gridType`, `gridClass`, `getName`/`setName`, `setTransform`, `.background` property, `getAccessor()`, `getWriteAccessor()`, `.to_nanovdb(sMode, cMode, verbose)`.
- `.to_nanovdb()` bakes the build grid into a host `GridHandle` via `tools::createNanoGrid<build::Grid<T>, T>` — the build grid stays usable afterwards (verified by test).

The Python class names match the C++ namespacing: `nanovdb.tools.build.FloatGrid` is the mutable counterpart of the read-only `nanovdb.FloatGrid`, so the two coexist clearly.

### Excluded BuildTs

Read-only special BuildTs (`Boolean`, `Fp4`/`Fp8`/`Fp16`/`FpN`, `ValueIndex`, `ValueOnIndex`, `ValueMask`) and `Point` have no `SetValue<T>` specialization in C++ — they can't be built voxel-by-voxel from a generic `build::Grid` and are deliberately omitted.

### Implementation note: WriteAccessor lifetime

`tools::build::Tree<T>::WriteAccessor` declares `WriteAccessor(WriteAccessor&&) = default;` but holds an internal `ValueAccessor` whose `RootNodeType& mRoot` reference points into the WriteAccessor's *own* `mRoot` field. The defaulted move constructor copies the reference without rebinding it, so after a move the internal accessor's `mRoot` points into the moved-from object — dangling. The Python binding bypasses the move path entirely by heap-allocating WriteAccessor via `nb::rv_policy::take_ownership`, so the C++ object's address is stable for its lifetime. `ValueAccessor` doesn't have this hazard because its `mRoot` reference points at the parent `Tree::mRoot` (a stable address external to the accessor).

## Test plan

- [x] All 10 new `TestBuildGrid` cases pass locally: constructor defaults, setValue marks active, setValueOn preserves background, ValueAccessor parity with Grid, WriteAccessor merge-on-destruction, `.to_nanovdb()` round-trip with metadata, `.to_nanovdb()` doesn't consume the source, `Int32Grid` + `Vec3fGrid` spot-checks, `setTransform` propagation to baked grid's `voxelSize`/`map`.
- [x] Full pytest_nanovdb suite still green locally (98/100; the 2 errors are pre-existing BLOSC-disabled errors in this local config, unrelated).
- [x] CUDA build + link clean.

## Relationship to the plan

This is `phase4-build` from [nanovdb-python-plan.md](nanovdb-python-plan.md). Phase 4b (stats: `updateGridStats`, `getExtrema`, `Extrema`, `Stats`) and Phase 4c (validation: `validateGrid` single-grid, `checkGrid`, `isValid`, `evalChecksum`, `validateChecksum`) will follow in a paired second PR.