### PR TITLE
NanoVDB: add cuda::Buffer, cuda::BufferView, and the synchronous resource concept (CUDA)

### DIFF
--- a/nanovdb/nanovdb/cuda/Buffer.h
+++ b/nanovdb/nanovdb/cuda/Buffer.h
@@ -1,0 +1,341 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+/// @file nanovdb/cuda/Buffer.h
+///
+/// @brief Typed containers for CUDA memory: the owning, resource-aware,
+///        stream-ordered cuda::Buffer and the non-owning cuda::BufferView.
+
+#ifndef NANOVDB_CUDA_BUFFER_H_HAS_BEEN_INCLUDED
+#define NANOVDB_CUDA_BUFFER_H_HAS_BEEN_INCLUDED
+
+#include <cuda_runtime_api.h>
+#include <nanovdb/cuda/DeviceResource.h>
+#include <nanovdb/util/cuda/Util.h>
+
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace nanovdb {
+
+namespace cuda {
+
+/// @brief Tag type selecting the Buffer constructors that skip element
+///        initialization, leaving the contents indeterminate.
+struct NoInit {};
+inline constexpr NoInit noInit{};
+
+namespace detail {
+
+/// @brief Conditional stream storage for Buffer. The async specialization
+///        retains the stream of the most recent allocation; the synchronous
+///        specialization is an empty base, so a Buffer over a synchronous
+///        resource carries no stream state and exposes no stream API.
+template<bool IsAsync>
+struct StreamHolder {};
+
+template<>
+struct StreamHolder<true> { cudaStream_t mStream = 0; };
+
+} // namespace detail
+
+/// @brief Owning, typed container of @c T elements allocated from a memory
+///        resource @c R held by value.
+/// @tparam T element type; sizes are expressed in elements, not bytes
+/// @tparam R memory resource, either stream-ordered (AsyncResource concept,
+///         see is_async_resource) or synchronous (Resource concept, see
+///         is_resource). When @c R provides both interfaces the stream-ordered
+///         one is used.
+/// @details With a stream-ordered resource the Buffer retains the stream of
+///          the most recent allocation (or the one supplied via setStream)
+///          and orders its deallocation on that stream. Buffer is move-only.
+template<typename T, typename R = DeviceResource>
+class Buffer : private detail::StreamHolder<is_async_resource<R>::value>
+{
+    static_assert(is_async_resource<R>::value || is_resource<R>::value,
+                  "Buffer requires R to model the AsyncResource or the Resource concept");
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Buffer requires a trivially copyable T: elements are copied bytewise and never constructed or destroyed");
+
+    static constexpr bool IsAsync = is_async_resource<R>::value;
+
+    R      mResource;
+    T*     mData = nullptr;
+    size_t mSize = 0; // element count
+
+public:
+    /// @brief Default c-tor of an empty buffer; performs no allocation.
+    Buffer() = default;
+
+    /// @brief C-tor allocating @c count uninitialized elements, stream-ordered
+    ///        on @c stream. Parameter order follows cuda::buffer:
+    ///        (stream, resource, count, no_init).
+    /// @param stream cuda stream the allocation is ordered on
+    /// @param resource resource instance the buffer takes ownership of
+    /// @param count number of elements
+    template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
+    explicit Buffer(cudaStream_t stream, R resource, size_t count, NoInit)
+        : detail::StreamHolder<true>{stream}, mResource(std::move(resource))
+    {
+        this->allocate(count, stream);
+    }
+
+    /// @brief Convenience c-tor using a default-constructed resource.
+    /// @note There is deliberately no count c-tor without NoInit: implicit
+    ///       initialization of freshly allocated memory costs a hidden fill
+    ///       pass that the dominant allocate-then-overwrite pattern wastes,
+    ///       so initialization is always explicit (matching cuda::buffer,
+    ///       whose count c-tor likewise requires cuda::no_init).
+    template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
+    Buffer(cudaStream_t stream, size_t count, NoInit) : Buffer(stream, R(), count, noInit) {}
+
+    /// @brief C-tor allocating @c count uninitialized elements from a
+    ///        synchronous resource: the stream-less analog of
+    ///        (stream, resource, count, no_init).
+    template<typename S = R, std::enable_if_t<!is_async_resource<S>::value && is_resource<S>::value, int> = 0>
+    explicit Buffer(R resource, size_t count, NoInit)
+        : mResource(std::move(resource))
+    {
+        this->allocate(count, cudaStream_t{0});
+    }
+
+    /// @brief Convenience c-tor using a default-constructed resource.
+    template<typename S = R, std::enable_if_t<!is_async_resource<S>::value && is_resource<S>::value, int> = 0>
+    Buffer(size_t count, NoInit) : Buffer(R(), count, noInit) {}
+
+    Buffer(const Buffer&) = delete;
+    Buffer& operator=(const Buffer&) = delete;
+
+    /// @brief Move c-tor; steals the allocation (and retained stream, if any)
+    ///        and leaves @c other empty.
+    Buffer(Buffer&& other) noexcept
+        : detail::StreamHolder<IsAsync>(other)
+        , mResource(std::move(other.mResource))
+        , mData(other.mData)
+        , mSize(other.mSize)
+    {
+        other.mData = nullptr;
+        other.mSize = 0;
+    }
+
+    /// @brief Move assignment; frees the current allocation first, then steals
+    ///        from @c other and leaves it empty. Self-move is a no-op.
+    Buffer& operator=(Buffer&& other) noexcept
+    {
+        if (this != &other) {
+            this->clear();
+            static_cast<detail::StreamHolder<IsAsync>&>(*this) = other;
+            mResource = std::move(other.mResource);
+            mData = other.mData;
+            mSize = other.mSize;
+            other.mData = nullptr;
+            other.mSize = 0;
+        }
+        return *this;
+    }
+
+    /// @brief Returns a deep copy of this buffer, allocated from a copy of the
+    ///        resource; the allocation and element copy are ordered on @c stream,
+    ///        which becomes the copy's retained stream.
+    template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
+    Buffer copy(cudaStream_t stream) const
+    {
+        Buffer out(stream, mResource, mSize, noInit);
+        if (mData) cudaCheck(cudaMemcpyAsync(out.mData, mData, this->size_bytes(), cudaMemcpyDefault, stream));
+        return out;
+    }
+
+    /// @brief Returns a deep copy of this buffer, allocated from a copy of the
+    ///        synchronous resource.
+    template<typename S = R, std::enable_if_t<!is_async_resource<S>::value && is_resource<S>::value, int> = 0>
+    Buffer copy() const
+    {
+        Buffer out(mResource, mSize, noInit);
+        if (mData) cudaCheck(cudaMemcpy(out.mData, mData, this->size_bytes(), cudaMemcpyDefault));
+        return out;
+    }
+
+    /// @brief D-tor. A stream-ordered resource frees on the retained stream;
+    ///        a synchronous resource frees immediately.
+    ~Buffer() { this->clear(); }
+
+    /// @brief Returns the retained stream, i.e. the stream the buffer's memory
+    ///        will be freed on.
+    template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
+    cudaStream_t stream() const { return this->mStream; }
+
+    /// @brief Replaces the retained stream without synchronizing; subsequent
+    ///        deallocation (and destruction) is ordered on @c stream instead.
+    /// @warning The caller is responsible for ordering @c stream after any
+    ///          in-flight work that uses the buffer's memory.
+    template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
+    void setStream(cudaStream_t stream) { this->mStream = stream; }
+
+    /// @brief Resizes the buffer to @c count elements, preserving the leading
+    ///        min(old, new) elements. Every operation — the new allocation, the
+    ///        prefix copy, and the free of the old block — is ordered on
+    ///        @c stream, which becomes the retained stream: the prefix copy is
+    ///        the old block's last use, so that is the stream its free must be
+    ///        ordered on.
+    /// @warning The caller is responsible for ordering @c stream after any
+    ///          in-flight work on the previously retained stream that uses the
+    ///          buffer's memory.
+    template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
+    void resize(size_t count, cudaStream_t stream)
+    {
+        if (count != mSize) {
+            // No member is mutated until every throwing operation has
+            // succeeded, so a failed resize leaves the buffer untouched --
+            // including its retained stream.
+            T* newData = count ? static_cast<T*>(mResource.allocate_async(checkedBytes(count), R::DEFAULT_ALIGNMENT, stream))
+                               : nullptr;
+            if (newData && mData) {
+                const size_t prefix = count < mSize ? count : mSize;
+                try {
+                    cudaCheck(cudaMemcpyAsync(newData, mData, prefix * sizeof(T), cudaMemcpyDefault, stream));
+                }
+                catch (...) {
+                    mResource.deallocate_async(newData, checkedBytes(count), R::DEFAULT_ALIGNMENT, stream);
+                    throw;
+                }
+            }
+            this->mStream = stream;
+            this->deallocate(mData, mSize); // ordered on stream: after the prefix copy
+            mData = newData;
+            mSize = count;
+        }
+        else {
+            this->mStream = stream; // no reallocation: setStream semantics
+        }
+    }
+
+    /// @brief Resizes the buffer to @c count elements through the synchronous
+    ///        resource, preserving the leading min(old, new) elements.
+    template<typename S = R, std::enable_if_t<!is_async_resource<S>::value && is_resource<S>::value, int> = 0>
+    void resize(size_t count)
+    {
+        if (count == mSize) return;
+        T* newData = count ? static_cast<T*>(mResource.allocate(checkedBytes(count), R::DEFAULT_ALIGNMENT))
+                           : nullptr;
+        if (newData && mData) {
+            const size_t prefix = count < mSize ? count : mSize;
+            cudaCheck(cudaMemcpy(newData, mData, prefix * sizeof(T), cudaMemcpyDefault));
+        }
+        this->deallocate(mData, mSize);
+        mData = newData;
+        mSize = count;
+    }
+
+    /// @brief Returns a pointer to the elements, or nullptr if empty.
+    T*       data()       { return mData; }
+    const T* data() const { return mData; }
+
+    /// @brief Returns the number of elements.
+    size_t size() const { return mSize; }
+
+    /// @brief Returns the size of the buffer's allocation in bytes.
+    size_t size_bytes() const { return mSize * sizeof(T); }
+
+    /// @brief Returns true if this buffer manages no memory.
+    bool empty() const { return mSize == 0; }
+
+    /// @brief Frees the buffer memory (if any) and resets to the empty state.
+    void clear()
+    {
+        this->deallocate(mData, mSize);
+        mData = nullptr;
+        mSize = 0;
+    }
+
+private:
+    /// @brief Returns @c count * sizeof(T), throwing std::runtime_error if the
+    ///        byte size would overflow size_t instead of silently wrapping into
+    ///        a tiny allocation.
+    static size_t checkedBytes(size_t count)
+    {
+        if (count > std::numeric_limits<size_t>::max() / sizeof(T))
+            throw std::runtime_error("nanovdb::cuda::Buffer: element count overflows the byte size");
+        return count * sizeof(T);
+    }
+
+    /// @brief Allocates @c count elements through the resource and records the
+    ///        new extent; @c stream is used by the stream-ordered form and
+    ///        ignored by the synchronous one. A zero count allocates nothing.
+    void allocate(size_t count, cudaStream_t stream)
+    {
+        if (count) {
+            if constexpr (IsAsync)
+                mData = static_cast<T*>(mResource.allocate_async(checkedBytes(count), R::DEFAULT_ALIGNMENT, stream));
+            else
+                mData = static_cast<T*>(mResource.allocate(checkedBytes(count), R::DEFAULT_ALIGNMENT));
+        }
+        mSize = count;
+    }
+
+    /// @brief Frees @c count elements at @c p through the resource; the
+    ///        stream-ordered form frees on the retained stream. Null is a no-op.
+    void deallocate(T* p, size_t count)
+    {
+        if (!p) return;
+        if constexpr (IsAsync)
+            mResource.deallocate_async(p, count * sizeof(T), R::DEFAULT_ALIGNMENT, this->mStream);
+        else
+            mResource.deallocate(p, count * sizeof(T), R::DEFAULT_ALIGNMENT);
+    }
+}; // Buffer<T, R> class
+
+/// @brief Non-owning, trivially copyable view of a contiguous range of @c T
+///        elements, with span semantics.
+/// @tparam T element type; spell constness in the element type
+///         (e.g. BufferView<const std::byte> is the read-only form), since
+///         const on the view itself is shallow.
+template<typename T>
+class BufferView
+{
+    T*     mData = nullptr;
+    size_t mSize = 0; // element count
+
+public:
+    /// @brief Default c-tor of an empty view.
+    BufferView() = default;
+
+    /// @brief C-tor viewing @c count elements starting at @c data; the caller
+    ///        guarantees the underlying storage outlives every use of the view.
+    /// @throw std::runtime_error if @c data is null while @c count is non-zero.
+    BufferView(T* data, size_t count) : mData(data), mSize(count)
+    {
+        if (data == nullptr && count != 0)
+            throw std::runtime_error("BufferView: null data with a non-zero element count");
+    }
+
+    /// @brief Returns a pointer to the viewed elements, or nullptr if empty.
+    T* data() const { return mData; }
+
+    /// @brief Returns the number of viewed elements.
+    size_t size() const { return mSize; }
+
+    /// @brief Returns the size of the viewed range in bytes.
+    size_t size_bytes() const { return mSize * sizeof(T); }
+
+    /// @brief Returns true if this view references no elements.
+    bool empty() const { return mSize == 0; }
+
+    /// @brief Detaches the view (nulls the pointer and zeroes the size)
+    ///        without touching the underlying storage. This is the one
+    ///        deliberate deviation from std::span, required by the buffer
+    ///        static interface: GridHandle::reset() calls buffer.clear().
+    void clear()
+    {
+        mData = nullptr;
+        mSize = 0;
+    }
+}; // BufferView<T> class
+
+} // namespace cuda
+
+} // namespace nanovdb
+
+#endif // end of NANOVDB_CUDA_BUFFER_H_HAS_BEEN_INCLUDED

--- a/nanovdb/nanovdb/cuda/Buffer.h
+++ b/nanovdb/nanovdb/cuda/Buffer.h
@@ -78,12 +78,15 @@ public:
     /// @param count number of elements
     template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
     explicit Buffer(cudaStream_t stream, R resource, size_t count, NoInit)
-        : detail::StreamHolder<true>{stream}, mResource(std::move(resource))
+        : detail::StreamHolder<true>{stream}
+        , mResource(std::move(resource))
     {
         this->allocate(count, stream);
     }
 
     /// @brief Convenience c-tor using a default-constructed resource.
+    /// @param stream cuda stream the allocation is ordered on
+    /// @param count number of elements
     /// @note There is deliberately no count c-tor without NoInit: implicit
     ///       initialization of freshly allocated memory costs a hidden fill
     ///       pass that the dominant allocate-then-overwrite pattern wastes,
@@ -95,6 +98,8 @@ public:
     /// @brief C-tor allocating @c count uninitialized elements from a
     ///        synchronous resource: the stream-less analog of
     ///        (stream, resource, count, no_init).
+    /// @param resource resource instance the buffer takes ownership of
+    /// @param count number of elements
     template<typename S = R, std::enable_if_t<!is_async_resource<S>::value && is_resource<S>::value, int> = 0>
     explicit Buffer(R resource, size_t count, NoInit)
         : mResource(std::move(resource))
@@ -103,9 +108,11 @@ public:
     }
 
     /// @brief Convenience c-tor using a default-constructed resource.
+    /// @param count number of elements
     template<typename S = R, std::enable_if_t<!is_async_resource<S>::value && is_resource<S>::value, int> = 0>
     Buffer(size_t count, NoInit) : Buffer(R(), count, noInit) {}
 
+    /// @brief Explicitly disallow copy construction and assignment operation
     Buffer(const Buffer&) = delete;
     Buffer& operator=(const Buffer&) = delete;
 
@@ -140,6 +147,7 @@ public:
     /// @brief Returns a deep copy of this buffer, allocated from a copy of the
     ///        resource; the allocation and element copy are ordered on @c stream,
     ///        which becomes the copy's retained stream.
+    /// @param stream cuda stream the allocation and element copy are ordered on
     template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
     Buffer copy(cudaStream_t stream) const
     {
@@ -169,6 +177,7 @@ public:
 
     /// @brief Replaces the retained stream without synchronizing; subsequent
     ///        deallocation (and destruction) is ordered on @c stream instead.
+    /// @param stream cuda stream subsequent deallocation is ordered on
     /// @warning The caller is responsible for ordering @c stream after any
     ///          in-flight work that uses the buffer's memory.
     template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
@@ -180,6 +189,8 @@ public:
     ///        @c stream, which becomes the retained stream: the prefix copy is
     ///        the old block's last use, so that is the stream its free must be
     ///        ordered on.
+    /// @param count number of elements
+    /// @param stream cuda stream the reallocation is ordered on
     /// @warning The caller is responsible for ordering @c stream after any
     ///          in-flight work on the previously retained stream that uses the
     ///          buffer's memory.
@@ -214,15 +225,24 @@ public:
 
     /// @brief Resizes the buffer to @c count elements through the synchronous
     ///        resource, preserving the leading min(old, new) elements.
+    /// @param count number of elements
     template<typename S = R, std::enable_if_t<!is_async_resource<S>::value && is_resource<S>::value, int> = 0>
     void resize(size_t count)
     {
         if (count == mSize) return;
+        // No member is mutated until every throwing operation has succeeded,
+        // so a failed resize leaves the buffer untouched.
         T* newData = count ? static_cast<T*>(mResource.allocate(checkedBytes(count), R::DEFAULT_ALIGNMENT))
                            : nullptr;
         if (newData && mData) {
             const size_t prefix = count < mSize ? count : mSize;
-            cudaCheck(cudaMemcpy(newData, mData, prefix * sizeof(T), cudaMemcpyDefault));
+            try {
+                cudaCheck(cudaMemcpy(newData, mData, prefix * sizeof(T), cudaMemcpyDefault));
+            }
+            catch (...) {
+                mResource.deallocate(newData, checkedBytes(count), R::DEFAULT_ALIGNMENT);
+                throw;
+            }
         }
         this->deallocate(mData, mSize);
         mData = newData;
@@ -254,6 +274,7 @@ private:
     /// @brief Returns @c count * sizeof(T), throwing std::runtime_error if the
     ///        byte size would overflow size_t instead of silently wrapping into
     ///        a tiny allocation.
+    /// @param count number of elements
     static size_t checkedBytes(size_t count)
     {
         if (count > std::numeric_limits<size_t>::max() / sizeof(T))
@@ -262,8 +283,10 @@ private:
     }
 
     /// @brief Allocates @c count elements through the resource and records the
-    ///        new extent; @c stream is used by the stream-ordered form and
-    ///        ignored by the synchronous one. A zero count allocates nothing.
+    ///        new extent. A zero count allocates nothing.
+    /// @param count number of elements
+    /// @param stream cuda stream the allocation is ordered on; used by the
+    ///        stream-ordered form and ignored by the synchronous one
     void allocate(size_t count, cudaStream_t stream)
     {
         if (count) {
@@ -277,6 +300,8 @@ private:
 
     /// @brief Frees @c count elements at @c p through the resource; the
     ///        stream-ordered form frees on the retained stream. Null is a no-op.
+    /// @param p pointer to the elements to free
+    /// @param count number of elements
     void deallocate(T* p, size_t count)
     {
         if (!p) return;
@@ -302,8 +327,10 @@ public:
     /// @brief Default c-tor of an empty view.
     BufferView() = default;
 
-    /// @brief C-tor viewing @c count elements starting at @c data; the caller
-    ///        guarantees the underlying storage outlives every use of the view.
+    /// @brief C-tor viewing a contiguous range; the caller guarantees the
+    ///        underlying storage outlives every use of the view.
+    /// @param data pointer to the first element
+    /// @param count number of elements
     /// @throw std::runtime_error if @c data is null while @c count is non-zero.
     BufferView(T* data, size_t count) : mData(data), mSize(count)
     {

--- a/nanovdb/nanovdb/cuda/DeviceResource.h
+++ b/nanovdb/nanovdb/cuda/DeviceResource.h
@@ -18,43 +18,61 @@ namespace cuda {
 /// @brief Default stream-ordered device memory resource. Allocations are made
 ///        with cudaMallocAsync and freed with cudaFreeAsync via the
 ///        util::cuda wrappers.
-/// @note Exposes both the legacy static methods (allocateAsync /
-///       deallocateAsync, retained for source compatibility) and the
-///       instance methods (allocate_async / deallocate_async) that model
-///       the AsyncResource concept. The instance methods forward to the
-///       static ones, so a default-constructed instance is stateless and
-///       adds no overhead.
+/// @note Models the AsyncResource concept, which refines the synchronous
+///       Resource concept (as in CCCL's cuda::mr): the instance methods
+///       provide both the stream-ordered allocate_async / deallocate_async
+///       and the synchronous allocate / deallocate. The type is stateless,
+///       so a default-constructed instance adds no overhead. The static
+///       allocateAsync / deallocateAsync methods are deprecated.
 class DeviceResource
 {
 public:
     // cudaMalloc aligns memory to 256 bytes by default
     static constexpr size_t DEFAULT_ALIGNMENT = 256;
 
-    static void* allocateAsync(size_t bytes, size_t, cudaStream_t stream) {
+    /// @brief Stream-ordered allocation.
+    /// @param bytes number of bytes to allocate
+    /// @param stream cuda stream the allocation is ordered on
+    /// @note the alignment parameter is unnamed: cudaMallocAsync always
+    ///       256B-aligns
+    void* allocate_async(size_t bytes, size_t, cudaStream_t stream) {
         void* p = nullptr;
         cudaCheck(util::cuda::mallocAsync(&p, bytes, stream));
         return p;
     }
 
-    static void deallocateAsync(void *p, size_t, size_t, cudaStream_t stream) {
+    /// @brief Stream-ordered deallocation.
+    /// @param p pointer previously returned by allocate_async
+    /// @param stream cuda stream the deallocation is ordered on
+    void deallocate_async(void* p, size_t, size_t, cudaStream_t stream) {
         cudaCheck(util::cuda::freeAsync(p, stream));
     }
 
-    /// @brief Instance allocation entry point modelling the AsyncResource concept.
+    /// @brief Synchronous allocation; the returned memory is immediately
+    ///        valid on every stream.
     /// @param bytes number of bytes to allocate
-    /// @param alignment requested alignment (cudaMallocAsync always 256B-aligns)
-    /// @param stream cuda stream the allocation is ordered on
-    void* allocate_async(size_t bytes, size_t alignment, cudaStream_t stream) {
-        return allocateAsync(bytes, alignment, stream);
+    /// @param alignment requested alignment
+    void* allocate(size_t bytes, size_t alignment) {
+        void* p = this->allocate_async(bytes, alignment, cudaStream_t(0));
+        cudaCheck(cudaStreamSynchronize(cudaStream_t(0)));
+        return p;
     }
 
-    /// @brief Instance deallocation entry point modelling the AsyncResource concept.
-    /// @param p pointer previously returned by allocate_async
-    /// @param bytes size passed to the matching allocate_async
-    /// @param alignment alignment passed to the matching allocate_async
-    /// @param stream cuda stream the deallocation is ordered on
-    void deallocate_async(void* p, size_t bytes, size_t alignment, cudaStream_t stream) {
-        deallocateAsync(p, bytes, alignment, stream);
+    /// @brief Synchronous deallocation; the caller guarantees that device
+    ///        work touching the memory has completed.
+    /// @param p pointer previously returned by allocate or allocate_async
+    void deallocate(void* p, size_t bytes, size_t alignment) {
+        this->deallocate_async(p, bytes, alignment, cudaStream_t(0));
+    }
+
+    [[deprecated("use the instance method allocate_async")]]
+    static void* allocateAsync(size_t bytes, size_t alignment, cudaStream_t stream) {
+        return DeviceResource().allocate_async(bytes, alignment, stream);
+    }
+
+    [[deprecated("use the instance method deallocate_async")]]
+    static void deallocateAsync(void *p, size_t bytes, size_t alignment, cudaStream_t stream) {
+        DeviceResource().deallocate_async(p, bytes, alignment, stream);
     }
 };
 
@@ -87,13 +105,44 @@ inline R& default_resource()
 ///         return resource.allocate(bytes, alignment);               // synchronous
 /// }
 /// @endcode
+/// @note AsyncResource refines the synchronous Resource concept, matching
+///       CCCL's cuda::mr: an async resource must also provide the
+///       synchronous allocate / deallocate, so is_async_resource<R> implies
+///       is_resource<R>. A synchronous-only resource (e.g. PinnedResource)
+///       models just is_resource. The synchronous methods of a stream-ordered
+///       resource are typically thin delegates (allocate_async on the null
+///       stream followed by a stream synchronize).
 template <class R, class = void>
 struct is_async_resource : std::false_type {};
 
 template <class R>
 struct is_async_resource<R, std::void_t<
     decltype(std::declval<R&>().allocate_async(size_t{0}, size_t{0}, cudaStream_t{0})),
-    decltype(std::declval<R&>().deallocate_async(std::declval<void*>(), size_t{0}, size_t{0}, cudaStream_t{0}))>>
+    decltype(std::declval<R&>().deallocate_async(std::declval<void*>(), size_t{0}, size_t{0}, cudaStream_t{0})),
+    decltype(std::declval<R&>().allocate(size_t{0}, size_t{0})),
+    decltype(std::declval<R&>().deallocate(std::declval<void*>(), size_t{0}, size_t{0}))>>
+    : std::true_type {};
+
+/// @brief Detection trait: @c is_resource<R>::value is true iff @c R models
+///        the synchronous Resource concept, i.e. exposes
+///        allocate(size_t, size_t) and deallocate(void*, size_t, size_t).
+/// @details Use it to constrain code paths that need a resource without a
+///          stream argument, e.g. host-side allocations:
+/// @code
+/// template<typename R>
+/// void* allocate(R& resource, size_t bytes, size_t alignment)
+/// {
+///     static_assert(nanovdb::cuda::is_resource<R>::value, "R must be a synchronous resource");
+///     return resource.allocate(bytes, alignment);
+/// }
+/// @endcode
+template <class R, class = void>
+struct is_resource : std::false_type {};
+
+template <class R>
+struct is_resource<R, std::void_t<
+    decltype(std::declval<R&>().allocate(size_t{0}, size_t{0})),
+    decltype(std::declval<R&>().deallocate(std::declval<void*>(), size_t{0}, size_t{0}))>>
     : std::true_type {};
 
 }

--- a/nanovdb/nanovdb/unittest/CMakeLists.txt
+++ b/nanovdb/nanovdb/unittest/CMakeLists.txt
@@ -62,6 +62,11 @@ if(NANOVDB_USE_CUDA)
   target_link_libraries(nanovdb_test_cuda_memory_resource PRIVATE nanovdb GTest::GTest GTest::Main)
   set_target_properties(nanovdb_test_cuda_memory_resource PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
   add_test(nanovdb_cuda_memory_resource_unit_test nanovdb_test_cuda_memory_resource)
+
+  add_executable(nanovdb_test_cuda_buffer "TestBuffer.cu")
+  target_link_libraries(nanovdb_test_cuda_buffer PRIVATE nanovdb GTest::GTest GTest::Main)
+  set_target_properties(nanovdb_test_cuda_buffer PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+  add_test(nanovdb_cuda_buffer_unit_test nanovdb_test_cuda_buffer)
 endif()
 
 # -----------------------------------------------------------------------------

--- a/nanovdb/nanovdb/unittest/TestBuffer.cu
+++ b/nanovdb/nanovdb/unittest/TestBuffer.cu
@@ -1,0 +1,631 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/// @file TestBuffer.cu
+///
+/// @brief Unit tests for the typed, resource-aware CUDA containers
+///        (cuda::Buffer, cuda::BufferView) and the synchronous Resource
+///        trait (cuda::is_resource).
+
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/cuda/Buffer.h>
+#include <nanovdb/cuda/DeviceResource.h>
+#include <nanovdb/cuda/PinnedResource.h>
+#include <nanovdb/tools/CreatePrimitives.h>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+//======================================================================
+// Shared test doubles
+//======================================================================
+
+/// @brief Bookkeeping shared by all copies of a CountingResource, so counts
+///        survive the resource being held by value inside a Buffer.
+struct Counters
+{
+    int    allocs       = 0;
+    int    deallocs     = 0;
+    size_t allocBytes   = 0; // bytes of the most recent allocation
+    size_t deallocBytes = 0; // bytes of the most recent deallocation
+};
+
+/// @brief Resource that counts (non-null) allocations and deallocations so
+///        leaks can be asserted. Delegates the actual work to DeviceResource.
+struct CountingResource
+{
+    static constexpr size_t DEFAULT_ALIGNMENT = nanovdb::cuda::DeviceResource::DEFAULT_ALIGNMENT;
+    Counters* counters = nullptr;
+    void* allocate_async(size_t bytes, size_t alignment, cudaStream_t stream) {
+        void* p = nanovdb::cuda::DeviceResource{}.allocate_async(bytes, alignment, stream);
+        if (p) { ++counters->allocs; counters->allocBytes = bytes; }
+        return p;
+    }
+    void deallocate_async(void* p, size_t bytes, size_t alignment, cudaStream_t stream) {
+        if (p) { ++counters->deallocs; counters->deallocBytes = bytes; }
+        nanovdb::cuda::DeviceResource{}.deallocate_async(p, bytes, alignment, stream);
+    }
+    void* allocate(size_t bytes, size_t alignment) {
+        void* p = nanovdb::cuda::DeviceResource{}.allocate(bytes, alignment);
+        if (p) { ++counters->allocs; counters->allocBytes = bytes; }
+        return p;
+    }
+    void deallocate(void* p, size_t bytes, size_t alignment) {
+        if (p) { ++counters->deallocs; counters->deallocBytes = bytes; }
+        nanovdb::cuda::DeviceResource{}.deallocate(p, bytes, alignment);
+    }
+};
+
+/// @brief Streams recorded by all copies of a StreamRecordingResource.
+struct StreamLog
+{
+    std::vector<cudaStream_t> allocStreams;
+    std::vector<cudaStream_t> deallocStreams;
+};
+
+/// @brief Resource that records the stream of every allocation/deallocation,
+///        to verify stream-ordered teardown. Delegates work to DeviceResource.
+struct StreamRecordingResource
+{
+    static constexpr size_t DEFAULT_ALIGNMENT = nanovdb::cuda::DeviceResource::DEFAULT_ALIGNMENT;
+    StreamLog* log = nullptr;
+    void* allocate_async(size_t bytes, size_t alignment, cudaStream_t stream) {
+        void* p = nanovdb::cuda::DeviceResource{}.allocate_async(bytes, alignment, stream);
+        if (p) log->allocStreams.push_back(stream);
+        return p;
+    }
+    void deallocate_async(void* p, size_t bytes, size_t alignment, cudaStream_t stream) {
+        if (p) log->deallocStreams.push_back(stream);
+        nanovdb::cuda::DeviceResource{}.deallocate_async(p, bytes, alignment, stream);
+    }
+    void* allocate(size_t bytes, size_t alignment) {
+        void* p = nanovdb::cuda::DeviceResource{}.allocate(bytes, alignment);
+        if (p) log->allocStreams.push_back(cudaStream_t(0));
+        return p;
+    }
+    void deallocate(void* p, size_t bytes, size_t alignment) {
+        if (p) log->deallocStreams.push_back(cudaStream_t(0));
+        nanovdb::cuda::DeviceResource{}.deallocate(p, bytes, alignment);
+    }
+};
+
+//======================================================================
+// Resource concept traits: is_resource (synchronous) / is_async_resource
+//======================================================================
+
+/// @brief Local double that provides both the synchronous and the
+///        stream-ordered allocation interface, like a CCCL-style resource.
+struct DualResource
+{
+    static constexpr size_t DEFAULT_ALIGNMENT = 256;
+    void* allocate(size_t, size_t) { return nullptr; }
+    void deallocate(void*, size_t, size_t) {}
+    void* allocate_async(size_t, size_t, cudaStream_t) { return nullptr; }
+    void deallocate_async(void*, size_t, size_t, cudaStream_t) {}
+};
+
+// PinnedResource is synchronous-only: allocate/deallocate without a stream.
+static_assert(nanovdb::cuda::is_resource<nanovdb::cuda::PinnedResource>::value,
+              "PinnedResource must satisfy the synchronous Resource concept");
+static_assert(!nanovdb::cuda::is_async_resource<nanovdb::cuda::PinnedResource>::value,
+              "PinnedResource must not satisfy the AsyncResource concept");
+
+// DeviceResource models the AsyncResource refinement: both the
+// stream-ordered and the synchronous interface (as in CCCL's cuda::mr).
+static_assert(nanovdb::cuda::is_async_resource<nanovdb::cuda::DeviceResource>::value,
+              "DeviceResource must satisfy the AsyncResource concept");
+static_assert(nanovdb::cuda::is_resource<nanovdb::cuda::DeviceResource>::value,
+              "DeviceResource must also satisfy the synchronous Resource concept");
+
+/// @brief Local double with only the stream-ordered interface; under the
+///        refinement this is NOT an async resource (the sync pair is missing).
+struct AsyncOnlyResource
+{
+    static constexpr size_t DEFAULT_ALIGNMENT = 256;
+    void* allocate_async(size_t, size_t, cudaStream_t) { return nullptr; }
+    void deallocate_async(void*, size_t, size_t, cudaStream_t) {}
+};
+static_assert(!nanovdb::cuda::is_async_resource<AsyncOnlyResource>::value,
+              "the async pair alone must not satisfy the AsyncResource refinement");
+static_assert(!nanovdb::cuda::is_resource<AsyncOnlyResource>::value,
+              "the async pair alone must not satisfy the Resource concept");
+
+// An unrelated type satisfies neither concept.
+static_assert(!nanovdb::cuda::is_resource<int>::value,
+              "int must not satisfy the Resource concept");
+static_assert(!nanovdb::cuda::is_async_resource<int>::value,
+              "int must not satisfy the AsyncResource concept");
+
+// A resource with both interfaces satisfies both concepts.
+static_assert(nanovdb::cuda::is_resource<DualResource>::value,
+              "DualResource must satisfy the synchronous Resource concept");
+static_assert(nanovdb::cuda::is_async_resource<DualResource>::value,
+              "DualResource must satisfy the AsyncResource concept");
+
+TEST(TestBuffer, ResourceTraits)
+{
+    // The static_asserts above are the real test; this anchors them in a
+    // runnable suite entry.
+    EXPECT_TRUE(nanovdb::cuda::is_resource<nanovdb::cuda::PinnedResource>::value);
+    EXPECT_TRUE(nanovdb::cuda::is_async_resource<nanovdb::cuda::DeviceResource>::value);
+}
+
+//======================================================================
+// Buffer<T, R> with a stream-ordered (async) resource: construction,
+// destruction, element counting, value-initialization
+//======================================================================
+
+TEST(TestBuffer, AsyncCountingAllocFree)
+{
+    cudaStream_t s = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);
+    Counters c;
+    const size_t n = 100;
+    {
+        nanovdb::cuda::Buffer<float, CountingResource> buf(s, CountingResource{&c}, n, nanovdb::cuda::noInit);
+        EXPECT_NE(buf.data(), nullptr);
+        EXPECT_EQ(buf.size(), n);                       // elements, not bytes
+        EXPECT_EQ(buf.size_bytes(), n * sizeof(float));
+        EXPECT_FALSE(buf.empty());
+        EXPECT_EQ(c.allocs, 1);                         // exactly one allocation
+        EXPECT_EQ(c.allocBytes, n * sizeof(float));
+        EXPECT_EQ(c.deallocs, 0);
+    }
+    EXPECT_EQ(c.deallocs, 1);                           // exactly one deallocation
+    EXPECT_EQ(c.deallocBytes, n * sizeof(float));       // with identical size
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(s), cudaSuccess);
+}
+
+TEST(TestBuffer, EmptyBuffersAllocateNothing)
+{
+    Counters c;
+    {
+        nanovdb::cuda::Buffer<float, CountingResource> def; // default ctor: empty
+        EXPECT_EQ(def.data(), nullptr);
+        EXPECT_EQ(def.size(), 0u);
+        EXPECT_EQ(def.size_bytes(), 0u);
+        EXPECT_TRUE(def.empty());
+
+        nanovdb::cuda::Buffer<float, CountingResource> zero(0, CountingResource{&c}, 0, nanovdb::cuda::noInit);
+        EXPECT_EQ(zero.data(), nullptr);
+        EXPECT_TRUE(zero.empty());
+    }
+    EXPECT_EQ(c.allocs, 0);
+    EXPECT_EQ(c.deallocs, 0);
+}
+
+TEST(TestBuffer, CountConstructionRequiresNoInit)
+{
+    // A count without NoInit must not construct: implicit initialization of
+    // freshly allocated memory is a hidden fill pass the dominant
+    // allocate-then-overwrite pattern wastes (the cuda::buffer rule).
+    using DevBuf = nanovdb::cuda::Buffer<int>;
+    using PinBuf = nanovdb::cuda::Buffer<int, nanovdb::cuda::PinnedResource>;
+    static_assert(!std::is_constructible<DevBuf, cudaStream_t, size_t>::value,
+                  "async count c-tor without NoInit must not exist");
+    static_assert(!std::is_constructible<DevBuf, cudaStream_t, nanovdb::cuda::DeviceResource, size_t>::value,
+                  "async count+resource c-tor without NoInit must not exist");
+    static_assert(!std::is_constructible<PinBuf, size_t>::value,
+                  "sync count c-tor without NoInit must not exist");
+    static_assert(!std::is_constructible<PinBuf, nanovdb::cuda::PinnedResource, size_t>::value,
+                  "sync count+resource c-tor without NoInit must not exist");
+    static_assert(std::is_constructible<DevBuf, cudaStream_t, size_t, nanovdb::cuda::NoInit>::value,
+                  "async count c-tor with NoInit exists");
+    static_assert(std::is_constructible<PinBuf, size_t, nanovdb::cuda::NoInit>::value,
+                  "sync count c-tor with NoInit exists");
+    SUCCEED();
+}
+
+TEST(TestBuffer, OversizedCountThrows)
+{
+    // An element count whose byte size overflows size_t must be rejected up
+    // front rather than silently wrapping into a tiny allocation.
+    const size_t oversized = std::numeric_limits<size_t>::max() / sizeof(int) + 1;
+    EXPECT_THROW((nanovdb::cuda::Buffer<int>(0, oversized, nanovdb::cuda::noInit)), std::runtime_error);
+    EXPECT_THROW((nanovdb::cuda::Buffer<int, nanovdb::cuda::PinnedResource>(oversized, nanovdb::cuda::noInit)), std::runtime_error);
+    nanovdb::cuda::Buffer<int> buf(0, 8, nanovdb::cuda::noInit);
+    cudaStream_t other = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&other), cudaSuccess);
+    EXPECT_THROW(buf.resize(oversized, other), std::runtime_error);
+    EXPECT_EQ(buf.size(), 8u);                // failed resize leaves the buffer untouched --
+    EXPECT_EQ(buf.stream(), cudaStream_t(0)); // including its retained stream
+    ASSERT_EQ(cudaStreamDestroy(other), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
+TEST(TestBuffer, ClearFreesAndEmpties)
+{
+    Counters c;
+    nanovdb::cuda::Buffer<float, CountingResource> buf(0, CountingResource{&c}, 64, nanovdb::cuda::noInit);
+    ASSERT_EQ(c.allocs, 1);
+    buf.clear();
+    EXPECT_EQ(buf.data(), nullptr);
+    EXPECT_EQ(buf.size(), 0u);
+    EXPECT_TRUE(buf.empty());
+    EXPECT_EQ(c.deallocs, 1);
+    buf.clear();                 // idempotent: no second free
+    EXPECT_EQ(c.deallocs, 1);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
+//======================================================================
+// Stream retention: the destructor and resize free on the retained stream
+// (stream of the most recent allocation, or the one supplied via setStream)
+//======================================================================
+
+TEST(TestBuffer, DestructorFreesOnAllocationStream)
+{
+    cudaStream_t a = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&a), cudaSuccess);
+    StreamLog log;
+    {
+        nanovdb::cuda::Buffer<float, StreamRecordingResource> buf(a, StreamRecordingResource{&log}, 32, nanovdb::cuda::noInit);
+        EXPECT_EQ(buf.stream(), a);
+    }
+    ASSERT_EQ(log.allocStreams.size(), 1u);
+    EXPECT_EQ(log.allocStreams.back(), a);
+    ASSERT_EQ(log.deallocStreams.size(), 1u);
+    EXPECT_EQ(log.deallocStreams.back(), a);
+    ASSERT_EQ(cudaStreamSynchronize(a), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(a), cudaSuccess);
+}
+
+TEST(TestBuffer, SetStreamRedirectsTheFree)
+{
+    cudaStream_t a = nullptr, b = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&a), cudaSuccess);
+    ASSERT_EQ(cudaStreamCreate(&b), cudaSuccess);
+    StreamLog log;
+    {
+        nanovdb::cuda::Buffer<float, StreamRecordingResource> buf(a, StreamRecordingResource{&log}, 32, nanovdb::cuda::noInit);
+        buf.setStream(b); // member update only, no synchronization
+        EXPECT_EQ(buf.stream(), b);
+    }
+    ASSERT_EQ(log.allocStreams.size(), 1u);
+    EXPECT_EQ(log.allocStreams.back(), a);
+    ASSERT_EQ(log.deallocStreams.size(), 1u);
+    EXPECT_EQ(log.deallocStreams.back(), b);
+    ASSERT_EQ(cudaStreamSynchronize(a), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(b), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(a), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(b), cudaSuccess);
+}
+
+TEST(TestBuffer, ResizePreservesPrefixAndRetainsNewStream)
+{
+    cudaStream_t a = nullptr, c = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&a), cudaSuccess);
+    ASSERT_EQ(cudaStreamCreate(&c), cudaSuccess);
+    StreamLog log;
+    const size_t n = 128, m = 256;
+    {
+        nanovdb::cuda::Buffer<int, StreamRecordingResource> buf(a, StreamRecordingResource{&log}, n, nanovdb::cuda::noInit);
+        std::vector<int> pattern(n);
+        for (size_t i = 0; i < n; ++i) pattern[i] = int(i) * 3 + 1;
+        ASSERT_EQ(cudaMemcpyAsync(buf.data(), pattern.data(), n * sizeof(int), cudaMemcpyHostToDevice, a), cudaSuccess);
+        ASSERT_EQ(cudaStreamSynchronize(a), cudaSuccess);
+
+        buf.resize(m, c); // grow on stream c
+        EXPECT_EQ(buf.size(), m);
+        EXPECT_EQ(buf.stream(), c);
+        ASSERT_EQ(log.allocStreams.size(), 2u);
+        EXPECT_EQ(log.allocStreams.back(), c);       // new block allocated on c
+        ASSERT_EQ(log.deallocStreams.size(), 1u);
+        // The prefix copy on c is the old block's last use, so the old block is
+        // freed on c as well; freeing it on a would let the allocator recycle
+        // it concurrently with the copy.
+        EXPECT_EQ(log.deallocStreams.back(), c);
+
+        std::vector<int> readback(m, -1);
+        ASSERT_EQ(cudaMemcpyAsync(readback.data(), buf.data(), m * sizeof(int), cudaMemcpyDeviceToHost, c), cudaSuccess);
+        ASSERT_EQ(cudaStreamSynchronize(c), cudaSuccess);
+        for (size_t i = 0; i < n; ++i)
+            ASSERT_EQ(readback[i], pattern[i]) << "prefix element " << i << " lost across resize";
+
+        buf.resize(n / 2, c); // shrink: keeps the min(old,new) prefix
+        std::vector<int> shrunk(n / 2, -1);
+        ASSERT_EQ(cudaMemcpyAsync(shrunk.data(), buf.data(), (n / 2) * sizeof(int), cudaMemcpyDeviceToHost, c), cudaSuccess);
+        ASSERT_EQ(cudaStreamSynchronize(c), cudaSuccess);
+        for (size_t i = 0; i < n / 2; ++i)
+            ASSERT_EQ(shrunk[i], pattern[i]) << "prefix element " << i << " lost across shrink";
+    }
+    EXPECT_EQ(log.allocStreams.size(), log.deallocStreams.size()); // every allocation freed
+    ASSERT_EQ(cudaStreamSynchronize(a), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(c), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(a), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(c), cudaSuccess);
+}
+
+//======================================================================
+// Move semantics (Buffer is move-only) and explicit deep copy
+//======================================================================
+
+TEST(TestBuffer, MoveConstructorSteals)
+{
+    Counters c;
+    {
+        nanovdb::cuda::Buffer<float, CountingResource> src(0, CountingResource{&c}, 64, nanovdb::cuda::noInit);
+        float* p = src.data();
+        nanovdb::cuda::Buffer<float, CountingResource> dst(std::move(src));
+        EXPECT_EQ(dst.data(), p);        // stolen, not reallocated
+        EXPECT_EQ(dst.size(), 64u);
+        EXPECT_EQ(src.data(), nullptr);  // source emptied
+        EXPECT_EQ(src.size(), 0u);
+        EXPECT_TRUE(src.empty());
+        EXPECT_EQ(c.allocs, 1);          // no allocation on move
+    }
+    EXPECT_EQ(c.allocs, c.deallocs);     // exactly one free, no double free
+    EXPECT_EQ(c.deallocs, 1);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
+TEST(TestBuffer, MoveAssignFreesDestination)
+{
+    Counters c;
+    {
+        nanovdb::cuda::Buffer<float, CountingResource> a(0, CountingResource{&c}, 64, nanovdb::cuda::noInit);
+        nanovdb::cuda::Buffer<float, CountingResource> b(0, CountingResource{&c}, 32, nanovdb::cuda::noInit);
+        ASSERT_EQ(c.allocs, 2);
+        float* p = a.data();
+        b = std::move(a);                // frees b's old block first
+        EXPECT_EQ(c.deallocs, 1);
+        EXPECT_EQ(b.data(), p);
+        EXPECT_EQ(b.size(), 64u);
+        EXPECT_EQ(a.data(), nullptr);
+    }
+    EXPECT_EQ(c.allocs, c.deallocs);     // both blocks freed exactly once
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
+TEST(TestBuffer, SelfMoveAssignIsSafe)
+{
+    Counters c;
+    {
+        nanovdb::cuda::Buffer<float, CountingResource> buf(0, CountingResource{&c}, 16, nanovdb::cuda::noInit);
+        auto& self = buf; // avoids the compiler warning on a literal self-move
+        buf = std::move(self);
+        EXPECT_NE(buf.data(), nullptr);  // still owns its block
+        EXPECT_EQ(buf.size(), 16u);
+        EXPECT_EQ(c.deallocs, 0);
+    }
+    EXPECT_EQ(c.allocs, 1);
+    EXPECT_EQ(c.deallocs, 1);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
+TEST(TestBuffer, CopyIsDeep)
+{
+    cudaStream_t s = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);
+    Counters c;
+    const size_t n = 96;
+    {
+        nanovdb::cuda::Buffer<int, CountingResource> src(s, CountingResource{&c}, n, nanovdb::cuda::noInit);
+        std::vector<int> pattern(n);
+        for (size_t i = 0; i < n; ++i) pattern[i] = int(i) - 7;
+        ASSERT_EQ(cudaMemcpyAsync(src.data(), pattern.data(), n * sizeof(int), cudaMemcpyHostToDevice, s), cudaSuccess);
+
+        auto dup = src.copy(s);
+        EXPECT_EQ(c.allocs, 2);              // deep copy allocates its own block
+        EXPECT_NE(dup.data(), src.data());
+        EXPECT_EQ(dup.size(), n);
+        EXPECT_EQ(dup.stream(), s);
+
+        std::vector<int> readback(n, 0);
+        ASSERT_EQ(cudaMemcpyAsync(readback.data(), dup.data(), n * sizeof(int), cudaMemcpyDeviceToHost, s), cudaSuccess);
+        ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+        EXPECT_EQ(readback, pattern);
+    }
+    EXPECT_EQ(c.allocs, c.deallocs);
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(s), cudaSuccess);
+}
+
+//======================================================================
+// CUDA graph capture: the async path (stream-ordered allocation, no hidden
+// synchronization or initialization) must be recordable in a graph. The
+// synchronous tier is excluded by construction -- it synchronizes.
+//======================================================================
+
+TEST(TestBuffer, AsyncPathIsGraphCapturable)
+{
+    cudaStream_t s = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);
+
+    cudaGraph_t graph = nullptr;
+    ASSERT_EQ(cudaStreamBeginCapture(s, cudaStreamCaptureModeGlobal), cudaSuccess);
+    {
+        // Allocation, use, and free are all recorded as graph nodes; the
+        // buffer is created and destroyed inside the capture so the graph
+        // owns the allocation's whole lifetime.
+        nanovdb::cuda::Buffer<int> buf(s, 256, nanovdb::cuda::noInit);
+        ASSERT_NE(buf.data(), nullptr);
+        ASSERT_EQ(cudaMemsetAsync(buf.data(), 0x5A, buf.size_bytes(), s), cudaSuccess);
+    }
+    ASSERT_EQ(cudaStreamEndCapture(s, &graph), cudaSuccess);
+    ASSERT_NE(graph, nullptr);
+
+    cudaGraphExec_t exec = nullptr;
+    ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+    ASSERT_EQ(cudaGraphLaunch(exec, s), cudaSuccess);
+    ASSERT_EQ(cudaGraphLaunch(exec, s), cudaSuccess); // relaunchable
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+
+    ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+    ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(s), cudaSuccess);
+}
+
+//======================================================================
+// Buffer over a synchronous resource (PinnedResource): no stream anywhere
+//======================================================================
+
+template<class B, class = void>
+struct HasSetStream : std::false_type {};
+template<class B>
+struct HasSetStream<B, std::void_t<decltype(std::declval<B&>().setStream(cudaStream_t{0}))>> : std::true_type {};
+
+template<class B, class = void>
+struct HasStreamGetter : std::false_type {};
+template<class B>
+struct HasStreamGetter<B, std::void_t<decltype(std::declval<const B&>().stream())>> : std::true_type {};
+
+using PinnedBufferF = nanovdb::cuda::Buffer<float, nanovdb::cuda::PinnedResource>;
+using DeviceBufferF = nanovdb::cuda::Buffer<float, nanovdb::cuda::DeviceResource>;
+
+// A Buffer over a synchronous resource exposes no stream API at all.
+static_assert(!HasSetStream<PinnedBufferF>::value, "sync-resource Buffer must not expose setStream");
+static_assert(!HasStreamGetter<PinnedBufferF>::value, "sync-resource Buffer must not expose stream()");
+static_assert(HasSetStream<DeviceBufferF>::value, "async-resource Buffer exposes setStream");
+static_assert(HasStreamGetter<DeviceBufferF>::value, "async-resource Buffer exposes stream()");
+
+TEST(TestBuffer, PinnedBufferIsPageLocked)
+{
+    const size_t n = 300;
+    PinnedBufferF buf(n, nanovdb::cuda::noInit); // synchronous: no stream parameter
+    ASSERT_NE(buf.data(), nullptr);
+    EXPECT_EQ(buf.size(), n);
+
+    cudaPointerAttributes attr{};
+    ASSERT_EQ(cudaPointerGetAttributes(&attr, buf.data()), cudaSuccess);
+    EXPECT_EQ(attr.type, cudaMemoryTypeHost); // genuine page-locked host memory
+}
+
+TEST(TestBuffer, PinnedBufferNoInitResizeAndCopy)
+{
+    const size_t n = 64;
+    nanovdb::cuda::Buffer<int, nanovdb::cuda::PinnedResource> buf(n, nanovdb::cuda::noInit);
+    ASSERT_NE(buf.data(), nullptr);
+    for (size_t i = 0; i < n; ++i) buf.data()[i] = int(i) + 11;
+
+    buf.resize(2 * n); // synchronous: no stream parameter
+    EXPECT_EQ(buf.size(), 2 * n);
+    for (size_t i = 0; i < n; ++i)
+        ASSERT_EQ(buf.data()[i], int(i) + 11) << "prefix element " << i << " lost across resize";
+
+    auto dup = buf.copy();
+    ASSERT_NE(dup.data(), nullptr);
+    EXPECT_NE(dup.data(), buf.data()); // deep copy
+    EXPECT_EQ(dup.size(), buf.size());
+    for (size_t i = 0; i < n; ++i)
+        ASSERT_EQ(dup.data()[i], int(i) + 11);
+}
+
+//======================================================================
+// Raw (untyped) form: Buffer<std::byte, DeviceResource>
+//======================================================================
+
+TEST(TestBuffer, RawByteBufferRoundTrip)
+{
+    cudaStream_t s = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);
+    const size_t n = 1000;
+    nanovdb::cuda::Buffer<std::byte> buf(s, n, nanovdb::cuda::noInit);
+    EXPECT_EQ(buf.size(), n);
+    EXPECT_EQ(buf.size_bytes(), n); // one byte per element
+
+    std::vector<std::byte> pattern(n);
+    for (size_t i = 0; i < n; ++i) pattern[i] = std::byte(i % 251);
+    ASSERT_EQ(cudaMemcpyAsync(buf.data(), pattern.data(), n, cudaMemcpyHostToDevice, s), cudaSuccess);
+    std::vector<std::byte> readback(n);
+    ASSERT_EQ(cudaMemcpyAsync(readback.data(), buf.data(), n, cudaMemcpyDeviceToHost, s), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    EXPECT_EQ(readback, pattern);
+    buf.clear();
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(s), cudaSuccess);
+}
+
+//======================================================================
+// BufferView: non-owning typed view with span semantics
+//======================================================================
+
+static_assert(std::is_trivially_copyable_v<nanovdb::cuda::BufferView<std::byte>>,
+              "BufferView must be trivially copyable");
+static_assert(std::is_trivially_copyable_v<nanovdb::cuda::BufferView<const std::byte>>,
+              "BufferView over const elements must be trivially copyable");
+
+TEST(TestBuffer, BufferViewWrapsHostArray)
+{
+    float host[5] = {0.f, 1.f, 2.f, 3.f, 4.f};
+
+    nanovdb::cuda::BufferView<float> empty;
+    EXPECT_EQ(empty.data(), nullptr);
+    EXPECT_EQ(empty.size(), 0u);
+    EXPECT_TRUE(empty.empty());
+
+    nanovdb::cuda::BufferView<float> view(host, 5);
+    EXPECT_EQ(view.data(), host);
+    EXPECT_EQ(view.size(), 5u);
+    EXPECT_EQ(view.size_bytes(), 5 * sizeof(float));
+    EXPECT_FALSE(view.empty());
+    view.data()[2] = 42.f; // writable through the view
+    EXPECT_EQ(host[2], 42.f);
+
+    view.clear(); // detaches, does not free
+    EXPECT_EQ(view.data(), nullptr);
+    EXPECT_TRUE(view.empty());
+    EXPECT_EQ(host[2], 42.f); // underlying storage untouched
+
+    // A null base pointer is only valid for an empty view.
+    EXPECT_THROW((nanovdb::cuda::BufferView<float>(nullptr, 5)), std::runtime_error);
+    EXPECT_NO_THROW((nanovdb::cuda::BufferView<float>(nullptr, 0)));
+}
+
+TEST(TestBuffer, BufferViewConstElements)
+{
+    const std::byte host[4] = {std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
+    nanovdb::cuda::BufferView<const std::byte> view(host, 4);
+    EXPECT_EQ(view.data(), host);
+    EXPECT_EQ(view.size_bytes(), 4u);
+    EXPECT_EQ(view.data()[3], std::byte{4}); // read-only access
+}
+
+//======================================================================
+// Zero-copy GridHandle over a BufferView: a handle that indexes grids in
+// storage owned elsewhere
+//======================================================================
+
+TEST(TestBuffer, GridHandleOverBufferViewIsZeroCopy)
+{
+    // Build a small host grid with the default (owning) HostBuffer.
+    auto owner = nanovdb::tools::createLevelSetSphere<float>(20.0, nanovdb::Vec3d(0), 1.0, 3.0, nanovdb::Vec3d(0), "sphere");
+    ASSERT_NE(owner.data(), nullptr);
+    const auto* grid = owner.grid<float>();
+    ASSERT_NE(grid, nullptr);
+
+    {
+        // Wrap the owning handle's storage in a non-owning view...
+        nanovdb::cuda::BufferView<std::byte> view(static_cast<std::byte*>(owner.data()), owner.bufferSize());
+        // ...and construct a second, zero-copy handle over the same bytes.
+        nanovdb::GridHandle<nanovdb::cuda::BufferView<std::byte>> viewHandle(std::move(view));
+
+        EXPECT_EQ(viewHandle.gridCount(), owner.gridCount());
+        EXPECT_EQ(viewHandle.data(), owner.data()); // same bytes, not a copy
+
+        const auto* viewGrid = viewHandle.grid<float>();
+        ASSERT_NE(viewGrid, nullptr);
+        EXPECT_EQ(viewGrid, grid);                  // zero copy: identical grid address
+        EXPECT_EQ(viewGrid->gridType(), grid->gridType());
+        EXPECT_EQ(viewGrid->activeVoxelCount(), grid->activeVoxelCount());
+        EXPECT_EQ(viewGrid->worldBBox(), grid->worldBBox());
+        EXPECT_STREQ(viewGrid->gridName(), grid->gridName());
+    } // view handle destroyed first: detaches without freeing
+
+    // The owning handle is still intact and is the single owner of the bytes.
+    ASSERT_NE(owner.data(), nullptr);
+    EXPECT_NE(owner.grid<float>(), nullptr);
+    EXPECT_EQ(owner.grid<float>()->activeVoxelCount(), grid->activeVoxelCount());
+} // owner destroyed here: the one and only free
+
+} // unnamed namespace


### PR DESCRIPTION
Step 2 (part A) of #2232 (NanoVDB injectable CUDA memory resources). New types and tests only — no existing call site changes; the scratch retrofit that consumes these lands separately.

## What

- **`cuda::Buffer<T, R>`** — typed, resource-aware, stream-ordered container modeled on CCCL's [`cuda::buffer<T>`](https://nvidia.github.io/cccl/unstable/libcudacxx/runtime/buffer.html). Constructor order and shape follow `cuda::buffer` exactly — `(stream, resource, count, noInit)`, with defaulted-resource conveniences and stream-less synchronous forms. `size()` counts elements, `size_bytes()` bytes. Move-only with an explicit `copy()`. The retained-stream rule throughout: frees are ordered on the stream of the last allocation (or `setStream`), and `resize` orders everything — including the free of the old block, whose last use is the prefix copy — on the passed stream.
- **`cuda::BufferView<T>`** — typed non-owning view with span semantics (element constness in `T`, shallow const, trivially copyable, no resource, no stream) satisfying the same static interface, so `GridHandle<BufferView<std::byte>>` wraps externally owned memory with zero copies (tested end-to-end against a `createLevelSetSphere` grid — pointer-equal, no double free).
- **`is_resource<R>`** (synchronous tier) beside `is_async_resource<R>`, which now enforces CCCL's refinement: an async resource provides the stream-ordered *and* the synchronous interface, so `is_async_resource<R>` implies `is_resource<R>`. `DeviceResource` gains the delegating sync pair; `PinnedResource` remains synchronous-only.
- **`DeviceResource`'s legacy static `allocateAsync`/`deallocateAsync` are `[[deprecated]]`** (the implementation moved into the instance methods, so nothing internal trips the warning). Migration note for v13-era custom resources is on #2232.

## Design decisions (rationale on #2232)

- **No implicitly initializing count constructor** — the `noInit` tag is mandatory, matching `cuda::buffer` (whose count constructor requires `cuda::no_init`) and the RMM `device_uvector` lesson: implicit fill of freshly allocated memory is a hidden cost the dominant allocate-then-overwrite pattern wastes. Enforced by `is_constructible` static_asserts.
- **A synchronous-`R` `Buffer` has no stream API at all** (member, constructor parameter, `stream()`, `setStream` — all absent, verified by detection-idiom static_asserts): a synchronous allocation is immediately valid on every stream, so no parameter exists to ignore.
- **CamelCase type names, standard member names**: type names are aliasable (`using Buffer = ::cuda::buffer<T>` remains available at CUDA ≥ 13.2), member names are structural and keep CCCL's spelling.
- **CUDA graph capture**: the async path is capture-safe — allocation/use/free inside a stream capture records, instantiates, and relaunches (tested). The sync tier synchronizes and is excluded from capture by construction.
- A failed `resize` (overflow or allocation error) leaves the buffer fully untouched, including its retained stream (tested).

## Testing

New `unittest/TestBuffer.cu` (`TestBuffer` suite, 20 tests; ctest `nanovdb_cuda_buffer_unit_test`): trait satisfaction for both tiers and the refinement; exact allocation sizes through a counting resource; stream retention, `setStream` redirection, and resize stream ordering via a stream-recording resource; move/copy semantics without double-free; byte-size overflow throws; pinned page-lock; graph capture; `BufferView` semantics incl. the zero-copy `GridHandle` round-trip. Full suites green: CPU 153/153, `nanovdb_test_cuda` 53/53, memory-resource 8/8; compute-sanitizer memcheck clean (sm_89, CUDA 12.6).

## Non-CUDA builds

No impact on `NANOVDB_USE_CUDA=OFF`: new headers live under `nanovdb/cuda/`, and the test target is registered inside `if(NANOVDB_USE_CUDA)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
