### PR TITLE
[WIP-Don't review] Templatized scratch buffers for topology/rasterization ops

### DIFF
--- a/TEMPLATIZED_BUFFERS_PLAN.md
+++ b/TEMPLATIZED_BUFFERS_PLAN.md
@@ -67,7 +67,9 @@ any headers** — and drop the `DeviceBuffer.h`/`DeviceResource.h` forks entirel
 
 6. **Lift `Data` out of `TopologyBuilder`** → `topology::detail::TopologyBuilderData<BuildT>`
    (parameterized on `BuildT` only), with `using Data = …;` alias in the class.
-   **Deferred to its own milestone (M5)** — *not* done in the M1–M3 templatization pass.
+   **DONE** (pulled forward, right after M1) — it's cleaner and unblocks making the
+   `TopologyBuilder` param non-defaulted. The 10 detail functors now reference
+   `TopologyBuilderData<BuildT>` directly (no `TopologyBuilder` mention).
    *Why it's needed:* `Data` is a nested type, so `TopologyBuilder<BuildT, A>::Data`
    and `…<BuildT, B>::Data` are **distinct** types per instantiation. The 10 detail
    functors hardcode `typename TopologyBuilder<BuildT>::Data` (= the *default*
@@ -155,11 +157,14 @@ No ABI concern.
 - **M3 — MeshToGrid.cuh.** Param + members + locals + cast fixes. Verify green.
 - **M4 — Build verification.** Build nanoVDB CUDA examples + full `TestNanoVDB.cu`
   with default `ScratchBufferT` → no regression.
-- **M5 — Lift `Data` + prove the seam (decision §2.6).** Move `Data` to
-  `topology::detail::TopologyBuilderData<BuildT>` + alias; repoint the 10 functors.
-  Add a non-default `ScratchBufferT` instantiation canary (e.g. `UnifiedBuffer`) so
-  the seam is actually compiled. This is the first step that exercises a non-default
-  type — see §2.6 corollary.
+- **`Data` lift — DONE** (between M1 and M2; see §2.6). Build + topology tests green.
+- **M5 — Make `TopologyBuilder` `ScratchBufferT` non-defaulted + prove the seam.**
+  Once M2/M3 thread the param through every client, drop the default on
+  `TopologyBuilder` (it's an internal helper; the default belongs only on the public
+  client classes) so a client that forgets to forward fails to compile instead of
+  silently falling back to `DeviceBuffer`. Add a non-default `ScratchBufferT`
+  instantiation canary (e.g. `UnifiedBuffer`) so the seam is actually compiled —
+  the first thing to exercise a non-default type.
 - **M6 — follow-ups (separate branches/PRs):** dual-use host/device split;
   `mTempDevicePool`; fvdb-side `TorchDeviceBuffer` + stream-accepting `clear()`,
   then retire the `DeviceBuffer.h`/`DeviceResource.h` forks.

--- a/TEMPLATIZED_BUFFERS_PLAN.md
+++ b/TEMPLATIZED_BUFFERS_PLAN.md
@@ -1,0 +1,154 @@
+# Templatized Scratch Buffers — Implementation Plan
+
+> Branch: `templatized-buffers` (forked from ASF `upstream/master`).
+> Working note — **delete before any upstream PR**.
+
+## 1. Goal & context
+
+fvdb-core [PR #655](https://github.com/openvdb/fvdb-core/pull/655) works around a real
+problem: nanoVDB's CUDA scratch allocations go through `cudaMallocAsync` /
+`cudaFreeAsync`, which live in a **separate pool** from PyTorch's
+`c10::cuda::CUDACachingAllocator`. The two pools fragment each other, and large
+workloads (multi-frame TSDF integration) hit OOM with memory still free in
+aggregate.
+
+That PR's fix is a workaround: it **forks** `nanovdb/cuda/DeviceBuffer.h` and
+`nanovdb/cuda/DeviceResource.h` into fvdb's tree and swaps the allocator *inside*
+`nanovdb::cuda::DeviceBuffer` to PyTorch's caching allocator. Fork-of-headers is
+fragile (their own PR text says CPM patching silently breaks on upstream drift).
+
+**This branch provides the upstream-side fix instead: a buffer *type* seam.** The
+transient scratch buffers in the topology operators become a defaulted template
+parameter, so a downstream like fvdb can inject its own
+PyTorch-allocator-backed buffer type (e.g. `TorchDeviceBuffer`) **without forking
+any headers** — and drop the `DeviceBuffer.h`/`DeviceResource.h` forks entirely.
+
+## 2. Locked design decisions
+
+1. **Type seam, not allocator seam.** Keep upstream `DeviceBuffer` /
+   `DeviceResource` untouched (still `cudaMallocAsync`). Inject behavior by
+   swapping the *buffer type*, matching nanoVDB's existing `BufferT` idiom
+   (`GridHandle<BufferT>`, `TopologyBuilder::getBuffer<BufferT>`).
+
+2. **`ScratchBufferT` is its own class-level, defaulted template parameter** —
+   decoupled from the *output* buffer type. This supports cases like
+   `ScratchBufferT = DeviceBuffer` while output `BufferT = UnifiedBuffer`, and
+   fvdb's `ScratchBufferT = TorchDeviceBuffer` with any output buffer.
+
+   ```cpp
+   template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
+   class TopologyBuilder { ... };
+   ```
+
+   The **output** buffer type stays exactly where it is: the method-level
+   `getBuffer<BufferT>` / `getHandle<BufferT>` parameter. Untouched by this work.
+
+3. **`ScratchBufferT` concept** — the contract the scratch sites rely on:
+   - `static ScratchBufferT create(size_t bytes, const ScratchBufferT* pool, int device, cudaStream_t stream)`
+   - `<ptr> deviceData()`  (device pointer; `void*` for `DeviceBuffer`, `uint8_t*` for `TorchDeviceBuffer`)
+   - `void clear(cudaStream_t stream)`  ← stream-accepting overload **to be added to `TorchDeviceBuffer`**
+   - default-constructible + move-assignable (members are default-constructed, then assigned)
+
+4. **Dual-use buffers stay `DeviceBuffer`** (not templatized in this branch):
+   - `TopologyBuilder::mProcessedRoot` — host-populated, then `deviceUpload`'d
+   - `TopologyBuilder::mData` — `sizeof(Data)`, host + device
+   These are the only two buffers with host+device dual use (verified: the only
+   `deviceUpload` sites; there are **no** `deviceDownload` calls anywhere).
+   *Future step (out of scope here):* split each into a host buffer + a device
+   `ScratchBufferT` half with an explicit `cudaMemcpyAsync`. The device half then
+   reuses the same `ScratchBufferT`; nothing escapes the downstream pool. The
+   concept above is already sufficient for that future device-half — no rework.
+
+5. **Cast fix.** `static_cast<T*>(void*)` is legal but `static_cast<T*>(uint8_t*)`
+   is not; `reinterpret_cast<T*>` is legal from both. So switch **direct**
+   `static_cast` on a templatized buffer's `.deviceData()`/`.data()` to
+   `reinterpret_cast` (same runtime behavior, no `if constexpr`). Surgical, **not**
+   a blanket replace — see §5.
+
+## 3. Files in scope
+
+| File | Work |
+| :-- | :-- |
+| `nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh` | **Core.** Add `ScratchBufferT` param; templatize 8 device-only scratch members + transient locals; cast fixes. |
+| `nanovdb/nanovdb/tools/cuda/DilateGrid.cuh` | Add `ScratchBufferT` param; `mBuilder` → `TopologyBuilder<BuildT, ScratchBufferT>`. |
+| `nanovdb/nanovdb/tools/cuda/PruneGrid.cuh`   | same |
+| `nanovdb/nanovdb/tools/cuda/MergeGrids.cuh`  | same |
+| `nanovdb/nanovdb/tools/cuda/CoarsenGrid.cuh` | same |
+| `nanovdb/nanovdb/tools/cuda/RefineGrid.cuh`  | same |
+| `nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh`  | Add `ScratchBufferT` param; templatize its 3 device members + transient locals; cast fixes. |
+
+## 4. Buffer inventory (per file)
+
+### TopologyBuilder — templatize → `ScratchBufferT`
+Members: `mUpperMasks`, `mLowerMasks`, `mUpperOffsets`, `mLowerOffsets`,
+`mLeafOffsets`, `mVoxelOffsets`, `mLowerParents`, `mLeafParents`.
+Transient locals: `upperCountsBuffer`, `lowerCountsBuffer`, `leafCountsBuffer`.
+
+**Stay `DeviceBuffer`:** `mProcessedRoot`, `mData` (dual-use, §2.4).
+
+### MeshToGrid — templatize → `ScratchBufferT`
+Members: `mXformedTriangles`, `mBoxTrianglePairsBuffer`, `mUniqueRootOriginsBuffer`.
+Transient locals: `rootBoxCounts`, `rootBoxOffsets`, `keysBuffer`,
+`sortedKeysBuffer`, `uniqueKeysBuffer`, `numSelectedBuffer`, `retainMaskBuffer`,
+`countsBuffer`, `offsetsBuffer`, `newPairsBuffer`, `sidecarBuffer`.
+(`mBuilder.mProcessedRoot` here is TopologyBuilder's dual-use buffer → unchanged.)
+
+### Morphology clients — no buffers of their own to templatize
+Only thread the param into `mBuilder`. Their `srcRoot*Buffer` locals are
+`nanovdb::HostBuffer` (host memory) → **out of scope**.
+
+## 5. Cast strategy (surgical)
+
+**Change** (direct cast on a templatized buffer):
+- `static_cast<uint32_t*>(mUpperOffsets.deviceData())` → `reinterpret_cast<...>`
+- ~22 sites in TopologyBuilder (the `*Offsets`/`*Parents`/`*CountsBuffer` ones),
+  plus the device-scratch sites in MeshToGrid.
+
+**Leave as `static_cast` (out of scope):**
+- `mProcessedRoot.deviceData()` / `mData.deviceData()` — dual-use, return `void*`.
+- `void* deviceUpperMasks(){ return mUpperMasks.deviceData(); }` accessors — the
+  accessor return type is `void*` (implicit `uint8_t*`→`void*` is fine), so call
+  sites like `static_cast<Mask<5>*>(mBuilder.deviceUpperMasks())` stay valid.
+- `static_cast<GridT*>(mBuilder.data()->d_bufferPtr)` — raw `void*` member.
+- `static_cast<...>(handle.deviceData())` — that's the **output** `BufferT`.
+
+## 6. ABI / compatibility
+
+Header-only templates; default `ScratchBufferT = nanovdb::cuda::DeviceBuffer`.
+All existing instantiations (the `ex_*_nanovdb_cuda` examples and
+`unittest/TestNanoVDB.cu`) compile unchanged and produce byte-identical behavior.
+No ABI concern.
+
+## 7. Known residuals outside a downstream pool (documented, not fixed here)
+
+- `mProcessedRoot`, `mData` — dual-use, stay `DeviceBuffer` (`cudaMallocAsync`).
+  `mData` is trivial; `mProcessedRoot` is the one real residual. Resolved later
+  by the host/device split (§2.4).
+- `mTempDevicePool` (`nanovdb::cuda::TempDevicePool`, via `DeviceResource`) — cub
+  temp storage, still `cudaMallocAsync`. Not templatized here; flagged for a
+  follow-up if its footprint matters to fvdb.
+
+## 8. Milestones
+
+- **M1 — TopologyBuilder.cuh.** Add `ScratchBufferT`; templatize members + locals;
+  cast fixes. Compile examples + unittest with default param → no regression.
+- **M2 — Morphology clients.** Thread `ScratchBufferT` through Dilate/Prune/Merge/
+  Coarsen/Refine (class param + `mBuilder` type).
+- **M3 — MeshToGrid.cuh.** Param + members + locals + cast fixes.
+- **M4 — Build verification.** Build nanoVDB CUDA examples + `TestNanoVDB.cu` with
+  default `ScratchBufferT`. Optional canary: instantiate a client with an
+  alternate `ScratchBufferT` (e.g. `UnifiedBuffer`) to prove the seam is real.
+- **M5 — follow-ups (separate branches/PRs):** dual-use host/device split;
+  `mTempDevicePool`; fvdb-side `TorchDeviceBuffer` + stream-accepting `clear()`,
+  then retire the `DeviceBuffer.h`/`DeviceResource.h` forks.
+
+## 9. Build / verify commands
+
+```bash
+# Configure with nanoVDB + CUDA + examples + unit tests
+cmake -S . -B build \
+  -DOPENVDB_BUILD_NANOVDB=ON -DNANOVDB_USE_CUDA=ON \
+  -DNANOVDB_BUILD_EXAMPLES=ON -DNANOVDB_BUILD_UNITTESTS=ON
+cmake --build build -j
+# (CUDA device required to *run* TestNanoVDB; compilation is the primary check here.)
+```

--- a/TEMPLATIZED_BUFFERS_PLAN.md
+++ b/TEMPLATIZED_BUFFERS_PLAN.md
@@ -65,6 +65,20 @@ any headers** — and drop the `DeviceBuffer.h`/`DeviceResource.h` forks entirel
    `reinterpret_cast` (same runtime behavior, no `if constexpr`). Surgical, **not**
    a blanket replace — see §5.
 
+6. **Lift `Data` out of `TopologyBuilder`** → `topology::detail::TopologyBuilderData<BuildT>`
+   (parameterized on `BuildT` only), with `using Data = …;` alias in the class.
+   **Deferred to its own milestone (M5)** — *not* done in the M1–M3 templatization pass.
+   *Why it's needed:* `Data` is a nested type, so `TopologyBuilder<BuildT, A>::Data`
+   and `…<BuildT, B>::Data` are **distinct** types per instantiation. The 10 detail
+   functors hardcode `typename TopologyBuilder<BuildT>::Data` (= the *default*
+   `…, DeviceBuffer>::Data`); a non-default `ScratchBufferT` instantiation's
+   `deviceData()` would return a mismatched `Data*` → compile error.
+   *Why it can be deferred:* with the default `DeviceBuffer` everything resolves to
+   one `Data` type, so M1–M3 compile and stay byte-identical without it. `Data` is
+   the **only** structural blocker for non-default instantiation (casts + concept are
+   handled in the M1–M3 pass), so lifting it + the canary in M5 validates M1–M3 at
+   once. **Corollary:** do **not** add a non-default instantiation until M5.
+
 ## 3. Files in scope
 
 | File | Work |
@@ -130,15 +144,23 @@ No ABI concern.
 
 ## 8. Milestones
 
-- **M1 — TopologyBuilder.cuh.** Add `ScratchBufferT`; templatize members + locals;
-  cast fixes. Compile examples + unittest with default param → no regression.
+> M1–M3 keep `Data` nested and use only the **default** `DeviceBuffer`; run the
+> topology unittests after each (`DilateInjectPrune_*`, `RefineCoarsen_*`,
+> `MergeGrids_*`, `MeshToGrid_*`, `mergeSplit*`) to confirm byte-identical behavior.
+
+- **M1 — TopologyBuilder.cuh.** Add `ScratchBufferT`; templatize 8 scratch members
+  + 3 transient locals; `static_cast`→`reinterpret_cast` on those. Verify green.
 - **M2 — Morphology clients.** Thread `ScratchBufferT` through Dilate/Prune/Merge/
-  Coarsen/Refine (class param + `mBuilder` type).
-- **M3 — MeshToGrid.cuh.** Param + members + locals + cast fixes.
-- **M4 — Build verification.** Build nanoVDB CUDA examples + `TestNanoVDB.cu` with
-  default `ScratchBufferT`. Optional canary: instantiate a client with an
-  alternate `ScratchBufferT` (e.g. `UnifiedBuffer`) to prove the seam is real.
-- **M5 — follow-ups (separate branches/PRs):** dual-use host/device split;
+  Coarsen/Refine (class param + `mBuilder` type). Verify green.
+- **M3 — MeshToGrid.cuh.** Param + members + locals + cast fixes. Verify green.
+- **M4 — Build verification.** Build nanoVDB CUDA examples + full `TestNanoVDB.cu`
+  with default `ScratchBufferT` → no regression.
+- **M5 — Lift `Data` + prove the seam (decision §2.6).** Move `Data` to
+  `topology::detail::TopologyBuilderData<BuildT>` + alias; repoint the 10 functors.
+  Add a non-default `ScratchBufferT` instantiation canary (e.g. `UnifiedBuffer`) so
+  the seam is actually compiled. This is the first step that exercises a non-default
+  type — see §2.6 corollary.
+- **M6 — follow-ups (separate branches/PRs):** dual-use host/device split;
   `mTempDevicePool`; fvdb-side `TorchDeviceBuffer` + stream-accepting `clear()`,
   then retire the `DeviceBuffer.h`/`DeviceResource.h` forks.
 

--- a/TEMPLATIZED_BUFFERS_PLAN.md
+++ b/TEMPLATIZED_BUFFERS_PLAN.md
@@ -158,13 +158,22 @@ No ABI concern.
 - **M4 — Build verification.** Build nanoVDB CUDA examples + full `TestNanoVDB.cu`
   with default `ScratchBufferT` → no regression.
 - **`Data` lift — DONE** (between M1 and M2; see §2.6). Build + topology tests green.
-- **M5 — Make `TopologyBuilder` `ScratchBufferT` non-defaulted + prove the seam.**
-  Once M2/M3 thread the param through every client, drop the default on
-  `TopologyBuilder` (it's an internal helper; the default belongs only on the public
-  client classes) so a client that forgets to forward fails to compile instead of
-  silently falling back to `DeviceBuffer`. Add a non-default `ScratchBufferT`
-  instantiation canary (e.g. `UnifiedBuffer`) so the seam is actually compiled —
-  the first thing to exercise a non-default type.
+- **M5 — Make `TopologyBuilder` `ScratchBufferT` non-defaulted + prove the seam. DONE.**
+  - Dropped the default on `TopologyBuilder` (internal helper; default lives only on
+    the public clients) → a client that forgets to forward fails to compile.
+  - Lifted `MeshToGrid::BoxTrianglePair` to `nanovdb::tools::cuda` scope (+ public
+    alias), mirroring the `Data` lift, so it's one type across instantiations.
+  - Added `UnifiedBuffer::clear(cudaStream_t)` so `UnifiedBuffer` satisfies the
+    scratch concept (parallels the `TorchDeviceBuffer` addition fvdb will make).
+  - Fixed `getHandleAndUDF` to actually honor `SidecarBufferT` (`SidecarBufferT::create`
+    + `reinterpret_cast`); previously it hardcoded `DeviceBuffer` for the sidecar.
+  - Forwarded `ScratchBufferT` into MeshToGrid's internal `PruneGrid` so the all-Unified
+    case is genuinely all-Unified scratch.
+  - Canary: refactored the 4 topology unittests into helpers templated on every buffer
+    axis (scratch / grid-output / sidecar-output), instantiated as all-`DeviceBuffer`
+    and all-`UnifiedBuffer`. All 8 pass; full CUDA suite 55/56 (only the pre-existing
+    `UnifiedBuffer_IO` data-file failure). First runtime exercise of a non-`DeviceBuffer`
+    type — the seam is real.
 - **M6 — follow-ups (separate branches/PRs):** dual-use host/device split;
   `mTempDevicePool`; fvdb-side `TorchDeviceBuffer` + stream-accepting `clear()`,
   then retire the `DeviceBuffer.h`/`DeviceResource.h` forks.

--- a/nanovdb/nanovdb/cuda/UnifiedBuffer.h
+++ b/nanovdb/nanovdb/cuda/UnifiedBuffer.h
@@ -145,6 +145,15 @@ public:
         mSize = mCapacity = 0;
     }
 
+    /// @brief Stream-accepting overload of clear(), so UnifiedBuffer satisfies the
+    ///        scratch-buffer interface used by the CUDA topology operators (which call
+    ///        clear(stream)). The stream is unused: this memory comes from
+    ///        cudaMallocManaged and must be released with the synchronous cudaFree
+    ///        (cudaFreeAsync only applies to the cudaMallocAsync pool). cudaFree itself
+    ///        blocks until all outstanding device work completes, so no preceding
+    ///        stream synchronization is required.
+    void clear(cudaStream_t) { this->clear(); }
+
     /// @brief Disallow copy assignment operation
     UnifiedBuffer& operator=(const UnifiedBuffer&) = delete;
 

--- a/nanovdb/nanovdb/tools/cuda/CoarsenGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/CoarsenGrid.cuh
@@ -30,7 +30,7 @@ namespace nanovdb {
 
 namespace tools::cuda {
 
-template <typename BuildT>
+template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
 class CoarsenGrid
 {
     using GridT  = NanoGrid<BuildT>;
@@ -74,7 +74,7 @@ private:
     static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
     static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
 
-    TopologyBuilder<BuildT> mBuilder;
+    TopologyBuilder<BuildT, ScratchBufferT> mBuilder;
     cudaStream_t            mStream{0};
     util::cuda::Timer       mTimer;
     int                     mVerbose{0};
@@ -84,10 +84,10 @@ private:
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
+template<typename BuildT, typename ScratchBufferT>
 template<typename BufferT>
 GridHandle<BufferT>
-CoarsenGrid<BuildT>::getHandle(const BufferT &pool)
+CoarsenGrid<BuildT, ScratchBufferT>::getHandle(const BufferT &pool)
 {
     // Copy TreeData from GPU -> CPU
     cudaStreamSynchronize(mStream);
@@ -147,12 +147,12 @@ CoarsenGrid<BuildT>::getHandle(const BufferT &pool)
     cudaStreamSynchronize(mStream);
 
     return GridHandle<BufferT>(std::move(buffer));
-}// CoarsenGrid<BuildT>::getHandle
+}// CoarsenGrid<BuildT, ScratchBufferT>::getHandle
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void CoarsenGrid<BuildT>::coarsenRoot()
+template<typename BuildT, typename ScratchBufferT>
+void CoarsenGrid<BuildT, ScratchBufferT>::coarsenRoot()
 {
     // This method coarsens the root tiles, to accommodate for the overall downsamping operation.
 
@@ -197,12 +197,12 @@ void CoarsenGrid<BuildT>::coarsenRoot()
     for (const auto& [key, tile] : coarsenedTiles)
         *coarsenedRootPtr->tile(t++) = tile;
     mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
-}// CoarsenGrid<BuildT>::coarsenRoot
+}// CoarsenGrid<BuildT, ScratchBufferT>::coarsenRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void CoarsenGrid<BuildT>::coarsenInternalNodes()
+template<typename BuildT, typename ScratchBufferT>
+void CoarsenGrid<BuildT, ScratchBufferT>::coarsenInternalNodes()
 {
     // Computes the masks of upper and (densified) lower internal nodes, as a result of the coarsening operation
     // Masks of lower internal nodes are densified in the sense that a serialized array of them is allocated,
@@ -212,24 +212,24 @@ void CoarsenGrid<BuildT>::coarsenInternalNodes()
             srcLeafCount, util::morphology::cuda::CoarsenInternalNodesFunctor<BuildT>(),
             mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.mUpperMasks.deviceData(), mBuilder.mLowerMasks.deviceData() );
     }
-}// CoarsenGrid<BuildT>::coarsenInternalNodes
+}// CoarsenGrid<BuildT, ScratchBufferT>::coarsenInternalNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT>
-void CoarsenGrid<BuildT>::processGridTreeRoot()
+template <typename BuildT, typename ScratchBufferT>
+void CoarsenGrid<BuildT, ScratchBufferT>::processGridTreeRoot()
 {
     // Copy GridData from source grid
     // By convention: this will duplicate grid name and map. Others will be reset later
     cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
     util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
     cudaCheckError();
-}// CoarsenGrid<BuildT>::processGridTreeRoot
+}// CoarsenGrid<BuildT, ScratchBufferT>::processGridTreeRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void CoarsenGrid<BuildT>::coarsenLeafNodes()
+template<typename BuildT, typename ScratchBufferT>
+void CoarsenGrid<BuildT, ScratchBufferT>::coarsenLeafNodes()
 {
     // Coarsens the active masks of the source grid (as indicated at the leaf level), into a new grid that
     // has been already topologically coarsened to include all necessary leaf nodes.
@@ -241,7 +241,7 @@ void CoarsenGrid<BuildT>::coarsenLeafNodes()
 
     // Update leaf offsets and prefix sums
     mBuilder.processLeafOffsets(mStream);
-}// CoarsenGrid<BuildT>::coarsenLeafNodes
+}// CoarsenGrid<BuildT, ScratchBufferT>::coarsenLeafNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/nanovdb/nanovdb/tools/cuda/DilateGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/DilateGrid.cuh
@@ -30,7 +30,7 @@ namespace nanovdb {
 
 namespace tools::cuda {
 
-template <typename BuildT>
+template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
 class DilateGrid
 {
     using GridT  = NanoGrid<BuildT>;
@@ -78,7 +78,7 @@ private:
     static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
     static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
 
-    TopologyBuilder<BuildT>      mBuilder;
+    TopologyBuilder<BuildT, ScratchBufferT>      mBuilder;
     cudaStream_t                 mStream{0};
     util::cuda::Timer            mTimer;
     int                          mVerbose{0};
@@ -89,10 +89,10 @@ private:
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
+template<typename BuildT, typename ScratchBufferT>
 template<typename BufferT>
 GridHandle<BufferT>
-DilateGrid<BuildT>::getHandle(const BufferT &pool)
+DilateGrid<BuildT, ScratchBufferT>::getHandle(const BufferT &pool)
 {
     // Copy TreeData from GPU -> CPU
     cudaStreamSynchronize(mStream);
@@ -152,12 +152,12 @@ DilateGrid<BuildT>::getHandle(const BufferT &pool)
     cudaStreamSynchronize(mStream);
 
     return GridHandle<BufferT>(std::move(buffer));
-}// DilateGrid<BuildT>::getHandle
+}// DilateGrid<BuildT, ScratchBufferT>::getHandle
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void DilateGrid<BuildT>::dilateRoot()
+template<typename BuildT, typename ScratchBufferT>
+void DilateGrid<BuildT, ScratchBufferT>::dilateRoot()
 {
     // This method conservatively and speculatively dilates the root tiles, to accommodate
     // any new root nodes that might be introduced by the dilation operation.
@@ -220,12 +220,12 @@ void DilateGrid<BuildT>::dilateRoot()
     for (const auto& [key, tile] : dilatedTiles)
         *dilatedRootPtr->tile(t++) = tile;
     mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
-}// DilateGrid<BuildT>::dilateRoot
+}// DilateGrid<BuildT, ScratchBufferT>::dilateRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void DilateGrid<BuildT>::dilateInternalNodes()
+template<typename BuildT, typename ScratchBufferT>
+void DilateGrid<BuildT, ScratchBufferT>::dilateInternalNodes()
 {
     // Computes the masks of upper and (densified) lower internal nodes, as a result of the dilation operation
     // Masks of lower internal nodes are densified in the sense that a serialized array of them is allocated,
@@ -247,24 +247,24 @@ void DilateGrid<BuildT>::dilateInternalNodes()
                 <<<dim3(mSrcTreeData.mNodeCount[1],Op::SlicesPerLowerNode,1), Op::MaxThreadsPerBlock, 0, mStream>>>
                 (mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.deviceUpperMasks(), mBuilder.deviceLowerMasks()); }
     }
-}// DilateGrid<BuildT>::dilateInternalNodes
+}// DilateGrid<BuildT, ScratchBufferT>::dilateInternalNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT>
-void DilateGrid<BuildT>::processGridTreeRoot()
+template <typename BuildT, typename ScratchBufferT>
+void DilateGrid<BuildT, ScratchBufferT>::processGridTreeRoot()
 {
     // Copy GridData from source grid
     // By convention: this will duplicate grid name and map. Others will be reset later
     cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
     util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
     cudaCheckError();
-}// DilateGrid<BuildT>::processGridTreeRoot
+}// DilateGrid<BuildT, ScratchBufferT>::processGridTreeRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void DilateGrid<BuildT>::dilateLeafNodes()
+template<typename BuildT, typename ScratchBufferT>
+void DilateGrid<BuildT, ScratchBufferT>::dilateLeafNodes()
 {
     // Dilates the active masks of the source grid (as indicated at the leaf level), into a new grid that
     // has been already topologically dilated to include all necessary leaf nodes.
@@ -285,7 +285,7 @@ void DilateGrid<BuildT>::dilateLeafNodes()
 
     // Update leaf offsets and prefix sums
     mBuilder.processLeafOffsets(mStream);
-}// DilateGrid<BuildT>::dilateLeafNodes
+}// DilateGrid<BuildT, ScratchBufferT>::dilateLeafNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/nanovdb/nanovdb/tools/cuda/MergeGrids.cuh
+++ b/nanovdb/nanovdb/tools/cuda/MergeGrids.cuh
@@ -30,7 +30,7 @@ namespace nanovdb {
 
 namespace tools::cuda {
 
-template <typename BuildT>
+template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
 class MergeGrids
 {
     using GridT  = NanoGrid<BuildT>;
@@ -75,7 +75,7 @@ private:
     static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
     static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
 
-    TopologyBuilder<BuildT> mBuilder;
+    TopologyBuilder<BuildT, ScratchBufferT> mBuilder;
     cudaStream_t            mStream{0};
     util::cuda::Timer       mTimer;
     int                     mVerbose{0};
@@ -87,10 +87,10 @@ private:
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
+template<typename BuildT, typename ScratchBufferT>
 template<typename BufferT>
 GridHandle<BufferT>
-MergeGrids<BuildT>::getHandle(const BufferT &pool)
+MergeGrids<BuildT, ScratchBufferT>::getHandle(const BufferT &pool)
 {
     // Copy TreeData from GPU -> CPU
     cudaStreamSynchronize(mStream);
@@ -152,12 +152,12 @@ MergeGrids<BuildT>::getHandle(const BufferT &pool)
     cudaStreamSynchronize(mStream);
 
     return GridHandle<BufferT>(std::move(buffer));
-}// MergeGrids<BuildT>::getHandle
+}// MergeGrids<BuildT, ScratchBufferT>::getHandle
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void MergeGrids<BuildT>::mergeRoot()
+template<typename BuildT, typename ScratchBufferT>
+void MergeGrids<BuildT, ScratchBufferT>::mergeRoot()
 {
     // Creates a new merged tree root with the merged tiles of the two input root topologies
 
@@ -219,12 +219,12 @@ void MergeGrids<BuildT>::mergeRoot()
     for (const auto& [key, tile] : mergedTiles)
         *mergedRootPtr->tile(t++) = tile;
     mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
-}// MergeGrids<BuildT>::mergeRoot
+}// MergeGrids<BuildT, ScratchBufferT>::mergeRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void MergeGrids<BuildT>::mergeInternalNodes()
+template<typename BuildT, typename ScratchBufferT>
+void MergeGrids<BuildT, ScratchBufferT>::mergeInternalNodes()
 {
     // Merges the masks of upper and lower nodes from both input topologies into the
     // densified, pre-allocated mask arrays of the merged result
@@ -239,12 +239,12 @@ void MergeGrids<BuildT>::mergeInternalNodes()
             <<<mSrcTreeData2.mNodeCount[1], Op::MaxThreadsPerBlock, 0, mStream>>>
             (mDeviceSrcGrid2, mBuilder.deviceProcessedRoot(), mBuilder.deviceUpperMasks(), mBuilder.deviceLowerMasks());
     }
-}// MergeGrids<BuildT>::mergeInternalNodes
+}// MergeGrids<BuildT, ScratchBufferT>::mergeInternalNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT>
-void MergeGrids<BuildT>::processGridTreeRoot()
+template <typename BuildT, typename ScratchBufferT>
+void MergeGrids<BuildT, ScratchBufferT>::processGridTreeRoot()
 {
     // Copy GridData from first source grid
     // TODO: Check for instances where extra processing is needed
@@ -252,12 +252,12 @@ void MergeGrids<BuildT>::processGridTreeRoot()
     cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid1->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
     util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
     cudaCheckError();
-}// MergeGrids<BuildT>::processGridTreeRoot
+}// MergeGrids<BuildT, ScratchBufferT>::processGridTreeRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void MergeGrids<BuildT>::mergeLeafNodes()
+template<typename BuildT, typename ScratchBufferT>
+void MergeGrids<BuildT, ScratchBufferT>::mergeLeafNodes()
 {
     using Op = util::morphology::cuda::MergeLeafNodesFunctor<BuildT>;
     if (mSrcTreeData1.mNodeCount[1]) { // Unless first input grid is empty
@@ -273,7 +273,7 @@ void MergeGrids<BuildT>::mergeLeafNodes()
 
     // Update leaf offsets and prefix sums
     mBuilder.processLeafOffsets(mStream);
-}// MergeGrids<BuildT>::mergeLeafNodes
+}// MergeGrids<BuildT, ScratchBufferT>::mergeLeafNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
@@ -48,7 +48,7 @@ struct Triangle {
     __hostdev__       nanovdb::Vec3f& operator[](int i)       { return v[i]; }
 };
 
-template <typename BuildT>
+template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
 class MeshToGrid
 {
     using PointT = nanovdb::Vec3f;
@@ -155,7 +155,7 @@ private:
     static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
     static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
 
-    TopologyBuilder<BuildT>      mBuilder;
+    TopologyBuilder<BuildT, ScratchBufferT> mBuilder;
     cudaStream_t                 mStream{0};
     std::string                  mGridName;
     util::cuda::Timer            mTimer;
@@ -168,15 +168,15 @@ private:
     const uint32_t               mTriangleCount;
     const nanovdb::Map           mMap;
 
-    nanovdb::cuda::DeviceBuffer  mXformedTriangles;
-    nanovdb::cuda::DeviceBuffer  mBoxTrianglePairsBuffer;
+    ScratchBufferT               mXformedTriangles;
+    ScratchBufferT               mBoxTrianglePairsBuffer;
     uint64_t                     mBoxTrianglePairCount{0};
-    nanovdb::cuda::DeviceBuffer  mUniqueRootOriginsBuffer;
+    ScratchBufferT               mUniqueRootOriginsBuffer;
     uint64_t                     mUniqueRootTileCount{0};
 
-    auto deviceXformedTriangles()  { return static_cast<TriangleT*>(mXformedTriangles.deviceData()); }
-    auto deviceBoxTrianglePairs()  { return static_cast<BoxTrianglePair*>(mBoxTrianglePairsBuffer.deviceData()); }
-    auto deviceUniqueRootOrigins() const { return static_cast<nanovdb::Coord*>(mUniqueRootOriginsBuffer.deviceData()); }
+    auto deviceXformedTriangles()  { return reinterpret_cast<TriangleT*>(mXformedTriangles.deviceData()); }
+    auto deviceBoxTrianglePairs()  { return reinterpret_cast<BoxTrianglePair*>(mBoxTrianglePairsBuffer.deviceData()); }
+    auto deviceUniqueRootOrigins() const { return reinterpret_cast<nanovdb::Coord*>(mUniqueRootOriginsBuffer.deviceData()); }
 
     nanovdb::cuda::TempDevicePool mTempDevicePool;
 }; // tools::cuda::MeshToGrid<BuildT>
@@ -200,10 +200,10 @@ private:
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
+template<typename BuildT, typename ScratchBufferT>
 template<typename BufferT>
 GridHandle<BufferT>
-MeshToGrid<BuildT>::getHandle(const BufferT &buffer)
+MeshToGrid<BuildT, ScratchBufferT>::getHandle(const BufferT &buffer)
 {
     cudaStreamSynchronize(mStream);
 
@@ -298,13 +298,13 @@ MeshToGrid<BuildT>::getHandle(const BufferT &buffer)
     const uint32_t leafCount = mBuilder.data()->nodeCount[0];
     auto handle = GridHandle<BufferT>(std::move(gridBuffer));
     if (leafCount) {
-        nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
+        ScratchBufferT retainMaskBuffer = ScratchBufferT::create(
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
         cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
         tools::cuda::PruneGrid<BuildT> pruner(
             static_cast<const GridT*>(handle.deviceData()),
-            static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
+            reinterpret_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
             mStream);
         handle = pruner.template getHandle<BufferT>(buffer);
     }
@@ -335,15 +335,15 @@ struct TransformTrianglesFunctor
 
 } // namespace topology::detail
 
-template<typename BuildT>
-void MeshToGrid<BuildT>::transformTriangles()
+template<typename BuildT, typename ScratchBufferT>
+void MeshToGrid<BuildT, ScratchBufferT>::transformTriangles()
 {
     if (mTriangleCount == 0) return;
 
     int device = 0;
     cudaGetDevice(&device);
 
-    mXformedTriangles = nanovdb::cuda::DeviceBuffer::create(mTriangleCount*sizeof(TriangleT), nullptr, device, mStream);
+    mXformedTriangles = ScratchBufferT::create(mTriangleCount*sizeof(TriangleT), nullptr, device, mStream);
     if (mXformedTriangles.deviceData() == nullptr) throw std::runtime_error("Failed to allocate transofmed upper mask buffer on device");
 
     util::cuda::lambdaKernel<<<numBlocks(mTriangleCount), mNumThreads, 0, mStream>>>(
@@ -471,8 +471,8 @@ struct ScatterRootTrianglePairsFunctor
 
 } // namespace topology::detail
 
-template<typename BuildT>
-void MeshToGrid<BuildT>::processRootTrianglePairs()
+template<typename BuildT, typename ScratchBufferT>
+void MeshToGrid<BuildT, ScratchBufferT>::processRootTrianglePairs()
 {
     if (mTriangleCount == 0) { mBoxTrianglePairCount = 0; return; }
 
@@ -481,15 +481,15 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
 
     // Pass 1: Count intersecting root boxes per triangle
 
-    nanovdb::cuda::DeviceBuffer
-        rootBoxCounts = nanovdb::cuda::DeviceBuffer::create(mTriangleCount * sizeof(uint64_t), nullptr, device, mStream);
+    ScratchBufferT
+        rootBoxCounts = ScratchBufferT::create(mTriangleCount * sizeof(uint64_t), nullptr, device, mStream);
     if (rootBoxCounts.deviceData() == nullptr) throw std::runtime_error("Failed to allocate root box counts buffer");
 
     util::cuda::lambdaKernel<<<numBlocks(mTriangleCount), mNumThreads, 0, mStream>>>(
         mTriangleCount,
         topology::detail::CountRootBoxesFunctor<BuildT>{
             deviceXformedTriangles(),
-            static_cast<uint64_t*>(rootBoxCounts.deviceData()),
+            reinterpret_cast<uint64_t*>(rootBoxCounts.deviceData()),
             mBandWidth
         }
     );
@@ -497,21 +497,21 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
 
     // Pass 2: InclusiveSum Scan to compute offsets and total allocations
 
-    nanovdb::cuda::DeviceBuffer rootBoxOffsets =
-        nanovdb::cuda::DeviceBuffer::create((mTriangleCount+1)*sizeof(uint64_t), nullptr, device, mStream);
+    ScratchBufferT rootBoxOffsets =
+        ScratchBufferT::create((mTriangleCount+1)*sizeof(uint64_t), nullptr, device, mStream);
     if (rootBoxOffsets.deviceData() == nullptr) throw std::runtime_error("Failed to allocate root box offsets buffer");
 
     cudaCheck(cudaMemsetAsync(rootBoxOffsets.deviceData(), 0, sizeof(uint64_t), mStream));
     CALL_CUBS(DeviceScan::InclusiveSum,
-        static_cast<uint64_t*>(rootBoxCounts.deviceData()),
-        static_cast<uint64_t*>(rootBoxOffsets.deviceData())+1,
+        reinterpret_cast<uint64_t*>(rootBoxCounts.deviceData()),
+        reinterpret_cast<uint64_t*>(rootBoxOffsets.deviceData())+1,
         mTriangleCount);
-    cudaCheck(cudaMemcpyAsync(&mBoxTrianglePairCount, static_cast<uint64_t*>(rootBoxOffsets.deviceData())+mTriangleCount, sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
+    cudaCheck(cudaMemcpyAsync(&mBoxTrianglePairCount, reinterpret_cast<uint64_t*>(rootBoxOffsets.deviceData())+mTriangleCount, sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
     cudaStreamSynchronize(mStream);
 
     // Pass 3: Re-enumerate intersections of (padded) root boxes and triangles, and scatter to allocated list
 
-    mBoxTrianglePairsBuffer = nanovdb::cuda::DeviceBuffer::create(
+    mBoxTrianglePairsBuffer = ScratchBufferT::create(
         mBoxTrianglePairCount * sizeof(typename MeshToGrid<BuildT>::BoxTrianglePair), nullptr, device, mStream);
     if (mBoxTrianglePairsBuffer.deviceData() == nullptr) throw std::runtime_error("Failed to allocate pairs buffer");
 
@@ -519,7 +519,7 @@ void MeshToGrid<BuildT>::processRootTrianglePairs()
         mTriangleCount,
         topology::detail::ScatterRootTrianglePairsFunctor<BuildT>{
             deviceXformedTriangles(),
-            static_cast<uint64_t*>(rootBoxOffsets.deviceData()),
+            reinterpret_cast<uint64_t*>(rootBoxOffsets.deviceData()),
             deviceBoxTrianglePairs(),
             mBandWidth
         }
@@ -763,8 +763,8 @@ struct DecodeRootOriginsFunctor
 
 } // namespace topology::detail
 
-template<typename BuildT>
-void MeshToGrid<BuildT>::enumerateRootTiles()
+template<typename BuildT, typename ScratchBufferT>
+void MeshToGrid<BuildT, ScratchBufferT>::enumerateRootTiles()
 {
     if (mBoxTrianglePairCount == 0) return;
 
@@ -772,9 +772,9 @@ void MeshToGrid<BuildT>::enumerateRootTiles()
     cudaGetDevice(&device);
 
     // Step 1: Encode each pair's root origin as a sortable uint64_t key
-    nanovdb::cuda::DeviceBuffer keysBuffer = nanovdb::cuda::DeviceBuffer::create(
+    ScratchBufferT keysBuffer = ScratchBufferT::create(
         mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
-    auto *dKeys = static_cast<uint64_t*>(keysBuffer.deviceData());
+    auto *dKeys = reinterpret_cast<uint64_t*>(keysBuffer.deviceData());
 
     util::cuda::lambdaKernel<<<numBlocks(mBoxTrianglePairCount), mNumThreads, 0, mStream>>>(
         mBoxTrianglePairCount,
@@ -783,20 +783,20 @@ void MeshToGrid<BuildT>::enumerateRootTiles()
     cudaCheckError();
 
     // Step 2: Sort keys (SortKeys requires separate in/out buffers)
-    nanovdb::cuda::DeviceBuffer sortedKeysBuffer = nanovdb::cuda::DeviceBuffer::create(
+    ScratchBufferT sortedKeysBuffer = ScratchBufferT::create(
         mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
-    auto *dSortedKeys = static_cast<uint64_t*>(sortedKeysBuffer.deviceData());
+    auto *dSortedKeys = reinterpret_cast<uint64_t*>(sortedKeysBuffer.deviceData());
 
     CALL_CUBS(DeviceRadixSort::SortKeys, dKeys, dSortedKeys, (int)mBoxTrianglePairCount, 0, 64);
 
     // Step 3: Select unique keys
-    nanovdb::cuda::DeviceBuffer uniqueKeysBuffer = nanovdb::cuda::DeviceBuffer::create(
+    ScratchBufferT uniqueKeysBuffer = ScratchBufferT::create(
         mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
-    auto *dUniqueKeys = static_cast<uint64_t*>(uniqueKeysBuffer.deviceData());
+    auto *dUniqueKeys = reinterpret_cast<uint64_t*>(uniqueKeysBuffer.deviceData());
 
-    nanovdb::cuda::DeviceBuffer numSelectedBuffer = nanovdb::cuda::DeviceBuffer::create(
+    ScratchBufferT numSelectedBuffer = ScratchBufferT::create(
         sizeof(int32_t), nullptr, device, mStream);
-    auto *dNumSelected = static_cast<int32_t*>(numSelectedBuffer.deviceData());
+    auto *dNumSelected = reinterpret_cast<int32_t*>(numSelectedBuffer.deviceData());
 
     CALL_CUBS(DeviceSelect::Unique, dSortedKeys, dUniqueKeys, dNumSelected, (int)mBoxTrianglePairCount);
 
@@ -806,7 +806,7 @@ void MeshToGrid<BuildT>::enumerateRootTiles()
     mUniqueRootTileCount = static_cast<uint64_t>(uniqueCount);
 
     // Step 4: Decode unique keys back to Coord origins
-    mUniqueRootOriginsBuffer = nanovdb::cuda::DeviceBuffer::create(
+    mUniqueRootOriginsBuffer = ScratchBufferT::create(
         mUniqueRootTileCount * sizeof(nanovdb::Coord), nullptr, device, mStream);
     auto *dOrigins = deviceUniqueRootOrigins();
 
@@ -820,8 +820,8 @@ void MeshToGrid<BuildT>::enumerateRootTiles()
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void MeshToGrid<BuildT>::buildRasterizedRoot()
+template<typename BuildT, typename ScratchBufferT>
+void MeshToGrid<BuildT, ScratchBufferT>::buildRasterizedRoot()
 {
     int device = 0;
     cudaGetDevice(&device);
@@ -854,8 +854,8 @@ void MeshToGrid<BuildT>::buildRasterizedRoot()
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void MeshToGrid<BuildT>::rasterizeInternalNodes()
+template<typename BuildT, typename ScratchBufferT>
+void MeshToGrid<BuildT, ScratchBufferT>::rasterizeInternalNodes()
 {
     if (mBoxTrianglePairCount == 0) return;
 
@@ -874,8 +874,8 @@ void MeshToGrid<BuildT>::rasterizeInternalNodes()
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void MeshToGrid<BuildT>::processGridTreeRoot()
+template<typename BuildT, typename ScratchBufferT>
+void MeshToGrid<BuildT, ScratchBufferT>::processGridTreeRoot()
 {
     // Initialize grid/tree/root metadata from scratch using the provided map.
     // InitGridTreeRootFunctor sets all GridData fields explicitly (magic, version,
@@ -896,8 +896,8 @@ void MeshToGrid<BuildT>::processGridTreeRoot()
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void MeshToGrid<BuildT>::rasterizeLeafNodes()
+template<typename BuildT, typename ScratchBufferT>
+void MeshToGrid<BuildT, ScratchBufferT>::rasterizeLeafNodes()
 {
     if (mBoxTrianglePairCount == 0) return;
 
@@ -912,8 +912,8 @@ void MeshToGrid<BuildT>::rasterizeLeafNodes()
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void MeshToGrid<BuildT>::processLeafTrianglePairs()
+template<typename BuildT, typename ScratchBufferT>
+void MeshToGrid<BuildT, ScratchBufferT>::processLeafTrianglePairs()
 {
     if (mBoxTrianglePairCount == 0) return;
 
@@ -925,21 +925,21 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
     for (int pass = 0; pass < 3; ++pass) {
         // Allocate Mask<3> buffer for the CTA hit results
         // Size: mBoxTrianglePairCount * sizeof(nanovdb::Mask<3>)
-        nanovdb::cuda::DeviceBuffer maskBuffer = nanovdb::cuda::DeviceBuffer::create(
+        ScratchBufferT maskBuffer = ScratchBufferT::create(
             mBoxTrianglePairCount * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
         if (maskBuffer.deviceData() == nullptr) {
             throw std::runtime_error("Failed to allocate mask buffer for subdivision pass");
         }
-        auto* dMasks = static_cast<nanovdb::Mask<3>*>(maskBuffer.deviceData());
+        auto* dMasks = reinterpret_cast<nanovdb::Mask<3>*>(maskBuffer.deviceData());
 
         // Allocate Counts buffer for Prefix Sum
         // Size: mBoxTrianglePairCount * sizeof(uint64_t)
-        nanovdb::cuda::DeviceBuffer countsBuffer = nanovdb::cuda::DeviceBuffer::create(
+        ScratchBufferT countsBuffer = ScratchBufferT::create(
             mBoxTrianglePairCount * sizeof(uint64_t), nullptr, device, mStream);
         if (countsBuffer.deviceData() == nullptr) {
             throw std::runtime_error("Failed to allocate counts buffer for subdivision pass");
         }
-        auto* dCounts = static_cast<uint64_t*>(countsBuffer.deviceData());
+        auto* dCounts = reinterpret_cast<uint64_t*>(countsBuffer.deviceData());
 
         // Evaluate & Count: 1 CTA per parent pair, 512 threads per CTA.
         // Uses AABB-only test for large child scales (>= mSATThreshold), full SAT below.
@@ -959,11 +959,11 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
 
         // Prefix Sum: element [i+1] = exclusive write offset for parent i's children,
         // element [0] = 0, element [mBoxTrianglePairCount] = total child pair count.
-        nanovdb::cuda::DeviceBuffer offsetsBuffer = nanovdb::cuda::DeviceBuffer::create(
+        ScratchBufferT offsetsBuffer = ScratchBufferT::create(
             (mBoxTrianglePairCount + 1) * sizeof(uint64_t), nullptr, device, mStream);
         if (offsetsBuffer.deviceData() == nullptr)
             throw std::runtime_error("Failed to allocate offsets buffer for subdivision pass");
-        auto* dOffsets = static_cast<uint64_t*>(offsetsBuffer.deviceData());
+        auto* dOffsets = reinterpret_cast<uint64_t*>(offsetsBuffer.deviceData());
 
         cudaCheck(cudaMemsetAsync(dOffsets, 0, sizeof(uint64_t), mStream));
         CALL_CUBS(DeviceScan::InclusiveSum,
@@ -977,11 +977,11 @@ void MeshToGrid<BuildT>::processLeafTrianglePairs()
         cudaStreamSynchronize(mStream);
 
         // Allocate new child pair buffer
-        nanovdb::cuda::DeviceBuffer newPairsBuffer = nanovdb::cuda::DeviceBuffer::create(
+        ScratchBufferT newPairsBuffer = ScratchBufferT::create(
             newPairCount * sizeof(BoxTrianglePair), nullptr, device, mStream);
         if (newPairsBuffer.deviceData() == nullptr)
             throw std::runtime_error("Failed to allocate child pairs buffer for subdivision pass");
-        auto* dNewPairs = static_cast<BoxTrianglePair*>(newPairsBuffer.deviceData());
+        auto* dNewPairs = reinterpret_cast<BoxTrianglePair*>(newPairsBuffer.deviceData());
 
         // Scatter surviving child pairs into the new buffer
         util::cuda::lambdaKernel<<<numBlocks(mBoxTrianglePairCount), mNumThreads, 0, mStream>>>(
@@ -1038,10 +1038,10 @@ struct FinalizeSidecarFunctor
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
+template<typename BuildT, typename ScratchBufferT>
 template<typename GridBufferT, typename SidecarBufferT>
 std::pair<GridHandle<GridBufferT>, SidecarBufferT>
-MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& buffer, const SidecarBufferT&)
+MeshToGrid<BuildT, ScratchBufferT>::getHandleAndUDF(const GridBufferT& buffer, const SidecarBufferT&)
 {
     cudaStreamSynchronize(mStream);
 
@@ -1118,13 +1118,13 @@ MeshToGrid<BuildT>::getHandleAndUDF(const GridBufferT& buffer, const SidecarBuff
     const uint32_t leafCount = mBuilder.data()->nodeCount[0];
     auto handle = GridHandle<GridBufferT>(std::move(gridBuffer));
     if (leafCount) {
-        nanovdb::cuda::DeviceBuffer retainMaskBuffer = nanovdb::cuda::DeviceBuffer::create(
+        ScratchBufferT retainMaskBuffer = ScratchBufferT::create(
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
         cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
         tools::cuda::PruneGrid<BuildT> pruner(
             static_cast<const GridT*>(handle.deviceData()),
-            static_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
+            reinterpret_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
             mStream);
         handle = pruner.template getHandle<GridBufferT>(buffer);
     }

--- a/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/MeshToGrid.cuh
@@ -48,6 +48,17 @@ struct Triangle {
     __hostdev__       nanovdb::Vec3f& operator[](int i)       { return v[i]; }
 };
 
+/// @brief POD (box origin, triangle id) pair used throughout MeshToGrid's rasterization
+///        pipeline, and passed as a template argument to the rasterization functors in
+///        Rasterization.cuh. Lifted to namespace scope here (next to Triangle) — independent
+///        of MeshToGrid's scratch buffer type — so it resolves to one consistent type across
+///        every MeshToGrid<BuildT, ScratchBufferT> instantiation. MeshToGrid keeps a public
+///        `BoxTrianglePair` alias to it for source/API compatibility.
+struct alignas(16) BoxTrianglePair { // sizeof(BoxTrianglePair) = 16B
+    nanovdb::Coord origin; // 12B
+    uint32_t triangleID;   // 4B
+};
+
 template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
 class MeshToGrid
 {
@@ -62,10 +73,9 @@ class MeshToGrid
     using LeafT  = NanoLeaf<BuildT>;
 
 public:
-    struct alignas(16) BoxTrianglePair { // sizeof(BoxTrianglePair) = 16B
-        nanovdb::Coord origin; // 12B
-        uint32_t triangleID;   // 4B
-    };
+    /// @brief Alias to the namespace-scope nanovdb::tools::cuda::BoxTrianglePair
+    ///        (see above), preserving the public MeshToGrid<BuildT>::BoxTrianglePair name.
+    using BoxTrianglePair = ::nanovdb::tools::cuda::BoxTrianglePair;
 
     /// @brief Constructor
     /// @param devicePoints Vertex list for input triangle surface
@@ -302,7 +312,7 @@ MeshToGrid<BuildT, ScratchBufferT>::getHandle(const BufferT &buffer)
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
         cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
-        tools::cuda::PruneGrid<BuildT> pruner(
+        tools::cuda::PruneGrid<BuildT, ScratchBufferT> pruner(
             static_cast<const GridT*>(handle.deviceData()),
             reinterpret_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
             mStream);
@@ -1122,7 +1132,7 @@ MeshToGrid<BuildT, ScratchBufferT>::getHandleAndUDF(const GridBufferT& buffer, c
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), nullptr, device, mStream);
         cudaCheck(cudaMemsetAsync(retainMaskBuffer.deviceData(), 0xFF,
             uint64_t(leafCount) * sizeof(nanovdb::Mask<3>), mStream));
-        tools::cuda::PruneGrid<BuildT> pruner(
+        tools::cuda::PruneGrid<BuildT, ScratchBufferT> pruner(
             static_cast<const GridT*>(handle.deviceData()),
             reinterpret_cast<nanovdb::Mask<3>*>(retainMaskBuffer.deviceData()),
             mStream);
@@ -1137,9 +1147,9 @@ MeshToGrid<BuildT, ScratchBufferT>::getHandleAndUDF(const GridBufferT& buffer, c
     const uint64_t activeVoxelCount = util::cuda::DeviceGridTraits<BuildT>::getActiveVoxelCount(
         handle.template deviceGrid<BuildT>());
 
-    auto sidecarBuffer = nanovdb::cuda::DeviceBuffer::create(
+    auto sidecarBuffer = SidecarBufferT::create(
         (activeVoxelCount + 1) * sizeof(float), nullptr, device, mStream);
-    auto *dSidecar = static_cast<float*>(sidecarBuffer.deviceData());
+    auto *dSidecar = reinterpret_cast<float*>(sidecarBuffer.deviceData());
 
     if (mVerbose==1) mTimer.start("Initializing UDF sidecar");
     util::cuda::lambdaKernel<<<numBlocks(activeVoxelCount + 1), mNumThreads, 0, mStream>>>(

--- a/nanovdb/nanovdb/tools/cuda/PruneGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/PruneGrid.cuh
@@ -30,7 +30,7 @@ namespace nanovdb {
 
 namespace tools::cuda {
 
-template <typename BuildT>
+template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
 class PruneGrid
 {
     using GridT  = NanoGrid<BuildT>;
@@ -75,7 +75,7 @@ private:
     static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
     static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
 
-    TopologyBuilder<BuildT> mBuilder;
+    TopologyBuilder<BuildT, ScratchBufferT> mBuilder;
     cudaStream_t            mStream{0};
     util::cuda::Timer       mTimer;
     int                     mVerbose{0};
@@ -86,10 +86,10 @@ private:
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
+template<typename BuildT, typename ScratchBufferT>
 template<typename BufferT>
 GridHandle<BufferT>
-PruneGrid<BuildT>::getHandle(const BufferT &pool)
+PruneGrid<BuildT, ScratchBufferT>::getHandle(const BufferT &pool)
 {
     // Copy TreeData from GPU -> CPU
     cudaStreamSynchronize(mStream);
@@ -150,12 +150,12 @@ PruneGrid<BuildT>::getHandle(const BufferT &pool)
     cudaStreamSynchronize(mStream);
 
     return GridHandle<BufferT>(std::move(buffer));
-}// PruneGrid<BuildT>::getHandle
+}// PruneGrid<BuildT, ScratchBufferT>::getHandle
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void PruneGrid<BuildT>::pruneRoot()
+template<typename BuildT, typename ScratchBufferT>
+void PruneGrid<BuildT, ScratchBufferT>::pruneRoot()
 {
     // This method conservatively (and trivially) prunes the root tile table.
     // For this simple approximation, it is assumed that all root tiles currently present will presist,
@@ -200,12 +200,12 @@ void PruneGrid<BuildT>::pruneRoot()
     for (const auto& [key, tile] : prunedTiles)
         *prunedRootPtr->tile(t++) = tile;
     mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
-}// PruneGrid<BuildT>::pruneRoot
+}// PruneGrid<BuildT, ScratchBufferT>::pruneRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void PruneGrid<BuildT>::pruneInternalNodes()
+template<typename BuildT, typename ScratchBufferT>
+void PruneGrid<BuildT, ScratchBufferT>::pruneInternalNodes()
 {
     // Computes the masks of upper and (densified) lower internal nodes, as a result of the pruning operation
     // Masks of lower internal nodes are densified in the sense that a serialized array of them is allocated,
@@ -215,24 +215,24 @@ void PruneGrid<BuildT>::pruneInternalNodes()
             srcLeafCount, util::morphology::cuda::PruneInternalNodesFunctor<BuildT>(),
             mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mDeviceSrcLeafMask, mBuilder.mUpperMasks.deviceData(), mBuilder.mLowerMasks.deviceData() );
     }
-}// PruneGrid<BuildT>::pruneInternalNodes
+}// PruneGrid<BuildT, ScratchBufferT>::pruneInternalNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT>
-void PruneGrid<BuildT>::processGridTreeRoot()
+template <typename BuildT, typename ScratchBufferT>
+void PruneGrid<BuildT, ScratchBufferT>::processGridTreeRoot()
 {
     // Copy GridData from source grid
     // By convention: this will duplicate grid name and map. Others will be reset later
     cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
     util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
     cudaCheckError();
-}// PruneGrid<BuildT>::processGridTreeRoot
+}// PruneGrid<BuildT, ScratchBufferT>::processGridTreeRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void PruneGrid<BuildT>::pruneLeafNodes()
+template<typename BuildT, typename ScratchBufferT>
+void PruneGrid<BuildT, ScratchBufferT>::pruneLeafNodes()
 {
     // Prunes the active masks of the source grid to the intersection with the leaf-mask sidecar
     // followed by rebuilding the leaf offsets
@@ -244,7 +244,7 @@ void PruneGrid<BuildT>::pruneLeafNodes()
 
     // Update leaf offsets and prefix sums
     mBuilder.processLeafOffsets(mStream);
-}// PruneGrid<BuildT>::pruneLeafNodes
+}// PruneGrid<BuildT, ScratchBufferT>::pruneLeafNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/nanovdb/nanovdb/tools/cuda/RefineGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/RefineGrid.cuh
@@ -30,7 +30,7 @@ namespace nanovdb {
 
 namespace tools::cuda {
 
-template <typename BuildT>
+template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
 class RefineGrid
 {
     using GridT  = NanoGrid<BuildT>;
@@ -74,7 +74,7 @@ private:
     static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
     static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
 
-    TopologyBuilder<BuildT> mBuilder;
+    TopologyBuilder<BuildT, ScratchBufferT> mBuilder;
     cudaStream_t            mStream{0};
     util::cuda::Timer       mTimer;
     int                     mVerbose{0};
@@ -84,10 +84,10 @@ private:
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
+template<typename BuildT, typename ScratchBufferT>
 template<typename BufferT>
 GridHandle<BufferT>
-RefineGrid<BuildT>::getHandle(const BufferT &pool)
+RefineGrid<BuildT, ScratchBufferT>::getHandle(const BufferT &pool)
 {
     // Copy TreeData from GPU -> CPU
     cudaStreamSynchronize(mStream);
@@ -147,12 +147,12 @@ RefineGrid<BuildT>::getHandle(const BufferT &pool)
     cudaStreamSynchronize(mStream);
 
     return GridHandle<BufferT>(std::move(buffer));
-}// RefineGrid<BuildT>::getHandle
+}// RefineGrid<BuildT, ScratchBufferT>::getHandle
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void RefineGrid<BuildT>::refineRoot()
+template<typename BuildT, typename ScratchBufferT>
+void RefineGrid<BuildT, ScratchBufferT>::refineRoot()
 {
     // This method conservatively and speculatively refines the root tiles, to accommodate
     // any new root nodes that might be introduced by the upsampling operation.
@@ -212,12 +212,12 @@ void RefineGrid<BuildT>::refineRoot()
     for (const auto& [key, tile] : refinedTiles)
         *refinedRootPtr->tile(t++) = tile;
     mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
-}// RefineGrid<BuildT>::refineRoot
+}// RefineGrid<BuildT, ScratchBufferT>::refineRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void RefineGrid<BuildT>::refineInternalNodes()
+template<typename BuildT, typename ScratchBufferT>
+void RefineGrid<BuildT, ScratchBufferT>::refineInternalNodes()
 {
     // Computes the masks of upper and (densified) lower internal nodes, as a result of the refinement operation
     // Masks of lower internal nodes are densified in the sense that a serialized array of them is allocated,
@@ -227,24 +227,24 @@ void RefineGrid<BuildT>::refineInternalNodes()
             srcLeafCount, util::morphology::cuda::RefineInternalNodesFunctor<BuildT>(),
             mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.mUpperMasks.deviceData(), mBuilder.mLowerMasks.deviceData() );
     }
-}// RefineGrid<BuildT>::refineInternalNodes
+}// RefineGrid<BuildT, ScratchBufferT>::refineInternalNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT>
-void RefineGrid<BuildT>::processGridTreeRoot()
+template <typename BuildT, typename ScratchBufferT>
+void RefineGrid<BuildT, ScratchBufferT>::processGridTreeRoot()
 {
     // Copy GridData from source grid
     // By convention: this will duplicate grid name and map. Others will be reset later
     cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
     util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
     cudaCheckError();
-}// RefineGrid<BuildT>::processGridTreeRoot
+}// RefineGrid<BuildT, ScratchBufferT>::processGridTreeRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void RefineGrid<BuildT>::refineLeafNodes()
+template<typename BuildT, typename ScratchBufferT>
+void RefineGrid<BuildT, ScratchBufferT>::refineLeafNodes()
 {
     // Refines the active masks of the source grid (as indicated at the leaf level), into a new grid that
     // has been already topologically refined to include all necessary leaf nodes.
@@ -256,7 +256,7 @@ void RefineGrid<BuildT>::refineLeafNodes()
 
     // Update leaf offsets and prefix sums
     mBuilder.processLeafOffsets(mStream);
-}// RefineGrid<BuildT>::refineLeafNodes
+}// RefineGrid<BuildT, ScratchBufferT>::refineLeafNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
+++ b/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
@@ -24,7 +24,7 @@ namespace nanovdb {
 
 namespace tools::cuda {
 
-template <typename BuildT>
+template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
 class TopologyBuilder
 {
     static_assert(nanovdb::BuildTraits<BuildT>::is_onindex);// For now, only OnIndexGrids supported
@@ -73,16 +73,16 @@ public:
 
     void postProcessGridTree(cudaStream_t stream);
 
-    nanovdb::cuda::DeviceBuffer  mProcessedRoot;
-    nanovdb::cuda::DeviceBuffer  mUpperMasks;
-    nanovdb::cuda::DeviceBuffer  mLowerMasks;
-    nanovdb::cuda::DeviceBuffer  mUpperOffsets;
-    nanovdb::cuda::DeviceBuffer  mLowerOffsets;
-    nanovdb::cuda::DeviceBuffer  mLeafOffsets;
-    nanovdb::cuda::DeviceBuffer  mVoxelOffsets;
-    nanovdb::cuda::DeviceBuffer  mLowerParents;
-    nanovdb::cuda::DeviceBuffer  mLeafParents;
-    nanovdb::cuda::DeviceBuffer  mData;
+    nanovdb::cuda::DeviceBuffer  mProcessedRoot;// dual-use (host+device); intentionally not templatized (see plan §2.4)
+    ScratchBufferT               mUpperMasks;
+    ScratchBufferT               mLowerMasks;
+    ScratchBufferT               mUpperOffsets;
+    ScratchBufferT               mLowerOffsets;
+    ScratchBufferT               mLeafOffsets;
+    ScratchBufferT               mVoxelOffsets;
+    ScratchBufferT               mLowerParents;
+    ScratchBufferT               mLeafParents;
+    nanovdb::cuda::DeviceBuffer  mData;// dual-use (host+device); intentionally not templatized (see plan §2.4)
     CheckMode                    mChecksum{CheckMode::Disable};
 
     auto deviceProcessedRoot() { return static_cast<RootT*>(mProcessedRoot.deviceData()); }
@@ -118,8 +118,8 @@ private:
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void TopologyBuilder<BuildT>::allocateInternalMaskBuffers(cudaStream_t stream)
+template<typename BuildT, typename ScratchBufferT>
+void TopologyBuilder<BuildT, ScratchBufferT>::allocateInternalMaskBuffers(cudaStream_t stream)
 {
     if (hostProcessedRoot()->tileCount() == 0) return; // Processing empty grid(s); nothing to allocate
 
@@ -130,18 +130,18 @@ void TopologyBuilder<BuildT>::allocateInternalMaskBuffers(cudaStream_t stream)
     cudaGetDevice(&device);
     uint64_t upperSize = hostProcessedRoot()->tileCount() * sizeof(Mask<5>);
     uint64_t lowerSize = hostProcessedRoot()->tileCount() * Mask<5>::SIZE * sizeof(Mask<4>);
-    mUpperMasks = nanovdb::cuda::DeviceBuffer::create(upperSize, nullptr, device, stream);
+    mUpperMasks = ScratchBufferT::create(upperSize, nullptr, device, stream);
     if (mUpperMasks.deviceData() == nullptr) throw std::runtime_error("Failed to allocate upper mask buffer on device");
     cudaCheck(cudaMemsetAsync(mUpperMasks.deviceData(), 0, upperSize, stream));
-    mLowerMasks = nanovdb::cuda::DeviceBuffer::create( lowerSize, nullptr, device, stream );
+    mLowerMasks = ScratchBufferT::create( lowerSize, nullptr, device, stream );
     if (mLowerMasks.deviceData() == nullptr) throw std::runtime_error("Failed to allocate lower mask buffer on device");
     cudaCheck(cudaMemsetAsync(mLowerMasks.deviceData(), 0, lowerSize, stream));
 }// TopologyBuilder<BuildT>::allocateInternalMaskBuffers
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void TopologyBuilder<BuildT>::countNodes(cudaStream_t stream)
+template<typename BuildT, typename ScratchBufferT>
+void TopologyBuilder<BuildT, ScratchBufferT>::countNodes(cudaStream_t stream)
 {
     auto processedTileCount = hostProcessedRoot()->tileCount();
     if (processedTileCount == 0) { // Processing empty grid(s); zero nodes at all levels
@@ -157,9 +157,9 @@ void TopologyBuilder<BuildT>::countNodes(cudaStream_t stream)
 
     int device = 0;
     cudaGetDevice(&device);
-    nanovdb::cuda::DeviceBuffer upperCountsBuffer = nanovdb::cuda::DeviceBuffer::create(processedTileCount*sizeof(uint32_t), nullptr, device, stream);
-    nanovdb::cuda::DeviceBuffer lowerCountsBuffer = nanovdb::cuda::DeviceBuffer::create(size*sizeof(uint32_t), nullptr, device, stream);
-    nanovdb::cuda::DeviceBuffer leafCountsBuffer = nanovdb::cuda::DeviceBuffer::create(size*sizeof(uint32_t), nullptr, device, stream);
+    ScratchBufferT upperCountsBuffer = ScratchBufferT::create(processedTileCount*sizeof(uint32_t), nullptr, device, stream);
+    ScratchBufferT lowerCountsBuffer = ScratchBufferT::create(size*sizeof(uint32_t), nullptr, device, stream);
+    ScratchBufferT leafCountsBuffer = ScratchBufferT::create(size*sizeof(uint32_t), nullptr, device, stream);
 
     using CountType = uint32_t (*)[Mask<5>::SIZE];
     auto lowerCounts = reinterpret_cast<CountType>( lowerCountsBuffer.deviceData() );
@@ -170,44 +170,44 @@ void TopologyBuilder<BuildT>::countNodes(cudaStream_t stream)
         <<<dim3(processedTileCount, Op::SlicesPerUpperNode, 1), Op::MaxThreadsPerBlock, 0, stream>>>
         (deviceUpperMasks(), deviceLowerMasks(), lowerCounts, leafCounts);
 
-    mUpperOffsets = nanovdb::cuda::DeviceBuffer::create((processedTileCount+1)*sizeof(uint32_t), nullptr, device, stream);
-    mLowerOffsets = nanovdb::cuda::DeviceBuffer::create((size+1)*sizeof(uint32_t), nullptr, device, stream);
-    mLeafOffsets = nanovdb::cuda::DeviceBuffer::create((size+1)*sizeof(uint32_t), nullptr, device, stream);
+    mUpperOffsets = ScratchBufferT::create((processedTileCount+1)*sizeof(uint32_t), nullptr, device, stream);
+    mLowerOffsets = ScratchBufferT::create((size+1)*sizeof(uint32_t), nullptr, device, stream);
+    mLeafOffsets = ScratchBufferT::create((size+1)*sizeof(uint32_t), nullptr, device, stream);
 
     cudaCheck(cudaMemsetAsync(mLowerOffsets.deviceData(), 0, sizeof(uint32_t), stream));
     CALL_CUBS(DeviceScan::InclusiveSum,
-        static_cast<uint32_t*>(lowerCountsBuffer.deviceData()),
-        static_cast<uint32_t*>(mLowerOffsets.deviceData())+1,
+        reinterpret_cast<uint32_t*>(lowerCountsBuffer.deviceData()),
+        reinterpret_cast<uint32_t*>(mLowerOffsets.deviceData())+1,
         size);
-    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[1], static_cast<uint32_t*>(mLowerOffsets.deviceData())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[1], reinterpret_cast<uint32_t*>(mLowerOffsets.deviceData())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
 
     cudaCheck(cudaMemsetAsync(mLeafOffsets.deviceData(), 0, sizeof(uint32_t), stream));
     CALL_CUBS(DeviceScan::InclusiveSum,
-        static_cast<uint32_t*>(leafCountsBuffer.deviceData()),
-        static_cast<uint32_t*>(mLeafOffsets.deviceData())+1,
+        reinterpret_cast<uint32_t*>(leafCountsBuffer.deviceData()),
+        reinterpret_cast<uint32_t*>(mLeafOffsets.deviceData())+1,
         size);
-    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[0], static_cast<uint32_t*>(mLeafOffsets.deviceData())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[0], reinterpret_cast<uint32_t*>(mLeafOffsets.deviceData())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
 
     util::cuda::lambdaKernel<<<numBlocks(processedTileCount), mNumThreads, 0, stream>>>(
         processedTileCount,
         [] __device__(size_t tileID, CountType lowerOffsets, uint32_t* upperCounts)
             { upperCounts[tileID] = (lowerOffsets[tileID+1][0] > lowerOffsets[tileID][0]) ? 1 : 0; },
-        static_cast<CountType>(mLowerOffsets.deviceData()),
-        static_cast<uint32_t*>(upperCountsBuffer.deviceData()));
+        reinterpret_cast<CountType>(mLowerOffsets.deviceData()),
+        reinterpret_cast<uint32_t*>(upperCountsBuffer.deviceData()));
 
     cudaCheck(cudaMemsetAsync( mUpperOffsets.deviceData(), 0, sizeof(uint32_t), stream));
     CALL_CUBS(DeviceScan::InclusiveSum,
-        static_cast<uint32_t*>(upperCountsBuffer.deviceData()),
-        static_cast<uint32_t*>(mUpperOffsets.deviceData())+1,
+        reinterpret_cast<uint32_t*>(upperCountsBuffer.deviceData()),
+        reinterpret_cast<uint32_t*>(mUpperOffsets.deviceData())+1,
         processedTileCount);
-    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[2], static_cast<uint32_t*>(mUpperOffsets.deviceData())+processedTileCount, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[2], reinterpret_cast<uint32_t*>(mUpperOffsets.deviceData())+processedTileCount, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
 }// TopologyBuilder<BuildT>::countNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT>
+template <typename BuildT, typename ScratchBufferT>
 template <typename BufferT>
-BufferT TopologyBuilder<BuildT>::getBuffer(const BufferT &pool, cudaStream_t stream)
+BufferT TopologyBuilder<BuildT, ScratchBufferT>::getBuffer(const BufferT &pool, cudaStream_t stream)
 {
     // Allocates a device buffer for the destination grid, once the topology/size of the tree is known
     data()->grid  = 0;// grid is always stored at the start of the buffer!
@@ -226,7 +226,7 @@ BufferT TopologyBuilder<BuildT>::getBuffer(const BufferT &pool, cudaStream_t str
     data()->d_bufferPtr = buffer.deviceData();
     if (data()->d_bufferPtr == nullptr) throw std::runtime_error("Failed to allocate grid buffer on the device");
     if (data()->nodeCount[2] != 0) // Unless the result is an empty grid
-        data()->d_upperOffsets = static_cast<uint32_t*>(mUpperOffsets.deviceData());
+        data()->d_upperOffsets = reinterpret_cast<uint32_t*>(mUpperOffsets.deviceData());
     mData.deviceUpload(device, stream, false);
 
     return buffer;
@@ -406,8 +406,8 @@ struct BuildUpperNodesFunctor
 
 }// namespace topology::detail
 
-template <typename BuildT>
-inline void TopologyBuilder<BuildT>::processUpperNodes(cudaStream_t stream)
+template <typename BuildT, typename ScratchBufferT>
+inline void TopologyBuilder<BuildT, ScratchBufferT>::processUpperNodes(cudaStream_t stream)
 {
     // Connect all newly allocated upper nodes to their respective tiles
     // Also fill in any necessary part of the preamble (in InternalData) of upper nodes
@@ -422,8 +422,8 @@ inline void TopologyBuilder<BuildT>::processUpperNodes(cudaStream_t stream)
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT>
-inline void TopologyBuilder<BuildT>::processLowerNodes(cudaStream_t stream)
+template <typename BuildT, typename ScratchBufferT>
+inline void TopologyBuilder<BuildT, ScratchBufferT>::processLowerNodes(cudaStream_t stream)
 {
     // Fill out the contents of all newly allocated lower nodes (using the densified upper/lower mask arrays)
     // Also fill in the preamble (most of LeafData) for their leaf children
@@ -434,21 +434,21 @@ inline void TopologyBuilder<BuildT>::processLowerNodes(cudaStream_t stream)
         int device = 0;
         cudaGetDevice(&device);
         std::size_t lowerCount = data()->nodeCount[1];
-        mLowerParents = nanovdb::cuda::DeviceBuffer::create(lowerCount*sizeof(uint32_t), nullptr, device, stream);
+        mLowerParents = ScratchBufferT::create(lowerCount*sizeof(uint32_t), nullptr, device, stream);
         std::size_t leafCount = data()->nodeCount[0];
-        mLeafParents = nanovdb::cuda::DeviceBuffer::create(leafCount*sizeof(uint32_t), nullptr, device, stream);
+        mLeafParents = ScratchBufferT::create(leafCount*sizeof(uint32_t), nullptr, device, stream);
 
         using Op = util::morphology::cuda::ProcessLowerNodesFunctor<BuildT>;
         util::cuda::operatorKernel<Op>
             <<<dim3(processedTileCount, Op::SlicesPerUpperNode, 1), Op::MaxThreadsPerBlock, 0, stream>>>(
                 deviceUpperMasks(),
                 deviceLowerMasks(),
-                static_cast<uint32_t*>(mUpperOffsets.deviceData()),
-                static_cast<CountType>(mLowerOffsets.deviceData()),
-                static_cast<CountType>(mLeafOffsets.deviceData()),
+                reinterpret_cast<uint32_t*>(mUpperOffsets.deviceData()),
+                reinterpret_cast<CountType>(mLowerOffsets.deviceData()),
+                reinterpret_cast<CountType>(mLeafOffsets.deviceData()),
                 static_cast<GridT*>(data()->d_bufferPtr),
-                static_cast<uint32_t*>(mLowerParents.deviceData()),
-                static_cast<uint32_t*>(mLeafParents.deviceData())
+                reinterpret_cast<uint32_t*>(mLowerParents.deviceData()),
+                reinterpret_cast<uint32_t*>(mLeafParents.deviceData())
             );
         cudaCheckError();
     }
@@ -492,23 +492,23 @@ struct UpdateLeafVoxelOffsetsFunctor
 
 }// namespace topology::detail
 
-template<typename BuildT>
-inline void TopologyBuilder<BuildT>::processLeafOffsets(cudaStream_t stream)
+template<typename BuildT, typename ScratchBufferT>
+inline void TopologyBuilder<BuildT, ScratchBufferT>::processLeafOffsets(cudaStream_t stream)
 {
     int device = 0;
     cudaGetDevice(&device);
     std::size_t leafCount = data()->nodeCount[0];
     if (leafCount) { // Unless output grid is empty
-        mVoxelOffsets = nanovdb::cuda::DeviceBuffer::create((leafCount+1)*sizeof(uint64_t), nullptr, device, stream);
+        mVoxelOffsets = ScratchBufferT::create((leafCount+1)*sizeof(uint64_t), nullptr, device, stream);
         cudaCheck(cudaMemsetAsync(mVoxelOffsets.deviceData(), 0, sizeof(uint64_t), stream));
         util::cuda::lambdaKernel<<<numBlocks(leafCount), mNumThreads, 0, stream>>>(
-            leafCount, topology::detail::UpdateLeafVoxelCountsAndPrefixSumFunctor<BuildT>(), deviceData(), static_cast<uint64_t*>(mVoxelOffsets.deviceData())+1);
+            leafCount, topology::detail::UpdateLeafVoxelCountsAndPrefixSumFunctor<BuildT>(), deviceData(), reinterpret_cast<uint64_t*>(mVoxelOffsets.deviceData())+1);
         CALL_CUBS(DeviceScan::InclusiveSum,
-            static_cast<uint64_t*>(mVoxelOffsets.deviceData())+1,
-            static_cast<uint64_t*>(mVoxelOffsets.deviceData())+1,
+            reinterpret_cast<uint64_t*>(mVoxelOffsets.deviceData())+1,
+            reinterpret_cast<uint64_t*>(mVoxelOffsets.deviceData())+1,
             leafCount);
         util::cuda::lambdaKernel<<<numBlocks(leafCount), mNumThreads, 0, stream>>>(
-            leafCount, topology::detail::UpdateLeafVoxelOffsetsFunctor<BuildT>(), deviceData(), static_cast<uint64_t*>(mVoxelOffsets.deviceData()));
+            leafCount, topology::detail::UpdateLeafVoxelOffsetsFunctor<BuildT>(), deviceData(), reinterpret_cast<uint64_t*>(mVoxelOffsets.deviceData()));
     }
 }// TopologyBuilder<BuildT>::processLeafOffsets
 
@@ -569,8 +569,8 @@ struct UpdateRootWorldBBoxFunctor
 
 }// namespace topology::detail
 
-template <typename BuildT>
-inline void TopologyBuilder<BuildT>::processBBox(cudaStream_t stream)
+template <typename BuildT, typename ScratchBufferT>
+inline void TopologyBuilder<BuildT, ScratchBufferT>::processBBox(cudaStream_t stream)
 {
     if (data()->nodeCount[0] == 0) return; // Output grid is empty; retain empty bounding box
 
@@ -578,13 +578,13 @@ inline void TopologyBuilder<BuildT>::processBBox(cudaStream_t stream)
 
     // update and propagate bbox from leaf -> lower/parent nodes
     util::cuda::lambdaKernel<<<numBlocks(data()->nodeCount[0]), mNumThreads, 0, stream>>>(
-        data()->nodeCount[0], topology::detail::UpdateAndPropagateLeafBBoxFunctor<BuildT>(), deviceData(), static_cast<uint32_t*>(mLeafParents.deviceData()));
+        data()->nodeCount[0], topology::detail::UpdateAndPropagateLeafBBoxFunctor<BuildT>(), deviceData(), reinterpret_cast<uint32_t*>(mLeafParents.deviceData()));
     mLeafParents.clear(stream);
     cudaCheckError();
 
     // propagate bbox from lower -> upper/parent node
     util::cuda::lambdaKernel<<<numBlocks(data()->nodeCount[1]), mNumThreads, 0, stream>>>(
-        data()->nodeCount[1], topology::detail::PropagateLowerBBoxFunctor<BuildT>(), deviceData(), static_cast<uint32_t*>(mLowerParents.deviceData()));
+        data()->nodeCount[1], topology::detail::PropagateLowerBBoxFunctor<BuildT>(), deviceData(), reinterpret_cast<uint32_t*>(mLowerParents.deviceData()));
     mLowerParents.clear(stream);
     cudaCheckError();
 
@@ -616,12 +616,12 @@ struct PostProcessGridTreeFunctor
 
 }// namespace topology::detail
 
-template <typename BuildT>
-inline void TopologyBuilder<BuildT>::postProcessGridTree(cudaStream_t stream)
+template <typename BuildT, typename ScratchBufferT>
+inline void TopologyBuilder<BuildT, ScratchBufferT>::postProcessGridTree(cudaStream_t stream)
 {
     // Finish updates to GridData/TreeData and (optionally) update checksum
     if (data()->nodeCount[0]) // if grid is empty, the default values are correct
-        util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, topology::detail::PostProcessGridTreeFunctor<BuildT>(), deviceData(), static_cast<uint64_t*>(mVoxelOffsets.deviceData()));
+        util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, topology::detail::PostProcessGridTreeFunctor<BuildT>(), deviceData(), reinterpret_cast<uint64_t*>(mVoxelOffsets.deviceData()));
     cudaCheckError();
     mVoxelOffsets.clear(stream);
 

--- a/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
+++ b/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
@@ -24,6 +24,34 @@ namespace nanovdb {
 
 namespace tools::cuda {
 
+namespace topology::detail {
+
+/// @brief Grid/tree/node layout metadata shared by TopologyBuilder and the CUDA
+///        functors it dispatches. Parameterized on BuildT only (independent of the
+///        scratch buffer type), so it is one consistent type across every
+///        TopologyBuilder<BuildT, ScratchBufferT> instantiation — see plan §2.6.
+template <typename BuildT>
+struct TopologyBuilderData {
+    using GridT  = NanoGrid<BuildT>;
+    using TreeT  = NanoTree<BuildT>;
+    using RootT  = NanoRoot<BuildT>;
+    using UpperT = NanoUpper<BuildT>;
+    using LowerT = NanoLower<BuildT>;
+    using LeafT  = NanoLeaf<BuildT>;
+    void     *d_bufferPtr;
+    uint64_t grid, tree, root, upper, lower, leaf, size;// byte offsets to nodes in buffer
+    uint32_t nodeCount[3];// 0=leaf,1=lower, 2=upper
+    uint32_t *d_upperOffsets;
+    __hostdev__ GridT&  getGrid() const {return *util::PtrAdd<GridT>(d_bufferPtr, grid);}
+    __hostdev__ TreeT&  getTree() const {return *util::PtrAdd<TreeT>(d_bufferPtr, tree);}
+    __hostdev__ RootT&  getRoot() const {return *util::PtrAdd<RootT>(d_bufferPtr, root);}
+    __hostdev__ UpperT& getUpper(int i) const {return *(util::PtrAdd<UpperT>(d_bufferPtr, upper)+i);}
+    __hostdev__ LowerT& getLower(int i) const {return *(util::PtrAdd<LowerT>(d_bufferPtr, lower)+i);}
+    __hostdev__ LeafT&  getLeaf(int i) const {return *(util::PtrAdd<LeafT>(d_bufferPtr, leaf)+i);}
+};// TopologyBuilderData
+
+}// namespace topology::detail
+
 template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
 class TopologyBuilder
 {
@@ -43,18 +71,7 @@ public:
         mData = nanovdb::cuda::DeviceBuffer::create(sizeof(Data));
     }
 
-    struct Data {
-        void     *d_bufferPtr;
-        uint64_t grid, tree, root, upper, lower, leaf, size;// byte offsets to nodes in buffer
-        uint32_t nodeCount[3];// 0=leaf,1=lower, 2=upper
-        uint32_t *d_upperOffsets;
-        __hostdev__ GridT&  getGrid() const {return *util::PtrAdd<GridT>(d_bufferPtr, grid);}
-        __hostdev__ TreeT&  getTree() const {return *util::PtrAdd<TreeT>(d_bufferPtr, tree);}
-        __hostdev__ RootT&  getRoot() const {return *util::PtrAdd<RootT>(d_bufferPtr, root);}
-        __hostdev__ UpperT& getUpper(int i) const {return *(util::PtrAdd<UpperT>(d_bufferPtr, upper)+i);}
-        __hostdev__ LowerT& getLower(int i) const {return *(util::PtrAdd<LowerT>(d_bufferPtr, lower)+i);}
-        __hostdev__ LeafT&  getLeaf(int i) const {return *(util::PtrAdd<LeafT>(d_bufferPtr, leaf)+i);}
-    };// Data
+    using Data = topology::detail::TopologyBuilderData<BuildT>;
 
     void allocateInternalMaskBuffers(cudaStream_t stream);
 
@@ -240,7 +257,7 @@ template <typename BuildT>
 struct BuildGridTreeRootFunctor
 {
     __device__
-    void operator()(size_t, typename TopologyBuilder<BuildT>::Data *d_data) {
+    void operator()(size_t, TopologyBuilderData<BuildT> *d_data) {
 
         // process Root
         auto &root = d_data->getRoot();
@@ -320,7 +337,7 @@ struct InitGridTreeRootFunctor
     Map map; // transform to embed in the output grid
 
     __device__
-    void operator()(size_t, typename TopologyBuilder<BuildT>::Data *d_data) {
+    void operator()(size_t, TopologyBuilderData<BuildT> *d_data) {
 
         // process Root (identical to BuildGridTreeRootFunctor)
         auto &root = d_data->getRoot();
@@ -389,7 +406,7 @@ template <typename BuildT>
 struct BuildUpperNodesFunctor
 {
     __device__
-    void operator()(size_t processedTileID, typename TopologyBuilder<BuildT>::Data *d_data, NanoRoot<BuildT> *d_processedRoot) {
+    void operator()(size_t processedTileID, TopologyBuilderData<BuildT> *d_data, NanoRoot<BuildT> *d_processedRoot) {
         uint32_t tileID = d_data->d_upperOffsets[processedTileID];
         if (tileID != d_data->d_upperOffsets[processedTileID+1]) // if the offsets are the same, this was a speculatively introduced tile which was not necessary
         {
@@ -468,7 +485,7 @@ template <typename BuildT>
 struct UpdateLeafVoxelCountsAndPrefixSumFunctor
 {
     __device__
-    void operator()(size_t leafID, typename TopologyBuilder<BuildT>::Data *d_data, uint64_t *d_voxelCounts) {
+    void operator()(size_t leafID, TopologyBuilderData<BuildT> *d_data, uint64_t *d_voxelCounts) {
         auto &leaf = d_data->getGrid().tree().template getFirstNode<0>()[leafID];
         const uint64_t *w = leaf.mValueMask.words();
         uint64_t prefixSum = 0, sum = util::countOn(*w++);
@@ -485,7 +502,7 @@ template <typename BuildT>
 struct UpdateLeafVoxelOffsetsFunctor
 {
     __device__
-    void operator()(size_t leafID, typename TopologyBuilder<BuildT>::Data *d_data, uint64_t *d_voxelOffsets) {
+    void operator()(size_t leafID, TopologyBuilderData<BuildT> *d_data, uint64_t *d_voxelOffsets) {
         auto &leaf = d_data->getGrid().tree().template getFirstNode<0>()[leafID];
         leaf.mOffset = d_voxelOffsets[leafID]+1; }
 };
@@ -527,7 +544,7 @@ template <typename BuildT>
 struct UpdateAndPropagateLeafBBoxFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data, const uint32_t* leafParents) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data, const uint32_t* leafParents) {
         auto &lower = d_data->getLower(leafParents[tid]);
         auto &leaf = d_data->getLeaf(tid);
         leaf.updateBBox();
@@ -539,7 +556,7 @@ template <typename BuildT>
 struct PropagateLowerBBoxFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data, const uint32_t* lowerParents) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data, const uint32_t* lowerParents) {
         auto &upper = d_data->getUpper(lowerParents[tid]);
         auto &lower = d_data->getLower(tid);
         upper.mBBox.expandAtomic(lower.bbox()); }
@@ -549,7 +566,7 @@ template <typename BuildT>
 struct PropagateUpperBBoxFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data) {
         d_data->getRoot().mBBox.expandAtomic(d_data->getUpper(tid).bbox());
     }
 };
@@ -558,7 +575,7 @@ template <typename BuildT>
 struct UpdateRootWorldBBoxFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data) {
         // TODO: check that the correct semantics are followed in this transformation
         auto BBox = d_data->getRoot().mBBox;
         BBox.max() += 1;
@@ -605,7 +622,7 @@ template <typename BuildT>
 struct PostProcessGridTreeFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data, uint64_t* d_voxelOffsets) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data, uint64_t* d_voxelOffsets) {
         auto& grid = d_data->getGrid();
         auto& tree = grid.tree();
         auto leafCount = tree.mNodeCount[0];

--- a/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
+++ b/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
@@ -52,7 +52,7 @@ struct TopologyBuilderData {
 
 }// namespace topology::detail
 
-template <typename BuildT, typename ScratchBufferT = nanovdb::cuda::DeviceBuffer>
+template <typename BuildT, typename ScratchBufferT>
 class TopologyBuilder
 {
     static_assert(nanovdb::BuildTraits<BuildT>::is_onindex);// For now, only OnIndexGrids supported

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -3546,33 +3546,35 @@ TEST(TestNanoVDBCUDA, VoxelBlockManager_ValueOnIndex_UnifiedBuffer)
     testVoxelBlockManager<nanovdb::ValueOnIndex,nanovdb::cuda::UnifiedBuffer>();
 }// VoxelBlockManager_ValueOnIndex_UnifiedBuffer
 
-TEST(TestNanoVDBCUDA, DilateInjectPrune_ValueOnIndex)
+// Templatized on the operator scratch-buffer type and the output (grid handle) buffer
+// type, so the same body can be instantiated for different buffer combinations.
+// The input grid is always built with DeviceBuffer; only the operators' scratch and
+// output buffers vary. Pre-download grid() null checks (DeviceBuffer-specific lazy
+// download) are intentionally omitted so the body is buffer-type agnostic.
+template<class BuildT, class ScratchBufferT, class OutputBufferT>
+void testDilateInjectPrune()
 {
-    using BuildT = nanovdb::ValueOnIndex;
-
     // Create an input (original) grid to use as input to dilation op
     std::vector<nanovdb::Coord> inputPoints;
     inputPoints.emplace_back(1,0,0); // Added nodes after dilation: 3 root, 3 upper, 3 lower, 3 leaf
     inputPoints.emplace_back(0,1,1); // Added nodes after dilation: 1 root, 1 upper, 1 lower, 1 leaf
     inputPoints.emplace_back(127,127,127); // Added nodes after dilation: 7 lower, 7 leaf
     auto inputBuffer = nanovdb::cuda::DeviceBuffer::create( inputPoints.size() * sizeof(nanovdb::Coord), nullptr, false);
-    EXPECT_FALSE(inputBuffer.data());
     EXPECT_TRUE(inputBuffer.deviceData());
     cudaCheck(cudaMemcpy(inputBuffer.deviceData(), inputPoints.data(), inputPoints.size() * sizeof(nanovdb::Coord), cudaMemcpyHostToDevice));
     nanovdb::tools::cuda::PointsToGrid<BuildT> converter;
     converter.setChecksum(nanovdb::CheckMode::Default);
     auto inputHandle = converter.getHandle(static_cast<nanovdb::Coord*>(inputBuffer.deviceData()), inputPoints.size());
-    EXPECT_TRUE(inputHandle.deviceGrid<BuildT>());
-    auto inputGrid = inputHandle.deviceGrid<BuildT>();
-    EXPECT_FALSE(inputHandle.grid<BuildT>());
+    auto inputGrid = inputHandle.template deviceGrid<BuildT>();
+    EXPECT_TRUE(inputGrid);
 
-    // Perform dilation
-    nanovdb::tools::cuda::DilateGrid<BuildT> dilator( inputGrid );
+    // Perform dilation (scratch through ScratchBufferT, output handle as OutputBufferT)
+    nanovdb::tools::cuda::DilateGrid<BuildT, ScratchBufferT> dilator( inputGrid );
     dilator.setOperation(nanovdb::tools::morphology::NN_FACE_EDGE_VERTEX);
     dilator.setChecksum(nanovdb::CheckMode::Default);
     dilator.setVerbose(0);
-    auto dilatedHandle = dilator.getHandle();
-    auto dilatedGrid = dilatedHandle.deviceGrid<BuildT>();
+    auto dilatedHandle = dilator.template getHandle<OutputBufferT>();
+    auto dilatedGrid = dilatedHandle.template deviceGrid<BuildT>();
     EXPECT_TRUE(dilatedGrid);
     auto dilatedTreeData = nanovdb::util::cuda::DeviceGridTraits<BuildT>::getTreeData(dilatedGrid);
     EXPECT_EQ(dilatedTreeData.mNodeCount[0], 13);
@@ -3591,26 +3593,34 @@ TEST(TestNanoVDBCUDA, DilateInjectPrune_ValueOnIndex)
         inputGrid, dilatedGrid, leafMasks);
 
     // Prune with computed mask
-    nanovdb::tools::cuda::PruneGrid<BuildT> pruner( dilatedGrid, leafMasks );
+    nanovdb::tools::cuda::PruneGrid<BuildT, ScratchBufferT> pruner( dilatedGrid, leafMasks );
     pruner.setChecksum(nanovdb::CheckMode::Default);
     pruner.setVerbose(0);
-    auto prunedHandle = pruner.getHandle();
-    auto prunedGrid = prunedHandle.deviceGrid<BuildT>();
+    auto prunedHandle = pruner.template getHandle<OutputBufferT>();
+    auto prunedGrid = prunedHandle.template deviceGrid<BuildT>();
     EXPECT_TRUE(prunedGrid);
 
     // The pruned grid should be identical to the original input
-    EXPECT_FALSE(prunedHandle.grid<BuildT>());
     inputHandle.deviceDownload();
     prunedHandle.deviceDownload();
-    EXPECT_TRUE(inputHandle.grid<BuildT>());
-    EXPECT_TRUE(prunedHandle.grid<BuildT>());
-    EXPECT_EQ(inputHandle.grid<BuildT>()->mChecksum.full(), prunedHandle.grid<BuildT>()->mChecksum.full());
+    EXPECT_TRUE(inputHandle.template grid<BuildT>());
+    EXPECT_TRUE(prunedHandle.template grid<BuildT>());
+    EXPECT_EQ(inputHandle.template grid<BuildT>()->mChecksum.full(), prunedHandle.template grid<BuildT>()->mChecksum.full());
+}// testDilateInjectPrune
+
+TEST(TestNanoVDBCUDA, DilateInjectPrune_ValueOnIndex)
+{
+    testDilateInjectPrune<nanovdb::ValueOnIndex, nanovdb::cuda::DeviceBuffer, nanovdb::cuda::DeviceBuffer>();
 }// DilateInjectPrune_ValueOnIndex
 
-TEST(TestNanoVDBCUDA, RefineCoarsen_ValueOnIndex)
+TEST(TestNanoVDBCUDA, DilateInjectPrune_ValueOnIndex_UnifiedBuffer)
 {
-    using BuildT = nanovdb::ValueOnIndex;
+    testDilateInjectPrune<nanovdb::ValueOnIndex, nanovdb::cuda::UnifiedBuffer, nanovdb::cuda::UnifiedBuffer>();
+}// DilateInjectPrune_ValueOnIndex_UnifiedBuffer
 
+template<class BuildT, class ScratchBufferT, class OutputBufferT>
+void testRefineCoarsen()
+{
     // Create an input (original) grid to use as input to refinement op
     std::vector<nanovdb::Coord> inputPoints;
     inputPoints.emplace_back(0,0,0); // Refinement doesn't introduce extra nodes
@@ -3618,22 +3628,20 @@ TEST(TestNanoVDBCUDA, RefineCoarsen_ValueOnIndex)
     inputPoints.emplace_back(0,64,0); // Refinement will introduce extra lower node
     inputPoints.emplace_back(0,0,2048); // Refinement will introduce extra upper node (and root tile)
     auto inputBuffer = nanovdb::cuda::DeviceBuffer::create( inputPoints.size() * sizeof(nanovdb::Coord), nullptr, false);
-    EXPECT_FALSE(inputBuffer.data());
     EXPECT_TRUE(inputBuffer.deviceData());
     cudaCheck(cudaMemcpy(inputBuffer.deviceData(), inputPoints.data(), inputPoints.size() * sizeof(nanovdb::Coord), cudaMemcpyHostToDevice));
     nanovdb::tools::cuda::PointsToGrid<BuildT> converter;
     converter.setChecksum(nanovdb::CheckMode::Default);
     auto inputHandle = converter.getHandle(static_cast<nanovdb::Coord*>(inputBuffer.deviceData()), inputPoints.size());
-    EXPECT_TRUE(inputHandle.deviceGrid<BuildT>());
-    auto inputGrid = inputHandle.deviceGrid<BuildT>();
-    EXPECT_FALSE(inputHandle.grid<BuildT>());
+    auto inputGrid = inputHandle.template deviceGrid<BuildT>();
+    EXPECT_TRUE(inputGrid);
 
-    // Perform refinement
-    nanovdb::tools::cuda::RefineGrid<BuildT> refiner( inputGrid );
+    // Perform refinement (scratch through ScratchBufferT, output handle as OutputBufferT)
+    nanovdb::tools::cuda::RefineGrid<BuildT, ScratchBufferT> refiner( inputGrid );
     refiner.setChecksum(nanovdb::CheckMode::Default);
     refiner.setVerbose(0);
-    auto refinedHandle = refiner.getHandle();
-    auto refinedGrid = refinedHandle.deviceGrid<BuildT>();
+    auto refinedHandle = refiner.template getHandle<OutputBufferT>();
+    auto refinedGrid = refinedHandle.template deviceGrid<BuildT>();
     EXPECT_TRUE(refinedGrid);
     auto refinedTreeData = nanovdb::util::cuda::DeviceGridTraits<BuildT>::getTreeData(refinedGrid);
     EXPECT_EQ(refinedTreeData.mNodeCount[0], 4);
@@ -3642,26 +3650,34 @@ TEST(TestNanoVDBCUDA, RefineCoarsen_ValueOnIndex)
     EXPECT_EQ(refinedTreeData.mVoxelCount, 32);
 
     // Coarsen back to original
-    nanovdb::tools::cuda::CoarsenGrid<BuildT> coarsener( refinedGrid );
+    nanovdb::tools::cuda::CoarsenGrid<BuildT, ScratchBufferT> coarsener( refinedGrid );
     coarsener.setChecksum(nanovdb::CheckMode::Default);
     coarsener.setVerbose(0);
-    auto coarsenedHandle = coarsener.getHandle();
-    auto coarsenedGrid = coarsenedHandle.deviceGrid<BuildT>();
+    auto coarsenedHandle = coarsener.template getHandle<OutputBufferT>();
+    auto coarsenedGrid = coarsenedHandle.template deviceGrid<BuildT>();
     EXPECT_TRUE(coarsenedGrid);
 
     // The coarsened grid should be identical to the original input
-    EXPECT_FALSE(coarsenedHandle.grid<BuildT>());
     inputHandle.deviceDownload();
     coarsenedHandle.deviceDownload();
-    EXPECT_TRUE(inputHandle.grid<BuildT>());
-    EXPECT_TRUE(coarsenedHandle.grid<BuildT>());
-    EXPECT_EQ(inputHandle.grid<BuildT>()->mChecksum.full(), coarsenedHandle.grid<BuildT>()->mChecksum.full());
+    EXPECT_TRUE(inputHandle.template grid<BuildT>());
+    EXPECT_TRUE(coarsenedHandle.template grid<BuildT>());
+    EXPECT_EQ(inputHandle.template grid<BuildT>()->mChecksum.full(), coarsenedHandle.template grid<BuildT>()->mChecksum.full());
+}// testRefineCoarsen
+
+TEST(TestNanoVDBCUDA, RefineCoarsen_ValueOnIndex)
+{
+    testRefineCoarsen<nanovdb::ValueOnIndex, nanovdb::cuda::DeviceBuffer, nanovdb::cuda::DeviceBuffer>();
 }// RefineCoarsen_ValueOnIndex
 
-TEST(TestNanoVDBCUDA, MergeGrids_ValueOnIndex)
+TEST(TestNanoVDBCUDA, RefineCoarsen_ValueOnIndex_UnifiedBuffer)
 {
-    using BuildT = nanovdb::ValueOnIndex;
+    testRefineCoarsen<nanovdb::ValueOnIndex, nanovdb::cuda::UnifiedBuffer, nanovdb::cuda::UnifiedBuffer>();
+}// RefineCoarsen_ValueOnIndex_UnifiedBuffer
 
+template<class BuildT, class ScratchBufferT, class OutputBufferT>
+void testMergeGrids()
+{
     // Create the first input grid for the merge op
     std::vector<nanovdb::Coord> inputPointsA;
     for (int i = 0; i <= 2; i++)
@@ -3669,13 +3685,11 @@ TEST(TestNanoVDBCUDA, MergeGrids_ValueOnIndex)
             for (int k = 0; k <= 2; k++)
                 inputPointsA.emplace_back(i-1, j*8-1, k*128); // 4 upper, 12 lower, 18 leaf nodes
     auto inputBufferA = nanovdb::cuda::DeviceBuffer::create( inputPointsA.size() * sizeof(nanovdb::Coord), nullptr, false);
-    EXPECT_FALSE(inputBufferA.data());
     EXPECT_TRUE(inputBufferA.deviceData());
     cudaCheck(cudaMemcpy(inputBufferA.deviceData(), inputPointsA.data(), inputPointsA.size() * sizeof(nanovdb::Coord), cudaMemcpyHostToDevice));
     auto inputHandleA = nanovdb::tools::cuda::voxelsToGrid<BuildT>(static_cast<nanovdb::Coord*>(inputBufferA.deviceData()), inputPointsA.size());
-    EXPECT_TRUE(inputHandleA.deviceGrid<BuildT>());
-    auto inputGridA = inputHandleA.deviceGrid<BuildT>();
-    EXPECT_FALSE(inputHandleA.grid<BuildT>());
+    auto inputGridA = inputHandleA.template deviceGrid<BuildT>();
+    EXPECT_TRUE(inputGridA);
 
     // Create the second input grid for the merge op
     std::vector<nanovdb::Coord> inputPointsB;
@@ -3684,27 +3698,35 @@ TEST(TestNanoVDBCUDA, MergeGrids_ValueOnIndex)
             for (int k = 0; k <= 2; k++)
                 inputPointsB.emplace_back(i, j*8-1, (k-1)*128); // 4 upper, 6 lower, 9 leaf nodes
     auto inputBufferB = nanovdb::cuda::DeviceBuffer::create( inputPointsB.size() * sizeof(nanovdb::Coord), nullptr, false);
-    EXPECT_FALSE(inputBufferB.data());
     EXPECT_TRUE(inputBufferB.deviceData());
     cudaCheck(cudaMemcpy(inputBufferB.deviceData(), inputPointsB.data(), inputPointsB.size() * sizeof(nanovdb::Coord), cudaMemcpyHostToDevice));
     auto inputHandleB = nanovdb::tools::cuda::voxelsToGrid<BuildT>(static_cast<nanovdb::Coord*>(inputBufferB.deviceData()), inputPointsB.size());
-    EXPECT_TRUE(inputHandleB.deviceGrid<BuildT>());
-    auto inputGridB = inputHandleB.deviceGrid<BuildT>();
-    EXPECT_FALSE(inputHandleB.grid<BuildT>());
+    auto inputGridB = inputHandleB.template deviceGrid<BuildT>();
+    EXPECT_TRUE(inputGridB);
 
-    // Perform the merge operation
-    nanovdb::tools::cuda::MergeGrids<BuildT> merger( inputGridA, inputGridB );
+    // Perform the merge operation (scratch through ScratchBufferT, output as OutputBufferT)
+    nanovdb::tools::cuda::MergeGrids<BuildT, ScratchBufferT> merger( inputGridA, inputGridB );
     merger.setChecksum(nanovdb::CheckMode::Disable);
     merger.setVerbose(0);
-    auto mergedHandle = merger.getHandle();
-    auto mergedGrid = mergedHandle.deviceGrid<BuildT>();
+    auto mergedHandle = merger.template getHandle<OutputBufferT>();
+    auto mergedGrid = mergedHandle.template deviceGrid<BuildT>();
     EXPECT_TRUE(mergedGrid);
     auto mergedTreeData = nanovdb::util::cuda::DeviceGridTraits<BuildT>::getTreeData(mergedGrid);
     EXPECT_EQ(mergedTreeData.mNodeCount[0], 21);
     EXPECT_EQ(mergedTreeData.mNodeCount[1], 14);
     EXPECT_EQ(mergedTreeData.mNodeCount[2], 6);
     EXPECT_EQ(mergedTreeData.mVoxelCount, 42); // Each input grid has 27 active voxels, 12 shared between the two
-}// DilateInjectPrune_ValueOnIndex
+}// testMergeGrids
+
+TEST(TestNanoVDBCUDA, MergeGrids_ValueOnIndex)
+{
+    testMergeGrids<nanovdb::ValueOnIndex, nanovdb::cuda::DeviceBuffer, nanovdb::cuda::DeviceBuffer>();
+}// MergeGrids_ValueOnIndex
+
+TEST(TestNanoVDBCUDA, MergeGrids_ValueOnIndex_UnifiedBuffer)
+{
+    testMergeGrids<nanovdb::ValueOnIndex, nanovdb::cuda::UnifiedBuffer, nanovdb::cuda::UnifiedBuffer>();
+}// MergeGrids_ValueOnIndex_UnifiedBuffer
 
 TEST(TestNanoVDBCUDA, GridHandle_from_HostBuffer)
 {
@@ -3759,10 +3781,9 @@ TEST(TestNanoVDBCUDA, MeshToGrid_EmptyMesh)
     EXPECT_EQ(grid->tree().activeVoxelCount(), 0);
 }// MeshToGrid_EmptyMesh
 
-TEST(TestNanoVDBCUDA, MeshToGrid_UnitTetrahedron)
+template<class BuildT, class ScratchBufferT, class GridBufferT, class SidecarBufferT>
+void testMeshToGridUnitTetrahedron()
 {
-    using BuildT = nanovdb::ValueOnIndex;
-
     // Unit tetrahedron: four vertices, four triangular faces.
     // Vertex coordinates are in world space.
     const std::vector<nanovdb::Vec3f> hostPoints = {
@@ -3825,25 +3846,25 @@ TEST(TestNanoVDBCUDA, MeshToGrid_UnitTetrahedron)
     // --- Topology-only path ---
     uint64_t topoChecksum = 0;
     {
-        nanovdb::tools::cuda::MeshToGrid<BuildT> conv(dPoints, nPoints, dTriangles, nTriangles, map);
+        nanovdb::tools::cuda::MeshToGrid<BuildT, ScratchBufferT> conv(dPoints, nPoints, dTriangles, nTriangles, map);
         conv.setVerbose(0);
         conv.setChecksum(nanovdb::CheckMode::Full);
-        auto handle = conv.getHandle();
+        auto handle = conv.template getHandle<GridBufferT>();
         handle.deviceDownload();
-        const auto* topoGrid = handle.grid<BuildT>();
+        const auto* topoGrid = handle.template grid<BuildT>();
         ASSERT_NE(topoGrid, nullptr);
         topoChecksum = topoGrid->mChecksum.full();
         EXPECT_GT(topoGrid->tree().activeVoxelCount(), uint64_t(0));
     }
 
     // --- UDF path ---
-    nanovdb::tools::cuda::MeshToGrid<BuildT> converter(dPoints, nPoints, dTriangles, nTriangles, map);
+    nanovdb::tools::cuda::MeshToGrid<BuildT, ScratchBufferT> converter(dPoints, nPoints, dTriangles, nTriangles, map);
     converter.setVerbose(0);
     converter.setChecksum(nanovdb::CheckMode::Full);
-    auto [handle, sidecarBuf] = converter.getHandleAndUDF();
+    auto [handle, sidecarBuf] = converter.template getHandleAndUDF<GridBufferT, SidecarBufferT>();
 
     handle.deviceDownload();
-    const auto* grid = handle.grid<BuildT>();
+    const auto* grid = handle.template grid<BuildT>();
     ASSERT_NE(grid, nullptr);
 
     const uint64_t sidecarCount = sidecarBuf.size() / sizeof(float);
@@ -3917,4 +3938,16 @@ TEST(TestNanoVDBCUDA, MeshToGrid_UnitTetrahedron)
 
     // getHandle() and getHandleAndUDF() must produce identical grids.
     EXPECT_EQ(grid->mChecksum.full(), topoChecksum);
+}// testMeshToGridUnitTetrahedron
+
+TEST(TestNanoVDBCUDA, MeshToGrid_UnitTetrahedron)
+{
+    testMeshToGridUnitTetrahedron<nanovdb::ValueOnIndex, nanovdb::cuda::DeviceBuffer,
+                                  nanovdb::cuda::DeviceBuffer, nanovdb::cuda::DeviceBuffer>();
 }// MeshToGrid_UnitTetrahedron
+
+TEST(TestNanoVDBCUDA, MeshToGrid_UnitTetrahedron_UnifiedBuffer)
+{
+    testMeshToGridUnitTetrahedron<nanovdb::ValueOnIndex, nanovdb::cuda::UnifiedBuffer,
+                                  nanovdb::cuda::UnifiedBuffer, nanovdb::cuda::UnifiedBuffer>();
+}// MeshToGrid_UnitTetrahedron_UnifiedBuffer


### PR DESCRIPTION
> ⚠️ **[WIP — please don't review yet]** This is a draft to share direction and run CI early. The API and commit history are still in flux.

## Summary

Make the **transient scratch buffer type** a (defaulted) template parameter of the CUDA topology/rasterization operators, so a downstream can inject its own buffer type for nanoVDB's internal scratch allocations **without forking any nanoVDB headers**.

Today these operators hardcode `nanovdb::cuda::DeviceBuffer` (i.e. `cudaMallocAsync`/`cudaFreeAsync`) for all of their internal scratch. A consumer that manages GPU memory through a different allocator — e.g. PyTorch's caching allocator in [fvdb-core](https://github.com/openvdb/fvdb-core) — currently has to **fork the headers** to redirect those allocations, otherwise the two allocator pools fragment each other and large workloads hit OOM. (See fvdb-core #655 for the workaround this is meant to replace.)

With this change the consumer instead instantiates the operator with its own `ScratchBufferT`, no patching required.

## Design

- New **`ScratchBufferT`** template parameter on the operators, used for all device-only scratch.
  - **Defaulted to `nanovdb::cuda::DeviceBuffer`** on the public operators, so existing call sites and behavior are unchanged (byte-identical under the default).
  - **Independent from the output buffer type.** The grid the caller receives is still controlled by the existing `getHandle<BufferT>()` parameter; scratch is a separate axis. So you can mix, e.g. `ScratchBufferT = DeviceBuffer` with output `BufferT = UnifiedBuffer`, or vice-versa.
- The shared internal helper `TopologyBuilder` takes `ScratchBufferT` as a **non-defaulted** parameter (it's an implementation detail; the default belongs only on the public operators). This way an operator that forgets to forward the type fails to compile rather than silently falling back to `DeviceBuffer`.
- A scratch buffer type only needs a small interface: `create(bytes, pool*, device, stream)`, `deviceData()`, and `clear(stream)`.

## What's covered

- `tools/cuda/TopologyBuilder.cuh` — the shared scratch (masks, offsets, parents, count buffers).
- `tools/cuda/{DilateGrid,PruneGrid,MergeGrids,CoarsenGrid,RefineGrid}.cuh` — thread the parameter through to `TopologyBuilder`.
- `tools/cuda/MeshToGrid.cuh` — its own scratch (transformed triangles, box/triangle pairs, sort/scan temporaries, etc.), plus its internal `PruneGrid`.

Supporting changes:
- Lifted `TopologyBuilder::Data` and `MeshToGrid::BoxTrianglePair` out to namespace scope (they don't depend on the scratch type), so the device functors that reference them see one consistent type across instantiations.
- `cuda::UnifiedBuffer`: added a stream-accepting `clear(cudaStream_t)` overload so it satisfies the scratch interface.
- `MeshToGrid::getHandleAndUDF` now actually honors its `SidecarBufferT` parameter (it previously hardcoded `DeviceBuffer` for the UDF sidecar allocation).

## Dual-use buffers (intentionally left as `DeviceBuffer` for now)

Two buffers are host-populated and then uploaded (`TopologyBuilder::mProcessedRoot`, `mData`). These remain `DeviceBuffer` in this pass. The clean follow-up is to split each into a host buffer + a device `ScratchBufferT` half with an explicit copy between them; the parameter introduced here is already sufficient for that device half.

## Testing

- The CUDA topology unit tests (`DilateInjectPrune`, `RefineCoarsen`, `MergeGrids`, `MeshToGrid_UnitTetrahedron`) were refactored into helpers templated on every buffer axis (scratch / grid-output / sidecar-output), following the existing `testVoxelBlockManager<BuildT, BufferT>` pattern, and are instantiated for both **all-`DeviceBuffer`** and **all-`UnifiedBuffer`**. All pass; results are identical between the two buffer types.
- Full `TestNanoVDB.cu` CUDA suite is green except one pre-existing, unrelated failure (`UnifiedBuffer_IO`, a missing test-data fixture).
- The `ex_dilate` / `ex_refine` / `ex_coarsen` / `ex_mesh_to_grid` CUDA examples build and run against OpenVDB references with correct results.

## Notes for later (not for review yet)

- A working design note (`TEMPLATIZED_BUFFERS_PLAN.md`) is currently committed at the repo root and will be removed before this is opened for real review.
- Commit history is intentionally milestone-by-milestone and may be squashed/rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
