### PR TITLE
Remove Boost dependency from OPENVDB_USE_DELAYED_LOADING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,8 +160,6 @@ preceeding flags. If you need more granular control you can provide your
 desired flags via CXX_FLAGS. Only applicable which compiling for x86 targets.
 ]=])
 
-cmake_dependent_option(OPENVDB_DISABLE_BOOST_IMPLICIT_LINKING
-  "Disable the implicit linking of Boost libraries on Windows" ON "WIN32" OFF)
 option(USE_STATIC_DEPENDENCIES [=[
 Only search for and use static libraries. If OFF the shared versions of requried libraries are prioritised, falling
 back to static libraries. Forcing individual static dependencies can be enabled by setting XXX_USE_STATIC_LIBS

--- a/cmake/FindOpenVDB.cmake
+++ b/cmake/FindOpenVDB.cmake
@@ -603,10 +603,6 @@ elseif(NOT OPENVDB_USE_STATIC_LIBS)
       set(OpenVDB_USES_IMATH_HALF ON)
     endif()
 
-    string(FIND ${PREREQUISITE} "boost_iostreams" _HAS_DEP)
-    if(NOT ${_HAS_DEP} EQUAL -1)
-      set(OpenVDB_USES_DELAYED_LOADING ON)
-    endif()
   endforeach()
 
   unset(_OPENVDB_PREREQUISITE_LIST)
@@ -644,7 +640,6 @@ endif()
 set(_OPENVDB_VISIBLE_DEPENDENCIES "")
 
 if(OpenVDB_USES_DELAYED_LOADING)
-  list(APPEND _OPENVDB_VISIBLE_DEPENDENCIES Boost::iostreams)
   list(APPEND OpenVDB_DEFINITIONS OPENVDB_USE_DELAYED_LOADING)
 endif()
 

--- a/openvdb/openvdb/CMakeLists.txt
+++ b/openvdb/openvdb/CMakeLists.txt
@@ -117,19 +117,6 @@ endif()
 
 # Collect and configure lib dependencies
 
-if(OPENVDB_USE_DELAYED_LOADING)
-  find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS iostreams)
-
-  if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_BOOST_VERSION)
-    # The X.Y.Z boost version value isn't available until CMake 3.14
-    set(FULL_BOOST_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-    if(${FULL_BOOST_VERSION} VERSION_LESS FUTURE_MINIMUM_BOOST_VERSION)
-      message(DEPRECATION "Support for Boost versions < ${FUTURE_MINIMUM_BOOST_VERSION} "
-        "is deprecated and will be removed.")
-    endif()
-  endif()
-endif()
-
 find_package(TBB ${MINIMUM_TBB_VERSION} REQUIRED COMPONENTS tbb)
 if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_TBB_VERSION)
   if(${TBB_VERSION} VERSION_LESS FUTURE_MINIMUM_TBB_VERSION)
@@ -250,27 +237,6 @@ endif()
 
 if(UNIX)
   list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Threads::Threads)
-endif()
-
-# Pull in Boost last as houdini's boost (hboost) is fully namespaced and libs
-# are renamed too. Boost can be pulled in at any time, but do it last so that,
-# if it's in a shared place (like /usr/local) it doesn't accidently pull in
-# other headers.
-
-if(OPENVDB_USE_DELAYED_LOADING)
-  list(APPEND OPENVDB_CORE_DEPENDENT_LIBS Boost::iostreams)
-  if(WIN32)
-    # Boost headers contain #pragma commands on Windows which causes Boost
-    # libraries to be linked in automatically. Custom boost installations
-    # may find that these naming conventions don't always match and can
-    # cause linker errors. This option disables this feature of Boost. Note
-    # -DBOOST_ALL_NO_LIB can also be provided manually.
-    if(OPENVDB_DISABLE_BOOST_IMPLICIT_LINKING)
-        list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
-          Boost::disable_autolinking  # add -DBOOST_ALL_NO_LIB
-        )
-    endif()
-  endif()
 endif()
 
 ##########################################################################

--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -14,31 +14,20 @@
 #include <openvdb/openvdb.h>
 
 #ifdef OPENVDB_USE_DELAYED_LOADING
-// Boost.Interprocess uses a header-only portion of Boost.DateTime
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-macros"
-#endif
-#define BOOST_DATE_TIME_NO_LIB
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-#include <boost/interprocess/file_mapping.hpp>
-#include <boost/interprocess/mapped_region.hpp>
-#include <boost/iostreams/device/array.hpp>
-#include <boost/iostreams/stream.hpp>
-
 #ifdef _WIN32
-#include <boost/interprocess/detail/os_file_functions.hpp> // open_existing_file(), close_file()
-extern "C" __declspec(dllimport) bool __stdcall GetFileTime(
-    void* fh, void* ctime, void* atime, void* mtime);
-// boost::interprocess::detail was renamed to boost::interprocess::ipcdetail in Boost 1.48.
-// Ensure that both namespaces exist.
-namespace boost { namespace interprocess { namespace detail {} namespace ipcdetail {} } }
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #else
+#include <sys/mman.h> // for mmap(), munmap()
 #include <sys/types.h> // for struct stat
-#include <sys/stat.h> // for stat()
-#include <unistd.h> // for unlink()
+#include <sys/stat.h> // for stat(), fstat()
+#include <fcntl.h> // for open(), O_RDONLY
+#include <unistd.h> // for unlink(), close()
 #endif
 #endif // OPENVDB_USE_DELAYED_LOADING
 
@@ -457,42 +446,69 @@ operator<<(std::ostream& os, const StreamMetadata::AuxDataMap& auxData)
 // there are unloaded leaf nodes; this is ensured by storing a shared pointer
 // to the map in each unloaded node.
 
+// Seekable read-only streambuf over a memory range; replaces boost::iostreams::array_source.
+struct ArrayStreambuf : std::streambuf {
+    ArrayStreambuf(const char* data, std::size_t n) {
+        char* p = const_cast<char*>(data);
+        setg(p, p, p + n);
+    }
+protected:
+    pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+        std::ios_base::openmode which = std::ios_base::in) override
+    {
+        if (!(which & std::ios_base::in)) return pos_type(off_type(-1));
+        char* base = eback();
+        char* newPos;
+        if      (dir == std::ios_base::beg) newPos = base    + off;
+        else if (dir == std::ios_base::cur) newPos = gptr()  + off;
+        else                                newPos = egptr() + off;
+        if (newPos < base || newPos > egptr()) return pos_type(off_type(-1));
+        setg(base, newPos, egptr());
+        return pos_type(newPos - base);
+    }
+    pos_type seekpos(pos_type pos,
+        std::ios_base::openmode which = std::ios_base::in) override
+    {
+        return seekoff(off_type(pos), std::ios_base::beg, which);
+    }
+};
+
 class MappedFile::Impl
 {
 public:
     Impl(const std::string& filename, bool autoDelete)
-        : mMap(filename.c_str(), boost::interprocess::read_only)
-        , mRegion(mMap, boost::interprocess::read_only)
+        : mFilename(filename)
         , mAutoDelete(autoDelete)
     {
+        this->map(filename);
         if (mAutoDelete) {
 #ifndef _WIN32
             // On Unix systems, unlink the file so that it gets deleted once it is closed.
-            ::unlink(mMap.get_name());
+            ::unlink(mFilename.c_str());
 #endif
         }
     }
 
     ~Impl()
     {
-        std::string filename;
-        if (const char* s = mMap.get_name()) filename = s;
-        OPENVDB_LOG_DEBUG_RUNTIME("closing memory-mapped file " << filename);
-        if (mNotifier) mNotifier(filename);
+        OPENVDB_LOG_DEBUG_RUNTIME("closing memory-mapped file " << mFilename);
+        if (mNotifier) mNotifier(mFilename);
+        this->unmap();
         if (mAutoDelete) {
-            if (!boost::interprocess::file_mapping::remove(filename.c_str())) {
+            if (std::remove(mFilename.c_str()) != 0) {
                 if (errno != ENOENT) {
                     // Warn if the file exists but couldn't be removed.
                     std::string mesg = getErrorString();
                     if (!mesg.empty()) mesg = " (" + mesg + ")";
-                    OPENVDB_LOG_WARN("failed to remove temporary file " << filename << mesg);
+                    OPENVDB_LOG_WARN("failed to remove temporary file " << mFilename << mesg);
                 }
             }
         }
     }
 
-    boost::interprocess::file_mapping mMap;
-    boost::interprocess::mapped_region mRegion;
+    std::string mFilename;
+    void* mAddr = nullptr;
+    std::size_t mSize = 0;
     bool mAutoDelete;
     Notifier mNotifier;
 #if OPENVDB_ABI_VERSION_NUMBER <= 12
@@ -500,8 +516,81 @@ public:
 #endif
 
 private:
-    Impl(const Impl&); // not copyable
-    Impl& operator=(const Impl&); // not copyable
+#ifndef _WIN32
+    void map(const std::string& filename)
+    {
+        const int fd = ::open(filename.c_str(), O_RDONLY);
+        if (fd < 0) {
+            OPENVDB_THROW(IoError, "failed to open file " + filename + " for memory mapping");
+        }
+        struct stat st;
+        if (::fstat(fd, &st) < 0) {
+            ::close(fd);
+            OPENVDB_THROW(IoError, "failed to stat file " + filename);
+        }
+        mSize = static_cast<std::size_t>(st.st_size);
+        mAddr = ::mmap(nullptr, mSize, PROT_READ, MAP_PRIVATE, fd, 0);
+        ::close(fd);
+        if (mAddr == MAP_FAILED) {
+            mAddr = nullptr;
+            OPENVDB_THROW(IoError, "failed to memory-map file " + filename);
+        }
+    }
+
+    void unmap()
+    {
+        if (mAddr) {
+            ::munmap(mAddr, mSize);
+            mAddr = nullptr;
+        }
+    }
+#else // _WIN32
+    void map(const std::string& filename)
+    {
+        mFileHandle = CreateFileA(filename.c_str(), GENERIC_READ, FILE_SHARE_READ,
+            NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        if (mFileHandle == INVALID_HANDLE_VALUE) {
+            OPENVDB_THROW(IoError, "failed to open file " + filename + " for memory mapping");
+        }
+        LARGE_INTEGER fileSize;
+        if (!GetFileSizeEx(mFileHandle, &fileSize)) {
+            CloseHandle(mFileHandle);
+            mFileHandle = INVALID_HANDLE_VALUE;
+            OPENVDB_THROW(IoError, "failed to get size of file " + filename);
+        }
+        mSize = static_cast<std::size_t>(fileSize.QuadPart);
+        mMapHandle = CreateFileMapping(mFileHandle, NULL, PAGE_READONLY, 0, 0, NULL);
+        if (!mMapHandle) {
+            CloseHandle(mFileHandle);
+            mFileHandle = INVALID_HANDLE_VALUE;
+            OPENVDB_THROW(IoError, "failed to create file mapping for " + filename);
+        }
+        mAddr = MapViewOfFile(mMapHandle, FILE_MAP_READ, 0, 0, 0);
+        if (!mAddr) {
+            CloseHandle(mMapHandle);
+            mMapHandle = NULL;
+            CloseHandle(mFileHandle);
+            mFileHandle = INVALID_HANDLE_VALUE;
+            OPENVDB_THROW(IoError, "failed to map view of file " + filename);
+        }
+    }
+
+    void unmap()
+    {
+        if (mAddr) { UnmapViewOfFile(mAddr); mAddr = nullptr; }
+        if (mMapHandle) { CloseHandle(mMapHandle); mMapHandle = NULL; }
+        if (mFileHandle != INVALID_HANDLE_VALUE) {
+            CloseHandle(mFileHandle);
+            mFileHandle = INVALID_HANDLE_VALUE;
+        }
+    }
+
+    HANDLE mFileHandle = INVALID_HANDLE_VALUE;
+    HANDLE mMapHandle = NULL;
+#endif // _WIN32
+
+    Impl(const Impl&) = delete;
+    Impl& operator=(const Impl&) = delete;
 };
 
 
@@ -519,9 +608,7 @@ MappedFile::~MappedFile()
 std::string
 MappedFile::filename() const
 {
-    std::string result;
-    if (const char* s = mImpl->mMap.get_name()) result = s;
-    return result;
+    return mImpl->mFilename;
 }
 
 
@@ -529,8 +616,8 @@ SharedPtr<std::streambuf>
 MappedFile::createBuffer() const
 {
     return SharedPtr<std::streambuf>{
-        new boost::iostreams::stream_buffer<boost::iostreams::array_source>{
-            static_cast<const char*>(mImpl->mRegion.get_address()), mImpl->mRegion.get_size()}};
+        new ArrayStreambuf{
+            static_cast<const char*>(mImpl->mAddr), mImpl->mSize}};
 }
 
 

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -12,7 +12,6 @@
 #include <cstdint>
 
 #ifdef OPENVDB_USE_DELAYED_LOADING
-#include <boost/iostreams/copy.hpp>
 #ifndef _WIN32
 #include <sys/types.h>
 #include <unistd.h>
@@ -311,7 +310,7 @@ File::open(bool /*delayLoad = true*/)
                 TempFile tempFile;
                 std::ifstream fstrm(filename().c_str(),
                     std::ios_base::in | std::ios_base::binary);
-                boost::iostreams::copy(fstrm, tempFile);
+                tempFile << fstrm.rdbuf();
                 fname = tempFile.filename();
                 isTempFile = true;
             } catch (std::exception& e) {

--- a/openvdb/openvdb/io/Stream.cc
+++ b/openvdb/openvdb/io/Stream.cc
@@ -9,10 +9,6 @@
 #include <openvdb/Exceptions.h>
 #include <cstdint>
 
-#ifdef OPENVDB_USE_DELAYED_LOADING
-#include <boost/iostreams/copy.hpp>
-#endif
-
 #include <cstdio> // for remove()
 #include <functional> // for std::bind()
 #include <iostream>
@@ -91,8 +87,10 @@ Stream::Stream(std::istream& is, bool delayLoad): mImpl(new Impl)
                 << "; will read directly from the input stream instead");
         }
         if (tempFile) {
-            boost::iostreams::copy(is, *tempFile);
-            const std::string& filename = tempFile->filename();
+            *tempFile << is.rdbuf();
+            const std::string filename = tempFile->filename();
+            tempFile->close(); // flush and close before memory-mapping
+            tempFile.reset();
             mImpl->mFile.reset(new File(filename));
             mImpl->mFile->setCopyMaxBytes(0); // don't make a copy of the temporary file
             /// @todo Need to pass auto-deletion flag to MappedFile.

--- a/openvdb/openvdb/io/TempFile.cc
+++ b/openvdb/openvdb/io/TempFile.cc
@@ -9,15 +9,12 @@
 
 #include <openvdb/Exceptions.h>
 #ifndef _WIN32
-#include <boost/iostreams/stream.hpp>
-#include <boost/iostreams/device/file_descriptor.hpp>
 #include <cstdlib> // for std::getenv(), mkstemp()
 #include <sys/types.h> // for mode_t
 #include <sys/stat.h> // for mkdir(), umask()
-#include <unistd.h> // for access()
-#else
-#include <fstream> // for std::filebuf
+#include <unistd.h> // for access(), close()
 #endif
+#include <fstream> // for std::filebuf
 #include <cstdio> // for std::tmpnam(), L_tmpnam, P_tmpdir
 #include <iostream>
 #include <sstream>
@@ -36,11 +33,8 @@ struct TempFile::TempFileImpl
 
     bool is_open() const { return mBuffer.is_open(); }
 
-    /// @internal boost::filesystem::unique_path(), etc. might be useful here,
-    /// but as of 9/2014, Houdini ships without the Boost.Filesystem library,
-    /// which makes it much less convenient to use that library.
 #ifndef _WIN32
-    TempFileImpl(std::ostream& os): mFileDescr(-1) { this->init(os); }
+    TempFileImpl(std::ostream& os) { this->init(os); }
 
     void init(std::ostream& os)
     {
@@ -49,24 +43,24 @@ struct TempFile::TempFileImpl
         fnbuf.push_back(char(0));
 
         //const mode_t savedMode = ::umask(~(S_IRUSR | S_IWUSR));
-        mFileDescr = ::mkstemp(&fnbuf[0]);
+        int fd = ::mkstemp(&fnbuf[0]);
         //::umask(savedMode);
-        if (mFileDescr < 0) {
+        if (fd < 0) {
             OPENVDB_THROW(IoError, "failed to generate temporary file");
         }
+        // Close the mkstemp fd; the file already exists with a guaranteed-unique name.
+        ::close(fd);
 
         mPath.assign(&fnbuf[0]);
 
-        mDevice = DeviceType(mFileDescr, boost::iostreams::never_close_handle);
-        mBuffer.open(mDevice);
-        os.rdbuf(&mBuffer);
+        os.rdbuf(mBuffer.open(mPath.c_str(), std::ios_base::out | std::ios_base::binary));
 
         if (!os.good()) {
             OPENVDB_THROW(IoError, "failed to open temporary file " + mPath);
         }
     }
 
-    void close() { mBuffer.close(); if (mFileDescr >= 0) ::close(mFileDescr); }
+    void close() { mBuffer.close(); }
 
     static std::string getTempDir()
     {
@@ -88,13 +82,8 @@ struct TempFile::TempFileImpl
         return P_tmpdir;
     }
 
-    using DeviceType = boost::iostreams::file_descriptor_sink;
-    using BufferType = boost::iostreams::stream_buffer<boost::iostreams::file_descriptor_sink>;
-
     std::string mPath;
-    DeviceType mDevice;
-    BufferType mBuffer;
-    int mFileDescr;
+    std::filebuf mBuffer;
 #else // _WIN32
     // Use only standard library routines; no POSIX.
 

--- a/openvdb/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/openvdb/unittest/TestAttributeArray.cc
@@ -13,25 +13,7 @@
 #include <gtest/gtest.h>
 
 #ifdef OPENVDB_USE_DELAYED_LOADING
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-macros"
-#endif
-// Boost.Interprocess uses a header-only portion of Boost.DateTime
-#define BOOST_DATE_TIME_NO_LIB
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-#include <boost/interprocess/file_mapping.hpp>
-#include <boost/interprocess/mapped_region.hpp>
-
-#ifdef _WIN32
-#include <boost/interprocess/detail/os_file_functions.hpp> // open_existing_file(), close_file()
-// boost::interprocess::detail was renamed to boost::interprocess::ipcdetail in Boost 1.48.
-// Ensure that both namespaces exist.
-namespace boost { namespace interprocess { namespace detail {} namespace ipcdetail {} } }
-#include <windows.h>
-#else
+#ifndef _WIN32
 #include <sys/types.h> // for struct stat
 #include <sys/stat.h> // for stat()
 #endif

--- a/openvdb/openvdb/unittest/TestFile.cc
+++ b/openvdb/openvdb/unittest/TestFile.cc
@@ -2686,3 +2686,71 @@ TestFile::testDelayedLoadMetadata()
 }
 TEST_F(TestFile, testDelayedLoadMetadata) { testDelayedLoadMetadata(); }
 
+#ifdef OPENVDB_USE_DELAYED_LOADING
+// Verify that MappedFile::createBuffer() returns a fully seekable streambuf so
+// that lazy leaf-node loading (which seeks to stored file offsets) works correctly.
+TEST_F(TestFile, testMappedFileSeek)
+{
+    using namespace openvdb;
+
+    openvdb::initialize();
+
+    // Write a small grid to a temporary file.
+    FloatGrid::Ptr grid = FloatGrid::create();
+    grid->setName("seektest");
+    grid->tree().setValue(Coord(0, 0, 0), 1.0f);
+    grid->tree().setValue(Coord(8, 0, 0), 2.0f);
+
+    const char* filename = "testMappedFileSeek.vdb";
+    SharedPtr<const char> scopedFile(filename, ::remove);
+    io::File(filename).write({grid});
+
+    // Open the file as a MappedFile and obtain a buffer.
+    auto mappedFile = TestMappedFile::create(filename);
+    EXPECT_EQ(filename, mappedFile->filename());
+
+    SharedPtr<std::streambuf> buf = mappedFile->createBuffer();
+    ASSERT_TRUE(bool(buf));
+
+    std::istream is(buf.get());
+
+    // Seek to the beginning and read the magic number.
+    is.seekg(0, std::ios_base::beg);
+    EXPECT_EQ(std::streampos(0), is.tellg());
+
+    uint64_t magic = 0;
+    is.read(reinterpret_cast<char*>(&magic), sizeof(magic));
+    EXPECT_TRUE(is.good());
+    EXPECT_EQ(std::streampos(sizeof(magic)), is.tellg());
+
+    // Seek forward relative to current position.
+    is.seekg(4, std::ios_base::cur);
+    EXPECT_EQ(std::streampos(sizeof(magic) + 4), is.tellg());
+
+    // Seek backward to beginning via seekg(0, beg).
+    is.seekg(0, std::ios_base::beg);
+    EXPECT_EQ(std::streampos(0), is.tellg());
+
+    // Seek from end: one byte before end should be valid.
+    is.seekg(-1, std::ios_base::end);
+    EXPECT_TRUE(is.good());
+
+    // A second independent buffer from the same mapping should have its own
+    // read position and not be affected by seeks on the first.
+    SharedPtr<std::streambuf> buf2 = mappedFile->createBuffer();
+    std::istream is2(buf2.get());
+    is2.seekg(0, std::ios_base::beg);
+    is.seekg(4, std::ios_base::beg); // move first stream
+    EXPECT_EQ(std::streampos(0), is2.tellg()); // second stream unchanged
+
+    // Verify that the file round-trips correctly via delayed load.
+    io::File readFile(filename);
+    readFile.open(/*delayLoad=*/true);
+    auto grids = readFile.getGrids();
+    ASSERT_EQ(1, int(grids->size()));
+    auto readGrid = gridPtrCast<FloatGrid>(*grids->begin());
+    ASSERT_TRUE(bool(readGrid));
+    EXPECT_NEAR(1.0f, readGrid->tree().getValue(Coord(0, 0, 0)), 1e-6f);
+    EXPECT_NEAR(2.0f, readGrid->tree().getValue(Coord(8, 0, 0)), 1e-6f);
+}
+#endif // OPENVDB_USE_DELAYED_LOADING

--- a/openvdb/openvdb/unittest/TestStreamCompression.cc
+++ b/openvdb/openvdb/unittest/TestStreamCompression.cc
@@ -9,24 +9,7 @@
 #include <gtest/gtest.h>
 
 #ifdef OPENVDB_USE_DELAYED_LOADING
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-macros"
-#endif
-// Boost.Interprocess uses a header-only portion of Boost.DateTime
-#define BOOST_DATE_TIME_NO_LIB
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-#include <boost/interprocess/file_mapping.hpp>
-#include <boost/interprocess/mapped_region.hpp>
-#include <boost/iostreams/device/array.hpp>
-#include <boost/iostreams/stream.hpp>
-
-#ifdef _WIN32
-#include <boost/interprocess/detail/os_file_functions.hpp> // open_existing_file(), close_file()
-#include <windows.h>
-#else
+#ifndef _WIN32
 #include <sys/types.h> // for struct stat
 #include <sys/stat.h> // for stat()
 #include <unistd.h> // for unlink()


### PR DESCRIPTION
### Motivation

  When `OPENVDB_USE_DELAYED_LOADING` is enabled (the default), the core OpenVDB
  library requires `Boost.Interprocess` and `Boost.Iostreams` as link-time
  dependencies. This is the only remaining Boost dependency in the core
  `openvdb/openvdb` library, and it covers functionality that is straightforwardly
  available through OS-native APIs and the C++ standard library.

  Removing it reduces the dependency surface for all downstream consumers of
  OpenVDB like OpenUSD, simplifies builds where Boost is not otherwise present, and brings the
  library closer to having no Boost dependency at all in its core.

  ---

  ### Changes

  #### `io/Archive.cc` — `MappedFile::Impl`

  Replaced `boost::interprocess::file_mapping` + `mapped_region` with a minimal
  cross-platform mmap wrapper:
  - **POSIX:** `open()` / `mmap()` / `munmap()` / `close()`
  - **Windows:** `CreateFileMapping()` / `MapViewOfFile()` / `UnmapViewOfFile()`

  Replaced `boost::iostreams::stream_buffer<array_source>` with `ArrayStreambuf`,
  a small `std::streambuf` subclass backed by a memory range. Crucially this
  overrides `seekoff`/`seekpos` since leaf node loading and point stream
  decompression both seek into the mapped buffer (`LeafBuffer.h`,
  `StreamCompression.cc`).

  #### `io/TempFile.cc`

  Replaced `boost::iostreams::file_descriptor_sink` (Unix path) with
  `std::filebuf`. `mkstemp()` is still used to guarantee a unique path; the fd it
  returns is closed immediately and the file is reopened via `std::filebuf`. The
  Windows path already used `std::filebuf` so both platforms now share the same
  implementation type.

  #### `io/Stream.cc` / `io/File.cc`

  Replaced `boost::iostreams::copy(src, dst)` with `dst << src.rdbuf()`.

  In `Stream.cc`, the `TempFile` is now explicitly closed before the path is
  handed to `MappedFile`. This is necessary because `std::filebuf` has user-space
  buffering — unlike the old `file_descriptor_sink` which wrote directly through
  the fd — so the file must be flushed before `mmap()` is called or the mapping
  may see incomplete data.

  #### `CMakeLists.txt` / `cmake/FindOpenVDB.cmake`

  - Removed `find_package(Boost COMPONENTS iostreams)` from the core library build
  - Removed `Boost::iostreams` from `OPENVDB_CORE_DEPENDENT_LIBS` and from
    downstream visible dependencies in `FindOpenVDB.cmake`
  - Removed the now-dead `OPENVDB_DISABLE_BOOST_IMPLICIT_LINKING` CMake option
    and its associated Windows link block
  - Removed the `boost_iostreams` prerequisite heuristic used to auto-detect
    delayed loading in installed builds (detection still works via the version
    header)

  #### `unittest/TestAttributeArray.cc` / `unittest/TestStreamCompression.cc`

  Removed stale Boost includes that were copied from the implementation files but
  never actually used in the test bodies.

  ---

  ### New test

  `TestFile.testMappedFileSeek` directly exercises `MappedFile::createBuffer()`
  and verifies that the returned `streambuf` supports seeking from the beginning,
  current position, and end — and that two independent buffers from the same
  mapping maintain independent read positions. Finishes with a full delayed-load
  round-trip to confirm voxel values survive the path end-to-end.

  ---

  ### Testing

  Built and tested on macOS (Apple Silicon) with TBB 2020.3 and Blosc 1.21.5.
  All 738 unit tests pass.

I do not have a Windows or Linux box to test on, so I'm hoping the CI can catch issues on those platforms, but would love some eyes from people who primarily use those platforms to test this out.