### PR TITLE
Fix Windows Static CI

### DIFF
--- a/cmake/FindBlosc.cmake
+++ b/cmake/FindBlosc.cmake
@@ -419,9 +419,11 @@ if(NOT TARGET Blosc::blosc)
         set(${BLOSC_EXTERNAL_LIB}_LIBRARIES       ${${BLOSC_EXTERNAL_LIB}_LIBRARY_DEBUG})
       endif()
 
-      target_link_libraries(Blosc::blosc INTERFACE
-        $<$<CONFIG:Release>:${${BLOSC_EXTERNAL_LIB}_LIBRARY_RELEASE}>
-        $<$<CONFIG:Debug>:${${BLOSC_EXTERNAL_LIB}_LIBRARY_DEBUG}>)
+      if(${BLOSC_EXTERNAL_LIB}_LIBRARY_RELEASE OR ${BLOSC_EXTERNAL_LIB}_LIBRARY_DEBUG)
+        target_link_libraries(Blosc::blosc INTERFACE
+          $<$<CONFIG:Release>:${${BLOSC_EXTERNAL_LIB}_LIBRARY_RELEASE}>
+          $<$<CONFIG:Debug>:${${BLOSC_EXTERNAL_LIB}_LIBRARY_DEBUG}>)
+      endif()
 
     endforeach()
   endif()

--- a/pendingchanges/windowsstatic.txt
+++ b/pendingchanges/windowsstatic.txt
@@ -1,0 +1,3 @@
+OpenVDB:
+  Build:
+  - Fixed an issue in FindBlosc.cmake when building static libs on Windows.


### PR DESCRIPTION
When OpenVDB is built against a static Blosc library with `BLOSC_USE_EXTERNAL_SOURCES` enabled, `FindBlosc.cmake` loops over Blosc's external dependencies (lz4 snappy zlib zstd) and tries to `find_library()` each one to add it as an
interface link dependency on `Blosc::blosc`. 

However, OpenVDB also links against zlib directly, so this change falls back to using that one if not found. I have confirmed that this resolves the static Windows CI failing in the weekly build.