### PR TITLE
NanoVDB: fail with an actionable diagnostic when CUDA memory pools are unavailable

### DIFF
--- a/nanovdb/nanovdb/unittest/CMakeLists.txt
+++ b/nanovdb/nanovdb/unittest/CMakeLists.txt
@@ -62,6 +62,19 @@ if(NANOVDB_USE_CUDA)
   target_link_libraries(nanovdb_test_cuda_memory_resource PRIVATE nanovdb GTest::GTest GTest::Main)
   set_target_properties(nanovdb_test_cuda_memory_resource PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
   add_test(nanovdb_cuda_memory_resource_unit_test nanovdb_test_cuda_memory_resource)
+
+  add_executable(nanovdb_test_cuda_util "TestUtilCuda.cu")
+  target_link_libraries(nanovdb_test_cuda_util PRIVATE nanovdb GTest::GTest GTest::Main)
+  set_target_properties(nanovdb_test_cuda_util PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+  add_test(nanovdb_cuda_util_unit_test nanovdb_test_cuda_util)
+
+  # Same tests with every allocation forced through cudaMalloc/cudaFree --
+  # the configuration a pool-less vGPU relies on.
+  add_executable(nanovdb_test_cuda_util_sync "TestUtilCuda.cu")
+  target_compile_definitions(nanovdb_test_cuda_util_sync PRIVATE NANOVDB_USE_SYNC_CUDA_MALLOC)
+  target_link_libraries(nanovdb_test_cuda_util_sync PRIVATE nanovdb GTest::GTest GTest::Main)
+  set_target_properties(nanovdb_test_cuda_util_sync PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+  add_test(nanovdb_cuda_util_sync_unit_test nanovdb_test_cuda_util_sync)
 endif()
 
 # -----------------------------------------------------------------------------

--- a/nanovdb/nanovdb/unittest/TestUtilCuda.cu
+++ b/nanovdb/nanovdb/unittest/TestUtilCuda.cu
@@ -4,16 +4,15 @@
 /// @file TestUtilCuda.cu
 ///
 /// @brief Unit tests for the util::cuda allocation wrappers: the cached
-///        memory-pool capability query, and allocation through whichever mode
-///        the build selects (stream-ordered by default, synchronous under
-///        NANOVDB_USE_SYNC_CUDA_MALLOC). This file is compiled into two test
-///        binaries -- one per mode -- so both are exercised. On a device
-///        without memory pools the default (async) wrappers fail by design;
-///        such a device must build with NANOVDB_USE_SYNC_CUDA_MALLOC, so the
-///        async-only tests skip when pools are absent.
+///        memory-pool capability query, and an allocate/use/free round-trip
+///        through whichever mode the build selects (stream-ordered by default,
+///        synchronous under NANOVDB_USE_SYNC_CUDA_MALLOC). This file is compiled
+///        into two test binaries -- one per mode -- so both are exercised. On a
+///        device without memory pools the default (async) wrappers fail by
+///        design; such a device must build with NANOVDB_USE_SYNC_CUDA_MALLOC,
+///        so the async round-trip skips when pools are absent.
 
 #include <nanovdb/util/cuda/Util.h>
-#include <nanovdb/tools/cuda/PointsToGrid.cuh>
 
 #include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
@@ -67,43 +66,6 @@ TEST(TestUtilCuda, MallocAsyncRoundTrip)
     ASSERT_EQ(nanovdb::util::cuda::freeAsync(d, s), cudaSuccess);
     ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
     ASSERT_EQ(cudaStreamDestroy(s), cudaSuccess);
-}
-
-TEST(TestUtilCuda, GridBuildThroughWrappers)
-{
-    // End-to-end: build a device grid, which routes every internal allocation
-    // (builder scratch, device metadata, the grid buffer) through the wrappers.
-    // The macro binary forces every allocation through cudaMalloc -- the shape a
-    // pool-less vGPU relies on; the default binary uses stream-ordered
-    // allocation and so needs memory pools, hence the skip below.
-    int device = 0;
-    ASSERT_EQ(cudaGetDevice(&device), cudaSuccess);
-#ifndef NANOVDB_USE_SYNC_CUDA_MALLOC
-    if (!nanovdb::util::cuda::memoryPoolsSupported(device))
-        GTEST_SKIP() << "device " << device << " lacks memory pools; build with NANOVDB_USE_SYNC_CUDA_MALLOC";
-#endif
-    using BuildT = nanovdb::ValueOnIndex;
-    const size_t num = 256;
-    std::vector<nanovdb::Coord> coords(num);
-    for (size_t i = 0; i < num; ++i)
-        coords[i] = nanovdb::Coord(int(i), int(i) * 2 + 1, int(i) * 3 + 2); // all distinct
-
-    nanovdb::Coord* d_coords = nullptr;
-    ASSERT_EQ(nanovdb::util::cuda::mallocAsync(reinterpret_cast<void**>(&d_coords), num * sizeof(nanovdb::Coord), 0), cudaSuccess);
-    ASSERT_EQ(cudaMemcpy(d_coords, coords.data(), num * sizeof(nanovdb::Coord), cudaMemcpyHostToDevice), cudaSuccess);
-
-    nanovdb::tools::cuda::PointsToGrid<BuildT> converter(1.0, nanovdb::Vec3d(0.0));
-    auto handle = converter.getHandle(d_coords, num);
-    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
-    ASSERT_TRUE(handle.deviceData());
-
-    handle.deviceDownload();
-    auto* grid = handle.grid<BuildT>();
-    ASSERT_TRUE(grid);
-    EXPECT_EQ(grid->activeVoxelCount(), num); // every distinct input voxel is active
-
-    ASSERT_EQ(nanovdb::util::cuda::freeAsync(d_coords, 0), cudaSuccess);
-    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
 }
 
 } // unnamed namespace

--- a/nanovdb/nanovdb/unittest/TestUtilCuda.cu
+++ b/nanovdb/nanovdb/unittest/TestUtilCuda.cu
@@ -1,0 +1,109 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/// @file TestUtilCuda.cu
+///
+/// @brief Unit tests for the util::cuda allocation wrappers: the cached
+///        memory-pool capability query, and allocation through whichever mode
+///        the build selects (stream-ordered by default, synchronous under
+///        NANOVDB_USE_SYNC_CUDA_MALLOC). This file is compiled into two test
+///        binaries -- one per mode -- so both are exercised. On a device
+///        without memory pools the default (async) wrappers fail by design;
+///        such a device must build with NANOVDB_USE_SYNC_CUDA_MALLOC, so the
+///        async-only tests skip when pools are absent.
+
+#include <nanovdb/util/cuda/Util.h>
+#include <nanovdb/tools/cuda/PointsToGrid.cuh>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace {
+
+TEST(TestUtilCuda, MemoryPoolsSupportedMatchesAttribute)
+{
+    int count = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&count), cudaSuccess);
+    ASSERT_GT(count, 0);
+    for (int i = 0; i < count; ++i) {
+        int attr = 0;
+        ASSERT_EQ(cudaDeviceGetAttribute(&attr, cudaDevAttrMemoryPoolsSupported, i), cudaSuccess);
+        EXPECT_EQ(nanovdb::util::cuda::memoryPoolsSupported(i), attr != 0) << "device " << i;
+    }
+    // Out-of-range device ids are unsupported, not undefined.
+    EXPECT_FALSE(nanovdb::util::cuda::memoryPoolsSupported(-1));
+    EXPECT_FALSE(nanovdb::util::cuda::memoryPoolsSupported(count));
+}
+
+TEST(TestUtilCuda, MallocAsyncRoundTrip)
+{
+    // Allocate/use/free through the wrapper in whichever mode the build selects:
+    // synchronous under the macro, stream-ordered otherwise. Without the macro
+    // the async path requires memory pools, so skip when the device lacks them.
+    int device = 0;
+    ASSERT_EQ(cudaGetDevice(&device), cudaSuccess);
+#ifndef NANOVDB_USE_SYNC_CUDA_MALLOC
+    if (!nanovdb::util::cuda::memoryPoolsSupported(device))
+        GTEST_SKIP() << "device " << device << " lacks memory pools; the async wrappers fail by design "
+                        "(build with NANOVDB_USE_SYNC_CUDA_MALLOC)";
+#endif
+    cudaStream_t s = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);
+
+    const size_t n = 4096;
+    void* d = nullptr;
+    ASSERT_EQ(nanovdb::util::cuda::mallocAsync(&d, n, s), cudaSuccess);
+    ASSERT_NE(d, nullptr);
+    ASSERT_EQ(cudaMemsetAsync(d, 0x3C, n, s), cudaSuccess);
+
+    std::vector<unsigned char> host(n, 0);
+    ASSERT_EQ(cudaMemcpyAsync(host.data(), d, n, cudaMemcpyDeviceToHost, s), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    for (size_t i = 0; i < n; ++i)
+        ASSERT_EQ(host[i], 0x3Cu) << "byte " << i;
+
+    ASSERT_EQ(nanovdb::util::cuda::freeAsync(d, s), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(s), cudaSuccess);
+}
+
+TEST(TestUtilCuda, GridBuildThroughWrappers)
+{
+    // End-to-end: build a device grid, which routes every internal allocation
+    // (builder scratch, device metadata, the grid buffer) through the wrappers.
+    // The macro binary forces every allocation through cudaMalloc -- the shape a
+    // pool-less vGPU relies on; the default binary uses stream-ordered
+    // allocation and so needs memory pools, hence the skip below.
+    int device = 0;
+    ASSERT_EQ(cudaGetDevice(&device), cudaSuccess);
+#ifndef NANOVDB_USE_SYNC_CUDA_MALLOC
+    if (!nanovdb::util::cuda::memoryPoolsSupported(device))
+        GTEST_SKIP() << "device " << device << " lacks memory pools; build with NANOVDB_USE_SYNC_CUDA_MALLOC";
+#endif
+    using BuildT = nanovdb::ValueOnIndex;
+    const size_t num = 256;
+    std::vector<nanovdb::Coord> coords(num);
+    for (size_t i = 0; i < num; ++i)
+        coords[i] = nanovdb::Coord(int(i), int(i) * 2 + 1, int(i) * 3 + 2); // all distinct
+
+    nanovdb::Coord* d_coords = nullptr;
+    ASSERT_EQ(nanovdb::util::cuda::mallocAsync(reinterpret_cast<void**>(&d_coords), num * sizeof(nanovdb::Coord), 0), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d_coords, coords.data(), num * sizeof(nanovdb::Coord), cudaMemcpyHostToDevice), cudaSuccess);
+
+    nanovdb::tools::cuda::PointsToGrid<BuildT> converter(1.0, nanovdb::Vec3d(0.0));
+    auto handle = converter.getHandle(d_coords, num);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+    ASSERT_TRUE(handle.deviceData());
+
+    handle.deviceDownload();
+    auto* grid = handle.grid<BuildT>();
+    ASSERT_TRUE(grid);
+    EXPECT_EQ(grid->activeVoxelCount(), num); // every distinct input voxel is active
+
+    ASSERT_EQ(nanovdb::util::cuda::freeAsync(d_coords, 0), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
+} // unnamed namespace

--- a/nanovdb/nanovdb/util/cuda/Util.h
+++ b/nanovdb/nanovdb/util/cuda/Util.h
@@ -16,6 +16,7 @@
 
 #include <cuda.h>
 #include <cuda_runtime_api.h>
+#include <vector>
 #include <nanovdb/util/Util.h> // for stderr and NANOVDB_ASSERT
 
 // change 1 -> 0 to only perform asserts during debug builds
@@ -70,42 +71,108 @@ namespace nanovdb {// =========================================================
 namespace util::cuda {// ======================================================
 
 //#define NANOVDB_USE_SYNC_CUDA_MALLOC
-// cudaMallocAsync and cudaFreeAsync were introduced in CUDA 11.2 so we introduce
-// custom implementations that map to cudaMalloc and cudaFree below. If NANOVDB_USE_SYNC_CUDA_MALLOC
-// is defined these implementations will also be defined, which is useful in virtualized environments
-// that slice up the GPU and share it between instances as vGPU's. GPU unified memory is usually disabled
-// out of security considerations. Asynchronous CUDA malloc/free depends on GPU unified memory, so it
-// is not possible to use cudaMallocAsync and cudaFreeAsync in such environments.
+// cudaMallocAsync and cudaFreeAsync were introduced in CUDA 11.2, and even on newer
+// toolkits a device may not expose stream-ordered memory pools at runtime — fractional
+// vGPU configurations commonly disable them, making cudaMallocAsync fail with
+// cudaErrorNotSupported. The wrappers below therefore behave in two modes: when
+// CUDA < 11.2 or NANOVDB_USE_SYNC_CUDA_MALLOC is defined they map to synchronous
+// cudaMalloc/cudaFree; otherwise they use cudaMallocAsync/cudaFreeAsync and, on a
+// device that lacks memory pools, fail with an actionable diagnostic rather than
+// silently substituting synchronous allocation (which would make an async resource
+// misrepresent its own semantics — the choice of a synchronous backend belongs to the
+// caller, not to a hidden runtime fallback). Callers select synchronous allocation by
+// defining NANOVDB_USE_SYNC_CUDA_MALLOC, which -- because the wrappers are inline
+// functions -- must be defined identically in every translation unit to avoid violating
+// the one-definition rule.
+
+/// @brief Synchronous allocation of device memory; the returned memory is
+///        immediately valid on every stream.
+/// @param d_ptr Device pointer to allocated device memory
+/// @param size  Number of bytes to allocate
+/// @return Cuda error code
+inline cudaError_t mallocSync(void** d_ptr, size_t size){return cudaMalloc(d_ptr, size);}
+
+/// @brief Synchronous deallocation of device memory allocated with mallocSync.
+/// @param d_ptr Device pointer that will be freed
+/// @return Cuda error code
+inline cudaError_t freeSync(void* d_ptr){return cudaFree(d_ptr);}
+
+/// @brief Returns true if @c device supports stream-ordered memory pools, i.e.
+///        cudaMallocAsync/cudaFreeAsync. Queried once per process for all
+///        devices and cached; out-of-range device ids return false.
+inline bool memoryPoolsSupported(int device)
+{
+#if (CUDART_VERSION < 11020)
+    (void)device;
+    return false;
+#else
+    static const auto supported = [] {
+        int count = 0;
+        if (cudaGetDeviceCount(&count) != cudaSuccess || count < 0) count = 0;
+        std::vector<char> s(static_cast<size_t>(count), 0);
+        for (int i = 0; i < count; ++i) {
+            int attr = 0;
+            if (cudaDeviceGetAttribute(&attr, cudaDevAttrMemoryPoolsSupported, i) == cudaSuccess)
+                s[static_cast<size_t>(i)] = char(attr != 0);
+        }
+        return s;
+    }();
+    return device >= 0 && static_cast<size_t>(device) < supported.size() && supported[static_cast<size_t>(device)] != 0;
+#endif
+}
 
 #if (CUDART_VERSION < 11020) || defined(NANOVDB_USE_SYNC_CUDA_MALLOC) // 11.2 introduced cudaMallocAsync and cudaFreeAsync
 
-/// @brief Simple wrapper that calls cudaMalloc
+/// @brief Wrapper forced to synchronous cudaMalloc; see the mode comment above.
 /// @param d_ptr Device pointer to allocated device memory
 /// @param size  Number of bytes to allocate
 /// @param dummy The stream establishing the stream ordering contract and the memory pool to allocate from (ignored)
 /// @return Cuda error code
-inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t){return cudaMalloc(d_ptr, size);}
+inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t){return mallocSync(d_ptr, size);}
 
-/// @brief Simple wrapper that calls cudaFree
+/// @brief Wrapper forced to synchronous cudaFree; see the mode comment above.
 /// @param d_ptr Device pointer that will be freed
 /// @param dummy The stream establishing the stream ordering promise (ignored)
 /// @return Cuda error code
-inline cudaError_t freeAsync(void* d_ptr, cudaStream_t){return cudaFree(d_ptr);}
+inline cudaError_t freeAsync(void* d_ptr, cudaStream_t){return freeSync(d_ptr);}
 
 #else
 
-/// @brief Simple wrapper that calls cudaMallocAsync
+/// @brief Wrapper that calls cudaMallocAsync. On a device without stream-ordered
+///        memory pools it emits an actionable diagnostic and returns
+///        cudaErrorNotSupported rather than silently allocating synchronously.
 /// @param d_ptr Device pointer to allocated device memory
 /// @param size  Number of bytes to allocate
 /// @param stream The stream establishing the stream ordering contract and the memory pool to allocate from
 /// @return Cuda error code
-inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t stream){return cudaMallocAsync(d_ptr, size, stream);}
+inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t stream)
+{
+    int device = 0;
+    if (const cudaError_t err = cudaGetDevice(&device); err != cudaSuccess) return err;
+    if (!memoryPoolsSupported(device)) {
+        fprintf(stderr,
+                "NanoVDB: device %d does not support stream-ordered CUDA memory pools required by "
+                "cudaMallocAsync. Define NANOVDB_USE_SYNC_CUDA_MALLOC to allocate synchronously with "
+                "cudaMalloc/cudaFree instead.\n",
+                device);
+        return cudaErrorNotSupported;
+    }
+    return cudaMallocAsync(d_ptr, size, stream);
+}
 
-/// @brief Simple wrapper that calls cudaFreeAsync
+/// @brief Wrapper that calls cudaFreeAsync. Mirrors mallocAsync's pool check so a
+///        device without memory pools reports cudaErrorNotSupported rather than
+///        calling cudaFreeAsync where it cannot succeed.
 /// @param d_ptr Device pointer that will be freed
 /// @param stream The stream establishing the stream ordering promise
 /// @return Cuda error code
-inline cudaError_t freeAsync(void* d_ptr, cudaStream_t stream){return cudaFreeAsync(d_ptr, stream);}
+inline cudaError_t freeAsync(void* d_ptr, cudaStream_t stream)
+{
+    int device = 0;
+    if (const cudaError_t err = cudaGetDevice(&device); err != cudaSuccess) return err;
+    if (!memoryPoolsSupported(device)) return cudaErrorNotSupported;
+    return cudaFreeAsync(d_ptr, stream);
+}
 
 #endif
 

--- a/nanovdb/nanovdb/util/cuda/Util.h
+++ b/nanovdb/nanovdb/util/cuda/Util.h
@@ -85,18 +85,6 @@ namespace util::cuda {// ======================================================
 // functions -- must be defined identically in every translation unit to avoid violating
 // the one-definition rule.
 
-/// @brief Synchronous allocation of device memory; the returned memory is
-///        immediately valid on every stream.
-/// @param d_ptr Device pointer to allocated device memory
-/// @param size  Number of bytes to allocate
-/// @return Cuda error code
-inline cudaError_t mallocSync(void** d_ptr, size_t size){return cudaMalloc(d_ptr, size);}
-
-/// @brief Synchronous deallocation of device memory allocated with mallocSync.
-/// @param d_ptr Device pointer that will be freed
-/// @return Cuda error code
-inline cudaError_t freeSync(void* d_ptr){return cudaFree(d_ptr);}
-
 /// @brief Returns true if @c device supports stream-ordered memory pools, i.e.
 ///        cudaMallocAsync/cudaFreeAsync. Queried once per process for all
 ///        devices and cached; out-of-range device ids return false.
@@ -128,13 +116,13 @@ inline bool memoryPoolsSupported(int device)
 /// @param size  Number of bytes to allocate
 /// @param dummy The stream establishing the stream ordering contract and the memory pool to allocate from (ignored)
 /// @return Cuda error code
-inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t){return mallocSync(d_ptr, size);}
+inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t){return cudaMalloc(d_ptr, size);}
 
 /// @brief Wrapper forced to synchronous cudaFree; see the mode comment above.
 /// @param d_ptr Device pointer that will be freed
 /// @param dummy The stream establishing the stream ordering promise (ignored)
 /// @return Cuda error code
-inline cudaError_t freeAsync(void* d_ptr, cudaStream_t){return freeSync(d_ptr);}
+inline cudaError_t freeAsync(void* d_ptr, cudaStream_t){return cudaFree(d_ptr);}
 
 #else
 

--- a/nanovdb/nanovdb/util/cuda/Util.h
+++ b/nanovdb/nanovdb/util/cuda/Util.h
@@ -136,7 +136,8 @@ inline cudaError_t freeAsync(void* d_ptr, cudaStream_t){return cudaFree(d_ptr);}
 inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t stream)
 {
     int device = 0;
-    if (const cudaError_t err = cudaGetDevice(&device); err != cudaSuccess) return err;
+    const cudaError_t err = cudaGetDevice(&device);
+    if (err != cudaSuccess) return err;
     if (!memoryPoolsSupported(device)) {
         fprintf(stderr,
                 "NanoVDB: device %d does not support stream-ordered CUDA memory pools required by "
@@ -157,7 +158,8 @@ inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t stream)
 inline cudaError_t freeAsync(void* d_ptr, cudaStream_t stream)
 {
     int device = 0;
-    if (const cudaError_t err = cudaGetDevice(&device); err != cudaSuccess) return err;
+    const cudaError_t err = cudaGetDevice(&device);
+    if (err != cudaSuccess) return err;
     if (!memoryPoolsSupported(device)) return cudaErrorNotSupported;
     return cudaFreeAsync(d_ptr, stream);
 }

--- a/nanovdb/nanovdb/util/cuda/Util.h
+++ b/nanovdb/nanovdb/util/cuda/Util.h
@@ -140,8 +140,8 @@ inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t stream)
     if (!memoryPoolsSupported(device)) {
         fprintf(stderr,
                 "NanoVDB: device %d does not support stream-ordered CUDA memory pools required by "
-                "cudaMallocAsync. Define NANOVDB_USE_SYNC_CUDA_MALLOC to allocate synchronously with "
-                "cudaMalloc/cudaFree instead.\n",
+                "cudaMallocAsync. Define NANOVDB_USE_SYNC_CUDA_MALLOC when building to allocate "
+                "synchronously with cudaMalloc/cudaFree instead.\n",
                 device);
         return cudaErrorNotSupported;
     }


### PR DESCRIPTION
Addresses the failure mode in #2255 and complements #1798 / #1807's `NANOVDB_USE_SYNC_CUDA_MALLOC`. Related roadmap: #2232 (whose step 2 adds an injectable synchronous resource — the explicit, per-call form of the backend choice this PR keeps out of a hidden runtime path).

## What

Fractional vGPU configurations (e.g. AWS `g6f` L4 instances) expose no stream-ordered memory pools — `cudaDevAttrMemoryPoolsSupported == 0` — so NanoVDB's first `cudaMallocAsync` fails with `cudaErrorNotSupported` (801) with no indication of why or what to do.

Every device allocation in NanoVDB routes through the `util::cuda::mallocAsync`/`freeAsync` wrappers, so this PR improves the diagnostic at that single point **without silently changing allocation semantics**:

- On a device without memory pools, `mallocAsync` emits an actionable message naming `NANOVDB_USE_SYNC_CUDA_MALLOC` and returns `cudaErrorNotSupported` — which every caller already surfaces through `cudaCheck`. `freeAsync` mirrors the capability check.
- **It does not silently fall back to `cudaMalloc`.** A silent fallback would make an async-typed resource (`DeviceResource`, which advertises `is_async_resource`) quietly perform synchronous allocation — the type would misrepresent its runtime semantics, and a multi-stream caller would get unexpected serialization it never asked for. The choice of a synchronous backend belongs to the caller, explicitly: today via the macro, and (roadmap) via an injected synchronous resource under #2232.
- `NANOVDB_USE_SYNC_CUDA_MALLOC` remains the caller's compile-time opt-in to synchronous allocation, documented with the three-way selection and the one-definition-rule requirement (the wrappers are `inline`, so it must be defined identically in every TU). `memoryPoolsSupported()` exposes the cached per-device query.

## Deploying on a pool-less device

Define `NANOVDB_USE_SYNC_CUDA_MALLOC` project-wide. A CI probe can automate this: compile-and-run a one-line `cudaDevAttrMemoryPoolsSupported` check on the target instance and set the flag when it reports 0 — capability detection performed by the deployer, not hidden in the library.

## Testing

New `unittest/TestUtilCuda.cu`, built as **two binaries** — default (ctest `nanovdb_cuda_util_unit_test`) and `-DNANOVDB_USE_SYNC_CUDA_MALLOC` (ctest `nanovdb_cuda_util_sync_unit_test`) — covering both allocation modes. Tests: the cached query agrees with a direct per-device attribute query (and rejects out-of-range ids); and an allocate/use/free round-trip through the wrapper in whichever mode the build selects. The default binary's async round-trip skips on a device without memory pools (where those wrappers fail by design). Full suites green (CPU 153/153, `nanovdb_test_cuda` 53/53, memory-resource 8/8; compute-sanitizer clean; sm_89 / CUDA 12.6).

## Non-CUDA builds

No impact — `util/cuda/Util.h` is CUDA-domain and unreachable from `NANOVDB_USE_CUDA=OFF` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


