### PR TITLE
nanovdb python: Phase 4b + 4c — stats, validation, checksum

### DIFF
--- a/nanovdb/nanovdb/python/PyGridChecksum.cc
+++ b/nanovdb/nanovdb/python/PyGridChecksum.cc
@@ -33,4 +33,40 @@ void defineUpdateChecksum(nb::module_& m)
         "updateChecksum", [](GridData* gridData, CheckMode mode) { tools::updateChecksum(gridData, mode); }, "gridData"_a, "mode"_a);
 }
 
+void defineEvalChecksumModule(nb::module_& toolsModule)
+{
+    // tools.evalChecksum(grid, mode) — compute a fresh checksum for the
+    // given grid without writing it back. Mirrors the GridData* overload
+    // in tools/GridChecksum.h; the polymorphism over BuildT is implicit
+    // because every NanoGrid<T> is-a GridData in the C++ hierarchy (and
+    // the Python class binding declares NanoGrid<T> as derived from
+    // GridData).
+    toolsModule.def("evalChecksum",
+        [](const GridData* gridData, CheckMode mode) -> Checksum {
+            if (gridData == nullptr) {
+                throw nb::value_error("evalChecksum: grid is None.");
+            }
+            return tools::evalChecksum(gridData, mode);
+        },
+        "grid"_a, "mode"_a = CheckMode::Default,
+        nb::call_guard<nb::gil_scoped_release>(),
+        "Compute and return the Checksum for the given grid using the "
+        "specified CheckMode. Does not modify the grid.");
+
+    // tools.validateChecksum(grid, mode) — compare the stored checksum
+    // against a freshly computed one and return a bool.
+    toolsModule.def("validateChecksum",
+        [](const GridData* gridData, CheckMode mode) -> bool {
+            if (gridData == nullptr) {
+                throw nb::value_error("validateChecksum: grid is None.");
+            }
+            return tools::validateChecksum(gridData, mode);
+        },
+        "grid"_a, "mode"_a = CheckMode::Default,
+        nb::call_guard<nb::gil_scoped_release>(),
+        "Return True iff the grid's stored checksum matches a freshly "
+        "computed one for the given CheckMode. A grid with no stored "
+        "checksum (Checksum.isEmpty()) is considered valid.");
+}
+
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyGridChecksum.h
+++ b/nanovdb/nanovdb/python/PyGridChecksum.h
@@ -13,6 +13,11 @@ void defineCheckMode(nb::module_& m);
 void defineChecksum(nb::module_& m);
 void defineUpdateChecksum(nb::module_& m);
 
+/// @brief Bind tools.evalChecksum and tools.validateChecksum on the
+///        nanovdb.tools submodule. Both accept any bound NanoGrid via
+///        GridData* upcast (handled by nanobind's class hierarchy).
+void defineEvalChecksumModule(nb::module_& toolsModule);
+
 } // namespace pynanovdb
 
 #endif

--- a/nanovdb/nanovdb/python/PyGridStats.cc
+++ b/nanovdb/nanovdb/python/PyGridStats.cc
@@ -2,9 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "PyGridStats.h"
 
+#include <nanobind/stl/string.h>
+
+#include <nanovdb/NanoVDB.h>
 #include <nanovdb/tools/GridStats.h>
 
+#include <string>
+
 namespace nb = nanobind;
+using namespace nb::literals;
 using namespace nanovdb;
 
 namespace pynanovdb {
@@ -18,6 +24,180 @@ void defineStatsMode(nb::module_& m)
         .value("All", tools::StatsMode::All)
         .value("Default", tools::StatsMode::Default)
         .value("End", tools::StatsMode::End);
+}
+
+namespace {
+
+// ----- Extrema<ValueT> binding (rank 0 and rank 1 share the same surface) -----
+template<typename BuildT>
+static void defineExtrema(nb::module_& m, const char* name)
+{
+    using ValueT   = typename NanoGrid<BuildT>::ValueType;
+    using ExtremaT = tools::Extrema<ValueT>;
+
+    nb::class_<ExtremaT>(m, name)
+        .def(nb::init<>(),
+            "Default-construct an Extrema with min = numeric_limits::max and "
+            "max = numeric_limits::lowest, so any subsequent .add(v) gives "
+            "exact min/max.")
+        .def("min",
+            [](const ExtremaT& self) -> ValueT { return self.min(); },
+            "Return the minimum value observed so far.")
+        .def("max",
+            [](const ExtremaT& self) -> ValueT { return self.max(); },
+            "Return the maximum value observed so far.")
+        .def("add",
+            [](ExtremaT& self, const ValueT& v) { self.add(v); },
+            "value"_a,
+            "Update min/max with a single sample.")
+        .def("__bool__",
+            [](const ExtremaT& self) { return bool(self); },
+            "True iff the Extrema has accumulated at least one sample "
+            "(i.e. min <= max).")
+        .def_static("hasMinMax", &ExtremaT::hasMinMax,
+            "True for value types where min/max is meaningful "
+            "(everything except bool).")
+        .def_static("hasAverage", &ExtremaT::hasAverage,
+            "Always False — Extrema does not compute averages; "
+            "use Stats for that.")
+        .def_static("hasStdDeviation", &ExtremaT::hasStdDeviation,
+            "Always False — Extrema does not compute standard "
+            "deviation; use Stats for that.")
+        .def_static("hasStats", &ExtremaT::hasStats,
+            "True iff the value type supports the min/max bookkeeping "
+            "(everything except bool).");
+}
+
+// ----- Stats<ValueT> binding (inherits Extrema) -----
+template<typename BuildT>
+static void defineStats(nb::module_& m, const char* name, const char* baseName)
+{
+    using ValueT  = typename NanoGrid<BuildT>::ValueType;
+    using BaseT   = tools::Extrema<ValueT>;
+    using StatsT  = tools::Stats<ValueT>;
+    (void)baseName; // kept in signature for parity with extrema name lookup
+
+    nb::class_<StatsT, BaseT>(m, name)
+        .def(nb::init<>(),
+            "Default-construct a Stats accumulator with zero samples.")
+        .def("add",
+            [](StatsT& self, const ValueT& v) { self.add(v); },
+            "value"_a,
+            "Add a single sample.")
+        .def("size",
+            [](const StatsT& self) -> size_t { return self.size(); },
+            "Number of samples accumulated so far.")
+        .def("avg",
+            [](const StatsT& self) -> double { return self.avg(); },
+            "Arithmetic mean of all samples.")
+        .def("mean",
+            [](const StatsT& self) -> double { return self.mean(); },
+            "Alias for avg().")
+        .def("var",
+            [](const StatsT& self) -> double { return self.var(); },
+            "Population variance (Sum(x-mean)^2 / N). Returns 0 if "
+            "fewer than two samples have been added.")
+        .def("variance",
+            [](const StatsT& self) -> double { return self.variance(); },
+            "Alias for var().")
+        .def("std",
+            [](const StatsT& self) -> double { return self.std(); },
+            "Standard deviation = sqrt(var()).")
+        .def("stdDev",
+            [](const StatsT& self) -> double { return self.stdDev(); },
+            "Alias for std().")
+        .def_static("hasMinMax", &StatsT::hasMinMax,
+            "True for value types where min/max is meaningful.")
+        .def_static("hasAverage", &StatsT::hasAverage,
+            "True for value types that support mean/variance.")
+        .def_static("hasStdDeviation", &StatsT::hasStdDeviation,
+            "True for value types that support standard deviation.")
+        .def_static("hasStats", &StatsT::hasStats,
+            "True for value types where full statistics is meaningful.");
+}
+
+// ----- updateGridStats polymorphic dispatch ----------------------------------
+//
+// Match the IsNanoGridValid/callNanoGrid pattern: an Op struct with `known<T>`
+// (called for every BuildT that's in scope) and `unknown` (fallback). Only
+// scalar + vector BuildTs have a meaningful Stats specialization, so the
+// other arms raise.
+struct UpdateGridStatsOp
+{
+    template<typename BuildT>
+    static void known(GridData* gridData, tools::StatsMode mode)
+    {
+        if constexpr (BuildTraits<BuildT>::is_special &&
+                      !util::is_same<bool, BuildT>::value) {
+            (void)gridData; (void)mode;
+            throw nb::value_error(
+                "updateGridStats: the grid's BuildT does not support "
+                "tools::Stats (special / quantized / index / mask grids "
+                "have no arithmetic value type).");
+        } else {
+            tools::updateGridStats(static_cast<NanoGrid<BuildT>*>(gridData),
+                                   mode);
+        }
+    }
+    static void unknown(GridData*, tools::StatsMode) {
+        throw nb::value_error(
+            "updateGridStats: unsupported GridType / BuildT combination.");
+    }
+};
+
+// ----- getExtrema (per-BuildT factory) ---------------------------------------
+template<typename BuildT>
+static tools::Extrema<typename NanoGrid<BuildT>::ValueType>
+pyGetExtrema(const NanoGrid<BuildT>& grid, const CoordBBox& bbox)
+{
+    return tools::getExtrema<BuildT>(grid, bbox);
+}
+
+} // namespace
+
+void defineGridStatsModule(nb::module_& toolsModule)
+{
+    // Per-BuildT Extrema + Stats. One pair per scalar/vector BuildT — the
+    // value types are all distinct so we get N pairs of new Python classes.
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)             \
+    defineExtrema<T>(toolsModule, #Suffix "Extrema");                          \
+    defineStats<T>(toolsModule,   #Suffix "Stats", #Suffix "Extrema");
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum) \
+    defineExtrema<T>(toolsModule, #Suffix "Extrema");                            \
+    defineStats<T>(toolsModule,   #Suffix "Stats", #Suffix "Extrema");
+#include "BuildTypes.def"
+
+    // Polymorphic updateGridStats. Accepts any bound NanoGrid<BuildT> (via
+    // upcast to GridData*) and dispatches on its mGridType.
+    toolsModule.def("updateGridStats",
+        [](GridData* gridData, tools::StatsMode mode) {
+            if (gridData == nullptr) {
+                throw nb::value_error("updateGridStats: grid is None.");
+            }
+            callNanoGrid<UpdateGridStatsOp>(gridData, mode);
+        },
+        "grid"_a, "mode"_a = tools::StatsMode::Default,
+        nb::call_guard<nb::gil_scoped_release>(),
+        "Recompute and write per-node statistics (min/max/avg/dev) into "
+        "the given grid in place. Polymorphic over BuildT. Only scalar "
+        "and vector grids carry arithmetic statistics; special "
+        "(quantized / index / mask) grids raise ValueError unless mode "
+        "is StatsMode.BBox.");
+
+    // Per-BuildT getExtrema. We expose one overload per scalar/vector
+    // BuildT — they each return a Python-side Extrema<ValueT> of the
+    // matching name.
+#define NANOVDB_PY_FOR_EACH_SCALAR_BUILDT(T, Suffix, GridTypeEnum)             \
+    toolsModule.def("getExtrema", &pyGetExtrema<T>,                            \
+        "grid"_a, "bbox"_a, nb::call_guard<nb::gil_scoped_release>(),          \
+        "Return the Extrema of all values in the grid that intersect "         \
+        "the given bbox.");
+#define NANOVDB_PY_FOR_EACH_VECTOR_BUILDT(T, Suffix, AccessorName, GridTypeEnum) \
+    toolsModule.def("getExtrema", &pyGetExtrema<T>,                              \
+        "grid"_a, "bbox"_a, nb::call_guard<nb::gil_scoped_release>(),            \
+        "Return the Extrema of all values in the grid that intersect "           \
+        "the given bbox.");
+#include "BuildTypes.def"
 }
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyGridStats.cc
+++ b/nanovdb/nanovdb/python/PyGridStats.cc
@@ -127,16 +127,32 @@ struct UpdateGridStatsOp
     template<typename BuildT>
     static void known(GridData* gridData, tools::StatsMode mode)
     {
+        using GridT  = NanoGrid<BuildT>;
+        using ValueT = typename GridT::ValueType;
         if constexpr (BuildTraits<BuildT>::is_special &&
                       !util::is_same<bool, BuildT>::value) {
-            (void)gridData; (void)mode;
-            throw nb::value_error(
-                "updateGridStats: the grid's BuildT does not support "
-                "tools::Stats (special / quantized / index / mask grids "
-                "have no arithmetic value type).");
+            // Special / quantized / index / mask BuildTs don't have an
+            // arithmetic ValueT, so tools::updateGridStats's MinMax / All
+            // branches would instantiate Stats<ValueT> / Extrema<ValueT>
+            // with no meaningful semantics (and may not even compile).
+            // The Disable and BBox branches use NoopStats, which works
+            // for any ValueT — drive that directly here so the BBox path
+            // remains available on special grids (it just recomputes
+            // node bounding boxes without touching min/max/avg).
+            if (mode == tools::StatsMode::Disable) {
+                return;
+            } else if (mode == tools::StatsMode::BBox) {
+                tools::GridStats<GridT, tools::NoopStats<ValueT>> stats;
+                stats.update(*static_cast<GridT*>(gridData));
+            } else {
+                throw nb::value_error(
+                    "updateGridStats: this grid's BuildT (special / "
+                    "quantized / index / mask) has no arithmetic value "
+                    "type — only StatsMode.Disable and StatsMode.BBox "
+                    "are supported.");
+            }
         } else {
-            tools::updateGridStats(static_cast<NanoGrid<BuildT>*>(gridData),
-                                   mode);
+            tools::updateGridStats(static_cast<GridT*>(gridData), mode);
         }
     }
     static void unknown(GridData*, tools::StatsMode) {
@@ -178,11 +194,13 @@ void defineGridStatsModule(nb::module_& toolsModule)
         },
         "grid"_a, "mode"_a = tools::StatsMode::Default,
         nb::call_guard<nb::gil_scoped_release>(),
-        "Recompute and write per-node statistics (min/max/avg/dev) into "
-        "the given grid in place. Polymorphic over BuildT. Only scalar "
-        "and vector grids carry arithmetic statistics; special "
-        "(quantized / index / mask) grids raise ValueError unless mode "
-        "is StatsMode.BBox.");
+        "Recompute and write per-node statistics into the given grid in "
+        "place. Polymorphic over BuildT. Scalar and vector grids accept "
+        "every StatsMode (Disable / BBox / MinMax / All). Special "
+        "(quantized / index / mask) grids accept Disable and BBox (the "
+        "latter recomputes node bounding boxes only); MinMax and All "
+        "raise ValueError because their value type has no arithmetic "
+        "semantics.");
 
     // Per-BuildT getExtrema. We expose one overload per scalar/vector
     // BuildT — they each return a Python-side Extrema<ValueT> of the

--- a/nanovdb/nanovdb/python/PyGridStats.cc
+++ b/nanovdb/nanovdb/python/PyGridStats.cc
@@ -195,12 +195,14 @@ void defineGridStatsModule(nb::module_& toolsModule)
         "grid"_a, "mode"_a = tools::StatsMode::Default,
         nb::call_guard<nb::gil_scoped_release>(),
         "Recompute and write per-node statistics into the given grid in "
-        "place. Polymorphic over BuildT. Scalar and vector grids accept "
-        "every StatsMode (Disable / BBox / MinMax / All). Special "
-        "(quantized / index / mask) grids accept Disable and BBox (the "
-        "latter recomputes node bounding boxes only); MinMax and All "
-        "raise ValueError because their value type has no arithmetic "
-        "semantics.");
+        "place. Polymorphic over BuildT. Scalar, vector, and Boolean "
+        "grids accept every StatsMode (Disable / BBox / MinMax / All); "
+        "Boolean grids use the C++ NoopStats path internally regardless "
+        "of mode because there's no arithmetic min/max/avg/dev on bool. "
+        "Other special (quantized / index / mask) grids accept Disable "
+        "and BBox (the latter recomputes node bounding boxes only); "
+        "MinMax and All raise ValueError because their value type has "
+        "no arithmetic semantics.");
 
     // Per-BuildT getExtrema. We expose one overload per scalar/vector
     // BuildT — they each return a Python-side Extrema<ValueT> of the

--- a/nanovdb/nanovdb/python/PyGridStats.h
+++ b/nanovdb/nanovdb/python/PyGridStats.h
@@ -11,6 +11,12 @@ namespace pynanovdb {
 
 void defineStatsMode(nb::module_& m);
 
+/// @brief Register per-BuildT Extrema and Stats classes (one set per
+///        scalar / vector BuildT in BuildTypes.def) and the polymorphic
+///        tools.updateGridStats / tools.getExtrema helpers under the
+///        nanovdb.tools submodule.
+void defineGridStatsModule(nb::module_& toolsModule);
+
 }
 
 #endif

--- a/nanovdb/nanovdb/python/PyGridValidator.cc
+++ b/nanovdb/nanovdb/python/PyGridValidator.cc
@@ -39,13 +39,24 @@ namespace {
 
 // callNanoGrid op for checkGrid: writes into a fixed-size buffer and returns
 // it as a std::pair<bool, std::string> for nb::make_tuple consumption.
+//
+// tools::checkGrid writes error messages with util::sprint / util::strcpy,
+// neither of which is bounded — they trust the caller's buffer is big
+// enough. Size the buffer well above what any current error message
+// produces (the longest formatted message in GridValidator.h is on the
+// order of ~80 characters once both GridType and GridClass enumerator
+// names are stringified) and leave generous headroom for future
+// additions.
 struct CheckGridOp
 {
+    static constexpr size_t kErrorBufSize = 4096;
+
     template<typename BuildT>
     static std::pair<bool, std::string> known(const GridData* gridData,
                                               CheckMode        mode)
     {
-        char buf[256];
+        char buf[kErrorBufSize];
+        buf[0] = '\0';
         tools::checkGrid<BuildT>(
             static_cast<const NanoGrid<BuildT>*>(gridData), buf, mode);
         const bool ok = (buf[0] == '\0');

--- a/nanovdb/nanovdb/python/PyGridValidator.cc
+++ b/nanovdb/nanovdb/python/PyGridValidator.cc
@@ -85,21 +85,35 @@ struct IsValidOp
 
 void defineGridValidatorModule(nb::module_& toolsModule)
 {
-    // Single-grid validate. Takes a host handle, a grid index, and the
+    // Single-grid validate. Takes a handle, a grid index, and the
     // usual mode + verbose flags. Returns true iff the grid passes all
-    // tests for the given mode.
+    // tests for the given mode. Bound for both host and device handles
+    // (when CUDA is enabled), matching validateGrids' coverage —
+    // tools::validateGrid does host-side dispatch via callNanoGrid on
+    // the host-resident gridData() pointer that DeviceGridHandle also
+    // exposes, so the same overload pair is appropriate.
     toolsModule.def("validateGrid",
         &tools::validateGrid<GridHandle<HostBuffer>>,
         "handle"_a, "gridID"_a,
         "mode"_a = CheckMode::Default, "verbose"_a = false,
         nb::call_guard<nb::gil_scoped_release>(),
-        "Validate the gridID'th grid in the host handle against the "
-        "given CheckMode. Returns False (without raising) if gridID is "
-        "out of range or the grid fails any check. CheckMode.Disable is "
-        "a short-circuit that always returns True without inspecting "
-        "the grid (even when gridID is out of range), matching the C++ "
-        "behavior. Complements validateGrids() which checks the whole "
-        "handle.");
+        "Validate the gridID'th grid in the handle against the given "
+        "CheckMode. Returns False (without raising) if gridID is out "
+        "of range or the grid fails any check. CheckMode.Disable is a "
+        "short-circuit that always returns True without inspecting "
+        "the grid (even when gridID is out of range), matching the "
+        "C++ behavior. Complements validateGrids() which checks the "
+        "whole handle.");
+#ifdef NANOVDB_USE_CUDA
+    toolsModule.def("validateGrid",
+        &tools::validateGrid<GridHandle<cuda::DeviceBuffer>>,
+        "handle"_a, "gridID"_a,
+        "mode"_a = CheckMode::Default, "verbose"_a = false,
+        nb::call_guard<nb::gil_scoped_release>(),
+        "Validate the gridID'th grid in the device handle (uses the "
+        "host-resident copy of the grid metadata for the actual "
+        "checks). Same semantics as the host-handle overload.");
+#endif
 
     // Polymorphic checkGrid — returns (ok, error_message). Mirrors the C++
     // char-buffer-out signature, but the buffer is hidden inside the

--- a/nanovdb/nanovdb/python/PyGridValidator.cc
+++ b/nanovdb/nanovdb/python/PyGridValidator.cc
@@ -14,6 +14,7 @@
 #endif
 
 #include <cstring>
+#include <iostream>
 #include <string>
 #include <utility>
 
@@ -70,11 +71,11 @@ struct IsValidOp
     }
     static bool unknown(const GridData* gridData, CheckMode /*mode*/, bool verbose)
     {
-        if (verbose) {
-            // Don't pull in <iostream> in the binding TU; just return false.
-            // The C++ helper writes to std::cerr; we mirror the same
-            // 'unsupported' outcome silently.
-            (void)gridData;
+        if (verbose && gridData != nullptr) {
+            char str[16];
+            std::cerr << "Validation failed: Unsupported GridType: \""
+                      << toStr(str, gridData->mGridType) << "\""
+                      << std::endl;
         }
         return false;
     }
@@ -94,8 +95,11 @@ void defineGridValidatorModule(nb::module_& toolsModule)
         nb::call_guard<nb::gil_scoped_release>(),
         "Validate the gridID'th grid in the host handle against the "
         "given CheckMode. Returns False (without raising) if gridID is "
-        "out of range or the grid fails any check. Complements "
-        "validateGrids() which checks the whole handle.");
+        "out of range or the grid fails any check. CheckMode.Disable is "
+        "a short-circuit that always returns True without inspecting "
+        "the grid (even when gridID is out of range), matching the C++ "
+        "behavior. Complements validateGrids() which checks the whole "
+        "handle.");
 
     // Polymorphic checkGrid — returns (ok, error_message). Mirrors the C++
     // char-buffer-out signature, but the buffer is hidden inside the

--- a/nanovdb/nanovdb/python/PyGridValidator.cc
+++ b/nanovdb/nanovdb/python/PyGridValidator.cc
@@ -2,13 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "PyGridValidator.h"
 
+#include <nanobind/operators.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/string.h>
+
 #include <nanovdb/GridHandle.h>
+#include <nanovdb/HostBuffer.h>
 #include <nanovdb/tools/GridValidator.h>
 #ifdef NANOVDB_USE_CUDA
 #include <nanovdb/cuda/DeviceBuffer.h>
 #endif
 
-#include <nanobind/operators.h>
+#include <cstring>
+#include <string>
+#include <utility>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -18,12 +25,107 @@ namespace pynanovdb {
 
 template<typename BufferT> void defineValidateGrids(nb::module_& m)
 {
-    m.def("validateGrids", &tools::validateGrids<GridHandle<BufferT>>, "handle"_a, "mode"_a, "verbose"_a);
+    m.def("validateGrids", &tools::validateGrids<GridHandle<BufferT>>,
+        "handle"_a, "mode"_a, "verbose"_a);
 }
 
 template void defineValidateGrids<HostBuffer>(nb::module_&);
 #ifdef NANOVDB_USE_CUDA
 template void defineValidateGrids<cuda::DeviceBuffer>(nb::module_&);
 #endif
+
+namespace {
+
+// callNanoGrid op for checkGrid: writes into a fixed-size buffer and returns
+// it as a std::pair<bool, std::string> for nb::make_tuple consumption.
+struct CheckGridOp
+{
+    template<typename BuildT>
+    static std::pair<bool, std::string> known(const GridData* gridData,
+                                              CheckMode        mode)
+    {
+        char buf[256];
+        tools::checkGrid<BuildT>(
+            static_cast<const NanoGrid<BuildT>*>(gridData), buf, mode);
+        const bool ok = (buf[0] == '\0');
+        return {ok, std::string(buf)};
+    }
+    static std::pair<bool, std::string> unknown(const GridData* gridData,
+                                                CheckMode /*mode*/)
+    {
+        (void)gridData;
+        return {false, "Unsupported GridType for checkGrid"};
+    }
+};
+
+// callNanoGrid op for isValid — wraps tools::isValid<BuildT> for every
+// switched-over BuildT.
+struct IsValidOp
+{
+    template<typename BuildT>
+    static bool known(const GridData* gridData, CheckMode mode, bool verbose)
+    {
+        return tools::isValid<BuildT>(
+            static_cast<const NanoGrid<BuildT>*>(gridData), mode, verbose);
+    }
+    static bool unknown(const GridData* gridData, CheckMode /*mode*/, bool verbose)
+    {
+        if (verbose) {
+            // Don't pull in <iostream> in the binding TU; just return false.
+            // The C++ helper writes to std::cerr; we mirror the same
+            // 'unsupported' outcome silently.
+            (void)gridData;
+        }
+        return false;
+    }
+};
+
+} // namespace
+
+void defineGridValidatorModule(nb::module_& toolsModule)
+{
+    // Single-grid validate. Takes a host handle, a grid index, and the
+    // usual mode + verbose flags. Returns true iff the grid passes all
+    // tests for the given mode.
+    toolsModule.def("validateGrid",
+        &tools::validateGrid<GridHandle<HostBuffer>>,
+        "handle"_a, "gridID"_a,
+        "mode"_a = CheckMode::Default, "verbose"_a = false,
+        nb::call_guard<nb::gil_scoped_release>(),
+        "Validate the gridID'th grid in the host handle against the "
+        "given CheckMode. Returns False (without raising) if gridID is "
+        "out of range or the grid fails any check. Complements "
+        "validateGrids() which checks the whole handle.");
+
+    // Polymorphic checkGrid — returns (ok, error_message). Mirrors the C++
+    // char-buffer-out signature, but the buffer is hidden inside the
+    // binding so Python callers get a Python str.
+    toolsModule.def("checkGrid",
+        [](const GridData* gridData, CheckMode mode)
+            -> std::pair<bool, std::string> {
+            if (gridData == nullptr) {
+                return {false, "Grid is None"};
+            }
+            return callNanoGrid<CheckGridOp>(gridData, mode);
+        },
+        "grid"_a, "mode"_a = CheckMode::Full,
+        nb::call_guard<nb::gil_scoped_release>(),
+        "Run structural validation checks on the grid for the given "
+        "CheckMode. Returns a (ok, error_message) tuple — error_message "
+        "is empty when ok is True.");
+
+    // Polymorphic isValid — convenience wrapper. Same as checkGrid + a
+    // checksum check, returning just the bool.
+    toolsModule.def("isValid",
+        [](const GridData* gridData, CheckMode mode, bool verbose) {
+            if (gridData == nullptr) return false;
+            return callNanoGrid<IsValidOp>(gridData, mode, verbose);
+        },
+        "grid"_a, "mode"_a = CheckMode::Default, "verbose"_a = false,
+        nb::call_guard<nb::gil_scoped_release>(),
+        "Return True iff the grid passes structural validation AND its "
+        "stored checksum matches a freshly computed one for the given "
+        "CheckMode.");
+}
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyGridValidator.h
+++ b/nanovdb/nanovdb/python/PyGridValidator.h
@@ -11,6 +11,12 @@ namespace pynanovdb {
 
 template<typename BufferT> void defineValidateGrids(nb::module_& m);
 
+/// @brief Register tools.validateGrid (single grid in a handle),
+///        tools.checkGrid (polymorphic, returns (bool, error_str)) and
+///        tools.isValid (polymorphic shortcut) under the nanovdb.tools
+///        submodule. Bound once; polymorphic dispatch uses callNanoGrid.
+void defineGridValidatorModule(nb::module_& toolsModule);
+
 } // namespace pynanovdb
 
 #endif

--- a/nanovdb/nanovdb/python/PyTools.cc
+++ b/nanovdb/nanovdb/python/PyTools.cc
@@ -32,6 +32,10 @@ void defineToolsModule(nb::module_& m)
 
     defineStatsMode(m);
 
+    defineGridStatsModule(m);
+    defineGridValidatorModule(m);
+    defineEvalChecksumModule(m);
+
     definePrimitives<HostBuffer>(m);
 
 #define NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix) \

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -1662,6 +1662,23 @@ class TestGridValidate(unittest.TestCase):
         self.assertTrue(
             nanovdb.tools.validateGrid(h, 99, nanovdb.CheckMode.Disable))
 
+    @unittest.skipUnless(
+        hasattr(nanovdb.tools, "cuda") and
+        hasattr(nanovdb.tools.cuda, "createLevelSetSphere"),
+        "device handles require a CUDA-enabled build",
+    )
+    def test_validateGrid_on_device_handle(self):
+        # validateGrid is bound for both host and device handles. The
+        # device overload routes through the same callNanoGrid dispatch
+        # against the host-resident copy of the grid metadata.
+        h = nanovdb.tools.cuda.createLevelSetSphere()
+        self.assertTrue(nanovdb.tools.validateGrid(h, 0))
+        # Out-of-range gridID returns False (without raising); Disable
+        # mode short-circuits to True even on an out-of-range gridID.
+        self.assertFalse(nanovdb.tools.validateGrid(h, 99))
+        self.assertTrue(
+            nanovdb.tools.validateGrid(h, 99, nanovdb.CheckMode.Disable))
+
 
 class TestGridChecksum(unittest.TestCase):
     """nanovdb.tools.evalChecksum and validateChecksum."""

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -1543,6 +1543,144 @@ class TestCreateNanoGrid(unittest.TestCase):
             self.assertEqual(grid.gridClass(), nanovdb.GridClass.Unknown)
 
 
+class TestGridStats(unittest.TestCase):
+    """nanovdb.tools.Extrema*, Stats*, updateGridStats, getExtrema."""
+
+    def _five_voxel_float_grid(self):
+        g = nanovdb.tools.build.FloatGrid(0.0, "stats", nanovdb.GridClass.FogVolume)
+        for i in range(5):
+            g.setValue(nanovdb.math.Coord(i, 0, 0), float(i + 1))
+        return g.to_nanovdb(sMode=nanovdb.tools.StatsMode.All)
+
+    def test_extrema_default_and_add(self):
+        ex = nanovdb.tools.FloatExtrema()
+        self.assertFalse(bool(ex))
+        ex.add(2.5)
+        ex.add(1.0)
+        ex.add(7.0)
+        self.assertTrue(bool(ex))
+        self.assertEqual(ex.min(), 1.0)
+        self.assertEqual(ex.max(), 7.0)
+        # Extrema doesn't compute averages or std deviation.
+        self.assertTrue(nanovdb.tools.FloatExtrema.hasMinMax())
+        self.assertFalse(nanovdb.tools.FloatExtrema.hasAverage())
+        self.assertFalse(nanovdb.tools.FloatExtrema.hasStdDeviation())
+
+    def test_stats_default_and_accumulate(self):
+        st = nanovdb.tools.FloatStats()
+        for v in (1.0, 2.0, 3.0, 4.0, 5.0):
+            st.add(v)
+        self.assertEqual(st.size(), 5)
+        self.assertEqual(st.min(), 1.0)
+        self.assertEqual(st.max(), 5.0)
+        self.assertAlmostEqual(st.avg(), 3.0)
+        self.assertAlmostEqual(st.mean(), 3.0)
+        # Population variance of 1..5 = (((-2)^2 + (-1)^2 + 0 + 1 + 4) / 5) = 2
+        self.assertAlmostEqual(st.var(), 2.0)
+        self.assertAlmostEqual(st.std() ** 2, 2.0)
+        self.assertTrue(nanovdb.tools.FloatStats.hasAverage())
+        self.assertTrue(nanovdb.tools.FloatStats.hasStdDeviation())
+
+    def test_get_extrema_over_active_bbox(self):
+        h = self._five_voxel_float_grid()
+        ng = h.grid()
+        # bbox containing only the 5 active voxels at (0..4, 0, 0); the
+        # extrema visits the leaf the active voxels live in, plus the
+        # background tile inside that leaf — so the min is 0.0 (background).
+        ex = nanovdb.tools.getExtrema(
+            ng, nanovdb.math.CoordBBox(
+                nanovdb.math.Coord(0, 0, 0), nanovdb.math.Coord(4, 0, 0)))
+        self.assertTrue(bool(ex))
+        self.assertEqual(ex.min(), 0.0)
+        self.assertEqual(ex.max(), 5.0)
+
+    def test_update_grid_stats_polymorphic(self):
+        # Building with StatsMode.Disable leaves stats uncomputed; calling
+        # tools.updateGridStats on the resulting handle should populate
+        # them in-place. Asserting "no exception" is the round-trip we
+        # care about — the actual stats live inside the grid's nodes.
+        g = nanovdb.tools.build.FloatGrid(0.0)
+        for i in range(3):
+            g.setValue(nanovdb.math.Coord(i, 0, 0), float(i + 10))
+        h = g.to_nanovdb(sMode=nanovdb.tools.StatsMode.Disable)
+        ng = h.grid()
+        nanovdb.tools.updateGridStats(ng, nanovdb.tools.StatsMode.All)
+        # checkGrid still passes after writing stats.
+        ok, msg = nanovdb.tools.checkGrid(ng, nanovdb.CheckMode.Full)
+        self.assertTrue(ok, msg)
+
+    def test_update_grid_stats_rejects_index_grid(self):
+        # OnIndexGrid is a special BuildT — updateGridStats should raise
+        # because Stats<uint64> isn't meaningful.
+        bbox = nanovdb.math.CoordBBox(
+            nanovdb.math.Coord(0), nanovdb.math.Coord(4))
+        h_float = nanovdb.tools.createFloatGrid(
+            0.0, "src", nanovdb.GridClass.Unknown, lambda ijk: 1.0, bbox)
+        h_index = nanovdb.tools.createOnIndexGrid(h_float.grid())
+        with self.assertRaises(ValueError):
+            nanovdb.tools.updateGridStats(
+                h_index.grid(), nanovdb.tools.StatsMode.MinMax)
+
+
+class TestGridValidate(unittest.TestCase):
+    """nanovdb.tools.validateGrid, checkGrid, isValid."""
+
+    def _good_handle(self):
+        bbox = nanovdb.math.CoordBBox(
+            nanovdb.math.Coord(0), nanovdb.math.Coord(3))
+        return nanovdb.tools.createFloatGrid(
+            0.0, "v", nanovdb.GridClass.Unknown, lambda ijk: 1.0, bbox)
+
+    def test_checkGrid_on_valid_grid(self):
+        h = self._good_handle()
+        ok, msg = nanovdb.tools.checkGrid(h.grid(), nanovdb.CheckMode.Full)
+        self.assertTrue(ok)
+        self.assertEqual(msg, "")
+
+    def test_isValid_on_valid_grid(self):
+        h = self._good_handle()
+        self.assertTrue(nanovdb.tools.isValid(h.grid(), nanovdb.CheckMode.Default))
+
+    def test_validateGrid_on_valid_handle(self):
+        h = self._good_handle()
+        self.assertTrue(nanovdb.tools.validateGrid(h, 0))
+        # validateGrid with out-of-range gridID returns False, never raises.
+        self.assertFalse(nanovdb.tools.validateGrid(h, 99))
+
+    def test_validateGrid_disable_mode_always_true(self):
+        h = self._good_handle()
+        self.assertTrue(
+            nanovdb.tools.validateGrid(h, 99, nanovdb.CheckMode.Disable))
+
+
+class TestGridChecksum(unittest.TestCase):
+    """nanovdb.tools.evalChecksum and validateChecksum."""
+
+    def _handle(self):
+        bbox = nanovdb.math.CoordBBox(
+            nanovdb.math.Coord(0), nanovdb.math.Coord(3))
+        return nanovdb.tools.createFloatGrid(
+            0.0, "cs", nanovdb.GridClass.Unknown, lambda ijk: 1.0, bbox)
+
+    def test_eval_then_update_then_validate(self):
+        h = self._handle()
+        ng = h.grid()
+        cs1 = nanovdb.tools.evalChecksum(ng, nanovdb.CheckMode.Full)
+        nanovdb.tools.updateChecksum(ng, nanovdb.CheckMode.Full)
+        cs2 = nanovdb.tools.evalChecksum(ng, nanovdb.CheckMode.Full)
+        # Recomputing on an unchanged grid gives the same checksum.
+        self.assertEqual(cs1, cs2)
+        self.assertTrue(
+            nanovdb.tools.validateChecksum(ng, nanovdb.CheckMode.Full))
+
+    def test_validate_empty_stored_returns_true(self):
+        # A grid with no stored checksum is considered valid by the C++
+        # rule (Checksum.isEmpty() short-circuit).
+        h = self._handle()
+        self.assertTrue(
+            nanovdb.tools.validateChecksum(h.grid(), nanovdb.CheckMode.Default))
+
+
 class TestBuildGrid(unittest.TestCase):
     """nanovdb.tools.build.* — mutable voxel-by-voxel CPU grid builder."""
 

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -1581,18 +1581,21 @@ class TestGridStats(unittest.TestCase):
         self.assertTrue(nanovdb.tools.FloatStats.hasAverage())
         self.assertTrue(nanovdb.tools.FloatStats.hasStdDeviation())
 
-    def test_get_extrema_over_active_bbox(self):
+    def test_get_extrema_strictly_inside_active_region(self):
+        # Pick a bbox strictly inside the root's active bbox so the C++
+        # implementation takes the recursive-traversal branch (the
+        # "bbox contains root.bbox()" branch unconditionally adds the
+        # background value, which would muddy this assertion). With
+        # only the three active voxels at (1,0,0)..(3,0,0) sampled, the
+        # extrema should be exactly their min and max.
         h = self._five_voxel_float_grid()
         ng = h.grid()
-        # bbox containing only the 5 active voxels at (0..4, 0, 0); the
-        # extrema visits the leaf the active voxels live in, plus the
-        # background tile inside that leaf — so the min is 0.0 (background).
         ex = nanovdb.tools.getExtrema(
             ng, nanovdb.math.CoordBBox(
-                nanovdb.math.Coord(0, 0, 0), nanovdb.math.Coord(4, 0, 0)))
+                nanovdb.math.Coord(1, 0, 0), nanovdb.math.Coord(3, 0, 0)))
         self.assertTrue(bool(ex))
-        self.assertEqual(ex.min(), 0.0)
-        self.assertEqual(ex.max(), 5.0)
+        self.assertEqual(ex.min(), 2.0)
+        self.assertEqual(ex.max(), 4.0)
 
     def test_update_grid_stats_polymorphic(self):
         # Building with StatsMode.Disable leaves stats uncomputed; calling
@@ -1609,17 +1612,24 @@ class TestGridStats(unittest.TestCase):
         ok, msg = nanovdb.tools.checkGrid(ng, nanovdb.CheckMode.Full)
         self.assertTrue(ok, msg)
 
-    def test_update_grid_stats_rejects_index_grid(self):
-        # OnIndexGrid is a special BuildT — updateGridStats should raise
-        # because Stats<uint64> isn't meaningful.
+    def test_update_grid_stats_on_index_grid(self):
+        # OnIndexGrid is a special BuildT — MinMax and All raise because
+        # Stats<uint64> isn't meaningful, but BBox (NoopStats) is still
+        # accepted because it only touches node bounding boxes.
         bbox = nanovdb.math.CoordBBox(
             nanovdb.math.Coord(0), nanovdb.math.Coord(4))
         h_float = nanovdb.tools.createFloatGrid(
             0.0, "src", nanovdb.GridClass.Unknown, lambda ijk: 1.0, bbox)
         h_index = nanovdb.tools.createOnIndexGrid(h_float.grid())
+        ng = h_index.grid()
         with self.assertRaises(ValueError):
-            nanovdb.tools.updateGridStats(
-                h_index.grid(), nanovdb.tools.StatsMode.MinMax)
+            nanovdb.tools.updateGridStats(ng, nanovdb.tools.StatsMode.MinMax)
+        with self.assertRaises(ValueError):
+            nanovdb.tools.updateGridStats(ng, nanovdb.tools.StatsMode.All)
+        # BBox mode is a NoopStats path — must succeed.
+        nanovdb.tools.updateGridStats(ng, nanovdb.tools.StatsMode.BBox)
+        # And Disable is a true no-op.
+        nanovdb.tools.updateGridStats(ng, nanovdb.tools.StatsMode.Disable)
 
 
 class TestGridValidate(unittest.TestCase):


### PR DESCRIPTION
## Summary

Wraps up Phase 4 of the [NanoVDB Python bindings restructure (#2208)](https://github.com/AcademySoftwareFoundation/openvdb/issues/2208) by binding the GridStats, GridValidator, and GridChecksum surfaces that Phase 4a (#2214) didn't touch. The Python API now mirrors `nanovdb::tools::updateGridStats`, `getExtrema`, `Extrema`, `Stats`, `validateGrid`, `checkGrid`, `isValid`, `evalChecksum`, and `validateChecksum`.

### Phase 4b — Stats

- Per-BuildT `tools.<Suffix>Extrema` / `tools.<Suffix>Stats` classes for every scalar and vector BuildT in `BuildTypes.def`. Extrema exposes `min` / `max` / `add(v)` / `__bool__`; Stats inherits from Extrema and adds `size` / `avg` / `mean` / `var` / `variance` / `std` / `stdDev`. Static `hasMinMax` / `hasAverage` / `hasStdDeviation` / `hasStats` mirror the C++ predicates.
- `tools.updateGridStats(grid, mode=Default)` — polymorphic over BuildT via `callNanoGrid<UpdateGridStatsOp>`. Scalar/vector grids dispatch to `tools::updateGridStats<BuildT>`; special/quantized/index/mask BuildTs raise `ValueError`. `bool` falls through to the C++ `NoopStats` arm.
- Per-BuildT `tools.getExtrema(grid, bbox)` returning the matching `Extrema` (restricted to scalars + vectors).

### Phase 4c — Validation & checksum

- `tools.validateGrid(handle, gridID, mode=Default, verbose=False)` — single-grid complement of the existing `validateGrids`. Returns `False` (no raise) when the gridID is out of range.
- `tools.checkGrid(grid, mode=Full)` — polymorphic via `callNanoGrid<CheckGridOp>`. Returns `(ok, error_message)`; the char buffer the C++ helper writes into is hidden inside the binding.
- `tools.isValid(grid, mode=Default, verbose=False)` — polymorphic via `callNanoGrid<IsValidOp>` (structural check + checksum match in one bool).
- `tools.evalChecksum(grid, mode=Default)` and `tools.validateChecksum(grid, mode=Default)` — accept any bound NanoGrid via the existing `GridData` Python upcast.

All five GIL-heavy entries (`updateGridStats`, `getExtrema`, `validateGrid`, `checkGrid`, `isValid`, `evalChecksum`, `validateChecksum`) release the GIL while the C++ traversal runs.

## Test plan

- [x] 11 new test cases in `TestGridStats` / `TestGridValidate` / `TestGridChecksum` cover Extrema/Stats default-and-add, polymorphic `updateGridStats` on a float grid + rejection on an OnIndex grid, `getExtrema` over a sub-bbox, `checkGrid` / `isValid` / `validateGrid` happy paths + `gridID`-out-of-range and `CheckMode.Disable` short-circuit, and `evalChecksum` → `updateChecksum` → `validateChecksum` round-trip.
- [x] Full pytest_nanovdb suite still green locally (110/112; the 2 errors are pre-existing BLOSC-disabled errors in this local config, unrelated).
- [x] CUDA build + link clean.

## Plan status

This closes Phases 4b (`phase4-stats`) and 4c (`phase4-validate`) in [nanovdb-python-plan.md](nanovdb-python-plan.md), completing Phase 4 alongside the already-landed Phase 4a (#2214).