### PR TITLE
fix: add else to constexpr-if chain in evalFirstCached to eliminate MSVC C4702 warning

### DIFF
--- a/openvdb/openvdb/tree/ValueAccessor.h
+++ b/openvdb/openvdb/tree/ValueAccessor.h
@@ -996,10 +996,12 @@ private:
     {
         return this->evalFirstPred([&](const auto Idx) -> bool
             {
-                if constexpr(Idx < Start)             return false;
-                if constexpr(Idx > NumCacheLevels+1)  return false;
-                using NodeType = typename NodeLevelList::template Get<Idx>;
-                return this->isHashed<NodeType>(xyz);
+                if constexpr(Idx < Start)                  return false;
+                else if constexpr(Idx > NumCacheLevels+1)  return false;
+                else {
+                    using NodeType = typename NodeLevelList::template Get<Idx>;
+                    return this->isHashed<NodeType>(xyz);
+                }
             }, op);
     }
 


### PR DESCRIPTION
## Description

Fix MSVC warning C4702 (unreachable code) in `ValueAccessor.h` when using `evalFirstCached()`.

When either `constexpr if` condition in the `evalFirstCached` lambda evaluates to true (`Idx < Start` or `Idx > NumCacheLevels + 1`), the function returns early, but the subsequent code (`return this->isHashed<NodeType>(xyz)`) remains in the function body. MSVC detects this as unreachable code and emits C4702.

## Fix

Add `else` keywords to form a proper `if constexpr / else if constexpr / else` chain, so the unreachable code path is excluded from the instantiated function body.

**Before:**
```cpp
if constexpr(Idx < Start)             return false;
if constexpr(Idx > NumCacheLevels+1)  return false;
using NodeType = typename NodeLevelList::template Get<Idx>;
return this->isHashed<NodeType>(xyz);
```

**After:**
```cpp
if constexpr(Idx < Start)                  return false;
else if constexpr(Idx > NumCacheLevels+1)  return false;
else {
    using NodeType = typename NodeLevelList::template Get<Idx>;
    return this->isHashed<NodeType>(xyz);
}
```

## Related issue

Fixes #2239
