### PR TITLE
Fix builds with newer TBB versions

### DIFF
--- a/openvdb/openvdb/thread/Threading.h
+++ b/openvdb/openvdb/thread/Threading.h
@@ -25,6 +25,7 @@
 ///   software doesn't need to provide compile time defines.
 #include <tbb/task_arena.h>
 #include <tbb/task_group.h>
+#include <tbb/version.h>
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE

--- a/openvdb/openvdb/thread/Threading.h
+++ b/openvdb/openvdb/thread/Threading.h
@@ -13,19 +13,24 @@
     #define OPENVDB_THREAD_THREADING_RESTORE_DEPRECATION_MESSAGE_TASK
 #endif
 
+/// @warning  the below changes what includes are available from this header
+///   depending on whether version.h is available
+#if __has_include(<tbb/version.h>)
+    #include <tbb/version.h>
+#else
+    /// @note tbb/task_arena.h is the ONLY include that persists from TBB 2020
+    ///   to TBB 2021 to TBB 2023 that itself includes the TBB specific version
+    ///   header files.
+    ///   In TBB 2020, the version header was called tbb/stddef.h. In 2021+, it's
+    ///   called tbb/version.h. We include tbb/task_arena.h here to indirectly
+    ///   access the version defines in a consistent way so that downstream
+    ///   software doesn't need to provide compile time defines.
+    #include <tbb/task_arena.h>
+#endif
 
+#include <tbb/task_group.h>
 #include <tbb/blocked_range.h>
 #include <tbb/task.h>
-/// @note tbb/task_arena.h is the ONLY include that persists from TBB 2020
-///   to TBB 2021 to TBB 2023 that itself includes the TBB specific version
-///   header files.
-///   In TBB 2020, the version header was called tbb/stddef.h. In 2021+, it's
-///   called tbb/version.h. We include tbb/task_arena.h here to indirectly
-///   access the version defines in a consistent way so that downstream
-///   software doesn't need to provide compile time defines.
-#include <tbb/task_arena.h>
-#include <tbb/task_group.h>
-#include <tbb/version.h>
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE

--- a/pendingchanges/tbb_version_fix.txt
+++ b/pendingchanges/tbb_version_fix.txt
@@ -1,0 +1,4 @@
+OpenVDB:
+  Build:
+  - Fixed a build issue with newer TBB versions where tbb/version.h was not being indirectly included
+    [Contributed by Maciej Małecki]


### PR DESCRIPTION
Such as `TBB_INTERFACE_VERSION`.
Without it, the `#else` statement always triggers, breaking build for newer TBB version (albeit rare at this point).