### PR TITLE
Renaming of MergeGrids in nanovdb/tools/cuda to TopologyUnion

### DIFF
--- a/nanovdb/nanovdb/CMakeLists.txt
+++ b/nanovdb/nanovdb/CMakeLists.txt
@@ -229,7 +229,7 @@ set(NANOVDB_INCLUDE_TOOLS_CUDA_FILES
   tools/cuda/IndexToGrid.cuh
   tools/cuda/PointsToGrid.cuh
   tools/cuda/SignedFloodFill.cuh
-  tools/cuda/MergeGrids.cuh
+  tools/cuda/TopologyUnion.cuh
   tools/cuda/TopologyBuilder.cuh
   tools/cuda/RefineGrid.cuh
   tools/cuda/PruneGrid.cuh

--- a/nanovdb/nanovdb/examples/ex_merge_nanovdb_cuda/merge_nanovdb_cuda.cpp
+++ b/nanovdb/nanovdb/examples/ex_merge_nanovdb_cuda/merge_nanovdb_cuda.cpp
@@ -11,7 +11,7 @@
 #include <nanovdb/tools/CreateNanoGrid.h>
 
 template<typename BuildT>
-void mainMergeGrids(
+void mainTopologyUnion(
     nanovdb::NanoGrid<BuildT> *deviceSrcGrid1,
     nanovdb::NanoGrid<BuildT> *deviceSrcGrid2,
     nanovdb::NanoGrid<BuildT> *deviceDstReferenceGrid,
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
             OPENVDB_THROW(openvdb::RuntimeError, "Failure while uploading indexGrids to GPU");
 
         // Launch benchmark
-        mainMergeGrids(
+        mainTopologyUnion(
             deviceSrcGrid1, deviceSrcGrid2, deviceDstReferenceGrid,
             srcIndexGrid1, srcIndexGrid2, dstReferenceGrid, benchmark_iters);
     }

--- a/nanovdb/nanovdb/examples/ex_merge_nanovdb_cuda/merge_nanovdb_cuda_kernels.cu
+++ b/nanovdb/nanovdb/examples/ex_merge_nanovdb_cuda/merge_nanovdb_cuda_kernels.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 
-#include <nanovdb/tools/cuda/MergeGrids.cuh>
+#include <nanovdb/tools/cuda/TopologyUnion.cuh>
 
 template<typename T>
 bool bufferCheck(const T* deviceBuffer, const T* hostBuffer, size_t elem_count) {
@@ -14,7 +14,7 @@ bool bufferCheck(const T* deviceBuffer, const T* hostBuffer, size_t elem_count) 
 }
 
 template<typename BuildT>
-void mainMergeGrids(
+void mainTopologyUnion(
     nanovdb::NanoGrid<BuildT> *deviceSrcGrid1,
     nanovdb::NanoGrid<BuildT> *deviceSrcGrid2,
     nanovdb::NanoGrid<BuildT> *deviceDstReferenceGrid,
@@ -26,7 +26,7 @@ void mainMergeGrids(
     nanovdb::util::cuda::Timer gpuTimer;
 
     // Initialize converter
-    nanovdb::tools::cuda::MergeGrids<BuildT> converter( deviceSrcGrid1, deviceSrcGrid2 );
+    nanovdb::tools::cuda::TopologyUnion<BuildT> converter( deviceSrcGrid1, deviceSrcGrid2 );
     converter.setChecksum(nanovdb::CheckMode::Default);
     converter.setVerbose(1);
 
@@ -35,9 +35,9 @@ void mainMergeGrids(
 
     // Check for correctness
     if (bufferCheck((char*)dstGrid, (char*)hostDstReferenceGrid->data(), hostDstReferenceGrid->gridSize()))
-        std::cout << "Result of MergeGrids check out CORRECT against reference" << std::endl;
+        std::cout << "Result of TopologyUnion check out CORRECT against reference" << std::endl;
     else
-        std::cout << "Result of MergeGrids compares INCORRECT against reference" << std::endl;
+        std::cout << "Result of TopologyUnion compares INCORRECT against reference" << std::endl;
 
     // Re-run warm-started iterations
     converter.setVerbose(0);
@@ -49,7 +49,7 @@ void mainMergeGrids(
 }
 
 template
-void mainMergeGrids(
+void mainTopologyUnion(
     nanovdb::NanoGrid<nanovdb::ValueOnIndex> *deviceSrcGrid1,
     nanovdb::NanoGrid<nanovdb::ValueOnIndex> *deviceSrcGrid2,
     nanovdb::NanoGrid<nanovdb::ValueOnIndex> *deviceDstReferenceGrid,

--- a/nanovdb/nanovdb/tools/cuda/TopologyUnion.cuh
+++ b/nanovdb/nanovdb/tools/cuda/TopologyUnion.cuh
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*!
-    \file nanovdb/tools/cuda/MergeGrids.cuh
+    \file nanovdb/tools/cuda/TopologyUnion.cuh
 
     \authors Efty Sifakis
 
@@ -12,8 +12,8 @@
              to only include it in .cu files (or other .cuh files)
 */
 
-#ifndef NVIDIA_TOOLS_CUDA_MERGEGRIDS_CUH_HAS_BEEN_INCLUDED
-#define NVIDIA_TOOLS_CUDA_MERGEGRIDS_CUH_HAS_BEEN_INCLUDED
+#ifndef NVIDIA_TOOLS_CUDA_TOPOLOGYUNION_CUH_HAS_BEEN_INCLUDED
+#define NVIDIA_TOOLS_CUDA_TOPOLOGYUNION_CUH_HAS_BEEN_INCLUDED
 
 #include <cub/cub.cuh>
 
@@ -34,7 +34,7 @@ namespace nanovdb {
 namespace tools::cuda {
 
 template <typename BuildT>
-class MergeGrids
+class TopologyUnion
 {
     using GridT  = NanoGrid<BuildT>;
     using TreeT  = NanoTree<BuildT>;
@@ -46,15 +46,15 @@ public:
     /// @brief Constructor for an N-ary merge
     /// @param d_srcGrids list of source device grids to be merged (active-mask union)
     /// @param stream optional CUDA stream (defaults to CUDA stream 0)
-    MergeGrids(const std::vector<const GridT*>& d_srcGrids, cudaStream_t stream = 0)
+    TopologyUnion(const std::vector<const GridT*>& d_srcGrids, cudaStream_t stream = 0)
         : mBuilder(stream), mStream(stream), mTimer(stream), mDeviceSrcGrids(d_srcGrids) {}
 
     /// @brief Convenience constructor for the common binary merge
     /// @param d_srcGrid1 first source device grid to be merged
     /// @param d_srcGrid2 second source device grid to be merged
     /// @param stream optional CUDA stream (defaults to CUDA stream 0)
-    MergeGrids(const GridT* d_srcGrid1, const GridT* d_srcGrid2, cudaStream_t stream = 0)
-        : MergeGrids(std::vector<const GridT*>{d_srcGrid1, d_srcGrid2}, stream) {}
+    TopologyUnion(const GridT* d_srcGrid1, const GridT* d_srcGrid2, cudaStream_t stream = 0)
+        : TopologyUnion(std::vector<const GridT*>{d_srcGrid1, d_srcGrid2}, stream) {}
 
     /// @brief Toggle on and off verbose mode
     /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
@@ -90,17 +90,17 @@ private:
     int                     mVerbose{0};
     std::vector<const GridT*> mDeviceSrcGrids;
     std::vector<TreeData>     mSrcTreeData;
-};// tools::cuda::MergeGrids<BuildT>
+};// tools::cuda::TopologyUnion<BuildT>
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template<typename BuildT>
 template<typename BufferT>
 GridHandle<BufferT>
-MergeGrids<BuildT>::getHandle(const BufferT &pool)
+TopologyUnion<BuildT>::getHandle(const BufferT &pool)
 {
     if (mDeviceSrcGrids.empty())
-        throw std::runtime_error("MergeGrids: no input grids");
+        throw std::runtime_error("TopologyUnion: no input grids");
 
     // Copy TreeData from GPU -> CPU for every input grid
     cudaStreamSynchronize(mStream);
@@ -163,12 +163,12 @@ MergeGrids<BuildT>::getHandle(const BufferT &pool)
     cudaStreamSynchronize(mStream);
 
     return GridHandle<BufferT>(std::move(buffer));
-}// MergeGrids<BuildT>::getHandle
+}// TopologyUnion<BuildT>::getHandle
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template<typename BuildT>
-void MergeGrids<BuildT>::mergeRoot()
+void TopologyUnion<BuildT>::mergeRoot()
 {
     // Creates a new merged tree root with the merged tiles of the two input root topologies
 
@@ -218,12 +218,12 @@ void MergeGrids<BuildT>::mergeRoot()
     for (const auto& [key, tile] : mergedTiles)
         *mergedRootPtr->tile(t++) = tile;
     mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
-}// MergeGrids<BuildT>::mergeRoot
+}// TopologyUnion<BuildT>::mergeRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template<typename BuildT>
-void MergeGrids<BuildT>::mergeInternalNodes()
+void TopologyUnion<BuildT>::mergeInternalNodes()
 {
     // Merges the masks of upper and lower nodes from both input topologies into the
     // densified, pre-allocated mask arrays of the merged result
@@ -236,12 +236,12 @@ void MergeGrids<BuildT>::mergeInternalNodes()
             <<<mSrcTreeData[i].mNodeCount[1], Op::MaxThreadsPerBlock, 0, mStream>>>
             (mDeviceSrcGrids[i], mBuilder.deviceProcessedRoot(), mBuilder.deviceUpperMasks(), mBuilder.deviceLowerMasks());
     }
-}// MergeGrids<BuildT>::mergeInternalNodes
+}// TopologyUnion<BuildT>::mergeInternalNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename BuildT>
-void MergeGrids<BuildT>::processGridTreeRoot()
+void TopologyUnion<BuildT>::processGridTreeRoot()
 {
     // Copy GridData from the first source grid
     // TODO: Check for instances where extra processing is needed
@@ -249,12 +249,12 @@ void MergeGrids<BuildT>::processGridTreeRoot()
     cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrids.front()->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
     util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
     cudaCheckError();
-}// MergeGrids<BuildT>::processGridTreeRoot
+}// TopologyUnion<BuildT>::processGridTreeRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template<typename BuildT>
-void MergeGrids<BuildT>::mergeLeafNodes()
+void TopologyUnion<BuildT>::mergeLeafNodes()
 {
     using Op = util::morphology::cuda::MergeLeafNodesFunctor<BuildT>;
     // Each input ORs its leaf active masks into the merged leaf topology.
@@ -267,7 +267,7 @@ void MergeGrids<BuildT>::mergeLeafNodes()
 
     // Update leaf offsets and prefix sums
     mBuilder.processLeafOffsets(mStream);
-}// MergeGrids<BuildT>::mergeLeafNodes
+}// TopologyUnion<BuildT>::mergeLeafNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -275,4 +275,4 @@ void MergeGrids<BuildT>::mergeLeafNodes()
 
 }// namespace nanovdb
 
-#endif // NVIDIA_TOOLS_CUDA_MERGEGRIDS_CUH_HAS_BEEN_INCLUDED
+#endif // NVIDIA_TOOLS_CUDA_TOPOLOGYUNION_CUH_HAS_BEEN_INCLUDED

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -18,7 +18,7 @@
 #include <nanovdb/tools/cuda/GridValidator.cuh>
 #include <nanovdb/tools/cuda/GridStats.cuh>
 #include <nanovdb/tools/cuda/DilateGrid.cuh>
-#include <nanovdb/tools/cuda/MergeGrids.cuh>
+#include <nanovdb/tools/cuda/TopologyUnion.cuh>
 #include <nanovdb/tools/cuda/PruneGrid.cuh>
 #include <nanovdb/tools/cuda/CoarsenGrid.cuh>
 #include <nanovdb/tools/cuda/RefineGrid.cuh>
@@ -3693,7 +3693,7 @@ TEST(TestNanoVDBCUDA, MergeGrids_ValueOnIndex)
     EXPECT_FALSE(inputHandleB.grid<BuildT>());
 
     // Perform the merge operation
-    nanovdb::tools::cuda::MergeGrids<BuildT> merger( inputGridA, inputGridB );
+    nanovdb::tools::cuda::TopologyUnion<BuildT> merger( inputGridA, inputGridB );
     merger.setChecksum(nanovdb::CheckMode::Disable);
     merger.setVerbose(0);
     auto mergedHandle = merger.getHandle();
@@ -3739,13 +3739,13 @@ TEST(TestNanoVDBCUDA, MergeGridsNary_ValueOnIndex)
     auto hC = buildGrid(ptsC, bufC); auto gC = hC.deviceGrid<BuildT>();
 
     // N-ary merge of all three in a single call
-    auto naryH = nanovdb::tools::cuda::MergeGrids<BuildT>(
+    auto naryH = nanovdb::tools::cuda::TopologyUnion<BuildT>(
         std::vector<const GridT*>{gA, gB, gC}).getHandle();
     auto nary = treeData(naryH.deviceGrid<BuildT>());
 
     // Chaining the binary form must yield byte-identical topology
-    auto abH = nanovdb::tools::cuda::MergeGrids<BuildT>(gA, gB).getHandle();
-    auto abcH = nanovdb::tools::cuda::MergeGrids<BuildT>(
+    auto abH = nanovdb::tools::cuda::TopologyUnion<BuildT>(gA, gB).getHandle();
+    auto abcH = nanovdb::tools::cuda::TopologyUnion<BuildT>(
         abH.deviceGrid<BuildT>(), gC).getHandle();
     auto chain = treeData(abcH.deviceGrid<BuildT>());
     EXPECT_EQ(nary.mNodeCount[0], chain.mNodeCount[0]);
@@ -3757,12 +3757,12 @@ TEST(TestNanoVDBCUDA, MergeGridsNary_ValueOnIndex)
     EXPECT_EQ(nary.mVoxelCount, 69u);
 
     // A single-element list returns a copy of that grid's topology
-    auto soloH = nanovdb::tools::cuda::MergeGrids<BuildT>(
+    auto soloH = nanovdb::tools::cuda::TopologyUnion<BuildT>(
         std::vector<const GridT*>{gA}).getHandle();
     EXPECT_EQ(treeData(soloH.deviceGrid<BuildT>()).mVoxelCount, treeData(gA).mVoxelCount);
 
     // An empty input list is rejected
-    EXPECT_THROW(nanovdb::tools::cuda::MergeGrids<BuildT>(
+    EXPECT_THROW(nanovdb::tools::cuda::TopologyUnion<BuildT>(
         std::vector<const GridT*>{}).getHandle(), std::runtime_error);
 }// MergeGridsNary_ValueOnIndex
 


### PR DESCRIPTION
I saw that issue #2242 was raised and thought that it looked like a good first issue for someone like me, new to this project, to contribute. 

As the name and description of the issue suggests, I renamed MergeGrids to TopologyUnion within the `nanovdb/nanovdb/tools/cuda` directory and other directories which seemed relevant such as `nanovdb/nanovdb/examples/ex_merge_nanovdb_cuda`. Since the issue only referred to making the rename change in the CUDA related directories I didn't, for example, rename it in `nanovdb/nanovdb/GridHandle.h`.

I am of course open to feedback on this PR and can make any necessary adjustments as required.