### PR TITLE
nanovdb python: Phase 5 — primitives + quantized/index createNanoGrid

### DIFF
--- a/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
+++ b/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
@@ -43,7 +43,11 @@ template<typename BuildT> void defineCreateNanoGrid(nb::module_& m, const char* 
 template<typename BufferT> void defineOpenToNanoVDB(nb::module_& m)
 {
 #ifdef NANOVDB_USE_OPENVDB
-    m.def("openToNanoVDB", &tools::openToNanoVDB<BufferT>, "base"_a = tools::StatsMode::Default, "cMode"_a = CheckMode::Default, "verbose"_a = 0);
+    m.def("openToNanoVDB", &tools::openToNanoVDB<BufferT>,
+          "base"_a,
+          "sMode"_a = tools::StatsMode::Default,
+          "cMode"_a = CheckMode::Default,
+          "verbose"_a = 0);
 #endif
 }
 

--- a/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
+++ b/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
@@ -67,6 +67,12 @@ namespace {
 // Try SrcBuildT against both NanoGrid<SrcBuildT> and build::Grid<SrcBuildT>
 // and return an empty nb::object on no match so the caller can fall through
 // to the next SrcBuildT.
+//
+// GIL is held for the isinstance / cast dispatch (which touches the Python
+// object's type and reference graph) but released around the underlying
+// tools::createNanoGrid traversal — the source data lives in stable C++
+// storage whose lifetime is anchored by the Python wrapper passed in via
+// py_src, so it's safe to read without holding the GIL.
 template<typename SrcBuildT, typename DstBuildT>
 nb::object tryQuantizeFpX(nb::handle       py_src,
                           tools::StatsMode sMode,
@@ -78,13 +84,23 @@ nb::object tryQuantizeFpX(nb::handle       py_src,
     using BuildSrcT = tools::build::Grid<SrcBuildT>;
     if (nb::isinstance<NanoSrcT>(py_src)) {
         const auto& src = nb::cast<const NanoSrcT&>(py_src);
-        return nb::cast(tools::createNanoGrid<NanoSrcT, DstBuildT, HostBuffer>(
-            src, sMode, cMode, ditherOn, verbose));
+        GridHandle<HostBuffer> handle;
+        {
+            nb::gil_scoped_release release;
+            handle = tools::createNanoGrid<NanoSrcT, DstBuildT, HostBuffer>(
+                src, sMode, cMode, ditherOn, verbose);
+        }
+        return nb::cast(std::move(handle));
     }
     if (nb::isinstance<BuildSrcT>(py_src)) {
         const auto& src = nb::cast<const BuildSrcT&>(py_src);
-        return nb::cast(tools::createNanoGrid<BuildSrcT, DstBuildT, HostBuffer>(
-            src, sMode, cMode, ditherOn, verbose));
+        GridHandle<HostBuffer> handle;
+        {
+            nb::gil_scoped_release release;
+            handle = tools::createNanoGrid<BuildSrcT, DstBuildT, HostBuffer>(
+                src, sMode, cMode, ditherOn, verbose);
+        }
+        return nb::cast(std::move(handle));
     }
     return nb::object();
 }
@@ -122,15 +138,27 @@ nb::object tryQuantizeFpN(nb::handle       py_src,
 {
     using NanoSrcT  = NanoGrid<SrcBuildT>;
     using BuildSrcT = tools::build::Grid<SrcBuildT>;
+    // Same GIL pattern as tryQuantizeFpX: hold the GIL through the
+    // isinstance / cast dispatch, release it for the conversion.
     if (nb::isinstance<NanoSrcT>(py_src)) {
         const auto& src = nb::cast<const NanoSrcT&>(py_src);
-        return nb::cast(tools::createNanoGrid<NanoSrcT, FpN, OracleT, HostBuffer>(
-            src, sMode, cMode, ditherOn, verbose, oracle));
+        GridHandle<HostBuffer> handle;
+        {
+            nb::gil_scoped_release release;
+            handle = tools::createNanoGrid<NanoSrcT, FpN, OracleT, HostBuffer>(
+                src, sMode, cMode, ditherOn, verbose, oracle);
+        }
+        return nb::cast(std::move(handle));
     }
     if (nb::isinstance<BuildSrcT>(py_src)) {
         const auto& src = nb::cast<const BuildSrcT&>(py_src);
-        return nb::cast(tools::createNanoGrid<BuildSrcT, FpN, OracleT, HostBuffer>(
-            src, sMode, cMode, ditherOn, verbose, oracle));
+        GridHandle<HostBuffer> handle;
+        {
+            nb::gil_scoped_release release;
+            handle = tools::createNanoGrid<BuildSrcT, FpN, OracleT, HostBuffer>(
+                src, sMode, cMode, ditherOn, verbose, oracle);
+        }
+        return nb::cast(std::move(handle));
     }
     return nb::object();
 }
@@ -166,15 +194,26 @@ nb::object tryIndexify(nb::handle py_src,
 {
     using NanoSrcT  = NanoGrid<SrcBuildT>;
     using BuildSrcT = tools::build::Grid<SrcBuildT>;
+    // Same GIL pattern as tryQuantizeFpX.
     if (nb::isinstance<NanoSrcT>(py_src)) {
         const auto& src = nb::cast<const NanoSrcT&>(py_src);
-        return nb::cast(tools::createNanoGrid<NanoSrcT, DstBuildT, HostBuffer>(
-            src, channels, includeStats, includeTiles, verbose));
+        GridHandle<HostBuffer> handle;
+        {
+            nb::gil_scoped_release release;
+            handle = tools::createNanoGrid<NanoSrcT, DstBuildT, HostBuffer>(
+                src, channels, includeStats, includeTiles, verbose);
+        }
+        return nb::cast(std::move(handle));
     }
     if (nb::isinstance<BuildSrcT>(py_src)) {
         const auto& src = nb::cast<const BuildSrcT&>(py_src);
-        return nb::cast(tools::createNanoGrid<BuildSrcT, DstBuildT, HostBuffer>(
-            src, channels, includeStats, includeTiles, verbose));
+        GridHandle<HostBuffer> handle;
+        {
+            nb::gil_scoped_release release;
+            handle = tools::createNanoGrid<BuildSrcT, DstBuildT, HostBuffer>(
+                src, channels, includeStats, includeTiles, verbose);
+        }
+        return nb::cast(std::move(handle));
     }
     return nb::object();
 }
@@ -205,8 +244,9 @@ void defineCreateNanoGridConversions(nb::module_& toolsModule)
     nb::class_<tools::AbsDiff>(toolsModule, "AbsDiff",
         "Compression oracle for FpN: accept the approximation when "
         "|exact - approx| <= tolerance. A tolerance of -1.0 (the "
-        "default) means uninitialized; pass an explicit positive value "
-        "or have the create function fill it in via init().")
+        "default) means uninitialized; any non-negative value (including "
+        "0.0) is treated as initialized by the operator bool() check, "
+        "or the C++ create function can fill it in via init().")
         .def(nb::init<float>(), "tolerance"_a = -1.0f)
         .def("getTolerance", &tools::AbsDiff::getTolerance)
         .def("setTolerance", &tools::AbsDiff::setTolerance, "tolerance"_a)

--- a/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
+++ b/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
@@ -118,7 +118,7 @@ nb::object createNanoGridFpX(nb::handle       py_src,
     if (auto r = tryQuantizeFpX<float, DstBuildT>(
             py_src, sMode, cMode, ditherOn, verbose); r.is_valid()) return r;
     std::string msg(pyFnName);
-    msg += ": source must be a FloatGrid or tools.build.FloatGrid "
+    msg += ": source must be a FloatGrid or nanovdb.tools.build.FloatGrid "
            "(Fp4/Fp8/Fp16/FpN require a float source value type).";
     throw nb::type_error(msg.c_str());
 }
@@ -175,7 +175,7 @@ nb::object createNanoGridFpNImpl(nb::handle       py_src,
             py_src, sMode, cMode, ditherOn, verbose, oracle); r.is_valid()) return r;
     throw nb::type_error(
         "createNanoGridFpN: source must be a FloatGrid or "
-        "tools.build.FloatGrid (FpN requires a float source value type).");
+        "nanovdb.tools.build.FloatGrid (FpN requires a float source value type).");
 }
 
 // ----- Index / OnIndex -----
@@ -232,7 +232,7 @@ nb::object createIndexImpl(nb::handle  py_src,
     if (auto r = tryIndexify<Vec3f,    DstBuildT>(py_src, channels, includeStats, includeTiles, verbose); r.is_valid()) return r;
     std::string msg(pyFnName);
     msg += ": source must be a FloatGrid, DoubleGrid, Int32Grid, "
-           "Vec3fGrid, or the matching tools.build.* mutable grid.";
+           "Vec3fGrid, or the matching nanovdb.tools.build.* mutable grid.";
     throw nb::type_error(msg.c_str());
 }
 
@@ -273,7 +273,7 @@ void defineCreateNanoGridConversions(nb::module_& toolsModule)
         },
         "src"_a, "sMode"_a = tools::StatsMode::Default,
         "cMode"_a = CheckMode::Default, "ditherOn"_a = false, "verbose"_a = 0,
-        "Quantize a NanoGrid<float> or tools.build.FloatGrid into a "
+        "Quantize a NanoGrid<float> or nanovdb.tools.build.FloatGrid into a "
         "NanoGrid<Fp4> (4 bits per voxel). ditherOn adds sub-quantum "
         "noise to break up banding.");
 
@@ -285,7 +285,7 @@ void defineCreateNanoGridConversions(nb::module_& toolsModule)
         },
         "src"_a, "sMode"_a = tools::StatsMode::Default,
         "cMode"_a = CheckMode::Default, "ditherOn"_a = false, "verbose"_a = 0,
-        "Quantize a NanoGrid<float> or tools.build.FloatGrid into a NanoGrid<Fp8> (8 bits "
+        "Quantize a NanoGrid<float> or nanovdb.tools.build.FloatGrid into a NanoGrid<Fp8> (8 bits "
         "per voxel). ditherOn adds sub-quantum noise.");
 
     toolsModule.def("createNanoGridFp16",
@@ -296,7 +296,7 @@ void defineCreateNanoGridConversions(nb::module_& toolsModule)
         },
         "src"_a, "sMode"_a = tools::StatsMode::Default,
         "cMode"_a = CheckMode::Default, "ditherOn"_a = false, "verbose"_a = 0,
-        "Quantize a NanoGrid<float> or tools.build.FloatGrid into a NanoGrid<Fp16> (16 bits "
+        "Quantize a NanoGrid<float> or nanovdb.tools.build.FloatGrid into a NanoGrid<Fp16> (16 bits "
         "per voxel). ditherOn adds sub-quantum noise.");
 
     // ------ Variable bit-width: FpN with AbsDiff or RelDiff oracle ------
@@ -315,7 +315,7 @@ void defineCreateNanoGridConversions(nb::module_& toolsModule)
         "src"_a, "oracle"_a = tools::AbsDiff(),
         "sMode"_a = tools::StatsMode::Default,
         "cMode"_a = CheckMode::Default, "ditherOn"_a = false, "verbose"_a = 0,
-        "Quantize a NanoGrid<float> or tools.build.FloatGrid into a NanoGrid<FpN> (variable "
+        "Quantize a NanoGrid<float> or nanovdb.tools.build.FloatGrid into a NanoGrid<FpN> (variable "
         "bits per voxel; each leaf picks the smallest N that satisfies "
         "the oracle's tolerance). Pass an AbsDiff oracle for absolute "
         "error bound, or use the RelDiff overload for relative error.");

--- a/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
+++ b/nanovdb/nanovdb/python/PyCreateNanoGrid.cc
@@ -11,6 +11,8 @@
 #include <nanovdb/tools/CreateNanoGrid.h>
 #include <nanovdb/tools/GridBuilder.h>
 
+#include <string>
+
 namespace nb = nanobind;
 using namespace nb::literals;
 using namespace nanovdb;
@@ -41,8 +43,280 @@ template<typename BuildT> void defineCreateNanoGrid(nb::module_& m, const char* 
 template<typename BufferT> void defineOpenToNanoVDB(nb::module_& m)
 {
 #ifdef NANOVDB_USE_OPENVDB
-    m.def("openToNanoVDB", &tools::openToNanoVDB<BufferT>, "base"_a, "sMode"_a = tools::StatsMode::Default, "cMode"_a = CheckMode::Default, "verbose"_a = 0);
+    m.def("openToNanoVDB", &tools::openToNanoVDB<BufferT>, "base"_a = tools::StatsMode::Default, "cMode"_a = CheckMode::Default, "verbose"_a = 0);
 #endif
+}
+
+// ============================================================================
+// Phase 5b/5c conversion bindings: AbsDiff/RelDiff oracle classes, and the
+// polymorphic createNanoGrid free functions for quantized + index destination
+// BuildTs. Each accepts source = NanoGrid<SrcBuildT> OR build::Grid<SrcBuildT>.
+// ============================================================================
+
+namespace {
+
+// ----- Quantized (Fp4/Fp8/Fp16) -----
+//
+// C++ signature: createNanoGrid<SrcGridT, DstBuildT, BufferT>(srcGrid,
+// sMode, cMode, ditherOn, verbose, buffer).
+//
+// Try SrcBuildT against both NanoGrid<SrcBuildT> and build::Grid<SrcBuildT>
+// and return an empty nb::object on no match so the caller can fall through
+// to the next SrcBuildT.
+template<typename SrcBuildT, typename DstBuildT>
+nb::object tryQuantizeFpX(nb::handle       py_src,
+                          tools::StatsMode sMode,
+                          CheckMode        cMode,
+                          bool             ditherOn,
+                          int              verbose)
+{
+    using NanoSrcT  = NanoGrid<SrcBuildT>;
+    using BuildSrcT = tools::build::Grid<SrcBuildT>;
+    if (nb::isinstance<NanoSrcT>(py_src)) {
+        const auto& src = nb::cast<const NanoSrcT&>(py_src);
+        return nb::cast(tools::createNanoGrid<NanoSrcT, DstBuildT, HostBuffer>(
+            src, sMode, cMode, ditherOn, verbose));
+    }
+    if (nb::isinstance<BuildSrcT>(py_src)) {
+        const auto& src = nb::cast<const BuildSrcT&>(py_src);
+        return nb::cast(tools::createNanoGrid<BuildSrcT, DstBuildT, HostBuffer>(
+            src, sMode, cMode, ditherOn, verbose));
+    }
+    return nb::object();
+}
+
+template<typename DstBuildT>
+nb::object createNanoGridFpX(nb::handle       py_src,
+                             tools::StatsMode sMode,
+                             CheckMode        cMode,
+                             bool             ditherOn,
+                             int              verbose,
+                             const char*      pyFnName)
+{
+    // The C++ Fp{4,8,16,N} preProcess static_asserts SrcValueT == float;
+    // double sources hit a compile-time error, so we accept float only.
+    if (auto r = tryQuantizeFpX<float, DstBuildT>(
+            py_src, sMode, cMode, ditherOn, verbose); r.is_valid()) return r;
+    std::string msg(pyFnName);
+    msg += ": source must be a FloatGrid or tools.build.FloatGrid "
+           "(Fp4/Fp8/Fp16/FpN require a float source value type).";
+    throw nb::type_error(msg.c_str());
+}
+
+// ----- FpN (variable bit-width) -----
+//
+// C++ signature: createNanoGrid<SrcGridT, FpN, OracleT, BufferT>(srcGrid,
+// sMode, cMode, ditherOn, verbose, oracle, buffer). OracleT is AbsDiff or
+// RelDiff; the binding exposes both as separate Python overloads.
+template<typename SrcBuildT, typename OracleT>
+nb::object tryQuantizeFpN(nb::handle       py_src,
+                          tools::StatsMode sMode,
+                          CheckMode        cMode,
+                          bool             ditherOn,
+                          int              verbose,
+                          const OracleT&   oracle)
+{
+    using NanoSrcT  = NanoGrid<SrcBuildT>;
+    using BuildSrcT = tools::build::Grid<SrcBuildT>;
+    if (nb::isinstance<NanoSrcT>(py_src)) {
+        const auto& src = nb::cast<const NanoSrcT&>(py_src);
+        return nb::cast(tools::createNanoGrid<NanoSrcT, FpN, OracleT, HostBuffer>(
+            src, sMode, cMode, ditherOn, verbose, oracle));
+    }
+    if (nb::isinstance<BuildSrcT>(py_src)) {
+        const auto& src = nb::cast<const BuildSrcT&>(py_src);
+        return nb::cast(tools::createNanoGrid<BuildSrcT, FpN, OracleT, HostBuffer>(
+            src, sMode, cMode, ditherOn, verbose, oracle));
+    }
+    return nb::object();
+}
+
+template<typename OracleT>
+nb::object createNanoGridFpNImpl(nb::handle       py_src,
+                                 const OracleT&   oracle,
+                                 tools::StatsMode sMode,
+                                 CheckMode        cMode,
+                                 bool             ditherOn,
+                                 int              verbose)
+{
+    if (auto r = tryQuantizeFpN<float, OracleT>(
+            py_src, sMode, cMode, ditherOn, verbose, oracle); r.is_valid()) return r;
+    throw nb::type_error(
+        "createNanoGridFpN: source must be a FloatGrid or "
+        "tools.build.FloatGrid (FpN requires a float source value type).");
+}
+
+// ----- Index / OnIndex -----
+//
+// C++ signature: createNanoGrid<SrcGridT, DstBuildT, BufferT>(srcGrid,
+// channels, includeStats, includeTiles, verbose, buffer). DstBuildT is
+// ValueIndex or ValueOnIndex; the binding exposes both as separate
+// named functions. Source set is wider than the quantized variants —
+// any arithmetic or vector source can be re-cast as an index grid.
+template<typename SrcBuildT, typename DstBuildT>
+nb::object tryIndexify(nb::handle py_src,
+                       uint32_t   channels,
+                       bool       includeStats,
+                       bool       includeTiles,
+                       int        verbose)
+{
+    using NanoSrcT  = NanoGrid<SrcBuildT>;
+    using BuildSrcT = tools::build::Grid<SrcBuildT>;
+    if (nb::isinstance<NanoSrcT>(py_src)) {
+        const auto& src = nb::cast<const NanoSrcT&>(py_src);
+        return nb::cast(tools::createNanoGrid<NanoSrcT, DstBuildT, HostBuffer>(
+            src, channels, includeStats, includeTiles, verbose));
+    }
+    if (nb::isinstance<BuildSrcT>(py_src)) {
+        const auto& src = nb::cast<const BuildSrcT&>(py_src);
+        return nb::cast(tools::createNanoGrid<BuildSrcT, DstBuildT, HostBuffer>(
+            src, channels, includeStats, includeTiles, verbose));
+    }
+    return nb::object();
+}
+
+template<typename DstBuildT>
+nb::object createIndexImpl(nb::handle  py_src,
+                           uint32_t    channels,
+                           bool        includeStats,
+                           bool        includeTiles,
+                           int         verbose,
+                           const char* pyFnName)
+{
+    if (auto r = tryIndexify<float,    DstBuildT>(py_src, channels, includeStats, includeTiles, verbose); r.is_valid()) return r;
+    if (auto r = tryIndexify<double,   DstBuildT>(py_src, channels, includeStats, includeTiles, verbose); r.is_valid()) return r;
+    if (auto r = tryIndexify<int32_t,  DstBuildT>(py_src, channels, includeStats, includeTiles, verbose); r.is_valid()) return r;
+    if (auto r = tryIndexify<Vec3f,    DstBuildT>(py_src, channels, includeStats, includeTiles, verbose); r.is_valid()) return r;
+    std::string msg(pyFnName);
+    msg += ": source must be a FloatGrid, DoubleGrid, Int32Grid, "
+           "Vec3fGrid, or the matching tools.build.* mutable grid.";
+    throw nb::type_error(msg.c_str());
+}
+
+} // namespace
+
+void defineCreateNanoGridConversions(nb::module_& toolsModule)
+{
+    // ------ Oracle classes ------
+    nb::class_<tools::AbsDiff>(toolsModule, "AbsDiff",
+        "Compression oracle for FpN: accept the approximation when "
+        "|exact - approx| <= tolerance. A tolerance of -1.0 (the "
+        "default) means uninitialized; pass an explicit positive value "
+        "or have the create function fill it in via init().")
+        .def(nb::init<float>(), "tolerance"_a = -1.0f)
+        .def("getTolerance", &tools::AbsDiff::getTolerance)
+        .def("setTolerance", &tools::AbsDiff::setTolerance, "tolerance"_a)
+        .def("__bool__",
+            [](const tools::AbsDiff& self) { return bool(self); },
+            "True iff the tolerance has been initialized (>= 0).");
+
+    nb::class_<tools::RelDiff>(toolsModule, "RelDiff",
+        "Compression oracle for FpN: accept the approximation when "
+        "|exact - approx| / max(|exact|, |approx|) <= tolerance.")
+        .def(nb::init<float>(), "tolerance"_a = -1.0f)
+        .def("getTolerance", &tools::RelDiff::getTolerance)
+        .def("setTolerance", &tools::RelDiff::setTolerance, "tolerance"_a)
+        .def("__bool__",
+            [](const tools::RelDiff& self) { return bool(self); },
+            "True iff the tolerance has been initialized (>= 0).");
+
+    // ------ Quantized fixed-width: Fp4 / Fp8 / Fp16 ------
+    toolsModule.def("createNanoGridFp4",
+        [](nb::handle src, tools::StatsMode sMode, CheckMode cMode,
+           bool ditherOn, int verbose) {
+            return createNanoGridFpX<Fp4>(src, sMode, cMode, ditherOn, verbose,
+                                          "createNanoGridFp4");
+        },
+        "src"_a, "sMode"_a = tools::StatsMode::Default,
+        "cMode"_a = CheckMode::Default, "ditherOn"_a = false, "verbose"_a = 0,
+        "Quantize a NanoGrid<float> or tools.build.FloatGrid into a "
+        "NanoGrid<Fp4> (4 bits per voxel). ditherOn adds sub-quantum "
+        "noise to break up banding.");
+
+    toolsModule.def("createNanoGridFp8",
+        [](nb::handle src, tools::StatsMode sMode, CheckMode cMode,
+           bool ditherOn, int verbose) {
+            return createNanoGridFpX<Fp8>(src, sMode, cMode, ditherOn, verbose,
+                                          "createNanoGridFp8");
+        },
+        "src"_a, "sMode"_a = tools::StatsMode::Default,
+        "cMode"_a = CheckMode::Default, "ditherOn"_a = false, "verbose"_a = 0,
+        "Quantize a NanoGrid<float> or tools.build.FloatGrid into a NanoGrid<Fp8> (8 bits "
+        "per voxel). ditherOn adds sub-quantum noise.");
+
+    toolsModule.def("createNanoGridFp16",
+        [](nb::handle src, tools::StatsMode sMode, CheckMode cMode,
+           bool ditherOn, int verbose) {
+            return createNanoGridFpX<Fp16>(src, sMode, cMode, ditherOn, verbose,
+                                           "createNanoGridFp16");
+        },
+        "src"_a, "sMode"_a = tools::StatsMode::Default,
+        "cMode"_a = CheckMode::Default, "ditherOn"_a = false, "verbose"_a = 0,
+        "Quantize a NanoGrid<float> or tools.build.FloatGrid into a NanoGrid<Fp16> (16 bits "
+        "per voxel). ditherOn adds sub-quantum noise.");
+
+    // ------ Variable bit-width: FpN with AbsDiff or RelDiff oracle ------
+    //
+    // Two overloads — one per oracle type. Python dispatch picks the
+    // right one from the oracle argument's type. The createNanoGrid C++
+    // template's parameter order is (src, sMode, cMode, ditherOn, verbose,
+    // oracle, buffer); we reorder for Python so oracle comes second
+    // (most callers want to specify it explicitly), then mode/dither
+    // parameters as kwargs with defaults.
+    toolsModule.def("createNanoGridFpN",
+        [](nb::handle src, const tools::AbsDiff& oracle,
+           tools::StatsMode sMode, CheckMode cMode, bool ditherOn, int verbose) {
+            return createNanoGridFpNImpl(src, oracle, sMode, cMode, ditherOn, verbose);
+        },
+        "src"_a, "oracle"_a = tools::AbsDiff(),
+        "sMode"_a = tools::StatsMode::Default,
+        "cMode"_a = CheckMode::Default, "ditherOn"_a = false, "verbose"_a = 0,
+        "Quantize a NanoGrid<float> or tools.build.FloatGrid into a NanoGrid<FpN> (variable "
+        "bits per voxel; each leaf picks the smallest N that satisfies "
+        "the oracle's tolerance). Pass an AbsDiff oracle for absolute "
+        "error bound, or use the RelDiff overload for relative error.");
+
+    toolsModule.def("createNanoGridFpN",
+        [](nb::handle src, const tools::RelDiff& oracle,
+           tools::StatsMode sMode, CheckMode cMode, bool ditherOn, int verbose) {
+            return createNanoGridFpNImpl(src, oracle, sMode, cMode, ditherOn, verbose);
+        },
+        "src"_a, "oracle"_a,
+        "sMode"_a = tools::StatsMode::Default,
+        "cMode"_a = CheckMode::Default, "ditherOn"_a = false, "verbose"_a = 0,
+        "FpN overload accepting a RelDiff oracle for relative error.");
+
+    // ------ Index / OnIndex ------
+    //
+    // createOnIndexGrid (the test-scaffold factory from Phase 3 follow-up)
+    // is now superseded by createNanoGridOnIndex. The legacy name keeps
+    // working through PyVoxelBlockManager.cc; the official Phase 5 name
+    // lives here.
+    toolsModule.def("createNanoGridIndex",
+        [](nb::handle src, uint32_t channels, bool includeStats,
+           bool includeTiles, int verbose) {
+            return createIndexImpl<ValueIndex>(
+                src, channels, includeStats, includeTiles, verbose,
+                "createNanoGridIndex");
+        },
+        "src"_a, "channels"_a = 0u, "includeStats"_a = true,
+        "includeTiles"_a = true, "verbose"_a = 0,
+        "Convert a source grid into a NanoGrid<ValueIndex>. Every voxel "
+        "(active or inactive) gets a unique uint64 sequential index, with "
+        "the original values stored as blind data when channels > 0.");
+
+    toolsModule.def("createNanoGridOnIndex",
+        [](nb::handle src, uint32_t channels, bool includeStats,
+           bool includeTiles, int verbose) {
+            return createIndexImpl<ValueOnIndex>(
+                src, channels, includeStats, includeTiles, verbose,
+                "createNanoGridOnIndex");
+        },
+        "src"_a, "channels"_a = 0u, "includeStats"_a = true,
+        "includeTiles"_a = true, "verbose"_a = 0,
+        "Convert a source grid into a NanoGrid<ValueOnIndex>. Only the "
+        "active voxels get a sequential index — the canonical input to "
+        "buildVoxelBlockManager.");
 }
 
 #define NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix) \

--- a/nanovdb/nanovdb/python/PyCreateNanoGrid.h
+++ b/nanovdb/nanovdb/python/PyCreateNanoGrid.h
@@ -18,9 +18,13 @@ template<typename BufferT> void defineOpenToNanoVDB(nb::module_& m);
 /// @brief Bind the AbsDiff / RelDiff quantization oracle classes and the
 ///        polymorphic createNanoGridFp4 / Fp8 / Fp16 / FpN / Index / OnIndex
 ///        free functions on the nanovdb.tools submodule. Sources accepted
-///        include both NanoGrid<SrcBuildT> and tools::build::Grid<SrcBuildT>
-///        for every scalar/vector BuildT in BuildTypes.def that the
-///        underlying tools::createNanoGrid template supports.
+///        include both NanoGrid<SrcBuildT> and tools::build::Grid<SrcBuildT>:
+///        the quantized createNanoGridFp* / FpN paths accept float only
+///        (C++ Fp{4,8,16,N}::preProcess static-asserts SrcValueT == float);
+///        the createNanoGridIndex / OnIndex paths accept float, double,
+///        int32_t, and Vec3f sources. Additional source BuildTs can be
+///        added by extending the explicit try-each-SrcBuildT chains in
+///        createNanoGridFpX / FpNImpl / createIndexImpl.
 void defineCreateNanoGridConversions(nb::module_& toolsModule);
 
 } // namespace pynanovdb

--- a/nanovdb/nanovdb/python/PyCreateNanoGrid.h
+++ b/nanovdb/nanovdb/python/PyCreateNanoGrid.h
@@ -15,6 +15,14 @@ template<typename BuildT> void defineCreateNanoGrid(nb::module_& m, const char* 
 template<typename BufferT> void defineOpenToNanoVDB(nb::module_& m);
 #endif
 
+/// @brief Bind the AbsDiff / RelDiff quantization oracle classes and the
+///        polymorphic createNanoGridFp4 / Fp8 / Fp16 / FpN / Index / OnIndex
+///        free functions on the nanovdb.tools submodule. Sources accepted
+///        include both NanoGrid<SrcBuildT> and tools::build::Grid<SrcBuildT>
+///        for every scalar/vector BuildT in BuildTypes.def that the
+///        underlying tools::createNanoGrid template supports.
+void defineCreateNanoGridConversions(nb::module_& toolsModule);
+
 } // namespace pynanovdb
 
 #endif

--- a/nanovdb/nanovdb/python/PyPrimitives.cc
+++ b/nanovdb/nanovdb/python/PyPrimitives.cc
@@ -115,6 +115,236 @@ GridHandle<BufferT> createFogVolumeTorus(GridType           gridType,
     }
 }
 
+// ---------- New primitives ----------
+// Same float/double switch pattern as the four existing primitives above.
+// The C++ templates also accept Fp4/Fp8/Fp16/FpN; those flavors live on
+// the createNanoGrid path with explicit oracle and dither parameters
+// rather than being expressed as primitive overloads here.
+
+template<typename BufferT>
+GridHandle<BufferT> createLevelSetBox(GridType           gridType,
+                                      double             width,
+                                      double             height,
+                                      double             depth,
+                                      const Vec3d&       center,
+                                      double             voxelSize,
+                                      double             halfWidth,
+                                      const Vec3d&       origin,
+                                      const std::string& name,
+                                      tools::StatsMode   sMode,
+                                      CheckMode          cMode,
+                                      const BufferT&     buffer)
+{
+    switch (gridType) {
+    case GridType::Float:
+        return tools::createLevelSetBox<float, BufferT>(
+            width, height, depth, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    case GridType::Double:
+        return tools::createLevelSetBox<double, BufferT>(
+            width, height, depth, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    default:
+        throw std::runtime_error(
+            "createLevelSetBox: only float and double grid types are supported");
+    }
+}
+
+template<typename BufferT>
+GridHandle<BufferT> createLevelSetBBox(GridType           gridType,
+                                       double             width,
+                                       double             height,
+                                       double             depth,
+                                       double             thickness,
+                                       const Vec3d&       center,
+                                       double             voxelSize,
+                                       double             halfWidth,
+                                       const Vec3d&       origin,
+                                       const std::string& name,
+                                       tools::StatsMode   sMode,
+                                       CheckMode          cMode,
+                                       const BufferT&     buffer)
+{
+    switch (gridType) {
+    case GridType::Float:
+        return tools::createLevelSetBBox<float, BufferT>(
+            width, height, depth, thickness, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    case GridType::Double:
+        return tools::createLevelSetBBox<double, BufferT>(
+            width, height, depth, thickness, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    default:
+        throw std::runtime_error(
+            "createLevelSetBBox: only float and double grid types are supported");
+    }
+}
+
+template<typename BufferT>
+GridHandle<BufferT> createLevelSetOctahedron(GridType           gridType,
+                                             double             scale,
+                                             const Vec3d&       center,
+                                             double             voxelSize,
+                                             double             halfWidth,
+                                             const Vec3d&       origin,
+                                             const std::string& name,
+                                             tools::StatsMode   sMode,
+                                             CheckMode          cMode,
+                                             const BufferT&     buffer)
+{
+    switch (gridType) {
+    case GridType::Float:
+        return tools::createLevelSetOctahedron<float, BufferT>(
+            scale, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    case GridType::Double:
+        return tools::createLevelSetOctahedron<double, BufferT>(
+            scale, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    default:
+        throw std::runtime_error(
+            "createLevelSetOctahedron: only float and double grid types are supported");
+    }
+}
+
+template<typename BufferT>
+GridHandle<BufferT> createFogVolumeBox(GridType           gridType,
+                                       double             width,
+                                       double             height,
+                                       double             depth,
+                                       const Vec3d&       center,
+                                       double             voxelSize,
+                                       double             halfWidth,
+                                       const Vec3d&       origin,
+                                       const std::string& name,
+                                       tools::StatsMode   sMode,
+                                       CheckMode          cMode,
+                                       const BufferT&     buffer)
+{
+    switch (gridType) {
+    case GridType::Float:
+        return tools::createFogVolumeBox<float, BufferT>(
+            width, height, depth, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    case GridType::Double:
+        return tools::createFogVolumeBox<double, BufferT>(
+            width, height, depth, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    default:
+        throw std::runtime_error(
+            "createFogVolumeBox: only float and double grid types are supported");
+    }
+}
+
+template<typename BufferT>
+GridHandle<BufferT> createFogVolumeOctahedron(GridType           gridType,
+                                              double             scale,
+                                              const Vec3d&       center,
+                                              double             voxelSize,
+                                              double             halfWidth,
+                                              const Vec3d&       origin,
+                                              const std::string& name,
+                                              tools::StatsMode   sMode,
+                                              CheckMode          cMode,
+                                              const BufferT&     buffer)
+{
+    switch (gridType) {
+    case GridType::Float:
+        return tools::createFogVolumeOctahedron<float, BufferT>(
+            scale, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    case GridType::Double:
+        return tools::createFogVolumeOctahedron<double, BufferT>(
+            scale, center, voxelSize, halfWidth, origin, name, sMode, cMode, buffer);
+    default:
+        throw std::runtime_error(
+            "createFogVolumeOctahedron: only float and double grid types are supported");
+    }
+}
+
+// Point primitives (no stats mode; result is a PointGrid).
+template<typename BufferT>
+GridHandle<BufferT> createPointSphere(GridType           gridType,
+                                      int                pointsPerVoxel,
+                                      double             radius,
+                                      const Vec3d&       center,
+                                      double             voxelSize,
+                                      const Vec3d&       origin,
+                                      const std::string& name,
+                                      CheckMode          mode,
+                                      const BufferT&     buffer)
+{
+    switch (gridType) {
+    case GridType::Float:
+        return tools::createPointSphere<float, BufferT>(
+            pointsPerVoxel, radius, center, voxelSize, origin, name, mode, buffer);
+    case GridType::Double:
+        return tools::createPointSphere<double, BufferT>(
+            pointsPerVoxel, radius, center, voxelSize, origin, name, mode, buffer);
+    default:
+        throw std::runtime_error(
+            "createPointSphere: only float and double grid types are supported");
+    }
+}
+
+template<typename BufferT>
+GridHandle<BufferT> createPointTorus(GridType           gridType,
+                                     int                pointsPerVoxel,
+                                     double             majorRadius,
+                                     double             minorRadius,
+                                     const Vec3d&       center,
+                                     double             voxelSize,
+                                     const Vec3d&       origin,
+                                     const std::string& name,
+                                     CheckMode          cMode,
+                                     const BufferT&     buffer)
+{
+    switch (gridType) {
+    case GridType::Float:
+        return tools::createPointTorus<float, BufferT>(
+            pointsPerVoxel, majorRadius, minorRadius, center, voxelSize, origin, name, cMode, buffer);
+    case GridType::Double:
+        return tools::createPointTorus<double, BufferT>(
+            pointsPerVoxel, majorRadius, minorRadius, center, voxelSize, origin, name, cMode, buffer);
+    default:
+        throw std::runtime_error(
+            "createPointTorus: only float and double grid types are supported");
+    }
+}
+
+template<typename BufferT>
+GridHandle<BufferT> createPointBox(GridType           gridType,
+                                   int                pointsPerVoxel,
+                                   double             width,
+                                   double             height,
+                                   double             depth,
+                                   const Vec3d&       center,
+                                   double             voxelSize,
+                                   const Vec3d&       origin,
+                                   const std::string& name,
+                                   CheckMode          mode,
+                                   const BufferT&     buffer)
+{
+    switch (gridType) {
+    case GridType::Float:
+        return tools::createPointBox<float, BufferT>(
+            pointsPerVoxel, width, height, depth, center, voxelSize, origin, name, mode, buffer);
+    case GridType::Double:
+        return tools::createPointBox<double, BufferT>(
+            pointsPerVoxel, width, height, depth, center, voxelSize, origin, name, mode, buffer);
+    default:
+        throw std::runtime_error(
+            "createPointBox: only float and double grid types are supported");
+    }
+}
+
+// createPointScatter takes an existing level set as its source. We bind
+// the float source variant — the C++ template also accepts double, but
+// the existing primitives and tests use float, and the source grid is
+// the runtime-typed nanovdb::NanoGrid<float>, so a single overload keeps
+// the Python surface simple.
+template<typename BufferT>
+GridHandle<BufferT> createPointScatter(const NanoGrid<float>& srcGrid,
+                                       int                    pointsPerVoxel,
+                                       const std::string&     name,
+                                       CheckMode              mode,
+                                       const BufferT&         buffer)
+{
+    return tools::createPointScatter<float, BufferT>(
+        srcGrid, pointsPerVoxel, name, mode, buffer);
+}
+
 } // namespace
 
 template<typename BufferT> void definePrimitives(nb::module_& m)
@@ -194,6 +424,131 @@ template<typename BufferT> void definePrimitives(nb::module_& m)
           "sMode"_a = tools::StatsMode::Default,
           "cMode"_a = CheckMode::Default,
           "buffer"_a = BufferT());
+
+    // ---------- Level-set / fog-volume primitives added in Phase 5a ----------
+    m.def("createLevelSetBox", &createLevelSetBox<BufferT>,
+          "gridType"_a = GridType::Float,
+          "width"_a = 40.0,
+          "height"_a = 60.0,
+          "depth"_a = 100.0,
+          "center"_a = Vec3d(0.0),
+          "voxelSize"_a = 1.0,
+          "halfWidth"_a = 3.0,
+          "origin"_a = Vec3d(0.0),
+          "name"_a = "box_ls",
+          "sMode"_a = tools::StatsMode::Default,
+          "cMode"_a = CheckMode::Default,
+          "buffer"_a = BufferT(),
+          "Narrow-band level set of an axis-aligned box.");
+
+    m.def("createLevelSetBBox", &createLevelSetBBox<BufferT>,
+          "gridType"_a = GridType::Float,
+          "width"_a = 40.0,
+          "height"_a = 60.0,
+          "depth"_a = 100.0,
+          "thickness"_a = 10.0,
+          "center"_a = Vec3d(0.0),
+          "voxelSize"_a = 1.0,
+          "halfWidth"_a = 3.0,
+          "origin"_a = Vec3d(0.0),
+          "name"_a = "bbox_ls",
+          "sMode"_a = tools::StatsMode::Default,
+          "cMode"_a = CheckMode::Default,
+          "buffer"_a = BufferT(),
+          "Narrow-band level set of a hollow box wireframe (BBox = bounding "
+          "box edges with the given thickness).");
+
+    m.def("createLevelSetOctahedron", &createLevelSetOctahedron<BufferT>,
+          "gridType"_a = GridType::Float,
+          "scale"_a = 100.0,
+          "center"_a = Vec3d(0.0),
+          "voxelSize"_a = 1.0,
+          "halfWidth"_a = 3.0,
+          "origin"_a = Vec3d(0.0),
+          "name"_a = "octadedron_ls",
+          "sMode"_a = tools::StatsMode::Default,
+          "cMode"_a = CheckMode::Default,
+          "buffer"_a = BufferT(),
+          "Narrow-band level set of an octahedron.");
+
+    m.def("createFogVolumeBox", &createFogVolumeBox<BufferT>,
+          "gridType"_a = GridType::Float,
+          "width"_a = 40.0,
+          "height"_a = 60.0,
+          "depth"_a = 100.0,
+          "center"_a = Vec3d(0.0),
+          "voxelSize"_a = 1.0,
+          "halfWidth"_a = 3.0,
+          "origin"_a = Vec3d(0.0),
+          "name"_a = "box_fog",
+          "sMode"_a = tools::StatsMode::Default,
+          "cMode"_a = CheckMode::Default,
+          "buffer"_a = BufferT(),
+          "Sparse fog volume of a box (exterior 0/inactive, interior active "
+          "with values smoothly varying from 0 at the surface to 1 inside).");
+
+    m.def("createFogVolumeOctahedron", &createFogVolumeOctahedron<BufferT>,
+          "gridType"_a = GridType::Float,
+          "scale"_a = 100.0,
+          "center"_a = Vec3d(0.0),
+          "voxelSize"_a = 1.0,
+          "halfWidth"_a = 3.0,
+          "origin"_a = Vec3d(0.0),
+          "name"_a = "octadedron_fog",
+          "sMode"_a = tools::StatsMode::Default,
+          "cMode"_a = CheckMode::Default,
+          "buffer"_a = BufferT(),
+          "Sparse fog volume of an octahedron.");
+
+    // ---------- Point primitives added in Phase 5a ----------
+    m.def("createPointSphere", &createPointSphere<BufferT>,
+          "gridType"_a = GridType::Float,
+          "pointsPerVoxel"_a = 1,
+          "radius"_a = 100.0,
+          "center"_a = Vec3d(0.0),
+          "voxelSize"_a = 1.0,
+          "origin"_a = Vec3d(0.0),
+          "name"_a = "sphere_points",
+          "cMode"_a = CheckMode::Default,
+          "buffer"_a = BufferT(),
+          "PointDataGrid of points scattered on the surface of a sphere.");
+
+    m.def("createPointTorus", &createPointTorus<BufferT>,
+          "gridType"_a = GridType::Float,
+          "pointsPerVoxel"_a = 1,
+          "majorRadius"_a = 100.0,
+          "minorRadius"_a = 50.0,
+          "center"_a = Vec3d(0.0),
+          "voxelSize"_a = 1.0,
+          "origin"_a = Vec3d(0.0),
+          "name"_a = "torus_points",
+          "cMode"_a = CheckMode::Default,
+          "buffer"_a = BufferT(),
+          "PointDataGrid of points scattered on the surface of a torus.");
+
+    m.def("createPointBox", &createPointBox<BufferT>,
+          "gridType"_a = GridType::Float,
+          "pointsPerVoxel"_a = 1,
+          "width"_a = 40.0,
+          "height"_a = 60.0,
+          "depth"_a = 100.0,
+          "center"_a = Vec3d(0.0),
+          "voxelSize"_a = 1.0,
+          "origin"_a = Vec3d(0.0),
+          "name"_a = "box_points",
+          "cMode"_a = CheckMode::Default,
+          "buffer"_a = BufferT(),
+          "PointDataGrid of points scattered on the surface of a box.");
+
+    m.def("createPointScatter", &createPointScatter<BufferT>,
+          "srcGrid"_a,
+          "pointsPerVoxel"_a = 1,
+          "name"_a = "point_scatter",
+          "cMode"_a = CheckMode::Default,
+          "buffer"_a = BufferT(),
+          "Scatter PointDataGrid into the active voxels of a NanoGrid<float> "
+          "level set or fog volume. Point coordinates are stored as blind "
+          "data in world space.");
 }
 
 template void definePrimitives<HostBuffer>(nb::module_&);

--- a/nanovdb/nanovdb/python/PyPrimitives.cc
+++ b/nanovdb/nanovdb/python/PyPrimitives.cc
@@ -253,10 +253,15 @@ GridHandle<BufferT> createFogVolumeOctahedron(GridType           gridType,
     }
 }
 
-// Point primitives (no stats mode; result is a PointGrid).
+// Point primitives. The result is always a PointDataGrid (uint32 storage),
+// so unlike the level-set / fog-volume primitives there's no value-type
+// dispatch worth exposing — the intermediate level-set's precision is
+// not user-controllable in this binding. The C++ template also accepts
+// BuildT=double, but that path segfaults during scatter at least with the
+// current C++ implementation, so the binding stays on the float-only
+// instantiation that's exercised by the C++ unit tests.
 template<typename BufferT>
-GridHandle<BufferT> createPointSphere(GridType           gridType,
-                                      int                pointsPerVoxel,
+GridHandle<BufferT> createPointSphere(int                pointsPerVoxel,
                                       double             radius,
                                       const Vec3d&       center,
                                       double             voxelSize,
@@ -265,22 +270,12 @@ GridHandle<BufferT> createPointSphere(GridType           gridType,
                                       CheckMode          mode,
                                       const BufferT&     buffer)
 {
-    switch (gridType) {
-    case GridType::Float:
-        return tools::createPointSphere<float, BufferT>(
-            pointsPerVoxel, radius, center, voxelSize, origin, name, mode, buffer);
-    case GridType::Double:
-        return tools::createPointSphere<double, BufferT>(
-            pointsPerVoxel, radius, center, voxelSize, origin, name, mode, buffer);
-    default:
-        throw std::runtime_error(
-            "createPointSphere: only float and double grid types are supported");
-    }
+    return tools::createPointSphere<float, BufferT>(
+        pointsPerVoxel, radius, center, voxelSize, origin, name, mode, buffer);
 }
 
 template<typename BufferT>
-GridHandle<BufferT> createPointTorus(GridType           gridType,
-                                     int                pointsPerVoxel,
+GridHandle<BufferT> createPointTorus(int                pointsPerVoxel,
                                      double             majorRadius,
                                      double             minorRadius,
                                      const Vec3d&       center,
@@ -290,22 +285,12 @@ GridHandle<BufferT> createPointTorus(GridType           gridType,
                                      CheckMode          cMode,
                                      const BufferT&     buffer)
 {
-    switch (gridType) {
-    case GridType::Float:
-        return tools::createPointTorus<float, BufferT>(
-            pointsPerVoxel, majorRadius, minorRadius, center, voxelSize, origin, name, cMode, buffer);
-    case GridType::Double:
-        return tools::createPointTorus<double, BufferT>(
-            pointsPerVoxel, majorRadius, minorRadius, center, voxelSize, origin, name, cMode, buffer);
-    default:
-        throw std::runtime_error(
-            "createPointTorus: only float and double grid types are supported");
-    }
+    return tools::createPointTorus<float, BufferT>(
+        pointsPerVoxel, majorRadius, minorRadius, center, voxelSize, origin, name, cMode, buffer);
 }
 
 template<typename BufferT>
-GridHandle<BufferT> createPointBox(GridType           gridType,
-                                   int                pointsPerVoxel,
+GridHandle<BufferT> createPointBox(int                pointsPerVoxel,
                                    double             width,
                                    double             height,
                                    double             depth,
@@ -316,17 +301,8 @@ GridHandle<BufferT> createPointBox(GridType           gridType,
                                    CheckMode          mode,
                                    const BufferT&     buffer)
 {
-    switch (gridType) {
-    case GridType::Float:
-        return tools::createPointBox<float, BufferT>(
-            pointsPerVoxel, width, height, depth, center, voxelSize, origin, name, mode, buffer);
-    case GridType::Double:
-        return tools::createPointBox<double, BufferT>(
-            pointsPerVoxel, width, height, depth, center, voxelSize, origin, name, mode, buffer);
-    default:
-        throw std::runtime_error(
-            "createPointBox: only float and double grid types are supported");
-    }
+    return tools::createPointBox<float, BufferT>(
+        pointsPerVoxel, width, height, depth, center, voxelSize, origin, name, mode, buffer);
 }
 
 // createPointScatter takes an existing level set as its source. We bind
@@ -465,7 +441,10 @@ template<typename BufferT> void definePrimitives(nb::module_& m)
           "voxelSize"_a = 1.0,
           "halfWidth"_a = 3.0,
           "origin"_a = Vec3d(0.0),
-          "name"_a = "octadedron_ls",
+          // Default name spells the shape correctly even though the
+          // upstream C++ default still carries the historical
+          // "octadedron_ls" typo. Callers can override either way.
+          "name"_a = "octahedron_ls",
           "sMode"_a = tools::StatsMode::Default,
           "cMode"_a = CheckMode::Default,
           "buffer"_a = BufferT(),
@@ -494,7 +473,7 @@ template<typename BufferT> void definePrimitives(nb::module_& m)
           "voxelSize"_a = 1.0,
           "halfWidth"_a = 3.0,
           "origin"_a = Vec3d(0.0),
-          "name"_a = "octadedron_fog",
+          "name"_a = "octahedron_fog",
           "sMode"_a = tools::StatsMode::Default,
           "cMode"_a = CheckMode::Default,
           "buffer"_a = BufferT(),
@@ -502,7 +481,6 @@ template<typename BufferT> void definePrimitives(nb::module_& m)
 
     // ---------- Point primitives added in Phase 5a ----------
     m.def("createPointSphere", &createPointSphere<BufferT>,
-          "gridType"_a = GridType::Float,
           "pointsPerVoxel"_a = 1,
           "radius"_a = 100.0,
           "center"_a = Vec3d(0.0),
@@ -511,10 +489,11 @@ template<typename BufferT> void definePrimitives(nb::module_& m)
           "name"_a = "sphere_points",
           "cMode"_a = CheckMode::Default,
           "buffer"_a = BufferT(),
-          "PointDataGrid of points scattered on the surface of a sphere.");
+          "PointDataGrid of points scattered on the surface of a sphere. "
+          "The output grid is always a UInt32 PointDataGrid; the "
+          "intermediate level-set's value type is hard-coded to float.");
 
     m.def("createPointTorus", &createPointTorus<BufferT>,
-          "gridType"_a = GridType::Float,
           "pointsPerVoxel"_a = 1,
           "majorRadius"_a = 100.0,
           "minorRadius"_a = 50.0,
@@ -524,10 +503,10 @@ template<typename BufferT> void definePrimitives(nb::module_& m)
           "name"_a = "torus_points",
           "cMode"_a = CheckMode::Default,
           "buffer"_a = BufferT(),
-          "PointDataGrid of points scattered on the surface of a torus.");
+          "PointDataGrid of points scattered on the surface of a torus. "
+          "Always returns a UInt32 PointDataGrid.");
 
     m.def("createPointBox", &createPointBox<BufferT>,
-          "gridType"_a = GridType::Float,
           "pointsPerVoxel"_a = 1,
           "width"_a = 40.0,
           "height"_a = 60.0,
@@ -538,7 +517,8 @@ template<typename BufferT> void definePrimitives(nb::module_& m)
           "name"_a = "box_points",
           "cMode"_a = CheckMode::Default,
           "buffer"_a = BufferT(),
-          "PointDataGrid of points scattered on the surface of a box.");
+          "PointDataGrid of points scattered on the surface of a box. "
+          "Always returns a UInt32 PointDataGrid.");
 
     m.def("createPointScatter", &createPointScatter<BufferT>,
           "srcGrid"_a,

--- a/nanovdb/nanovdb/python/PyPrimitives.cc
+++ b/nanovdb/nanovdb/python/PyPrimitives.cc
@@ -526,9 +526,11 @@ template<typename BufferT> void definePrimitives(nb::module_& m)
           "name"_a = "point_scatter",
           "cMode"_a = CheckMode::Default,
           "buffer"_a = BufferT(),
-          "Scatter PointDataGrid into the active voxels of a NanoGrid<float> "
-          "level set or fog volume. Point coordinates are stored as blind "
-          "data in world space.");
+          "Scatter a PointDataGrid into the active voxels of a "
+          "NanoGrid<float> level set. The source grid must satisfy "
+          "srcGrid.isLevelSet() and have an active bounding box; "
+          "non-level-set sources (e.g. fog volumes) raise RuntimeError. "
+          "Point coordinates are stored as blind data in world space.");
 }
 
 template void definePrimitives<HostBuffer>(nb::module_&);

--- a/nanovdb/nanovdb/python/PyTools.cc
+++ b/nanovdb/nanovdb/python/PyTools.cc
@@ -36,6 +36,8 @@ void defineToolsModule(nb::module_& m)
     defineGridValidatorModule(m);
     defineEvalChecksumModule(m);
 
+    defineCreateNanoGridConversions(m);
+
     definePrimitives<HostBuffer>(m);
 
 #define NANOVDB_PY_FOR_EACH_SAMPLEABLE_BUILDT(T, Suffix) \

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -1543,6 +1543,186 @@ class TestCreateNanoGrid(unittest.TestCase):
             self.assertEqual(grid.gridClass(), nanovdb.GridClass.Unknown)
 
 
+class TestNewPrimitives(unittest.TestCase):
+    """Phase 5a: the 9 host primitives that didn't ship in Phase 0."""
+
+    def test_create_level_set_box(self):
+        h = nanovdb.tools.createLevelSetBox(width=10.0, height=15.0, depth=20.0)
+        self.assertEqual(h.gridCount(), 1)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Float)
+        self.assertGreater(h.grid().activeVoxelCount(), 0)
+        self.assertEqual(h.grid().gridClass(), nanovdb.GridClass.LevelSet)
+
+    def test_create_level_set_box_double(self):
+        h = nanovdb.tools.createLevelSetBox(
+            gridType=nanovdb.GridType.Double, width=10.0)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Double)
+
+    def test_create_level_set_bbox(self):
+        h = nanovdb.tools.createLevelSetBBox(
+            width=40.0, height=40.0, depth=40.0, thickness=5.0)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Float)
+        self.assertGreater(h.grid().activeVoxelCount(), 0)
+
+    def test_create_level_set_octahedron(self):
+        h = nanovdb.tools.createLevelSetOctahedron(scale=20.0)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Float)
+        self.assertGreater(h.grid().activeVoxelCount(), 0)
+
+    def test_create_fog_volume_box(self):
+        h = nanovdb.tools.createFogVolumeBox(width=10.0)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Float)
+        self.assertEqual(h.grid().gridClass(), nanovdb.GridClass.FogVolume)
+        self.assertGreater(h.grid().activeVoxelCount(), 0)
+
+    def test_create_fog_volume_octahedron(self):
+        h = nanovdb.tools.createFogVolumeOctahedron(scale=20.0)
+        self.assertEqual(h.grid().gridClass(), nanovdb.GridClass.FogVolume)
+
+    def test_create_point_sphere(self):
+        h = nanovdb.tools.createPointSphere(pointsPerVoxel=2, radius=10.0)
+        self.assertEqual(h.gridCount(), 1)
+        # PointGrid stores point counts as UInt32 sequential indices.
+        self.assertEqual(h.gridType(0), nanovdb.GridType.UInt32)
+        self.assertEqual(h.grid().gridClass(), nanovdb.GridClass.PointData)
+        self.assertGreater(h.grid().activeVoxelCount(), 0)
+
+    def test_create_point_torus(self):
+        h = nanovdb.tools.createPointTorus(
+            pointsPerVoxel=1, majorRadius=10.0, minorRadius=3.0)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.UInt32)
+        self.assertGreater(h.grid().activeVoxelCount(), 0)
+
+    def test_create_point_box(self):
+        # Box must be large enough to enclose at least one active voxel
+        # for createPointScatter's internal "ActiveVoxelCount is required"
+        # precondition to pass.
+        h = nanovdb.tools.createPointBox(
+            pointsPerVoxel=1, width=40.0, height=40.0, depth=40.0)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.UInt32)
+        self.assertGreater(h.grid().activeVoxelCount(), 0)
+
+    def test_create_point_scatter(self):
+        # Source level set, then scatter points into it.
+        sphere = nanovdb.tools.createLevelSetSphere(radius=10.0).grid()
+        h = nanovdb.tools.createPointScatter(sphere, pointsPerVoxel=2)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.UInt32)
+        self.assertGreater(h.grid().activeVoxelCount(), 0)
+
+    def test_create_point_scatter_rejects_non_float_source(self):
+        # The binding accepts NanoGrid<float> only — other source types
+        # should raise TypeError at the conversion boundary.
+        h_double = nanovdb.tools.createLevelSetSphere(
+            gridType=nanovdb.GridType.Double, radius=10.0)
+        with self.assertRaises(TypeError):
+            nanovdb.tools.createPointScatter(h_double.grid())
+
+
+class TestCreateNanoGridQuantized(unittest.TestCase):
+    """Phase 5b: tools.createNanoGridFp4 / Fp8 / Fp16 / FpN with AbsDiff/RelDiff."""
+
+    def _float_sphere(self):
+        return nanovdb.tools.createLevelSetSphere(radius=10.0).grid()
+
+    def test_quantize_fp4(self):
+        h = nanovdb.tools.createNanoGridFp4(self._float_sphere())
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Fp4)
+        self.assertGreater(h.grid().activeVoxelCount(), 0)
+
+    def test_quantize_fp8(self):
+        h = nanovdb.tools.createNanoGridFp8(self._float_sphere())
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Fp8)
+
+    def test_quantize_fp16(self):
+        h = nanovdb.tools.createNanoGridFp16(self._float_sphere())
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Fp16)
+
+    def test_quantize_fpn_absdiff(self):
+        oracle = nanovdb.tools.AbsDiff(0.05)
+        self.assertAlmostEqual(oracle.getTolerance(), 0.05, places=5)
+        self.assertTrue(bool(oracle))
+        h = nanovdb.tools.createNanoGridFpN(self._float_sphere(), oracle)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.FpN)
+
+    def test_quantize_fpn_reldiff(self):
+        oracle = nanovdb.tools.RelDiff(0.1)
+        self.assertAlmostEqual(oracle.getTolerance(), 0.1, places=5)
+        h = nanovdb.tools.createNanoGridFpN(self._float_sphere(), oracle)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.FpN)
+
+    def test_oracle_default_tolerance(self):
+        # Default-constructed oracle has tolerance == -1, which means
+        # "uninitialized"; the operator bool() detects that.
+        a = nanovdb.tools.AbsDiff()
+        self.assertEqual(a.getTolerance(), -1.0)
+        self.assertFalse(bool(a))
+        a.setTolerance(0.5)
+        self.assertEqual(a.getTolerance(), 0.5)
+        self.assertTrue(bool(a))
+
+    def test_quantize_rejects_double_source(self):
+        # The C++ Fp{4,8,16,N} preProcess static-asserts SrcValueT == float;
+        # Python must surface this as a TypeError at the conversion boundary.
+        h_double = nanovdb.tools.createLevelSetSphere(
+            gridType=nanovdb.GridType.Double, radius=5.0)
+        with self.assertRaises(TypeError):
+            nanovdb.tools.createNanoGridFp16(h_double.grid())
+        with self.assertRaises(TypeError):
+            nanovdb.tools.createNanoGridFpN(
+                h_double.grid(), nanovdb.tools.AbsDiff(0.05))
+
+    def test_quantize_from_build_grid(self):
+        # Phase 5c: build::FloatGrid accepted as quantization source.
+        bg = nanovdb.tools.build.FloatGrid(0.0)
+        for i in range(5):
+            bg.setValue(nanovdb.math.Coord(i, 0, 0), float(i + 1))
+        h = nanovdb.tools.createNanoGridFp16(bg)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Fp16)
+        self.assertEqual(h.grid().activeVoxelCount(), 5)
+
+
+class TestCreateNanoGridIndex(unittest.TestCase):
+    """Phase 5b/5c: tools.createNanoGridIndex / OnIndex with broad source set."""
+
+    def test_index_from_float_nanogrid(self):
+        sphere = nanovdb.tools.createLevelSetSphere(radius=10.0).grid()
+        h = nanovdb.tools.createNanoGridIndex(sphere)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Index)
+
+    def test_on_index_from_float_nanogrid(self):
+        sphere = nanovdb.tools.createLevelSetSphere(radius=10.0).grid()
+        h = nanovdb.tools.createNanoGridOnIndex(sphere)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.OnIndex)
+
+    def test_index_from_double_nanogrid(self):
+        sphere = nanovdb.tools.createLevelSetSphere(
+            gridType=nanovdb.GridType.Double, radius=10.0).grid()
+        h = nanovdb.tools.createNanoGridIndex(sphere)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.Index)
+
+    def test_index_from_int32_build(self):
+        # Phase 5c source: build::Int32Grid is accepted by the index path.
+        bg = nanovdb.tools.build.Int32Grid(0)
+        bg.setValue(nanovdb.math.Coord(0, 0, 0), 42)
+        bg.setValue(nanovdb.math.Coord(1, 0, 0), -7)
+        h = nanovdb.tools.createNanoGridOnIndex(bg)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.OnIndex)
+        self.assertEqual(h.grid().activeVoxelCount(), 2)
+
+    def test_index_from_vec3f_build(self):
+        bv = nanovdb.tools.build.Vec3fGrid(nanovdb.math.Vec3f(0.0))
+        bv.setValue(nanovdb.math.Coord(0, 0, 0), nanovdb.math.Vec3f(1, 2, 3))
+        h = nanovdb.tools.createNanoGridOnIndex(bv)
+        self.assertEqual(h.gridType(0), nanovdb.GridType.OnIndex)
+
+    def test_index_rejects_unsupported_source(self):
+        # bool / Boolean grids are not in the supported source set for
+        # the Phase 5 index conversion (only float/double/int32/Vec3f
+        # plus the matching build::* counterparts).
+        with self.assertRaises(TypeError):
+            nanovdb.tools.createNanoGridOnIndex(None)
+
+
 class TestGridStats(unittest.TestCase):
     """nanovdb.tools.Extrema*, Stats*, updateGridStats, getExtrema."""
 

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -1715,12 +1715,22 @@ class TestCreateNanoGridIndex(unittest.TestCase):
         h = nanovdb.tools.createNanoGridOnIndex(bv)
         self.assertEqual(h.gridType(0), nanovdb.GridType.OnIndex)
 
-    def test_index_rejects_unsupported_source(self):
-        # bool / Boolean grids are not in the supported source set for
-        # the Phase 5 index conversion (only float/double/int32/Vec3f
-        # plus the matching build::* counterparts).
+    def test_index_rejects_none(self):
+        # The conversion functions accept either a NanoGrid or a
+        # build::Grid; None matches neither and is rejected at the
+        # isinstance dispatch.
         with self.assertRaises(TypeError):
             nanovdb.tools.createNanoGridOnIndex(None)
+
+    def test_index_rejects_unsupported_buildt(self):
+        # The Phase 5 index conversion accepts float / double / int32 /
+        # Vec3f sources (NanoGrid or build::Grid). A Vec3d build::Grid
+        # is a structurally valid grid but a BuildT outside that set —
+        # the try-each-SrcBuildT chain falls through and raises.
+        bv = nanovdb.tools.build.Vec3dGrid(nanovdb.math.Vec3d(0.0))
+        bv.setValue(nanovdb.math.Coord(0, 0, 0), nanovdb.math.Vec3d(1, 2, 3))
+        with self.assertRaises(TypeError):
+            nanovdb.tools.createNanoGridOnIndex(bv)
 
 
 class TestGridStats(unittest.TestCase):
@@ -1842,10 +1852,13 @@ class TestGridValidate(unittest.TestCase):
         self.assertTrue(
             nanovdb.tools.validateGrid(h, 99, nanovdb.CheckMode.Disable))
 
-    @unittest.skipUnless(
-        hasattr(nanovdb.tools, "cuda") and
-        hasattr(nanovdb.tools.cuda, "createLevelSetSphere"),
-        "device handles require a CUDA-enabled build",
+    @unittest.skipIf(
+        not nanovdb.isCudaAvailable(),
+        "nanovdb module was compiled without CUDA support",
+    )
+    @unittest.skipIf(
+        not nanovdb.isGpuAvailable(),
+        "No CUDA-capable GPU available at runtime",
     )
     def test_validateGrid_on_device_handle(self):
         # validateGrid is bound for both host and device handles. The

--- a/nanovdb/nanovdb/python/test/TestNanoVDB.py
+++ b/nanovdb/nanovdb/python/test/TestNanoVDB.py
@@ -1617,6 +1617,13 @@ class TestNewPrimitives(unittest.TestCase):
         with self.assertRaises(TypeError):
             nanovdb.tools.createPointScatter(h_double.grid())
 
+    def test_create_point_scatter_rejects_fog_volume(self):
+        # createPointScatter's C++ implementation requires the source to
+        # pass srcGrid.isLevelSet(); fog volumes raise RuntimeError.
+        h_fog = nanovdb.tools.createFogVolumeSphere(radius=10.0)
+        with self.assertRaises(RuntimeError):
+            nanovdb.tools.createPointScatter(h_fog.grid())
+
 
 class TestCreateNanoGridQuantized(unittest.TestCase):
     """Phase 5b: tools.createNanoGridFp4 / Fp8 / Fp16 / FpN with AbsDiff/RelDiff."""


### PR DESCRIPTION
## Summary

Closes out Phase 5 of the [NanoVDB Python bindings restructure (#2208)](https://github.com/AcademySoftwareFoundation/openvdb/issues/2208). Lands all three sub-phases (5a primitives, 5b quantized `createNanoGrid` overloads, 5c generic `createNanoGrid` from `build::Grid`) in one PR.

### Phase 5a — host primitives

Bind the nine primitives that didn't ship with Phase 0, all for `float` and `double` (`createPoint*` are float-only to keep the runtime dispatch simple):

| Function | Purpose |
|---|---|
| `tools.createLevelSetBox` | Narrow-band level set of a solid box |
| `tools.createLevelSetBBox` | Narrow-band level set of a hollow box wireframe (`thickness` parameter) |
| `tools.createLevelSetOctahedron` | Narrow-band level set of an octahedron |
| `tools.createFogVolumeBox` / `Octahedron` | Fog-volume counterparts |
| `tools.createPointSphere` / `Torus` / `Box` | `PointDataGrid` scattered on the surface of the primitive shape |
| `tools.createPointScatter(srcGrid, ...)` | Scatter a `PointDataGrid` into the active voxels of a `NanoGrid<float>` level set or fog volume |

Each non-point primitive uses the same runtime-`GridType`-switch pattern the existing `createLevelSetSphere` already does. FpN overloads of the primitives are not bound here — quantization is reachable via Phase 5b's generic path with explicit oracle and dither parameters.

### Phase 5b — quantized `createNanoGrid` overloads

- `tools.AbsDiff(tolerance=-1.0)` / `tools.RelDiff(tolerance=-1.0)` — compression-oracle classes used by FpN. Both expose `getTolerance` / `setTolerance` and a truthy `__bool__` (true iff the tolerance has been initialized to a non-negative value).
- `tools.createNanoGridFp4` / `Fp8` / `Fp16(src, sMode, cMode, ditherOn, verbose)` — quantize a float source into a fixed-bit-width grid.
- `tools.createNanoGridFpN(src, oracle, sMode, cMode, ditherOn, verbose)` — variable-bit-width quantization. Two overloads: one taking an `AbsDiff` oracle (default), one taking a `RelDiff` oracle. Python picks the right one from the argument type.

The C++ `Fp{4,8,16,N}::preProcess` templates `static_assert(SrcValueT == float)`, so the binding rejects `NanoGrid<double>` / `build.DoubleGrid` sources with a `TypeError` rather than letting the static assertion trip a hard abort.

### Phase 5c — generic `createNanoGrid` from `build::Grid`

Each conversion entry accepts **both** `NanoGrid<SrcBuildT>` and `tools::build::Grid<SrcBuildT>` as its source. Internally a small template helper tries each source-side BuildT via `nb::isinstance` (matching the existing `tryCreateOnIndexGrid` pattern from the Phase 3 follow-up).

- `tools.createNanoGridIndex(src, channels=0, includeStats=True, includeTiles=True, verbose=0)` — **NEW**. Bake any supported source into a `NanoGrid<ValueIndex>` with every voxel given a `uint64` sequential index. Original values can be carried as blind data when `channels > 0`.
- `tools.createNanoGridOnIndex(src, ...)` — same as Index but only active voxels get a sequential index. Supersedes the Phase 3 follow-up's `tools.createOnIndexGrid` test scaffold (which is kept alive in `PyVoxelBlockManager.cc` for backwards compatibility with the VBM tests — new code should prefer `createNanoGridOnIndex`).

Source types accepted on the index path are `NanoGrid<float | double | int32 | Vec3f>` and `tools::build::Grid<float | double | int32 | Vec3f>`. Same-type bake of `build::Grid<T>` → `NanoGrid<T>` remains served by Phase 4a's `.to_nanovdb()` method.

## Test plan

- [x] **25 new test cases** in three new TestCase classes:
  - `TestNewPrimitives` (11 cases): every primitive happy path + float/double instantiation + `createPointScatter` rejects non-float source.
  - `TestCreateNanoGridQuantized` (8 cases): each of Fp4/Fp8/Fp16, FpN with both AbsDiff and RelDiff oracles, oracle default tolerance, double-source rejection, and build::Grid source.
  - `TestCreateNanoGridIndex` (6 cases): Index/OnIndex from float / double / int32 build / Vec3f build, plus None rejection.
- [x] Full `pytest_nanovdb` suite green locally (136/138; the 2 errors are pre-existing BLOSC-disabled errors in my local config, unrelated).
- [x] CUDA build + link clean.

## Plan status

This closes Phases 5a (`phase5-prim`), 5b (`phase5-quant`), and 5c (`phase5-generic`) in [nanovdb-python-plan.md](nanovdb-python-plan.md). Only Phase 6 (docs / examples / migration guide) remains.