### PR TITLE
VBM select-based inverse-map decode

### DIFF
--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -19,7 +19,7 @@
         jumpMap on the GPU from a device-resident NanoGrid.
       - decodeInverseMaps (device): per-block SIMT decode of the inverse maps
         (sequential active-voxel index -> leaf ID + intra-leaf voxel offset),
-        executed cooperatively across a CUDA thread block.
+        with one thread per output slot across a CUDA thread block.
 */
 
 #ifndef NANOVDB_VOXELBLOCKMANAGER_CUH_HAS_BEEN_INCLUDED
@@ -87,42 +87,49 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     {
         // Verify that the nodes can be accessed linearly
         NANOVDB_ASSERT(grid->isSequential());
-
-        int tID = threadIdx.x;
-
-        // Count how many additional leaves (following the one indicated by firstLeafID)
-        // overlap with this voxel block
-        int nExtraLeaves = 0;
-        for (int i = 0; i < JumpMapLength; i++)
-            nExtraLeaves += util::countOn(jumpMap[i]);
-
-        // Initialize leafIndex & voxelOffset to sentinel values
-        // for blocks that extend beyond the last active voxel in the grid
-        if (tID < BlockWidth)
-            #pragma unroll
-            for (int i = 0; i < BlockWidth; i += blockDim.x) {
-                smem_leafIndex[i+tID] = UnusedLeafIndex;
-                smem_voxelOffset[i+tID] = UnusedVoxelOffset;
-            }
-        __syncthreads();
-
         NANOVDB_ASSERT(blockDim.x <= 512);
-        const auto& tree = grid->tree();
-        // Loop through all leafNodes overlapping the voxel block
-        // with all threads in threadblock working collaboratively within each leafNode
-        for (int leafID = firstLeafID; leafID <= firstLeafID + nExtraLeaves; leafID++) {
-            const auto& leaf = tree.template getFirstNode<0>()[leafID];
-            if (leaf.data()->firstOffset() >= blockFirstOffset + BlockWidth) break;
-            const Coord origin = leaf.origin();
-            for (int threadOffset = 0; threadOffset < 512; threadOffset += blockDim.x) {
-                int localOffset = threadOffset + tID;
-                auto index = leaf.data()->getValue(localOffset);
-                if ((index >= blockFirstOffset) && (index < blockFirstOffset + BlockWidth)) {
-                    int blockOffset = index - blockFirstOffset;
-                    // Write inverse map to shared memory; no collisions
-                    smem_leafIndex[blockOffset] = leafID;
-                    smem_voxelOffset[blockOffset] = localOffset;
+
+        // Select-based decode: one thread per OUTPUT slot. Here each
+        // slot ranks itself into its leaf via the jumpMap popcount,
+        // then locates its voxel with the leaf's 9-bit prefix sums
+        // plus an in-word bit select - O(1) per slot.
+        int tID = threadIdx.x;
+        const auto *leaf0 = grid->tree().template getFirstNode<0>();
+        for (int blockOffset = tID; blockOffset < BlockWidth; blockOffset += blockDim.x) {
+            // rank this slot into its leaf: count leaves beginning at in-block positions
+            // [1, blockOffset] (bit 0 is never set) via the jumpMap popcount
+            uint32_t leafRank = 0;
+            const int jumpWord = blockOffset >> 6;
+            #pragma unroll
+            for (int i = 0; i < JumpMapLength; ++i) {
+                if (i < jumpWord) leafRank += util::countOn(jumpMap[i]);
+                else if (i == jumpWord) leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
+            }
+            const uint32_t leafID = firstLeafID + leafRank;
+            const auto& leafData = *leaf0[leafID].data();
+            const uint64_t rankInLeaf = (blockFirstOffset + blockOffset) - leafData.firstOffset();// 0-based rank among the leaf's actives
+            if (rankInLeaf < leafData.valueCount()) {
+                // select the rankInLeaf-th active voxel: find its 64-bit mask word via the
+                // leaf's 9-bit prefix sums, then its bit within that word
+                uint32_t activesBeforeWord = 0;
+                int wordID = 0;
+                #pragma unroll
+                for (int candidateWord = 1; candidateWord < 8; ++candidateWord) {
+                    const uint32_t cumulative = uint32_t(leafData.mPrefixSum >> (9*(candidateWord-1))) & 0x1ffu;
+                    if (cumulative <= rankInLeaf) { wordID = candidateWord; activesBeforeWord = cumulative; }
                 }
+                uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord;
+                const uint64_t maskWord = leafData.mValueMask.words()[wordID];
+                const uint32_t lowHalf = uint32_t(maskWord);
+                const uint32_t lowHalfCount = util::countOn(uint64_t(lowHalf));
+                int bit;
+                if (rankInWord < lowHalfCount) bit = __fns(lowHalf, 0, rankInWord + 1);
+                else                           bit = 32 + __fns(uint32_t(maskWord >> 32), 0, rankInWord - lowHalfCount + 1);
+                smem_leafIndex[blockOffset] = leafID;
+                smem_voxelOffset[blockOffset] = uint16_t((wordID << 6) + bit);
+            } else {// beyond the last active voxel in the grid
+                smem_leafIndex[blockOffset] = UnusedLeafIndex;
+                smem_voxelOffset[blockOffset] = UnusedVoxelOffset;
             }
         }
         __syncthreads();

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -89,40 +89,56 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         NANOVDB_ASSERT(grid->isSequential());
         NANOVDB_ASSERT(blockDim.x <= 512);
 
-        // Select-based decode: one thread per OUTPUT slot. Here each
+        // Select-based decode: one thread per output slot. Here each
         // slot ranks itself into its leaf via the jumpMap popcount,
         // then locates its voxel with the leaf's 9-bit prefix sums
         // plus an in-word bit select - O(1) per slot.
-        int tID = threadIdx.x;
+        const int tID = threadIdx.x;
         const auto *leaf0 = grid->tree().template getFirstNode<0>();
         for (int blockOffset = tID; blockOffset < BlockWidth; blockOffset += blockDim.x) {
             // rank this slot into its leaf: count leaves beginning at in-block positions
             // [1, blockOffset] (bit 0 is never set) via the jumpMap popcount
             uint32_t leafRank = 0;
-            const int jumpWord = blockOffset >> 6;
+            const int jumpWord = blockOffset >> 6;  // index into jumpMap
+            // count the number of leaves that begin before blockOffset
             #pragma unroll
             for (int i = 0; i < JumpMapLength; ++i) {
-                if (i < jumpWord) leafRank += util::countOn(jumpMap[i]);
-                else if (i == jumpWord) leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
+                if (i < jumpWord) leafRank += util::countOn(jumpMap[i]); // count leaves before the current jump word
+                else if (i == jumpWord) {
+                    // count leaves in the current jump word, masking those that are before blockOffset
+                    leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
+                }
+
             }
             const uint32_t leafID = firstLeafID + leafRank;
             const auto& leafData = *leaf0[leafID].data();
-            const uint64_t rankInLeaf = (blockFirstOffset + blockOffset) - leafData.firstOffset();// 0-based rank among the leaf's actives
-            if (rankInLeaf < leafData.valueCount()) {
+            // 0-based rank among the leaf's actives
+            const uint64_t rankInLeaf = (blockFirstOffset + blockOffset) - leafData.firstOffset();
+            if (rankInLeaf < leafData.valueCount()) { // if the rank is within the leaf's active voxels (bounds check)
                 // select the rankInLeaf-th active voxel: find its 64-bit mask word via the
                 // leaf's 9-bit prefix sums, then its bit within that word
-                uint32_t activesBeforeWord = 0;
                 int wordID = 0;
+                uint32_t activesBeforeWord = 0;
                 #pragma unroll
                 for (int candidateWord = 1; candidateWord < 8; ++candidateWord) {
+                    // the number of active voxels before the candidateWord's mask word (& 0x1ffu masks to 9 bits)
                     const uint32_t cumulative = uint32_t(leafData.mPrefixSum >> (9*(candidateWord-1))) & 0x1ffu;
-                    if (cumulative <= rankInLeaf) { wordID = candidateWord; activesBeforeWord = cumulative; }
+                    if (cumulative <= rankInLeaf) {
+                        wordID = candidateWord; // word ID of the mask word that contains the rankInLeaf-th active voxel
+                        activesBeforeWord = cumulative; // the number of active voxels before the wordID's mask word
+                    }
                 }
-                uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord;
+
+                uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord; // active voxel's rank within the mask word (0-based)
+                // select the in-word bit position of the voxel using __fns (find n-th set bit)
+                // /__fns(mask, base, k) is the hardware find-nth-set-bit intrinsic - the k-th set bit (1-based) at/after base
+                // but it's a 32-bit op while `maskWord` is 64-bit, so we need to split it into two 32-bit halves
                 const uint64_t maskWord = leafData.mValueMask.words()[wordID];
-                const uint32_t lowHalf = uint32_t(maskWord);
+                const uint32_t lowHalf = uint32_t(maskWord);  // low 32 bits of the mask word
                 const uint32_t lowHalfCount = util::countOn(uint64_t(lowHalf));
                 int bit;
+                // if rank is less than the number of active voxels in the low half, __fns finds the bit in the lower half
+                // otherwise, shift maskWord by 32 bits and __fns finds the bit in the upper half
                 if (rankInWord < lowHalfCount) bit = __fns(lowHalf, 0, rankInWord + 1);
                 else                           bit = 32 + __fns(uint32_t(maskWord >> 32), 0, rankInWord - lowHalfCount + 1);
                 smem_leafIndex[blockOffset] = leafID;

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -17,9 +17,14 @@
       of an OnIndexGrid, independent of occupancy.  This file provides:
       - buildVoxelBlockManager (device): constructs the firstLeafID array and
         jumpMap on the GPU from a device-resident NanoGrid.
-      - decodeInverseMaps (device): per-block SIMT decode of the inverse maps
-        (sequential active-voxel index -> leaf ID + intra-leaf voxel offset),
-        with one thread per output slot across a CUDA thread block.
+      - decodeInverseMap (device): per-slot, thread-local decode of one inverse
+        map entry (sequential active-voxel index -> leaf ID + intra-leaf voxel
+        offset) into registers; no shared memory or synchronization, callable
+        from divergent threads. Block-level facts a cooperative consumer might
+        otherwise read from a materialized map are derivable directly from the
+        VBM metadata: the block's first leaf is firstLeafID, slot p starts a
+        new leaf iff jumpMap bit p is set, and the number of leaves spanned by
+        the block is 1 + the jumpMap popcount.
 */
 
 #ifndef NANOVDB_VOXELBLOCKMANAGER_CUH_HAS_BEEN_INCLUDED
@@ -48,117 +53,134 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     using Base::UnusedLeafIndex;
     using Base::UnusedVoxelOffset;
 
-    // The efficiency of the functions in this class are contingent on
-    // threadblock-level coordination, which manifests either as using shared
-    // memory for synchronization, or warp-level shift operations.
+    // The decode is a rank + select over the VBM's bit-vectors and is
+    // thread-local per output slot: decodeInverseMap requires no threadblock
+    // coordination. Consumers that need cross-slot information derive it from
+    // the VBM metadata (firstLeafID + jumpMap) rather than from a materialized
+    // per-block map.
 
-    /// @brief Decode the inverse maps for a single voxel block on the device.
+    /// @brief Rank one output slot into its leaf: the number of leaves that
+    /// begin at in-block positions [1, blockOffset] (bit 0 is never set),
+    /// counted via popcounts over the block's jumpMap.
+    /// Thread-local; no synchronization.
+    __device__
+    static uint32_t jumpMapRank(const uint64_t *jumpMap, const int blockOffset)
+    {
+        uint32_t leafRank = 0;
+        const int jumpWord = blockOffset >> 6;  // index into jumpMap
+        #pragma unroll
+        for (int i = 0; i < JumpMapLength; ++i) {
+            if (i < jumpWord) leafRank += util::countOn(jumpMap[i]); // count leaves before the current jump word
+            else if (i == jumpWord) {
+                // count leaves in the current jump word, masking those that are at or before blockOffset
+                leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
+            }
+        }
+        return leafRank;
+    }
+
+    /// @brief Select the voxel with sequential index @c globalOffset inside leaf
+    /// @c leafID: find its 64-bit mask word via the leaf's precomputed 9-bit
+    /// prefix sums (mPrefixSum), then its bit within that word via __fns.
+    /// Writes the sentinels if globalOffset lies beyond the leaf's last active
+    /// voxel (i.e. beyond the last active voxel of the grid).
+    /// Thread-local; no synchronization.
+    template <class BuildT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    selectVoxelInLeaf(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t leafID,
+        const uint64_t globalOffset,
+        uint32_t &leafIndex,
+        uint16_t &voxelOffset)
+    {
+        const auto& leafData = *grid->tree().template getFirstNode<0>()[leafID].data();
+        // 0-based rank among the leaf's actives
+        const uint64_t rankInLeaf = globalOffset - leafData.firstOffset();
+        if (rankInLeaf < leafData.valueCount()) { // if the rank is within the leaf's active voxels (bounds check)
+            int wordID = 0;
+            uint32_t activesBeforeWord = 0;
+            #pragma unroll
+            for (int candidateWord = 1; candidateWord < 8; ++candidateWord) {
+                // the number of active voxels before the candidateWord's mask word (& 0x1ffu masks to 9 bits)
+                const uint32_t cumulative = uint32_t(leafData.mPrefixSum >> (9*(candidateWord-1))) & 0x1ffu;
+                if (cumulative <= rankInLeaf) {
+                    wordID = candidateWord; // word ID of the mask word that contains the rankInLeaf-th active voxel
+                    activesBeforeWord = cumulative; // the number of active voxels before the wordID's mask word
+                }
+            }
+            uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord; // active voxel's rank within the mask word (0-based)
+            // select the in-word bit position of the voxel using __fns (find n-th set bit)
+            // __fns(mask, base, k) is the hardware find-nth-set-bit intrinsic - the k-th set bit (1-based) at/after base
+            // but it's a 32-bit op while `maskWord` is 64-bit, so we need to split it into two 32-bit halves
+            const uint64_t maskWord = leafData.mValueMask.words()[wordID];
+            const uint32_t lowHalf = uint32_t(maskWord);  // low 32 bits of the mask word
+            const uint32_t lowHalfCount = __popc(lowHalf);
+            int bit;
+            // if rank is less than the number of active voxels in the low half, __fns finds the bit in the lower half
+            // otherwise, shift maskWord by 32 bits and __fns finds the bit in the upper half
+            if (rankInWord < lowHalfCount) bit = __fns(lowHalf, 0, rankInWord + 1);
+            else                           bit = 32 + __fns(uint32_t(maskWord >> 32), 0, rankInWord - lowHalfCount + 1);
+            leafIndex = leafID;
+            voxelOffset = uint16_t((wordID << 6) + bit);
+        } else { // beyond the last active voxel in the grid
+            leafIndex = UnusedLeafIndex;
+            voxelOffset = UnusedVoxelOffset;
+        }
+    }
+
+    /// @brief Decode a single inverse-map entry into registers on the device.
     ///
     /// Given the VBM metadata for one block (firstLeafID and the block's slice of
-    /// the jumpMap) and the block's base sequential offset, fills smem_leafIndex[]
-    /// and smem_voxelOffset[] in shared memory so that for each position p in
-    /// [0, BlockWidth):
-    ///   - smem_leafIndex[p]   = index of the leaf node containing sequential voxel
-    ///                           (blockFirstOffset + p), or UnusedLeafIndex if that
-    ///                           index is beyond the last active voxel.
-    ///   - smem_voxelOffset[p] = local (0..511) offset of that voxel within its leaf,
-    ///                           or UnusedVoxelOffset.
+    /// the jumpMap), the block's base sequential offset, and a slot position
+    /// blockOffset in [0, BlockWidth), computes:
+    ///   - leafIndex   = index of the leaf node containing sequential voxel
+    ///                   (blockFirstOffset + blockOffset), or UnusedLeafIndex if
+    ///                   that index is beyond the last active voxel.
+    ///   - voxelOffset = local (0..511) offset of that voxel within its leaf,
+    ///                   or UnusedVoxelOffset.
     ///
-    /// Must be called by all threads in the block (uses __syncthreads internally).
-    /// Do not call from divergent threads within a thread block.
+    /// No shared memory or synchronization; may be called from divergent threads.
     ///
     /// @tparam BuildT  Build type of the grid (must be an index type)
     /// @param grid              Device-accessible OnIndex grid
     /// @param firstLeafID       Index of the first leaf overlapping this block
     /// @param jumpMap           Pointer to the JumpMapLength words for this block
     /// @param blockFirstOffset  Sequential index of the first voxel in this block
-    /// @param smem_leafIndex    Output array of length BlockWidth in shared memory
-    /// @param smem_voxelOffset  Output array of length BlockWidth in shared memory
+    /// @param blockOffset       Slot position within the block, in [0, BlockWidth)
+    /// @param leafIndex         Output leaf index (register)
+    /// @param voxelOffset       Output intra-leaf voxel offset (register)
     template <class BuildT>
     __device__
     static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
-    decodeInverseMaps(
+    decodeInverseMap(
         const NanoGrid<BuildT> *grid,
         const uint32_t firstLeafID,
         const uint64_t *jumpMap,
         const uint64_t blockFirstOffset,
-        uint32_t *smem_leafIndex,
-        uint16_t *smem_voxelOffset)
+        const int blockOffset,
+        uint32_t &leafIndex,
+        uint16_t &voxelOffset)
     {
         // Verify that the nodes can be accessed linearly
         NANOVDB_ASSERT(grid->isSequential());
-        NANOVDB_ASSERT(blockDim.x <= 512);
+        NANOVDB_ASSERT(blockOffset >= 0 && blockOffset < BlockWidth);
 
-        // Select-based decode: one thread per output slot. Here each
-        // slot ranks itself into its leaf via the jumpMap popcount,
-        // then locates its voxel with the leaf's 9-bit prefix sums
-        // plus an in-word bit select - O(1) per slot.
-        const int tID = threadIdx.x;
-        const auto *leaf0 = grid->tree().template getFirstNode<0>();
-        for (int blockOffset = tID; blockOffset < BlockWidth; blockOffset += blockDim.x) {
-            // rank this slot into its leaf: count leaves beginning at in-block positions
-            // [1, blockOffset] (bit 0 is never set) via the jumpMap popcount
-            uint32_t leafRank = 0;
-            const int jumpWord = blockOffset >> 6;  // index into jumpMap
-            // count the number of leaves that begin before blockOffset
-            #pragma unroll
-            for (int i = 0; i < JumpMapLength; ++i) {
-                if (i < jumpWord) leafRank += util::countOn(jumpMap[i]); // count leaves before the current jump word
-                else if (i == jumpWord) {
-                    // count leaves in the current jump word, masking those that are before blockOffset
-                    leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
-                }
-
-            }
-            const uint32_t leafID = firstLeafID + leafRank;
-            const auto& leafData = *leaf0[leafID].data();
-            // 0-based rank among the leaf's actives
-            const uint64_t rankInLeaf = (blockFirstOffset + blockOffset) - leafData.firstOffset();
-            if (rankInLeaf < leafData.valueCount()) { // if the rank is within the leaf's active voxels (bounds check)
-                // select the rankInLeaf-th active voxel: find its 64-bit mask word via the
-                // leaf's 9-bit prefix sums, then its bit within that word
-                int wordID = 0;
-                uint32_t activesBeforeWord = 0;
-                #pragma unroll
-                for (int candidateWord = 1; candidateWord < 8; ++candidateWord) {
-                    // the number of active voxels before the candidateWord's mask word (& 0x1ffu masks to 9 bits)
-                    const uint32_t cumulative = uint32_t(leafData.mPrefixSum >> (9*(candidateWord-1))) & 0x1ffu;
-                    if (cumulative <= rankInLeaf) {
-                        wordID = candidateWord; // word ID of the mask word that contains the rankInLeaf-th active voxel
-                        activesBeforeWord = cumulative; // the number of active voxels before the wordID's mask word
-                    }
-                }
-
-                uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord; // active voxel's rank within the mask word (0-based)
-                // select the in-word bit position of the voxel using __fns (find n-th set bit)
-                // /__fns(mask, base, k) is the hardware find-nth-set-bit intrinsic - the k-th set bit (1-based) at/after base
-                // but it's a 32-bit op while `maskWord` is 64-bit, so we need to split it into two 32-bit halves
-                const uint64_t maskWord = leafData.mValueMask.words()[wordID];
-                const uint32_t lowHalf = uint32_t(maskWord);  // low 32 bits of the mask word
-                const uint32_t lowHalfCount = util::countOn(uint64_t(lowHalf));
-                int bit;
-                // if rank is less than the number of active voxels in the low half, __fns finds the bit in the lower half
-                // otherwise, shift maskWord by 32 bits and __fns finds the bit in the upper half
-                if (rankInWord < lowHalfCount) bit = __fns(lowHalf, 0, rankInWord + 1);
-                else                           bit = 32 + __fns(uint32_t(maskWord >> 32), 0, rankInWord - lowHalfCount + 1);
-                smem_leafIndex[blockOffset] = leafID;
-                smem_voxelOffset[blockOffset] = uint16_t((wordID << 6) + bit);
-            } else {// beyond the last active voxel in the grid
-                smem_leafIndex[blockOffset] = UnusedLeafIndex;
-                smem_voxelOffset[blockOffset] = UnusedVoxelOffset;
-            }
-        }
-        __syncthreads();
+        const uint32_t leafRank = jumpMapRank(jumpMap, blockOffset);
+        selectVoxelInLeaf(grid, firstLeafID + leafRank,
+                          blockFirstOffset + blockOffset, leafIndex, voxelOffset);
     }
 
-    /// @brief Given a grid and its decoded voxel map, compute the stencil.
-    /// This function accesses shared memory but does not synchronize threads
-    /// so it may be called from divergent threads within a thread block.
-    /// offsets for a 3x3x3 box stencil.
+    /// @brief Given a grid and one decoded inverse-map entry (from
+    /// decodeInverseMap), compute the stencil indices for a 3x3x3 box stencil.
+    /// Thread-local: no shared memory, no synchronization; may be called from
+    /// divergent threads within a thread block. Leaves stencilIndices untouched
+    /// when leafIndex is UnusedLeafIndex (a slot beyond the last active voxel).
     /// @tparam BuildT Build type of the grid
-    /// @param grid
-    /// @param smem_leafIndex Leaf indices stored in shared memory
-    /// @param smem_voxelOffset Voxel offsets stored in shared memory
+    /// @param grid         Device-accessible OnIndex grid
+    /// @param leafIndex    This thread's decoded leaf index (or UnusedLeafIndex)
+    /// @param voxelOffset  This thread's decoded intra-leaf voxel offset
     /// @param stencilIndices Pointer to output stencil indices. Must have
     /// length of at least 27 (corresponding to the 3x3x3 stencil)
     template <class BuildT>
@@ -166,20 +188,18 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
     computeBoxStencil(
         const NanoGrid<BuildT> *grid,
-        const uint32_t *smem_leafIndex,
-        const uint16_t *smem_voxelOffset,
+        const uint32_t leafIndex,
+        const uint16_t voxelOffset,
         uint64_t *stencilIndices)
     {
         // Verify that the nodes can be accessed linearly
         NANOVDB_ASSERT(grid->isSequential());
 
-        int tID = threadIdx.x;
         const auto& tree = grid->tree();
-        if (smem_leafIndex[tID] != UnusedLeafIndex) {
+        if (leafIndex != UnusedLeafIndex) {
             // This presumes that leaf nodes are fixed-size and sequentially accessible in memory
-            const auto& leaf = tree.template getFirstNode<0>()[ smem_leafIndex[tID] ];
-            const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
-            const auto index = leaf.getValue( smem_voxelOffset[tID] );
+            const auto& leaf = tree.template getFirstNode<0>()[ leafIndex ];
+            const Coord coord = leaf.offsetToGlobalCoord( voxelOffset );
             for (int di = -1; di <= 1; di++)
             for (int dj = -1; dj <= 1; dj++)
             for (int dk = -1; dk <= 1; dk++) {

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -25,6 +25,9 @@
         VBM metadata: the block's first leaf is firstLeafID, slot p starts a
         new leaf iff jumpMap bit p is set, and the number of leaves spanned by
         the block is 1 + the jumpMap popcount.
+      - decodeInverseMaps (device): cooperative wrapper over decodeInverseMap
+        that materializes all BlockWidth slots into shared memory, preserving
+        the pre-existing signature for consumers that read across slots.
 */
 
 #ifndef NANOVDB_VOXELBLOCKMANAGER_CUH_HAS_BEEN_INCLUDED
@@ -55,9 +58,9 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
 
     // The decode is a rank + select over the VBM's bit-vectors and is
     // thread-local per output slot: decodeInverseMap requires no threadblock
-    // coordination. Consumers that need cross-slot information derive it from
-    // the VBM metadata (firstLeafID + jumpMap) rather than from a materialized
-    // per-block map.
+    // coordination. Consumers that need cross-slot information can derive it
+    // from the VBM metadata (firstLeafID + jumpMap), or materialize all slots
+    // in shared memory via the cooperative decodeInverseMaps wrapper.
 
     /// @brief Rank one output slot into its leaf: the number of leaves that
     /// begin at in-block positions [1, blockOffset] (bit 0 is never set),
@@ -170,6 +173,49 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         const uint32_t leafRank = jumpMapRank(jumpMap, blockOffset);
         selectVoxelInLeaf(grid, firstLeafID + leafRank,
                           blockFirstOffset + blockOffset, leafIndex, voxelOffset);
+    }
+
+    /// @brief Decode the inverse maps for a single voxel block into shared memory.
+    ///
+    /// Cooperative form of decodeInverseMap, preserving the pre-existing signature:
+    /// fills smem_leafIndex[] and smem_voxelOffset[] so that for each position p in
+    /// [0, BlockWidth):
+    ///   - smem_leafIndex[p]   = index of the leaf node containing sequential voxel
+    ///                           (blockFirstOffset + p), or UnusedLeafIndex if that
+    ///                           index is beyond the last active voxel.
+    ///   - smem_voxelOffset[p] = local (0..511) offset of that voxel within its leaf,
+    ///                           or UnusedVoxelOffset.
+    ///
+    /// Each slot is decoded independently by decodeInverseMap; this wrapper only
+    /// materializes the results, striding over the slots so any blockDim.x <= 512
+    /// fills the maps correctly. Must be called by all threads in the block (ends
+    /// in __syncthreads); do not call from divergent threads. Consumers that only
+    /// read their own slot's result should prefer decodeInverseMap, which needs no
+    /// shared memory or barrier.
+    ///
+    /// @tparam BuildT  Build type of the grid (must be an index type)
+    /// @param grid              Device-accessible OnIndex grid
+    /// @param firstLeafID       Index of the first leaf overlapping this block
+    /// @param jumpMap           Pointer to the JumpMapLength words for this block
+    /// @param blockFirstOffset  Sequential index of the first voxel in this block
+    /// @param smem_leafIndex    Output array of length BlockWidth in shared memory
+    /// @param smem_voxelOffset  Output array of length BlockWidth in shared memory
+    template <class BuildT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    decodeInverseMaps(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t firstLeafID,
+        const uint64_t *jumpMap,
+        const uint64_t blockFirstOffset,
+        uint32_t *smem_leafIndex,
+        uint16_t *smem_voxelOffset)
+    {
+        NANOVDB_ASSERT(blockDim.x <= 512);
+        for (int blockOffset = threadIdx.x; blockOffset < BlockWidth; blockOffset += blockDim.x)
+            decodeInverseMap(grid, firstLeafID, jumpMap, blockFirstOffset, blockOffset,
+                             smem_leafIndex[blockOffset], smem_voxelOffset[blockOffset]);
+        __syncthreads();
     }
 
     /// @brief Given a grid and one decoded inverse-map entry (from

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -3465,15 +3465,17 @@ __global__ void testComputeStencilNeighborsKernel(
     uint64_t *jumpMap = jumpMapArray + JumpMapLength * bID;
     int firstOffset = 1;
     int blockFirstOffset = firstOffset + bID * BlockWidth;
-    uint32_t leafIndex;
-    uint16_t voxelOffset;
+    // Decode through the cooperative wrapper (which exercises the per-slot
+    // decodeInverseMap internally), then resolve this thread's own slot.
+    __shared__ uint32_t leafIndex[BlockWidth];
+    __shared__ uint16_t voxelOffset[BlockWidth];
 
-    nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::decodeInverseMap(
-        grid, firstLeafID, jumpMap, blockFirstOffset, tID, leafIndex, voxelOffset);
+    nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::decodeInverseMaps(
+        grid, firstLeafID, jumpMap, blockFirstOffset, &leafIndex[0], &voxelOffset[0]);
 
     uint64_t localNeighbors[27] = {};
     nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::computeBoxStencil(
-        grid, leafIndex, voxelOffset, localNeighbors);
+        grid, leafIndex[tID], voxelOffset[tID], localNeighbors);
 
     using StencilNeighborsType = uint64_t (*)[27];
     auto stencilNeighbors = reinterpret_cast<StencilNeighborsType>(stencilNeighborsArray+27*BlockWidth*bID);

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -3465,16 +3465,15 @@ __global__ void testComputeStencilNeighborsKernel(
     uint64_t *jumpMap = jumpMapArray + JumpMapLength * bID;
     int firstOffset = 1;
     int blockFirstOffset = firstOffset + bID * BlockWidth;
-    __shared__ uint32_t leafIndex[BlockWidth];
-    __shared__ uint16_t voxelOffset[BlockWidth];
+    uint32_t leafIndex;
+    uint16_t voxelOffset;
 
-    nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::decodeInverseMaps(
-        grid, firstLeafID, jumpMap, blockFirstOffset, &leafIndex[0], &voxelOffset[0]);
+    nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::decodeInverseMap(
+        grid, firstLeafID, jumpMap, blockFirstOffset, tID, leafIndex, voxelOffset);
 
     uint64_t localNeighbors[27] = {};
     nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::computeBoxStencil(
-        grid, &leafIndex[0], &voxelOffset[0], localNeighbors);
-    __syncthreads();
+        grid, leafIndex, voxelOffset, localNeighbors);
 
     using StencilNeighborsType = uint64_t (*)[27];
     auto stencilNeighbors = reinterpret_cast<StencilNeighborsType>(stencilNeighborsArray+27*BlockWidth*bID);

--- a/pendingchanges/nanovdbvbmdecode.txt
+++ b/pendingchanges/nanovdbvbmdecode.txt
@@ -1,0 +1,5 @@
+NanoVDB:
+  Improvements:
+  - Replaced the CUDA VoxelBlockManager inverse-map decode's O(nLeaves x 512) per-block
+    sweep with an O(1)-per-slot select (jumpMap popcount rank + the leaf's 9-bit prefix
+    sums + an in-word bit select); byte-identical decode maps and ~2x faster decode.

--- a/pendingchanges/nanovdbvbmdecode.txt
+++ b/pendingchanges/nanovdbvbmdecode.txt
@@ -4,12 +4,14 @@ NanoVDB:
     sweep with an O(1)-per-slot select (jumpMap popcount rank + the leaf's 9-bit prefix
     sums + an in-word bit select); byte-identical decode maps and ~2x faster decode.
   API Changes:
-  - Consolidated the CUDA VoxelBlockManager decode to a single thread-local API:
+  - Restructured the CUDA VoxelBlockManager decode around a thread-local primitive:
     decodeInverseMap decodes one slot into registers (no shared memory or
-    synchronization; callable from divergent threads) and replaces the cooperative
-    shared-memory decodeInverseMaps, which has been removed. computeBoxStencil now
-    takes the decoded (leafIndex, voxelOffset) by value instead of shared-memory
-    arrays. Block-level facts formerly read from the materialized maps derive
+    synchronization; callable from divergent threads). The cooperative
+    decodeInverseMaps keeps its pre-existing signature and is now a thin wrapper
+    that materializes all slots via decodeInverseMap; prefer the per-slot form for
+    consumers that only read their own slot. computeBoxStencil now takes the
+    decoded (leafIndex, voxelOffset) by value instead of shared-memory arrays.
+    Block-level facts formerly read from the materialized maps also derive
     directly from the VBM metadata: the block's first leaf is firstLeafID, slot p
     starts a new leaf iff jumpMap bit p is set, and the spanned-leaf count is
     1 + the jumpMap popcount.

--- a/pendingchanges/nanovdbvbmdecode.txt
+++ b/pendingchanges/nanovdbvbmdecode.txt
@@ -3,3 +3,13 @@ NanoVDB:
   - Replaced the CUDA VoxelBlockManager inverse-map decode's O(nLeaves x 512) per-block
     sweep with an O(1)-per-slot select (jumpMap popcount rank + the leaf's 9-bit prefix
     sums + an in-word bit select); byte-identical decode maps and ~2x faster decode.
+  API Changes:
+  - Consolidated the CUDA VoxelBlockManager decode to a single thread-local API:
+    decodeInverseMap decodes one slot into registers (no shared memory or
+    synchronization; callable from divergent threads) and replaces the cooperative
+    shared-memory decodeInverseMaps, which has been removed. computeBoxStencil now
+    takes the decoded (leafIndex, voxelOffset) by value instead of shared-memory
+    arrays. Block-level facts formerly read from the materialized maps derive
+    directly from the VBM metadata: the block's first leaf is firstLeafID, slot p
+    starts a new leaf iff jumpMap bit p is set, and the spanned-leaf count is
+    1 + the jumpMap popcount.


### PR DESCRIPTION
## Summary

This PR replaces the inverse-map decode in the NanoVDB **VoxelBlockManager** with an output-centric **rank + select**, and consolidates the decode API down to a single **thread-local, per-slot** function.

The old `decodeInverseMaps` had every thread in the block sweep all 512 voxel slots of every leaf overlapping the block — **O(nLeaves × 512)** work per block, cooperative by necessity (scatter into shared memory behind `__syncthreads`). The new `decodeInverseMap` runs **one thread per output slot** and computes that slot's `(leafIndex, voxelOffset)` **entirely in registers**: a jumpMap popcount ranks the slot into its leaf, then the leaf's precomputed 9-bit `mPrefixSum` directory plus an in-word `__fns` bit select recover the voxel — **O(1) per slot**, no shared memory, no barrier, callable from divergent threads.

<img width="1640" height="1420" alt="diagram1" src="https://github.com/user-attachments/assets/0733a1cb-afeb-4b3e-9e92-7acc94d1fd7f" />

## What changed

The decode is a **rank + select** over the VBM's bit-vectors:

- **rank** into the block's jumpMap (a popcount of leaf-start bits at or before the slot) selects which leaf owns the slot;
- **select** into that leaf's 512-bit value mask — the precomputed 9-bit prefix-sum directory finds the containing 64-bit word, an in-word `__fns` finds the bit — recovers the voxel offset.

This removes the old sweep's per-leaf full scan and its data-dependent inner branch, making the decode's work **independent of leaf sparsity**. And since each slot's result is fully thread-local, the shared-memory materialization the sweep required is no longer part of the algorithm — so it is no longer part of the API.

## API changes

- **Added** `decodeInverseMap` — per-slot decode into registers (composed from the also-public `jumpMapRank` and `selectVoxelInLeaf` helpers). No shared memory, no `__syncthreads`, divergent-safe.
- **Removed** `decodeInverseMaps` — the cooperative shared-memory form. It performed no cooperative *computation* (only cooperative materialization), and every block-level fact a consumer read from the materialized maps derives directly from the VBM metadata:
  - the block's first leaf **is** `firstLeafID`;
  - slot `p` starts a new leaf **iff** jumpMap bit `p` is set;
  - the spanned-leaf count is **1 + popcount(jumpMap)**.
- `computeBoxStencil` now takes the decoded `(leafIndex, voxelOffset)` by value instead of shared-memory arrays.

Migration:

```cpp
// before                                          // after
__shared__ uint32_t li[BW];                        uint32_t leafIndex;
__shared__ uint16_t vo[BW];                        uint16_t voxelOffset;
VBM::decodeInverseMaps(grid, firstLeafID,          VBM::decodeInverseMap(grid, firstLeafID,
    jumpMap, blockFirstOffset, li, vo);                jumpMap, blockFirstOffset, threadIdx.x,
VBM::computeBoxStencil(grid, li, vo, taps);            leafIndex, voxelOffset);
                                                   VBM::computeBoxStencil(grid, leafIndex,
                                                       voxelOffset, taps);
```

A consumer that genuinely needs cross-slot results can materialize them at the call site (store + `__syncthreads`) at exactly the old wrapper's cost — nothing is lost, the cost just isn't imposed on consumers that don't need it.

## A/B vs master — decode across leaf sparsity

Level-set spheres at narrow-band half-widths 1–32 voxels sweep per-leaf occupancy from 16% to 86% (occupancy is the old sweep's cost driver: sparser leaves mean more leaves — each costing a full 512-slot scan — per block). RTX PRO 6000 (sm_120), median of 50 iterations, decode-only:


| leaf occupancy      | width 64  | width 128 | width 512 |
| ------------------- | --------- | --------- | --------- |
| 16% (half-width 1)  | **2.20×** | 2.04×     | 1.72×     |
| 36% (half-width 3)  | 2.04×     | 1.97×     | 1.52×     |
| 60% (half-width 8)  | 2.00×     | 1.94×     | 1.40×     |
| 86% (half-width 32) | 2.00×     | 1.55×     | **1.24×** |


<img width="1536" height="1344" alt="image" src="https://github.com/user-attachments/assets/95e0c7be-8894-46d6-b54b-7deaa38e2cda" />


The sweep's per-voxel cost roughly doubles as occupancy falls (top panel, blue); the select stays flat (orange), so the win grows exactly where grids are sparsest. Width 64 is the strongest case at every occupancy — there the sweep needs 8 rounds of 64 threads to scan each 512-slot leaf, so it is slow even on dense grids and the select holds a uniform ~2× (2.20× peak). Consumer-side, the register decode also removes a barrier and 6 bytes/slot of shared memory from every stencil kernel's budget; on a streaming cached box-stencil consumer this measured an additional 8–15% over the shared-memory decode, independent of the decode speedup itself.

## Validation

- **Byte-identical outputs**: decode maps *and* all 27 box-stencil taps compared bytewise against the master sweep at widths 64/128/512, across 16–86% leaf occupancy (11 sphere configurations per width) — identical everywhere, including the final partial block and the beyond-last-active-voxel sentinels.
- The `TestNanoVDBCUDA.VoxelBlockManager_*` unit tests are updated to the new API and pass.
