### PR TITLE
NanoVDB: add stream-ordered async memory-resource seam (CUDA)

### DIFF
--- a/nanovdb/nanovdb/cuda/DeviceResource.h
+++ b/nanovdb/nanovdb/cuda/DeviceResource.h
@@ -7,10 +7,23 @@
 #include <cuda_runtime_api.h>
 #include <nanovdb/util/cuda/Util.h>
 
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
 namespace nanovdb {
 
 namespace cuda {
 
+/// @brief Default stream-ordered device memory resource. Allocations are made
+///        with cudaMallocAsync and freed with cudaFreeAsync via the
+///        util::cuda wrappers.
+/// @note Exposes both the legacy static methods (allocateAsync /
+///       deallocateAsync, retained for source compatibility) and the
+///       instance methods (allocate_async / deallocate_async) that model
+///       the AsyncResource concept. The instance methods forward to the
+///       static ones, so a default-constructed instance is stateless and
+///       adds no overhead.
 class DeviceResource
 {
 public:
@@ -26,7 +39,49 @@ public:
     static void deallocateAsync(void *p, size_t, size_t, cudaStream_t stream) {
         cudaCheck(util::cuda::freeAsync(p, stream));
     }
+
+    /// @brief Instance allocation entry point modelling the AsyncResource concept.
+    /// @param bytes number of bytes to allocate
+    /// @param alignment requested alignment (cudaMallocAsync always 256B-aligns)
+    /// @param stream cuda stream the allocation is ordered on
+    void* allocate_async(size_t bytes, size_t alignment, cudaStream_t stream) {
+        return allocateAsync(bytes, alignment, stream);
+    }
+
+    /// @brief Instance deallocation entry point modelling the AsyncResource concept.
+    /// @param p pointer previously returned by allocate_async
+    /// @param bytes size passed to the matching allocate_async
+    /// @param alignment alignment passed to the matching allocate_async
+    /// @param stream cuda stream the deallocation is ordered on
+    void deallocate_async(void* p, size_t bytes, size_t alignment, cudaStream_t stream) {
+        deallocateAsync(p, bytes, alignment, stream);
+    }
 };
+
+/// @brief Returns a program-lifetime, address-stable reference to a default
+///        instance of resource @c R.
+/// @details The instance is a function-local static, so it outlives every
+///          caller and is safe to bind through a default function/constructor
+///          argument. @c R must be default-constructible.
+template <class R>
+inline R& default_resource()
+{
+    static R sResource;
+    return sResource;
+}
+
+/// @brief Detection trait: @c is_async_resource<R>::value is true iff @c R
+///        models the stream-ordered AsyncResource concept, i.e. exposes
+///        allocate_async(size_t, size_t, cudaStream_t) and
+///        deallocate_async(void*, size_t, size_t, cudaStream_t).
+template <class R, class = void>
+struct is_async_resource : std::false_type {};
+
+template <class R>
+struct is_async_resource<R, std::void_t<
+    decltype(std::declval<R&>().allocate_async(size_t{0}, size_t{0}, cudaStream_t{0})),
+    decltype(std::declval<R&>().deallocate_async(std::declval<void*>(), size_t{0}, size_t{0}, cudaStream_t{0}))>>
+    : std::true_type {};
 
 }
 

--- a/nanovdb/nanovdb/cuda/DeviceResource.h
+++ b/nanovdb/nanovdb/cuda/DeviceResource.h
@@ -74,6 +74,19 @@ inline R& default_resource()
 ///        models the stream-ordered AsyncResource concept, i.e. exposes
 ///        allocate_async(size_t, size_t, cudaStream_t) and
 ///        deallocate_async(void*, size_t, size_t, cudaStream_t).
+/// @details Use it to dispatch between a stream-ordered resource and a
+///          synchronous one (which exposes allocate/deallocate without a
+///          stream argument):
+/// @code
+/// template<typename R>
+/// void* allocate(R& resource, size_t bytes, size_t alignment, cudaStream_t stream)
+/// {
+///     if constexpr (nanovdb::cuda::is_async_resource<R>::value)
+///         return resource.allocate_async(bytes, alignment, stream); // stream-ordered
+///     else
+///         return resource.allocate(bytes, alignment);               // synchronous
+/// }
+/// @endcode
 template <class R, class = void>
 struct is_async_resource : std::false_type {};
 

--- a/nanovdb/nanovdb/cuda/PinnedResource.h
+++ b/nanovdb/nanovdb/cuda/PinnedResource.h
@@ -17,44 +17,37 @@ namespace cuda {
 ///        host memory (cudaMallocHost) that is both host-accessible and
 ///        device-accessible, so it can serve as the host side of an
 ///        asynchronous host<->device copy.
-/// @note The default implementation is *synchronous*: cudaMallocHost /
-///       cudaFreeHost ignore the supplied stream and synchronize the context.
-///       The stream parameter is accepted purely so this type models the same
-///       AsyncResource shape as cuda::DeviceResource; the reason the resource
-///       is a seam at all is so callers can substitute a pooled / genuinely
-///       stream-ordered pinned-host resource and avoid that synchronization.
+/// @note This resource is *synchronous*: cudaMallocHost / cudaFreeHost
+///       synchronize the context, so it models the synchronous Resource
+///       concept (allocate / deallocate, no stream) rather than the
+///       stream-ordered AsyncResource concept. It is a seam so callers can
+///       substitute a pooled / genuinely stream-ordered pinned-host resource
+///       and avoid that synchronization.
 class PinnedResource
 {
 public:
-    // cudaMallocHost over-aligns (to at least the page size); 256 is the
-    // nominal default this resource advertises through the AsyncResource API.
+    // cudaMallocHost over-aligns (to at least the page size), so the requested
+    // alignment is always satisfied; 256 is the nominal default advertised here.
     static constexpr size_t DEFAULT_ALIGNMENT = 256;
 
-    static void* allocateAsync(size_t bytes, size_t, cudaStream_t) {
+    /// @brief Synchronous allocation of page-locked host memory.
+    /// @param bytes number of bytes to allocate
+    /// @param alignment requested alignment (ignored; cudaMallocHost is page-aligned)
+    void* allocate(size_t bytes, size_t alignment) {
+        (void)alignment;
         void* p = nullptr;
         cudaCheck(cudaMallocHost(&p, bytes));
         return p;
     }
 
-    static void deallocateAsync(void* p, size_t, size_t, cudaStream_t) {
+    /// @brief Synchronous deallocation.
+    /// @param p pointer previously returned by allocate
+    /// @param bytes size passed to the matching allocate (unused)
+    /// @param alignment alignment passed to the matching allocate (unused)
+    void deallocate(void* p, size_t bytes, size_t alignment) {
+        (void)bytes;
+        (void)alignment;
         cudaCheck(cudaFreeHost(p));
-    }
-
-    /// @brief Instance allocation entry point modelling the AsyncResource concept.
-    /// @param bytes number of bytes to allocate
-    /// @param alignment requested alignment (cudaMallocHost is page-aligned)
-    /// @param stream cuda stream (ignored by the synchronous default impl)
-    void* allocate_async(size_t bytes, size_t alignment, cudaStream_t stream) {
-        return allocateAsync(bytes, alignment, stream);
-    }
-
-    /// @brief Instance deallocation entry point modelling the AsyncResource concept.
-    /// @param p pointer previously returned by allocate_async
-    /// @param bytes size passed to the matching allocate_async
-    /// @param alignment alignment passed to the matching allocate_async
-    /// @param stream cuda stream (ignored by the synchronous default impl)
-    void deallocate_async(void* p, size_t bytes, size_t alignment, cudaStream_t stream) {
-        deallocateAsync(p, bytes, alignment, stream);
     }
 };
 

--- a/nanovdb/nanovdb/cuda/PinnedResource.h
+++ b/nanovdb/nanovdb/cuda/PinnedResource.h
@@ -1,0 +1,65 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef NANOVDB_CUDA_PINNEDRESOURCE_H_HAS_BEEN_INCLUDED
+#define NANOVDB_CUDA_PINNEDRESOURCE_H_HAS_BEEN_INCLUDED
+
+#include <cuda_runtime_api.h>
+#include <nanovdb/util/cuda/Util.h>
+
+#include <cstddef>
+
+namespace nanovdb {
+
+namespace cuda {
+
+/// @brief Default host-pinned memory resource. Allocations are page-locked
+///        host memory (cudaMallocHost) that is both host-accessible and
+///        device-accessible, so it can serve as the host side of an
+///        asynchronous host<->device copy.
+/// @note The default implementation is *synchronous*: cudaMallocHost /
+///       cudaFreeHost ignore the supplied stream and synchronize the context.
+///       The stream parameter is accepted purely so this type models the same
+///       AsyncResource shape as cuda::DeviceResource; the reason the resource
+///       is a seam at all is so callers can substitute a pooled / genuinely
+///       stream-ordered pinned-host resource and avoid that synchronization.
+class PinnedResource
+{
+public:
+    // cudaMallocHost over-aligns (to at least the page size); 256 is the
+    // nominal default this resource advertises through the AsyncResource API.
+    static constexpr size_t DEFAULT_ALIGNMENT = 256;
+
+    static void* allocateAsync(size_t bytes, size_t, cudaStream_t) {
+        void* p = nullptr;
+        cudaCheck(cudaMallocHost(&p, bytes));
+        return p;
+    }
+
+    static void deallocateAsync(void* p, size_t, size_t, cudaStream_t) {
+        cudaCheck(cudaFreeHost(p));
+    }
+
+    /// @brief Instance allocation entry point modelling the AsyncResource concept.
+    /// @param bytes number of bytes to allocate
+    /// @param alignment requested alignment (cudaMallocHost is page-aligned)
+    /// @param stream cuda stream (ignored by the synchronous default impl)
+    void* allocate_async(size_t bytes, size_t alignment, cudaStream_t stream) {
+        return allocateAsync(bytes, alignment, stream);
+    }
+
+    /// @brief Instance deallocation entry point modelling the AsyncResource concept.
+    /// @param p pointer previously returned by allocate_async
+    /// @param bytes size passed to the matching allocate_async
+    /// @param alignment alignment passed to the matching allocate_async
+    /// @param stream cuda stream (ignored by the synchronous default impl)
+    void deallocate_async(void* p, size_t bytes, size_t alignment, cudaStream_t stream) {
+        deallocateAsync(p, bytes, alignment, stream);
+    }
+};
+
+}
+
+} // namespace nanovdb::cuda
+
+#endif // end of NANOVDB_CUDA_PINNEDRESOURCE_H_HAS_BEEN_INCLUDED

--- a/nanovdb/nanovdb/cuda/TempPool.h
+++ b/nanovdb/nanovdb/cuda/TempPool.h
@@ -5,12 +5,15 @@
 ///
 /// @details See nanovdb/tools/cuda/PointToGrid.cuh and nanovdb/tools/cuda/DistributedPointToGrid.cuh
 ///          for examples. Also note that this explains the somewhat unusual API with direct access to
-///          protected member data.
+///          private member data.
 //
 #ifndef NANOVDB_CUDA_TEMPPOOL_H_HAS_BEEN_INCLUDED
 #define NANOVDB_CUDA_TEMPPOOL_H_HAS_BEEN_INCLUDED
 
 #include <nanovdb/cuda/DeviceResource.h>
+
+#include <cstddef>
+#include <cuda_runtime_api.h>
 
 namespace nanovdb {
 
@@ -20,13 +23,21 @@ template <class Resource>
 class TempPool {
 public:
 
-    /// @brief Default c-tor of an empty memory pool.
-    TempPool() : mData(nullptr), mSize(0), mRequestedSize(0) {}
+    /// @brief Default c-tor of an empty memory pool that uses the default
+    ///        instance of @c Resource for all allocations.
+    TempPool() : mResource(&default_resource<Resource>()), mData(nullptr), mSize(0), mRequestedSize(0), mStream(nullptr) {}
 
-    /// @brief Destructor
+    /// @brief C-tor of an empty memory pool that routes all allocations through
+    ///        the supplied @c Resource instance.
+    /// @param resource resource instance to allocate from; must outlive this pool.
+    explicit TempPool(Resource& resource) : mResource(&resource), mData(nullptr), mSize(0), mRequestedSize(0), mStream(nullptr) {}
+
+    /// @brief Destructor. Frees the managed memory on the stream of the most
+    ///        recent reallocate(), so the stream-ordered free is ordered after
+    ///        the work that used the memory (rather than on the null stream).
     ~TempPool() {
         mRequestedSize = 0;
-        Resource::deallocateAsync(mData, mSize, Resource::DEFAULT_ALIGNMENT, nullptr);
+        mResource->deallocate_async(mData, mSize, Resource::DEFAULT_ALIGNMENT, mStream);
         mData = nullptr;
         mSize = 0;
     }
@@ -41,20 +52,27 @@ public:
     /// @note This requested size should always be less than or smaller than the actual size().
     size_t& requestedSize() {return mRequestedSize;}
 
+    /// @brief Returns the stream that the managed memory was last (re)allocated on,
+    ///        i.e. the stream this pool will free on at destruction.
+    cudaStream_t stream() const {return mStream;}
+
     /// @brief Re-allocation of the data managed by this instance. Only has affect if the pool in empty or
     ///        the requested memory is larger than the existing size.
     /// @param stream cuda stream used for asynchronous de-allocation and allocation.
     void reallocate(cudaStream_t stream) {
         if (!mData || mRequestedSize > mSize) {
-            Resource::deallocateAsync(mData, mSize, Resource::DEFAULT_ALIGNMENT, stream);
-            mData = Resource::allocateAsync(mRequestedSize, Resource::DEFAULT_ALIGNMENT, stream);
+            mResource->deallocate_async(mData, mSize, Resource::DEFAULT_ALIGNMENT, stream);
+            mData = mResource->allocate_async(mRequestedSize, Resource::DEFAULT_ALIGNMENT, stream);
             mSize = mRequestedSize;
         }
+        mStream = stream;// retained so the destructor frees on the most-recently-used stream
     }
 private:
-    void  *mData;
-    size_t mSize;
-    size_t mRequestedSize;
+    Resource    *mResource;
+    void        *mData;
+    size_t       mSize;
+    size_t       mRequestedSize;
+    cudaStream_t mStream;
 };// TempPool<Resource> class
 
 using TempDevicePool = TempPool<DeviceResource>;

--- a/nanovdb/nanovdb/tools/cuda/PointsToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/PointsToGrid.cuh
@@ -298,34 +298,36 @@ public:
     /// @brief Map constructor, which other constructors might call
     /// @param map Map to be used for the output device grid
     /// @param stream optional CUDA stream (defaults to CUDA stream 0)
-    PointsToGrid(const Map &map, cudaStream_t stream = 0)
+    PointsToGrid(const Map &map, cudaStream_t stream = 0, ResourceT& resource = nanovdb::cuda::default_resource<ResourceT>())
         : mStream(stream)
+        , mResource(&resource)
         , mTimer(stream)
         , mPointType(util::is_same<BuildT,Point>::value ? PointType::Default : PointType::Disable)
+        , mTempDevicePool(resource)
     {
         mData.map = map;
-        mDeviceData = static_cast<PointsToGridData<BuildT>*>(ResourceT::allocateAsync(sizeof(PointsToGridData<BuildT>), ResourceT::DEFAULT_ALIGNMENT, mStream));
+        mDeviceData = static_cast<PointsToGridData<BuildT>*>(mResource->allocate_async(sizeof(PointsToGridData<BuildT>), ResourceT::DEFAULT_ALIGNMENT, mStream));
     }
 
     /// @brief Default constructor that calls the Map constructor defined above
     /// @param scale Voxel size in world units
     /// @param trans Translation of origin in world units
     /// @param stream optional CUDA stream (defaults to CUDA stream 0)
-    PointsToGrid(const double scale = 1.0, const Vec3d &trans = Vec3d(0.0), cudaStream_t stream = 0)
-        : PointsToGrid(Map(scale, trans), stream){}
+    PointsToGrid(const double scale = 1.0, const Vec3d &trans = Vec3d(0.0), cudaStream_t stream = 0, ResourceT& resource = nanovdb::cuda::default_resource<ResourceT>())
+        : PointsToGrid(Map(scale, trans), stream, resource){}
 
     /// @brief Constructor from a target maximum number of particles per voxel. Calls the Map constructor defined above
     /// @param maxPointsPerVoxel Maximum number of points oer voxel
     /// @param stream optional CUDA stream (defaults to CUDA stream 0)
-    PointsToGrid(int maxPointsPerVoxel, int tolerance = 1, int maxIterations = 10, cudaStream_t stream = 0)
-        : PointsToGrid(Map(1.0), stream)
+    PointsToGrid(int maxPointsPerVoxel, int tolerance = 1, int maxIterations = 10, cudaStream_t stream = 0, ResourceT& resource = nanovdb::cuda::default_resource<ResourceT>())
+        : PointsToGrid(Map(1.0), stream, resource)
     {
         mMaxPointsPerVoxel = maxPointsPerVoxel;
         mTolerance = tolerance;
         mMaxIterations = maxIterations;
     }
 
-    ~PointsToGrid(){ ResourceT::deallocateAsync(mDeviceData, sizeof(PointsToGridData<BuildT>), ResourceT::DEFAULT_ALIGNMENT, mStream); }
+    ~PointsToGrid(){ mResource->deallocate_async(mDeviceData, sizeof(PointsToGridData<BuildT>), ResourceT::DEFAULT_ALIGNMENT, mStream); }
 
     /// @brief Toggle on and off verbose mode
     /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
@@ -384,6 +386,7 @@ private:
     static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
 
     cudaStream_t             mStream{0};
+    ResourceT*               mResource;// non-owning; all device allocations (mDeviceData + scratch) route through this resource instance
     util::cuda::Timer        mTimer;
     PointType                mPointType;
     std::string              mGridName;
@@ -602,13 +605,13 @@ void PointsToGrid<BuildT, ResourceT>::countNodes(const PtrT points, size_t point
 
 jump:// this marks the beginning of the actual algorithm
 
-    mData.d_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
-    mData.d_indx = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));// uint32_t can index 4.29 billion Coords, corresponding to 48 GB
+    mData.d_keys = static_cast<uint64_t*>(mResource->allocate_async(pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    mData.d_indx = static_cast<uint32_t*>(mResource->allocate_async(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));// uint32_t can index 4.29 billion Coords, corresponding to 48 GB
     cudaCheck(cudaMemcpyAsync(mDeviceData, &mData, sizeof(PointsToGridData<BuildT>), cudaMemcpyHostToDevice, mStream));// copy mData from CPU -> GPU
 
     if (mVerbose==2) mTimer.start("\nAllocating arrays for keys and indices");
-    auto *d_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
-    auto *d_indx = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    auto *d_keys = static_cast<uint64_t*>(mResource->allocate_async(pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    auto *d_indx = static_cast<uint32_t*>(mResource->allocate_async(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
 
     if (mVerbose==2) mTimer.restart("Generate tile keys");
     util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, TileKeyFunctor<BuildT, PtrT>(), mDeviceData, points, d_keys, d_indx);
@@ -618,35 +621,35 @@ jump:// this marks the beginning of the actual algorithm
     std::swap(d_indx, mData.d_indx);// sorted indices are now in d_indx
 
     if (mVerbose==2) mTimer.restart("Allocate runs");
-    auto *d_points_per_tile = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
-    uint32_t *d_node_count  = static_cast<uint32_t*>(ResourceT::allocateAsync(3*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    auto *d_points_per_tile = static_cast<uint32_t*>(mResource->allocate_async(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    uint32_t *d_node_count  = static_cast<uint32_t*>(mResource->allocate_async(3*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
 
     if (mVerbose==2) mTimer.restart("DeviceRunLengthEncode tile keys");
     CALL_CUBS(DeviceRunLengthEncode::Encode, mData.d_keys, d_keys, d_points_per_tile, d_node_count+2, pointCount);
     cudaCheck(cudaMemcpyAsync(mData.nodeCount+2, d_node_count+2, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
     cudaCheck(cudaStreamSynchronize(mStream));
-    mData.d_tile_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[2]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    mData.d_tile_keys = static_cast<uint64_t*>(mResource->allocate_async(mData.nodeCount[2]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     cudaCheck(cudaMemcpyAsync(mData.d_tile_keys, d_keys, mData.nodeCount[2]*sizeof(uint64_t), cudaMemcpyDeviceToDevice, mStream));
 
     static constexpr uint32_t SEGMENTED_SORT_TILE_THRESHOLD = 32;
     if (mData.nodeCount[2] >= SEGMENTED_SORT_TILE_THRESHOLD) {
         // Bulk segmented sort: one kernel launch + one segmented radix sort (faster for many tiles)
         if (mVerbose==2) mTimer.restart("Segmented radix sort of " + std::to_string(pointCount) + " voxel keys in " + std::to_string(mData.nodeCount[2]) + " tiles");
-        auto *d_tile_offsets = static_cast<uint32_t*>(ResourceT::allocateAsync((mData.nodeCount[2]+1)*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+        auto *d_tile_offsets = static_cast<uint32_t*>(mResource->allocate_async((mData.nodeCount[2]+1)*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
         cudaCheck(cudaMemsetAsync(d_tile_offsets, 0, sizeof(uint32_t), mStream));
         CALL_CUBS(DeviceScan::InclusiveSum, d_points_per_tile, d_tile_offsets + 1, mData.nodeCount[2]);
-        ResourceT::deallocateAsync(d_points_per_tile, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+        mResource->deallocate_async(d_points_per_tile, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 
         util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, BulkVoxelKeyFunctor<BuildT, PtrT>(), mDeviceData, points, d_tile_offsets, mData.nodeCount[2], d_keys, d_indx, uint32_t(0));
         cudaCheckError();
         CALL_CUBS(DeviceSegmentedRadixSort::SortPairs, d_keys, mData.d_keys, d_indx, mData.d_indx, (int)pointCount, (int)mData.nodeCount[2], d_tile_offsets, d_tile_offsets + 1, 0, 36);
-        ResourceT::deallocateAsync(d_tile_offsets, (mData.nodeCount[2]+1)*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+        mResource->deallocate_async(d_tile_offsets, (mData.nodeCount[2]+1)*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     } else {
         // Serial per-tile sort: individual kernel + sort per tile (lower overhead for few tiles)
         if (mVerbose==2) mTimer.restart("DeviceRadixSort of " + std::to_string(pointCount) + " voxel keys in " + std::to_string(mData.nodeCount[2]) + " tiles");
         uint32_t *points_per_tile = new uint32_t[mData.nodeCount[2]];
         cudaCheck(cudaMemcpyAsync(points_per_tile, d_points_per_tile, mData.nodeCount[2]*sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
-        ResourceT::deallocateAsync(d_points_per_tile, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+        mResource->deallocate_async(d_points_per_tile, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
         for (uint32_t id = 0, offset = 0; id < mData.nodeCount[2]; ++id) {
             const uint32_t count = points_per_tile[id];
             util::cuda::offsetLambdaKernel<<<numBlocks(count), mNumThreads, 0, mStream>>>(count, offset, VoxelKeyFunctor<BuildT, PtrT>(), mDeviceData, points, id, d_keys, d_indx);
@@ -656,27 +659,27 @@ jump:// this marks the beginning of the actual algorithm
         }
         delete [] points_per_tile;
     }
-    ResourceT::deallocateAsync(d_indx, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(d_indx, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 
     if (mVerbose==2) mTimer.restart("Count points per voxel");
 
     cudaEvent_t copyEvent;
     cudaCheck(cudaEventCreate(&copyEvent));
-    mData.pointsPerVoxel    = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
-    uint32_t *d_voxel_count = static_cast<uint32_t*>(ResourceT::allocateAsync(sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    mData.pointsPerVoxel    = static_cast<uint32_t*>(mResource->allocate_async(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    uint32_t *d_voxel_count = static_cast<uint32_t*>(mResource->allocate_async(sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     CALL_CUBS(DeviceRunLengthEncode::Encode, mData.d_keys, d_keys, mData.pointsPerVoxel, d_voxel_count, pointCount);
     cudaCheck(cudaMemcpyAsync(&mData.voxelCount, d_voxel_count, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
     cudaCheck(cudaEventRecord(copyEvent, mStream));
-    ResourceT::deallocateAsync(d_voxel_count, sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(d_voxel_count, sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 
     if (util::is_same<BuildT, Point>::value) {
         if (mVerbose==2) mTimer.restart("Count max points per voxel");
-        uint32_t *d_maxPointsPerVoxel = static_cast<uint32_t*>(ResourceT::allocateAsync(sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream)), maxPointsPerVoxel;
+        uint32_t *d_maxPointsPerVoxel = static_cast<uint32_t*>(mResource->allocate_async(sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream)), maxPointsPerVoxel;
         cudaCheck(cudaEventSynchronize(copyEvent));
         CALL_CUBS(DeviceReduce::Max, mData.pointsPerVoxel, d_maxPointsPerVoxel, mData.voxelCount);
         cudaCheck(cudaMemcpyAsync(&maxPointsPerVoxel, d_maxPointsPerVoxel, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
         cudaCheck(cudaEventRecord(copyEvent, mStream));
-        ResourceT::deallocateAsync(d_maxPointsPerVoxel, sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+        mResource->deallocate_async(d_maxPointsPerVoxel, sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
         double dx = mData.map.getVoxelSize()[0];
         cudaCheck(cudaEventSynchronize(copyEvent));
         if (++iterCounter >= mMaxIterations || pointCount == 1u || math::Abs((int)maxPointsPerVoxel - (int)mMaxPointsPerVoxel) <= mTolerance) {
@@ -697,12 +700,12 @@ jump:// this marks the beginning of the actual algorithm
             }
             if (mVerbose==2) printf("\ntarget density = %" PRIu32 ", current density = %" PRIu32 ", current dx = %f, next dx = %f\n", mMaxPointsPerVoxel, maxPointsPerVoxel, tmp.dx, dx);
             mData.map = Map(dx);
-            ResourceT::deallocateAsync(mData.d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-            ResourceT::deallocateAsync(mData.d_indx, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-            ResourceT::deallocateAsync(d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-            ResourceT::deallocateAsync(mData.d_tile_keys, mData.nodeCount[2]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-            ResourceT::deallocateAsync(d_node_count, 3*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-            ResourceT::deallocateAsync(mData.pointsPerVoxel, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            mResource->deallocate_async(mData.d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            mResource->deallocate_async(mData.d_indx, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            mResource->deallocate_async(d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            mResource->deallocate_async(mData.d_tile_keys, mData.nodeCount[2]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            mResource->deallocate_async(d_node_count, 3*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            mResource->deallocate_async(mData.pointsPerVoxel, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
             goto jump;
         }
     }
@@ -710,16 +713,16 @@ jump:// this marks the beginning of the actual algorithm
 
     if (mVerbose==2) mTimer.restart("Compute prefix sum of points per voxel");
     cudaCheck(cudaEventSynchronize(copyEvent));
-    mData.pointsPerVoxelPrefix = static_cast<uint32_t*>(ResourceT::allocateAsync(mData.voxelCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    mData.pointsPerVoxelPrefix = static_cast<uint32_t*>(mResource->allocate_async(mData.voxelCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     CALL_CUBS(DeviceScan::ExclusiveSum, mData.pointsPerVoxel, mData.pointsPerVoxelPrefix, mData.voxelCount);
 
-    mData.pointsPerLeaf = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    mData.pointsPerLeaf = static_cast<uint32_t*>(mResource->allocate_async(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     CALL_CUBS(DeviceRunLengthEncode::Encode, thrust::make_transform_iterator(mData.d_keys, ShiftRight<9>()), d_keys, mData.pointsPerLeaf, d_node_count, pointCount);
     cudaCheck(cudaMemcpyAsync(mData.nodeCount, d_node_count, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
     cudaCheck(cudaEventRecord(copyEvent, mStream));
 
     if constexpr(util::is_same<BuildT, Point>::value) {
-        uint32_t *d_maxPointsPerLeaf = static_cast<uint32_t*>(ResourceT::allocateAsync(sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+        uint32_t *d_maxPointsPerLeaf = static_cast<uint32_t*>(mResource->allocate_async(sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
         cudaCheck(cudaEventSynchronize(copyEvent));
         CALL_CUBS(DeviceReduce::Max, mData.pointsPerLeaf, d_maxPointsPerLeaf, mData.nodeCount[0]);
         cudaCheck(cudaMemcpyAsync(&mMaxPointsPerLeaf, d_maxPointsPerLeaf, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
@@ -727,25 +730,25 @@ jump:// this marks the beginning of the actual algorithm
         if (mMaxPointsPerLeaf > std::numeric_limits<uint16_t>::max()) {
             throw std::runtime_error("Too many points per leaf: "+std::to_string(mMaxPointsPerLeaf));
         }
-        ResourceT::deallocateAsync(d_maxPointsPerLeaf, sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+        mResource->deallocate_async(d_maxPointsPerLeaf, sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     }
 
     cudaCheck(cudaEventSynchronize(copyEvent));
-    mData.pointsPerLeafPrefix = static_cast<uint32_t*>(ResourceT::allocateAsync(mData.nodeCount[0]*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    mData.pointsPerLeafPrefix = static_cast<uint32_t*>(mResource->allocate_async(mData.nodeCount[0]*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     CALL_CUBS(DeviceScan::ExclusiveSum, mData.pointsPerLeaf, mData.pointsPerLeafPrefix, mData.nodeCount[0]);
 
     cudaCheck(cudaStreamSynchronize(mStream));
-    mData.d_leaf_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    mData.d_leaf_keys = static_cast<uint64_t*>(mResource->allocate_async(mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     cudaCheck(cudaMemcpyAsync(mData.d_leaf_keys, d_keys, mData.nodeCount[0]*sizeof(uint64_t), cudaMemcpyDeviceToDevice, mStream));
 
     CALL_CUBS(DeviceSelect::Unique, thrust::make_transform_iterator(mData.d_leaf_keys, ShiftRight<12>()), d_keys, d_node_count+1, mData.nodeCount[0]);// count lower nodes
     cudaCheck(cudaMemcpyAsync(mData.nodeCount+1, d_node_count+1, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
     cudaCheck(cudaStreamSynchronize(mStream));
-    mData.d_lower_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[1]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    mData.d_lower_keys = static_cast<uint64_t*>(mResource->allocate_async(mData.nodeCount[1]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     cudaCheck(cudaMemcpyAsync(mData.d_lower_keys, d_keys, mData.nodeCount[1]*sizeof(uint64_t), cudaMemcpyDeviceToDevice, mStream));
 
-    ResourceT::deallocateAsync(d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-    ResourceT::deallocateAsync(d_node_count, 3*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(d_node_count, 3*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     if (mVerbose==2) mTimer.stop();
     cudaCheck(cudaEventDestroy(copyEvent));
 
@@ -990,7 +993,7 @@ inline void PointsToGrid<BuildT, ResourceT>::processUpperNodes()
     util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[2]), mNumThreads, 0, mStream>>>(mData.nodeCount[2], BuildUpperNodesFunctor<BuildT>(), mDeviceData);
     cudaCheckError();
 
-    ResourceT::deallocateAsync(mData.d_tile_keys, mData.nodeCount[2]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(mData.d_tile_keys, mData.nodeCount[2]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 
     const uint64_t valueCount = mData.nodeCount[2] << 15;
     util::cuda::lambdaKernel<<<numBlocks(valueCount), mNumThreads, 0, mStream>>>(valueCount, SetUpperBackgroundValuesFunctor<BuildT>(), mDeviceData);
@@ -1125,11 +1128,11 @@ inline void PointsToGrid<BuildT, ResourceT>::processLeafNodes(size_t pointCount)
     util::cuda::lambdaKernel<<<numBlocks(mData.voxelCount), mNumThreads, 0, mStream>>>(mData.voxelCount, SetLeafActiveVoxelStateAndValuesFunctor<BuildT>(), mDeviceData);
     cudaCheckError();
 
-    ResourceT::deallocateAsync(mData.d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-    ResourceT::deallocateAsync(mData.pointsPerVoxel, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-    ResourceT::deallocateAsync(mData.pointsPerVoxelPrefix, mData.voxelCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-    ResourceT::deallocateAsync(mData.pointsPerLeafPrefix, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
-    ResourceT::deallocateAsync(mData.pointsPerLeaf,mData.nodeCount[0]*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(mData.d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(mData.pointsPerVoxel, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(mData.pointsPerVoxelPrefix, mData.voxelCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(mData.pointsPerLeafPrefix, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(mData.pointsPerLeaf,mData.nodeCount[0]*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 
     if (mVerbose==2) mTimer.restart("set inactive voxel values");
     const uint64_t denseVoxelCount = mData.nodeCount[0] << 9;
@@ -1138,15 +1141,15 @@ inline void PointsToGrid<BuildT, ResourceT>::processLeafNodes(size_t pointCount)
 
     if constexpr(BuildTraits<BuildT>::is_onindex) {
         if (mVerbose==2) mTimer.restart("prefix-sum for index grid");
-        auto devValueIndex = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
-        auto devValueIndexPrefix = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+        auto devValueIndex = static_cast<uint64_t*>(mResource->allocate_async(mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+        auto devValueIndexPrefix = static_cast<uint64_t*>(mResource->allocate_async(mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
         kernels::fillValueIndexKernel<BuildT><<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], 0, devValueIndex, mDeviceData);
         cudaCheckError();
         CALL_CUBS(DeviceScan::InclusiveSum, devValueIndex, devValueIndexPrefix, mData.nodeCount[0]);
-        ResourceT::deallocateAsync(devValueIndex, mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+        mResource->deallocate_async(devValueIndex, mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
         kernels::leafPrefixSumKernel<BuildT><<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], 0, devValueIndexPrefix, mDeviceData);
         cudaCheckError();
-        ResourceT::deallocateAsync(devValueIndexPrefix, mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+        mResource->deallocate_async(devValueIndexPrefix, mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     }
 
     if (mVerbose==2) mTimer.stop();
@@ -1165,7 +1168,7 @@ template<typename BuildT, typename ResourceT>
 template<typename PtrT>
 inline void PointsToGrid<BuildT, ResourceT>::processPoints(const PtrT, size_t pointCount)
 {
-    ResourceT::deallocateAsync(mData.d_indx, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(mData.d_indx, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1226,7 +1229,9 @@ inline void PointsToGrid<Point>::processPoints(const PtrT points, size_t pointCo
     default:
         printf("Internal error in PointsToGrid<Point>::processPoints\n");
     }
-    nanovdb::cuda::DeviceResource::deallocateAsync(mData.d_indx, pointCount*sizeof(uint32_t), nanovdb::cuda::DeviceResource::DEFAULT_ALIGNMENT, mStream);
+    // This is the PointsToGrid<Point> (== <Point, DeviceResource>) member specialization,
+    // so ResourceT is not a name here; mResource is a DeviceResource* and the alignment is concrete.
+    mResource->deallocate_async(mData.d_indx, pointCount*sizeof(uint32_t), nanovdb::cuda::DeviceResource::DEFAULT_ALIGNMENT, mStream);
 }// PointsToGrid<Point>::processPoints
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1305,7 +1310,7 @@ inline void PointsToGrid<BuildT, ResourceT>::processBBox()
 
     // update and propagate bbox from leaf -> lower/parent nodes
     util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], UpdateAndPropagateLeafBBoxFunctor<BuildT>(), mDeviceData);
-    ResourceT::deallocateAsync(mData.d_leaf_keys, mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(mData.d_leaf_keys, mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     cudaCheckError();
 
     // reset bbox in upper nodes
@@ -1314,7 +1319,7 @@ inline void PointsToGrid<BuildT, ResourceT>::processBBox()
 
     // propagate bbox from lower -> upper/parent node
     util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[1]), mNumThreads, 0, mStream>>>(mData.nodeCount[1], PropagateLowerBBoxFunctor<BuildT>(), mDeviceData);
-    ResourceT::deallocateAsync(mData.d_lower_keys, mData.nodeCount[1]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    mResource->deallocate_async(mData.d_lower_keys, mData.nodeCount[1]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     cudaCheckError()
 
     // propagate bbox from upper -> root/parent node

--- a/nanovdb/nanovdb/unittest/CMakeLists.txt
+++ b/nanovdb/nanovdb/unittest/CMakeLists.txt
@@ -57,6 +57,11 @@ if(NANOVDB_USE_CUDA)
   target_link_libraries(nanovdb_test_mgpu PRIVATE nanovdb GTest::GTest GTest::Main)
   set_target_properties(nanovdb_test_mgpu PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
   add_test(nanovdb_mgpu_unit_test nanovdb_test_mgpu)
+
+  add_executable(nanovdb_test_cuda_memory_resource "TestMemoryResource.cu")
+  target_link_libraries(nanovdb_test_cuda_memory_resource PRIVATE nanovdb GTest::GTest GTest::Main)
+  set_target_properties(nanovdb_test_cuda_memory_resource PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+  add_test(nanovdb_cuda_memory_resource_unit_test nanovdb_test_cuda_memory_resource)
 endif()
 
 # -----------------------------------------------------------------------------

--- a/nanovdb/nanovdb/unittest/TestMemoryResource.cu
+++ b/nanovdb/nanovdb/unittest/TestMemoryResource.cu
@@ -93,15 +93,15 @@ TEST(TestMemoryResource, DefaultResource_AddressStable)
 // PinnedResource (host-pinned, host- and device-accessible)
 //======================================================================
 
-static_assert(nanovdb::cuda::is_async_resource<nanovdb::cuda::PinnedResource>::value,
-              "PinnedResource must satisfy the AsyncResource concept");
+static_assert(!nanovdb::cuda::is_async_resource<nanovdb::cuda::PinnedResource>::value,
+              "PinnedResource is synchronous (no stream-ordered allocate_async)");
 
 TEST(TestMemoryResource, PinnedResource_IsPageLocked)
 {
     using P = nanovdb::cuda::PinnedResource;
     P res;
     const size_t bytes = 4096;
-    void* host = res.allocate_async(bytes, P::DEFAULT_ALIGNMENT, 0);
+    void* host = res.allocate(bytes, P::DEFAULT_ALIGNMENT);
     ASSERT_NE(host, nullptr);
 
     // Must be genuine page-locked (pinned) host memory, not pageable.
@@ -118,16 +118,16 @@ TEST(TestMemoryResource, PinnedResource_IsPageLocked)
     EXPECT_EQ(reinterpret_cast<unsigned char*>(host)[0], 0xABu);
     ASSERT_EQ(cudaFree(d), cudaSuccess);
 
-    res.deallocate_async(host, bytes, P::DEFAULT_ALIGNMENT, 0);
+    res.deallocate(host, bytes, P::DEFAULT_ALIGNMENT);
 }
 
 TEST(TestMemoryResource, PinnedResource_DefaultResourceRoundTrip)
 {
     using P = nanovdb::cuda::PinnedResource;
     P& res = nanovdb::cuda::default_resource<P>();
-    void* p = res.allocate_async(256, P::DEFAULT_ALIGNMENT, 0);
+    void* p = res.allocate(256, P::DEFAULT_ALIGNMENT);
     ASSERT_NE(p, nullptr);
-    res.deallocate_async(p, 256, P::DEFAULT_ALIGNMENT, 0);
+    res.deallocate(p, 256, P::DEFAULT_ALIGNMENT);
     EXPECT_EQ(&res, &nanovdb::cuda::default_resource<P>()); // address-stable
 }
 

--- a/nanovdb/nanovdb/unittest/TestMemoryResource.cu
+++ b/nanovdb/nanovdb/unittest/TestMemoryResource.cu
@@ -1,0 +1,212 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/// @file TestMemoryResource.cu
+///
+/// @brief Unit tests for the CUDA memory-resource concept (cuda::DeviceResource,
+///        cuda::PinnedResource) and the cuda::TempPool / tools::cuda::PointsToGrid
+///        resource plumbing.
+
+#include <nanovdb/cuda/DeviceResource.h>
+#include <nanovdb/cuda/PinnedResource.h>
+#include <nanovdb/cuda/TempPool.h>
+#include <nanovdb/tools/cuda/PointsToGrid.cuh>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace {
+
+//======================================================================
+// Shared test doubles
+//======================================================================
+
+/// @brief Resource that counts (non-null) allocations and deallocations so
+///        leaks can be asserted. Delegates the actual work to DeviceResource.
+struct CountingResource
+{
+    static constexpr size_t DEFAULT_ALIGNMENT = nanovdb::cuda::DeviceResource::DEFAULT_ALIGNMENT;
+    int allocs = 0;
+    int deallocs = 0;
+    void* allocate_async(size_t bytes, size_t alignment, cudaStream_t stream) {
+        void* p = nanovdb::cuda::DeviceResource{}.allocate_async(bytes, alignment, stream);
+        if (p) ++allocs;
+        return p;
+    }
+    void deallocate_async(void* p, size_t bytes, size_t alignment, cudaStream_t stream) {
+        if (p) ++deallocs;
+        nanovdb::cuda::DeviceResource{}.deallocate_async(p, bytes, alignment, stream);
+    }
+};
+
+/// @brief Resource that records the stream of every allocation/deallocation,
+///        to verify stream-ordered teardown. Delegates work to DeviceResource.
+struct StreamRecordingResource
+{
+    static constexpr size_t DEFAULT_ALIGNMENT = nanovdb::cuda::DeviceResource::DEFAULT_ALIGNMENT;
+    std::vector<cudaStream_t> allocStreams;
+    std::vector<cudaStream_t> deallocStreams;
+    void* allocate_async(size_t bytes, size_t alignment, cudaStream_t stream) {
+        void* p = nanovdb::cuda::DeviceResource{}.allocate_async(bytes, alignment, stream);
+        if (p) allocStreams.push_back(stream);
+        return p;
+    }
+    void deallocate_async(void* p, size_t bytes, size_t alignment, cudaStream_t stream) {
+        if (p) deallocStreams.push_back(stream);
+        nanovdb::cuda::DeviceResource{}.deallocate_async(p, bytes, alignment, stream);
+    }
+};
+
+//======================================================================
+// AsyncResource concept + DeviceResource instance methods
+//======================================================================
+
+// Concept satisfaction: DeviceResource must model the async-resource shape,
+// and a plainly-unrelated type must not.
+static_assert(nanovdb::cuda::is_async_resource<nanovdb::cuda::DeviceResource>::value,
+              "DeviceResource must satisfy the AsyncResource concept");
+static_assert(!nanovdb::cuda::is_async_resource<int>::value,
+              "int must not satisfy the AsyncResource concept");
+
+TEST(TestMemoryResource, DeviceResource_InstanceAllocateFree)
+{
+    using R = nanovdb::cuda::DeviceResource;
+    R res;
+    const size_t bytes = 1024;
+    void* p = res.allocate_async(bytes, R::DEFAULT_ALIGNMENT, 0);
+    ASSERT_NE(p, nullptr);
+    res.deallocate_async(p, bytes, R::DEFAULT_ALIGNMENT, 0);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
+TEST(TestMemoryResource, DefaultResource_AddressStable)
+{
+    using R = nanovdb::cuda::DeviceResource;
+    R& a = nanovdb::cuda::default_resource<R>();
+    R& b = nanovdb::cuda::default_resource<R>();
+    EXPECT_EQ(&a, &b); // program-lifetime singleton, address-stable
+}
+
+//======================================================================
+// PinnedResource (host-pinned, host- and device-accessible)
+//======================================================================
+
+static_assert(nanovdb::cuda::is_async_resource<nanovdb::cuda::PinnedResource>::value,
+              "PinnedResource must satisfy the AsyncResource concept");
+
+TEST(TestMemoryResource, PinnedResource_IsPageLocked)
+{
+    using P = nanovdb::cuda::PinnedResource;
+    P res;
+    const size_t bytes = 4096;
+    void* host = res.allocate_async(bytes, P::DEFAULT_ALIGNMENT, 0);
+    ASSERT_NE(host, nullptr);
+
+    // Must be genuine page-locked (pinned) host memory, not pageable.
+    cudaPointerAttributes attr{};
+    ASSERT_EQ(cudaPointerGetAttributes(&attr, host), cudaSuccess);
+    EXPECT_EQ(attr.type, cudaMemoryTypeHost);
+
+    // ...and usable as the host side of an asynchronous device->host copy.
+    unsigned char* d = nullptr;
+    ASSERT_EQ(cudaMalloc(&d, bytes), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d, 0xAB, bytes), cudaSuccess);
+    ASSERT_EQ(cudaMemcpyAsync(host, d, bytes, cudaMemcpyDeviceToHost, 0), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+    EXPECT_EQ(reinterpret_cast<unsigned char*>(host)[0], 0xABu);
+    ASSERT_EQ(cudaFree(d), cudaSuccess);
+
+    res.deallocate_async(host, bytes, P::DEFAULT_ALIGNMENT, 0);
+}
+
+TEST(TestMemoryResource, PinnedResource_DefaultResourceRoundTrip)
+{
+    using P = nanovdb::cuda::PinnedResource;
+    P& res = nanovdb::cuda::default_resource<P>();
+    void* p = res.allocate_async(256, P::DEFAULT_ALIGNMENT, 0);
+    ASSERT_NE(p, nullptr);
+    res.deallocate_async(p, 256, P::DEFAULT_ALIGNMENT, 0);
+    EXPECT_EQ(&res, &nanovdb::cuda::default_resource<P>()); // address-stable
+}
+
+//======================================================================
+// TempPool routes allocations through a resource instance and frees on its
+// retained stream (the stream of the most recent reallocate), not the null stream.
+//======================================================================
+
+TEST(TestMemoryResource, TempPool_FreesOnRetainedStream)
+{
+    cudaStream_t s = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);
+    StreamRecordingResource rec;
+    {
+        nanovdb::cuda::TempPool<StreamRecordingResource> pool(rec);
+        pool.requestedSize() = 1024;
+        pool.reallocate(s);            // allocate on stream s
+        ASSERT_NE(pool.data(), nullptr);
+    }                                  // pool destroyed here -> must free on s
+    ASSERT_FALSE(rec.allocStreams.empty());
+    EXPECT_EQ(rec.allocStreams.back(), s);
+    ASSERT_FALSE(rec.deallocStreams.empty());
+    EXPECT_EQ(rec.deallocStreams.back(), s);
+    EXPECT_NE(rec.deallocStreams.back(), static_cast<cudaStream_t>(nullptr));
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(s), cudaSuccess);
+}
+
+TEST(TestMemoryResource, TempPool_NoLeakAcrossGrowth)
+{
+    CountingResource res;
+    {
+        nanovdb::cuda::TempPool<CountingResource> pool(res);
+        pool.requestedSize() = 256;  pool.reallocate(0);
+        pool.requestedSize() = 4096; pool.reallocate(0);   // grow -> free old + alloc new
+        pool.requestedSize() = 64;   pool.reallocate(0);   // smaller request -> no realloc
+    }                                                      // destroy -> free current block
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+    EXPECT_GT(res.allocs, 0);
+    EXPECT_EQ(res.allocs, res.deallocs);                   // every allocation freed
+}
+
+TEST(TestMemoryResource, TempPool_DefaultConstructsWithDefaultResource)
+{
+    // A default-constructed pool uses the default resource and behaves as the
+    // existing builders rely on.
+    nanovdb::cuda::TempDevicePool pool;
+    pool.requestedSize() = 512;
+    pool.reallocate(0);
+    EXPECT_NE(pool.data(), nullptr);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
+//======================================================================
+// PointsToGrid routes its internal scratch through an injected resource instance.
+//======================================================================
+
+TEST(TestMemoryResource, PointsToGrid_InjectedInstanceSeam)
+{
+    using BuildT = float;
+    const size_t num = 64;
+    std::vector<nanovdb::Coord> coords(num);
+    for (size_t i = 0; i < num; ++i)
+        coords[i] = nanovdb::Coord(int(i), int(i) * 2 + 1, int(i) * 3 + 2);
+    nanovdb::Coord* d_coords = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_coords, num * sizeof(nanovdb::Coord)), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d_coords, coords.data(), num * sizeof(nanovdb::Coord), cudaMemcpyHostToDevice), cudaSuccess);
+
+    CountingResource res;
+    {
+        nanovdb::tools::cuda::PointsToGrid<BuildT, CountingResource> converter(1.0, nanovdb::Vec3d(0.0), 0, res);
+        auto handle = converter.getHandle(d_coords, num);
+        ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+        EXPECT_TRUE(handle.deviceData());      // grid built on the device
+        EXPECT_GT(res.allocs, 0);              // internal scratch + mDeviceData went through the injected instance
+    }                                          // converter destroyed -> mDeviceData freed via res
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+    EXPECT_EQ(res.allocs, res.deallocs);       // every allocation through the resource was freed (no leak)
+    ASSERT_EQ(cudaFree(d_coords), cudaSuccess);
+}
+
+} // unnamed namespace


### PR DESCRIPTION
Part of #2232 (NanoVDB injectable CUDA memory resources — design & roadmap).

## What

Adds an instance-based async memory-resource concept to NanoVDB's CUDA path so downstream code (PyTorch extensions, custom CUDA apps, …) can inject its own allocator **without forking headers** — with zero change to existing call sites at the default.

- **`cuda::DeviceResource`** — adds instance `allocate_async`/`deallocate_async` alongside the existing static methods, plus `default_resource<R>()` (a program-lifetime singleton) and an `is_async_resource<R>` detection trait.
- **`cuda::PinnedResource`** (new) — host-pinned resource wrapping `cudaMallocHost`/`cudaFreeHost`. Since those are synchronous, it models the synchronous `Resource` concept (`allocate`/`deallocate`, **no stream**) — `is_async_resource<PinnedResource>` is false — rather than the stream-ordered `async_resource` shape.
- **`cuda::TempPool`** — routes allocations through a resource *instance* and frees on the stream of the most recent `reallocate()` at destruction (previously the null stream). This stream-retained free reaches every `TempDevicePool` user (TopologyBuilder, MeshToGrid, DistributedPointsToGrid, radixSort) automatically.
- **`tools::cuda::PointsToGrid`** — routes its internal scratch and `mDeviceData` through an injected resource instance via a defaulted `ResourceT&` constructor argument.

The method shapes (`allocate_async(bytes, alignment, stream)`) deliberately mirror CCCL's `cuda::mr::async_resource`, so a future type-erased `resource_ref` adapter is a thin shim.

## Why

Downstream projects currently fork NanoVDB headers to route allocations through their own pool (e.g. PyTorch's caching allocator). This adds the injection seam so they don't have to.

## Non-CUDA builds

This PR has **no impact on non-CUDA (`NANOVDB_USE_CUDA=OFF`) usage of NanoVDB.** Everything it adds is CUDA-domain: the headers live under `nanovdb/cuda/` and are reachable only behind `#if defined(__CUDACC__)` (the same gate `GridHandle.h` already uses for `cuda/GridHandle.cuh`), and the new unit test + test target are added only inside `if(NANOVDB_USE_CUDA)`. The CUDA-free core (`NanoVDB.h`, `GridHandle.h`, `HostBuffer.h`) is untouched and gains no new include.

Verified with a clean `NANOVDB_USE_CUDA=OFF` build (host compiler, no CUDA toolkit): it configures with no CUDA/CCCL pulled, and the CPU unit tests pass 152/152. CI also exercises this configuration via the `nanovdb-lite` (Linux) and `macos-nanovdb` jobs.

## Testing

New `unittest/TestMemoryResource.cu` (`TestMemoryResource` suite, 8 tests): concept satisfaction (`static_assert`), instance alloc/free, pinned page-lock + async H↔D copy, stream-retained free, no-leak-across-growth, default-ctor backward-compat, and `PointsToGrid` resource-injection (counts allocations through an injected mock, asserts no leak). Existing `nanovdb_test_cuda` suite is unchanged (52/52). Built and run on `sm_89` / CUDA 12.6.

## Scope / follow-ups (intentionally not in this PR)

- `TopologyBuilder` / `MeshToGrid` allocate through the dual `cuda::DeviceBuffer`; routing those — and the pinned-host `cudaMallocHost` stall fix — needs a resource-parameterized buffer (`ResourceDeviceBuffer`) and is deferred.
- `DistributedPointsToGrid` (multi-GPU) deferred.
- Converting `PointsToGrid`'s raw scratch to RAII containers (`DeviceVector<T,R>`) is a planned follow-up.
- `PointsToGrid<Point, CustomResource>` point-encoding is a pre-existing limitation (the `PointsToGrid<Point>` specialization is keyed to the default resource); tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


