### PR TITLE
NanoVDB: CUDA connected-components labeling for ValueOnIndex grids

### DIFF
--- a/nanovdb/nanovdb/CMakeLists.txt
+++ b/nanovdb/nanovdb/CMakeLists.txt
@@ -237,6 +237,7 @@ set(NANOVDB_INCLUDE_TOOLS_CUDA_FILES
   tools/cuda/DilateGrid.cuh
   tools/cuda/CoarsenGrid.cuh
   tools/cuda/VoxelBlockManager.cuh
+  tools/cuda/ConnectedComponents.cuh
 )
 
 # NanoVDB util header files

--- a/nanovdb/nanovdb/examples/CMakeLists.txt
+++ b/nanovdb/nanovdb/examples/CMakeLists.txt
@@ -115,6 +115,7 @@ nanovdb_example(NAME "ex_merge_nanovdb_cuda" OPENVDB)
 nanovdb_example(NAME "ex_refine_nanovdb_cuda" OPENVDB)
 nanovdb_example(NAME "ex_coarsen_nanovdb_cuda" OPENVDB)
 nanovdb_example(NAME "ex_mesh_to_grid_cuda" OPENVDB)
+nanovdb_example(NAME "ex_connected_components_cuda")
 
 if(CUDAToolkit_FOUND)
   nanovdb_example(NAME "ex_make_mgpu_nanovdb") # requires cuRAND

--- a/nanovdb/nanovdb/examples/ex_connected_components_cuda/connected_components_cuda.cpp
+++ b/nanovdb/nanovdb/examples/ex_connected_components_cuda/connected_components_cuda.cpp
@@ -5,9 +5,10 @@
 ///
 /// @brief Host driver for the connected-components example (NanoVDB / CUDA only, no OpenVDB).
 ///
-///        Reads a triangle mesh from a Wavefront .obj file, builds the index<->world transform,
-///        and hands the mesh to the CUDA side, which rasterizes it into a ValueOnIndex narrow-band
-///        grid, discards the surface/barrier shell, and runs connected-components labeling
+///        Reads one or more Wavefront .obj meshes (concatenated into a single vertex/triangle list),
+///        builds the index<->world transform, and hands the mesh to the CUDA side, which rasterizes
+///        it into a ValueOnIndex narrow-band grid, optionally discards the surface/barrier shell
+///        (--discard-surface-voxels), and runs connected-components labeling
 ///        (nanovdb::tools::cuda::ConnectedComponents) on the result. The device side also runs a
 ///        CPU union-find oracle that independently verifies the GPU labeling.
 ///
@@ -27,14 +28,17 @@
 
 // ---- Host/device seam (implemented in connected_components_cuda_kernels.cu) -----------------------
 //
-// Rasterize the mesh -> ValueOnIndex narrow band, discard the barrier shell (unsigned distance
-// within sqrt(3)/2 voxels of the surface), and run connected-components labeling. Prints topology
-// diagnostics, the component count, and a CPU-oracle PASS/FAIL, and returns the number of
-// connected components.
+// Rasterize the mesh -> ValueOnIndex narrow band and run connected-components labeling. When
+// @a discardSurfaceVoxels is true, the surface/barrier shell (unsigned distance within sqrt(3)/2
+// voxels of the surface) is pruned first, splitting each closed surface's band into disjoint
+// inner/outer shells; otherwise labeling runs on the full narrow band (one component per closed
+// surface). Prints topology diagnostics, the component count, and a CPU-oracle PASS/FAIL, and
+// returns the number of connected components.
 uint64_t connectedComponentsFromMesh(const std::vector<nanovdb::Vec3f>& points,
                                      const std::vector<nanovdb::Vec3i>& triangles,
                                      const nanovdb::Map&                map,
-                                     float                              bandWidth);
+                                     float                              bandWidth,
+                                     bool                               discardSurfaceVoxels);
 
 /// @brief Minimal Wavefront .obj reader (vertices + faces) using NanoVDB types.
 ///
@@ -86,20 +90,47 @@ static void readOBJ(const std::string&            filename,
 int main(int argc, char* argv[])
 {
     try {
-        if (argc < 2)
-            throw std::runtime_error("usage: " + std::string(argv[0]) +
-                                     " <input.obj> [voxelSize] [bandWidth]");
+        // Parse args: any non-option token is an input .obj; options set the transform and the
+        // barrier-discard switch.
+        std::vector<std::string> objFiles;
+        float voxelSize            = 0.01f;
+        float bandWidth            = 3.0f;
+        bool  discardSurfaceVoxels = false;
 
-        const std::string inputFile = argv[1];
-        const float voxelSize = (argc > 2) ? std::stof(argv[2]) : 0.01f;
-        const float bandWidth = (argc > 3) ? std::stof(argv[3]) : 3.0f;
+        auto nextValue = [&](int& i, const char* opt) -> const char* {
+            if (i + 1 >= argc) throw std::runtime_error(std::string("missing value for ") + opt);
+            return argv[++i];
+        };
+        for (int i = 1; i < argc; ++i) {
+            const std::string a = argv[i];
+            if      (a == "--discard-surface-voxels") discardSurfaceVoxels = true;
+            else if (a == "--voxel-size")  voxelSize = std::stof(nextValue(i, "--voxel-size"));
+            else if (a == "--band-width")  bandWidth = std::stof(nextValue(i, "--band-width"));
+            else if (a.rfind("--", 0) == 0) throw std::runtime_error("unknown option: " + a);
+            else objFiles.push_back(a);
+        }
+        if (objFiles.empty())
+            throw std::runtime_error(
+                "usage: " + std::string(argv[0]) +
+                " <input.obj> [more.obj ...] [--voxel-size S] [--band-width W] [--discard-surface-voxels]");
 
+        // Read and merge all input meshes into one vertex/triangle list. Merging simply concatenates
+        // the meshes in their own coordinates (no repositioning), offsetting each mesh's triangle
+        // indices past the vertices already added.
         std::vector<nanovdb::Vec3f> points;
         std::vector<nanovdb::Vec3i> triangles;
-        std::cout << "Reading " << inputFile << "...\n";
-        readOBJ(inputFile, points, triangles);
-        std::cout << "Loaded " << points.size() << " vertices, "
-                  << triangles.size() << " triangles.\n";
+        for (const std::string& file : objFiles) {
+            std::vector<nanovdb::Vec3f> filePoints;
+            std::vector<nanovdb::Vec3i> fileTriangles;
+            std::cout << "Reading " << file << "...\n";
+            readOBJ(file, filePoints, fileTriangles);
+            const int offset = int(points.size());
+            points.insert(points.end(), filePoints.begin(), filePoints.end());
+            for (const nanovdb::Vec3i& t : fileTriangles)
+                triangles.emplace_back(t[0] + offset, t[1] + offset, t[2] + offset);
+        }
+        std::cout << "Loaded " << points.size() << " vertices, " << triangles.size()
+                  << " triangles from " << objFiles.size() << " mesh(es).\n";
         if (points.empty() || triangles.empty())
             throw std::runtime_error("mesh has no triangles");
 
@@ -107,8 +138,11 @@ int main(int argc, char* argv[])
         nanovdb::Map map;
         map.set(double(voxelSize), nanovdb::Vec3d(0.0), 1.0);
 
+        std::cout << "Surface voxels: "
+                  << (discardSurfaceVoxels ? "discarded (barrier shell pruned)"
+                                           : "kept (full narrow band)") << "\n";
         const uint64_t numComponents =
-            connectedComponentsFromMesh(points, triangles, map, bandWidth);
+            connectedComponentsFromMesh(points, triangles, map, bandWidth, discardSurfaceVoxels);
         std::cout << "Connected components: " << numComponents << "\n";
 
         return 0;

--- a/nanovdb/nanovdb/examples/ex_connected_components_cuda/connected_components_cuda.cpp
+++ b/nanovdb/nanovdb/examples/ex_connected_components_cuda/connected_components_cuda.cpp
@@ -1,0 +1,120 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/// @file  connected_components_cuda.cpp
+///
+/// @brief Host driver for the connected-components example (NanoVDB / CUDA only, no OpenVDB).
+///
+///        Reads a triangle mesh from a Wavefront .obj file, builds the index<->world transform,
+///        and hands the mesh to the CUDA side, which rasterizes it into a ValueOnIndex narrow-band
+///        grid, discards the surface/barrier shell, and runs connected-components labeling
+///        (nanovdb::tools::cuda::ConnectedComponents) on the result. The device side also runs a
+///        CPU union-find oracle that independently verifies the GPU labeling.
+///
+///        This example exercises ONLY the connected-components stage. For the full mesh->SDF
+///        pipeline that builds on top of it, see ex_mesh_to_sdf_cuda.
+
+#include <nanovdb/NanoVDB.h>          // host-usable: Vec3f, Vec3i, Vec3d, Map
+#include <nanovdb/GridHandle.h>       // GridHandle (header-only, host-usable)
+#include <nanovdb/cuda/DeviceBuffer.h>// nanovdb::cuda::DeviceBuffer
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// ---- Host/device seam (implemented in connected_components_cuda_kernels.cu) -----------------------
+//
+// Rasterize the mesh -> ValueOnIndex narrow band, discard the barrier shell (unsigned distance
+// within sqrt(3)/2 voxels of the surface), and run connected-components labeling. Prints topology
+// diagnostics, the component count, and a CPU-oracle PASS/FAIL, and returns the number of
+// connected components.
+uint64_t connectedComponentsFromMesh(const std::vector<nanovdb::Vec3f>& points,
+                                     const std::vector<nanovdb::Vec3i>& triangles,
+                                     const nanovdb::Map&                map,
+                                     float                              bandWidth);
+
+/// @brief Minimal Wavefront .obj reader (vertices + faces) using NanoVDB types.
+///
+///        Polygons with more than 3 vertices are fan-triangulated. Vertex references of the form
+///        `v`, `v/vt`, `v//vn`, `v/vt/vn` are accepted, as are negative (relative) indices. Lines
+///        that are not `v` or `f` are ignored.
+static void readOBJ(const std::string&            filename,
+                    std::vector<nanovdb::Vec3f>&  points,
+                    std::vector<nanovdb::Vec3i>&  triangles)
+{
+    std::ifstream file(filename);
+    if (!file.is_open())
+        throw std::runtime_error("Failed to open OBJ file: " + filename);
+
+    std::string line;
+    int lineNumber = 0;
+    while (std::getline(file, line)) {
+        ++lineNumber;
+        std::istringstream iss(line);
+        std::string type;
+        iss >> type;
+
+        if (type == "v") {
+            float x, y, z;
+            iss >> x >> y >> z;
+            points.emplace_back(x, y, z);
+        } else if (type == "f") {
+            std::vector<int> face;
+            std::string vert;
+            while (iss >> vert) {
+                const size_t slash = vert.find('/');
+                const std::string idxStr = vert.substr(0, slash);
+                if (idxStr.empty()) continue;
+                int raw = std::stoi(idxStr);
+                // OBJ indices are 1-based; negatives are relative to points read so far.
+                int idx = (raw < 0) ? int(points.size()) + raw : raw - 1;
+                if (idx < 0 || idx >= int(points.size()))
+                    throw std::runtime_error("OBJ parse error on line " +
+                                             std::to_string(lineNumber) +
+                                             ": face index out of bounds");
+                face.push_back(idx);
+            }
+            for (size_t i = 2; i < face.size(); ++i)
+                triangles.emplace_back(face[0], face[i - 1], face[i]);
+        }
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    try {
+        if (argc < 2)
+            throw std::runtime_error("usage: " + std::string(argv[0]) +
+                                     " <input.obj> [voxelSize] [bandWidth]");
+
+        const std::string inputFile = argv[1];
+        const float voxelSize = (argc > 2) ? std::stof(argv[2]) : 0.01f;
+        const float bandWidth = (argc > 3) ? std::stof(argv[3]) : 3.0f;
+
+        std::vector<nanovdb::Vec3f> points;
+        std::vector<nanovdb::Vec3i> triangles;
+        std::cout << "Reading " << inputFile << "...\n";
+        readOBJ(inputFile, points, triangles);
+        std::cout << "Loaded " << points.size() << " vertices, "
+                  << triangles.size() << " triangles.\n";
+        if (points.empty() || triangles.empty())
+            throw std::runtime_error("mesh has no triangles");
+
+        // Index<->world transform: uniform voxel size, no translation.
+        nanovdb::Map map;
+        map.set(double(voxelSize), nanovdb::Vec3d(0.0), 1.0);
+
+        const uint64_t numComponents =
+            connectedComponentsFromMesh(points, triangles, map, bandWidth);
+        std::cout << "Connected components: " << numComponents << "\n";
+
+        return 0;
+    }
+    catch (const std::exception& e) {
+        std::cerr << "An exception occurred: \"" << e.what() << "\"\n";
+        return 1;
+    }
+}

--- a/nanovdb/nanovdb/examples/ex_connected_components_cuda/connected_components_cuda_kernels.cu
+++ b/nanovdb/nanovdb/examples/ex_connected_components_cuda/connected_components_cuda_kernels.cu
@@ -1,0 +1,228 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/// @file  connected_components_cuda_kernels.cu
+///
+/// @brief CUDA / NanoVDB side of the connected-components example. Rasterizes a triangle mesh into a
+///        ValueOnIndex narrow-band grid (nanovdb::tools::cuda::MeshToGrid), discards the
+///        surface/barrier shell (unsigned distance within sqrt(3)/2 voxels of the surface) with
+///        nanovdb::tools::cuda::PruneGrid, and runs connected-components labeling with
+///        nanovdb::tools::cuda::ConnectedComponents. A CPU union-find oracle independently verifies
+///        the GPU labeling (component count + per-voxel partition).
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/cuda/DeviceBuffer.h>
+
+#include <nanovdb/tools/cuda/MeshToGrid.cuh>            // rasterize mesh -> ValueOnIndex + UDF
+#include <nanovdb/tools/cuda/PruneGrid.cuh>             // topological prune (barrier removal)
+#include <nanovdb/tools/cuda/ConnectedComponents.cuh>  // the connected-components labeling
+#include <nanovdb/util/cuda/Util.h>                     // operatorKernel, cudaCheck
+#include <nanovdb/util/cuda/DeviceGridTraits.cuh>       // DeviceGridTraits
+
+#include <thrust/universal_vector.h>
+
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <numeric>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+using BuildT      = nanovdb::ValueOnIndex;
+using GridHandleT = nanovdb::GridHandle<nanovdb::cuda::DeviceBuffer>;
+using Traits      = nanovdb::util::cuda::DeviceGridTraits<BuildT>;
+
+constexpr int LEAF_SIZE = 512;  // 8^3
+
+// Per-leaf retain-mask functor: a voxel is kept iff its unsigned distance to the surface exceeds the
+// barrier threshold sqrt(3)/2 voxels (i.e. UDF^2 >= 0.75 * voxelSize^2 in world units). Removing the
+// barrier shell splits each closed surface's narrow band into disjoint inner/outer shells, which is
+// what connected components then labels. One CUDA block per leaf, one thread per voxel offset.
+struct UDFBarrierPruneMaskFunctor
+{
+    static constexpr int MaxThreadsPerBlock         = LEAF_SIZE;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    __device__ void operator()(const nanovdb::NanoGrid<BuildT>* d_grid,
+                               const float*                     d_udf,          // UDF sidecar, WORLD units
+                               float                            barrierSqWorld, // (sqrt(3)/2 * voxelSize)^2
+                               nanovdb::Mask<3>*                d_dstLeafMasks)
+    {
+        const int leafID   = blockIdx.x;
+        const int threadID = threadIdx.x;
+
+        const auto& leaf       = d_grid->tree().getFirstNode<0>()[leafID];
+        auto&       resultMask = d_dstLeafMasks[leafID];
+
+        // Clear the leaf's mask words in parallel, then set the retain bits.
+        if (threadID < nanovdb::Mask<3>::WORD_COUNT)
+            resultMask.words()[threadID] = 0UL;
+        __syncthreads();
+
+        if (auto n = leaf.data()->getValue(threadID)) {  // n != 0 => active voxel
+            const float udf = d_udf[n];
+            if (udf * udf >= barrierSqWorld)              // retain non-barrier voxels
+                resultMask.setOnAtomic(threadID);
+        }
+    }
+};
+
+// Pack a voxel coordinate into a sortable/ hashable int64 key (offset so negatives stay positive).
+inline int64_t encodeCoord(const nanovdb::Coord& c)
+{
+    return  (int64_t(c[0]) + (1 << 20))
+         | ((int64_t(c[1]) + (1 << 20)) << 21)
+         | ((int64_t(c[2]) + (1 << 20)) << 42);
+}
+
+// CPU union-find oracle: independently label the derived grid's active voxels by 6-connectivity and
+// verify the GPU result (a) has the same component count and (b) induces the same partition (two
+// voxels share a GPU label iff the oracle puts them in the same component). Returns true on PASS.
+bool validateAgainstOracle(const GridHandleT& derivedHandle, uint32_t leafCount, uint64_t active,
+                           const uint32_t* d_labels, uint64_t gpuCount)
+{
+    // Download the derived grid blob + the per-voxel labels to the host.
+    std::vector<char> blob(derivedHandle.bufferSize());
+    cudaCheck(cudaMemcpy(blob.data(), derivedHandle.deviceData(), blob.size(), cudaMemcpyDeviceToHost));
+    const auto* h_grid = reinterpret_cast<const nanovdb::NanoGrid<BuildT>*>(blob.data());
+
+    if (active == 0) {
+        std::cout << "CPU-oracle self-check: PASS (empty grid, 0 components)\n";
+        return gpuCount == 0;
+    }
+
+    std::vector<uint32_t> labels(active + 1);
+    cudaCheck(cudaMemcpy(labels.data(), d_labels, (active + 1) * sizeof(uint32_t), cudaMemcpyDeviceToHost));
+
+    // Gather active voxels: dense id -> {coord, gpu label}, plus a coord->id lookup for neighbours.
+    std::unordered_map<int64_t, uint32_t> coordToId;
+    std::vector<nanovdb::Coord>           idToCoord;
+    std::vector<uint32_t>                 idToGpuLabel;
+    coordToId.reserve(active * 2);
+    idToCoord.reserve(active);
+    idToGpuLabel.reserve(active);
+
+    const auto* leaves = h_grid->tree().getFirstLeaf();
+    for (uint32_t li = 0; li < leafCount; ++li) {
+        const auto& leaf = leaves[li];
+        for (uint32_t n = 0; n < uint32_t(LEAF_SIZE); ++n) {
+            if (!leaf.isActive(n)) continue;
+            const nanovdb::Coord c = leaf.origin() + nanovdb::NanoLeaf<BuildT>::OffsetToLocalCoord(n);
+            const uint64_t       slot = leaf.getValue(n);
+            const uint32_t       id   = uint32_t(idToCoord.size());
+            coordToId.emplace(encodeCoord(c), id);
+            idToCoord.push_back(c);
+            idToGpuLabel.push_back(labels[slot]);
+        }
+    }
+
+    // Union-find over 6-connectivity. Visiting only +X/+Y/+Z reaches every undirected edge once.
+    std::vector<uint32_t> parent(idToCoord.size());
+    std::iota(parent.begin(), parent.end(), 0u);
+    std::function<uint32_t(uint32_t)> find = [&](uint32_t x) {
+        while (parent[x] != x) { parent[x] = parent[parent[x]]; x = parent[x]; }
+        return x;
+    };
+    auto unite = [&](uint32_t a, uint32_t b) {
+        a = find(a); b = find(b);
+        if (a != b) parent[a > b ? a : b] = (a < b ? a : b);
+    };
+    const nanovdb::Coord dirs[3] = { {1,0,0}, {0,1,0}, {0,0,1} };
+    for (uint32_t id = 0; id < idToCoord.size(); ++id)
+        for (const auto& d : dirs) {
+            auto it = coordToId.find(encodeCoord(idToCoord[id] + d));
+            if (it != coordToId.end()) unite(id, it->second);
+        }
+
+    // Count oracle components and check the GPU labels induce the same partition.
+    std::unordered_map<uint32_t, uint32_t> rootToComp;   // oracle root -> dense component id
+    for (uint32_t id = 0; id < parent.size(); ++id) {
+        const uint32_t r = find(id);
+        if (!rootToComp.count(r)) rootToComp.emplace(r, uint32_t(rootToComp.size()));
+    }
+    const uint64_t oracleCount = rootToComp.size();
+
+    std::unordered_map<uint32_t, uint32_t> gpuToOracle;  // gpu label -> oracle component
+    uint64_t partitionViolations = 0;
+    for (uint32_t id = 0; id < parent.size(); ++id) {
+        const uint32_t gl = idToGpuLabel[id];
+        const uint32_t oc = rootToComp[find(id)];
+        auto it = gpuToOracle.find(gl);
+        if (it == gpuToOracle.end()) gpuToOracle.emplace(gl, oc);
+        else if (it->second != oc)   ++partitionViolations;
+    }
+    const uint64_t gpuDistinctLabels = gpuToOracle.size();
+
+    const bool pass = (gpuCount == oracleCount) &&
+                      (gpuDistinctLabels == oracleCount) &&
+                      (partitionViolations == 0);
+
+    std::cout << "CPU-oracle self-check: " << (pass ? "PASS" : "FAIL")
+              << "  (gpu=" << gpuCount << ", oracle=" << oracleCount
+              << ", distinct gpu labels=" << gpuDistinctLabels
+              << ", partition violations=" << partitionViolations << ")\n";
+    return pass;
+}
+
+} // anonymous namespace
+
+uint64_t connectedComponentsFromMesh(const std::vector<nanovdb::Vec3f>& points,
+                                     const std::vector<nanovdb::Vec3i>& triangles,
+                                     const nanovdb::Map&                map,
+                                     float                              bandWidth)
+{
+    const cudaStream_t stream = 0;
+
+    // ---- Step 1: rasterize the mesh -> ValueOnIndex narrow-band grid + UDF sidecar. ----
+    thrust::universal_vector<nanovdb::Vec3f> dPoints(points.begin(), points.end());
+    thrust::universal_vector<nanovdb::Vec3i> dTriangles(triangles.begin(), triangles.end());
+
+    nanovdb::tools::cuda::MeshToGrid<BuildT> converter(
+        dPoints.data().get(),    uint32_t(dPoints.size()),
+        dTriangles.data().get(), uint32_t(dTriangles.size()), map);
+    converter.setVerbose(1);
+    converter.setNarrowBandWidth(bandWidth);
+    auto [origHandle, udfSidecar] = converter.getHandleAndUDF();
+    const auto* d_orig = origHandle.template deviceGrid<BuildT>();
+
+    // World-space voxel size from the map (uniform scale here, but read it generically).
+    const nanovdb::Vec3d w0 = map.applyMap(nanovdb::Vec3d(0.0, 0.0, 0.0));
+    const nanovdb::Vec3d wx = map.applyMap(nanovdb::Vec3d(1.0, 0.0, 0.0));
+    const float voxelSize   = float(wx[0] - w0[0]);
+
+    // ---- Step 2: discard the surface/barrier shell -> derived topology. ----
+    const float    barrierSqWorld = 0.75f * voxelSize * voxelSize;  // (sqrt(3)/2 * voxelSize)^2
+    const uint32_t srcLeafCount   = Traits::getTreeData(d_orig).mNodeCount[0];
+
+    auto  retainMask   = nanovdb::cuda::DeviceBuffer::create(
+        std::size_t(srcLeafCount) * sizeof(nanovdb::Mask<3>), nullptr, false);
+    auto* d_retainMask = static_cast<nanovdb::Mask<3>*>(retainMask.deviceData());
+
+    nanovdb::util::cuda::operatorKernel<UDFBarrierPruneMaskFunctor>
+        <<<srcLeafCount, UDFBarrierPruneMaskFunctor::MaxThreadsPerBlock, 0, stream>>>(
+            d_orig, static_cast<const float*>(udfSidecar.deviceData()), barrierSqWorld, d_retainMask);
+    cudaCheckError();
+
+    nanovdb::tools::cuda::PruneGrid<BuildT> pruner(d_orig, d_retainMask, stream);
+    auto        derivedHandle = pruner.getHandle();
+    const auto* d_derived     = derivedHandle.template deviceGrid<BuildT>();
+
+    // ---- Step 3: connected-components labeling on the derived grid. ----
+    nanovdb::tools::cuda::ConnectedComponents<BuildT> cc(d_derived, stream);
+    auto [d_labels, numComponents] = cc.getVoxelLabelsAndCount();
+    cudaCheck(cudaStreamSynchronize(stream));
+
+    // Diagnostics.
+    const uint64_t derivedActive = Traits::getActiveVoxelCount(d_derived);
+    const uint32_t derivedLeaves = Traits::getTreeData(d_derived).mNodeCount[0];
+    std::cout << "Derived (barrier-removed) grid: " << derivedActive << " active voxels, "
+              << derivedLeaves << " leaves.\n";
+
+    // CPU-oracle self-check.
+    validateAgainstOracle(derivedHandle, derivedLeaves, derivedActive, d_labels, numComponents);
+
+    return numComponents;
+}

--- a/nanovdb/nanovdb/examples/ex_connected_components_cuda/connected_components_cuda_kernels.cu
+++ b/nanovdb/nanovdb/examples/ex_connected_components_cuda/connected_components_cuda_kernels.cu
@@ -4,7 +4,7 @@
 /// @file  connected_components_cuda_kernels.cu
 ///
 /// @brief CUDA / NanoVDB side of the connected-components example. Rasterizes a triangle mesh into a
-///        ValueOnIndex narrow-band grid (nanovdb::tools::cuda::MeshToGrid), discards the
+///        ValueOnIndex narrow-band grid (nanovdb::tools::cuda::MeshToGrid), optionally discards the
 ///        surface/barrier shell (unsigned distance within sqrt(3)/2 voxels of the surface) with
 ///        nanovdb::tools::cuda::PruneGrid, and runs connected-components labeling with
 ///        nanovdb::tools::cuda::ConnectedComponents. A CPU union-find oracle independently verifies
@@ -172,7 +172,8 @@ bool validateAgainstOracle(const GridHandleT& derivedHandle, uint32_t leafCount,
 uint64_t connectedComponentsFromMesh(const std::vector<nanovdb::Vec3f>& points,
                                      const std::vector<nanovdb::Vec3i>& triangles,
                                      const nanovdb::Map&                map,
-                                     float                              bandWidth)
+                                     float                              bandWidth,
+                                     bool                               discardSurfaceVoxels)
 {
     const cudaStream_t stream = 0;
 
@@ -188,41 +189,46 @@ uint64_t connectedComponentsFromMesh(const std::vector<nanovdb::Vec3f>& points,
     auto [origHandle, udfSidecar] = converter.getHandleAndUDF();
     const auto* d_orig = origHandle.template deviceGrid<BuildT>();
 
-    // World-space voxel size from the map (uniform scale here, but read it generically).
-    const nanovdb::Vec3d w0 = map.applyMap(nanovdb::Vec3d(0.0, 0.0, 0.0));
-    const nanovdb::Vec3d wx = map.applyMap(nanovdb::Vec3d(1.0, 0.0, 0.0));
-    const float voxelSize   = float(wx[0] - w0[0]);
+    // ---- Step 2 (optional): discard the surface/barrier shell -> derived topology. ----
+    // With the shell removed, each closed surface's band splits into disjoint inner/outer shells;
+    // without it, connected components run on the full narrow band (one component per closed surface).
+    GridHandleT                      derivedHandle;   // stays empty unless we prune
+    const nanovdb::NanoGrid<BuildT>* d_cc = d_orig;    // grid connected components will label
+    if (discardSurfaceVoxels) {
+        // World-space voxel size from the map (uniform scale here, but read it generically).
+        const nanovdb::Vec3d w0 = map.applyMap(nanovdb::Vec3d(0.0, 0.0, 0.0));
+        const nanovdb::Vec3d wx = map.applyMap(nanovdb::Vec3d(1.0, 0.0, 0.0));
+        const float    voxelSize      = float(wx[0] - w0[0]);
+        const float    barrierSqWorld = 0.75f * voxelSize * voxelSize;  // (sqrt(3)/2 * voxelSize)^2
+        const uint32_t srcLeafCount   = Traits::getTreeData(d_orig).mNodeCount[0];
 
-    // ---- Step 2: discard the surface/barrier shell -> derived topology. ----
-    const float    barrierSqWorld = 0.75f * voxelSize * voxelSize;  // (sqrt(3)/2 * voxelSize)^2
-    const uint32_t srcLeafCount   = Traits::getTreeData(d_orig).mNodeCount[0];
+        auto  retainMask   = nanovdb::cuda::DeviceBuffer::create(
+            std::size_t(srcLeafCount) * sizeof(nanovdb::Mask<3>), nullptr, false);
+        auto* d_retainMask = static_cast<nanovdb::Mask<3>*>(retainMask.deviceData());
 
-    auto  retainMask   = nanovdb::cuda::DeviceBuffer::create(
-        std::size_t(srcLeafCount) * sizeof(nanovdb::Mask<3>), nullptr, false);
-    auto* d_retainMask = static_cast<nanovdb::Mask<3>*>(retainMask.deviceData());
+        nanovdb::util::cuda::operatorKernel<UDFBarrierPruneMaskFunctor>
+            <<<srcLeafCount, UDFBarrierPruneMaskFunctor::MaxThreadsPerBlock, 0, stream>>>(
+                d_orig, static_cast<const float*>(udfSidecar.deviceData()), barrierSqWorld, d_retainMask);
+        cudaCheckError();
 
-    nanovdb::util::cuda::operatorKernel<UDFBarrierPruneMaskFunctor>
-        <<<srcLeafCount, UDFBarrierPruneMaskFunctor::MaxThreadsPerBlock, 0, stream>>>(
-            d_orig, static_cast<const float*>(udfSidecar.deviceData()), barrierSqWorld, d_retainMask);
-    cudaCheckError();
+        nanovdb::tools::cuda::PruneGrid<BuildT> pruner(d_orig, d_retainMask, stream);
+        derivedHandle = pruner.getHandle();
+        d_cc          = derivedHandle.template deviceGrid<BuildT>();
+    }
 
-    nanovdb::tools::cuda::PruneGrid<BuildT> pruner(d_orig, d_retainMask, stream);
-    auto        derivedHandle = pruner.getHandle();
-    const auto* d_derived     = derivedHandle.template deviceGrid<BuildT>();
-
-    // ---- Step 3: connected-components labeling on the derived grid. ----
-    nanovdb::tools::cuda::ConnectedComponents<BuildT> cc(d_derived, stream);
+    // ---- Step 3: connected-components labeling on the selected grid. ----
+    nanovdb::tools::cuda::ConnectedComponents<BuildT> cc(d_cc, stream);
     auto [d_labels, numComponents] = cc.getVoxelLabelsAndCount();
     cudaCheck(cudaStreamSynchronize(stream));
 
-    // Diagnostics.
-    const uint64_t derivedActive = Traits::getActiveVoxelCount(d_derived);
-    const uint32_t derivedLeaves = Traits::getTreeData(d_derived).mNodeCount[0];
-    std::cout << "Derived (barrier-removed) grid: " << derivedActive << " active voxels, "
-              << derivedLeaves << " leaves.\n";
+    // Diagnostics + CPU-oracle self-check (on whichever grid was labeled).
+    const GridHandleT& ccHandle = discardSurfaceVoxels ? derivedHandle : origHandle;
+    const uint64_t     ccActive = Traits::getActiveVoxelCount(d_cc);
+    const uint32_t     ccLeaves = Traits::getTreeData(d_cc).mNodeCount[0];
+    std::cout << (discardSurfaceVoxels ? "Derived (barrier-removed) grid: " : "Full narrow-band grid: ")
+              << ccActive << " active voxels, " << ccLeaves << " leaves.\n";
 
-    // CPU-oracle self-check.
-    validateAgainstOracle(derivedHandle, derivedLeaves, derivedActive, d_labels, numComponents);
+    validateAgainstOracle(ccHandle, ccLeaves, ccActive, d_labels, numComponents);
 
     return numComponents;
 }

--- a/nanovdb/nanovdb/tools/cuda/ConnectedComponents.cuh
+++ b/nanovdb/nanovdb/tools/cuda/ConnectedComponents.cuh
@@ -1,0 +1,827 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/cuda/ConnectedComponents.cuh
+
+    \authors Efty Sifakis and JaeHyun Lee
+
+    \brief Connected-components labeling of NanoVDB indexGrids on the device.
+
+           Identifies connected components of active voxels in a ValueOnIndex grid: two
+           active voxels share a component label iff they are connected through a path of
+           adjacent active voxels.
+
+    \warning The header file contains cuda device code so be sure
+             to only include it in .cu files (or other .cuh files)
+*/
+
+#ifndef NVIDIA_TOOLS_CUDA_CONNECTEDCOMPONENTS_CUH_HAS_BEEN_INCLUDED
+#define NVIDIA_TOOLS_CUDA_CONNECTEDCOMPONENTS_CUH_HAS_BEEN_INCLUDED
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/cuda/DeviceBuffer.h>
+#include <nanovdb/cuda/TempPool.h>
+#include <nanovdb/util/cuda/DeviceGridTraits.cuh>
+#include <nanovdb/util/cuda/Timer.h>
+#include <nanovdb/util/cuda/Util.h> // for operatorKernel
+
+#include <cub/cub.cuh>
+
+#include <utility>  // std::pair
+
+// Private helper macro to call CUB functions that use dynamic temporary storage, in terms of the
+// enclosing class's mTempDevicePool + mStream members. Uniquely named and #undef'd at the end of
+// this header so it never leaks into or collides with similarly-named macros in other headers
+// (e.g. TopologyBuilder.cuh's own CALL_CUBS, which is written in terms of a local `stream`).
+#ifdef _WIN32
+#define NANOVDB_CC_CALL_CUBS(func, ...) \
+    cudaCheck(cub::func(nullptr, mTempDevicePool.requestedSize(), __VA_ARGS__, mStream)); \
+    mTempDevicePool.reallocate(mStream); \
+    cudaCheck(cub::func(mTempDevicePool.data(), mTempDevicePool.size(), __VA_ARGS__, mStream));
+#else
+#define NANOVDB_CC_CALL_CUBS(func, args...) \
+    cudaCheck(cub::func(nullptr, mTempDevicePool.requestedSize(), args, mStream)); \
+    mTempDevicePool.reallocate(mStream); \
+    cudaCheck(cub::func(mTempDevicePool.data(), mTempDevicePool.size(), args, mStream));
+#endif
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+/// @brief Index of each of the 6 leaf faces into a component's face-mask array. Each face is a
+///        uint64_t bitmask over the 8x8 boundary plane; cross-leaf adjacency is one AND of the
+///        touching faces (faceMasks[I][plusX] & faceMasks[J][minusX]). Bit index per axis:
+///          ±X: y*8+z    ±Y: x*8+z    ±Z: y*8+x
+enum LeafNeighborTap : int {
+    minusX = 0,
+    plusX  = 1,
+    minusY = 2,
+    plusY  = 3,
+    minusZ = 4,
+    plusZ  = 5
+};
+
+/// @brief Undirected edge between two leaf-local components (global slots) touching across a leaf
+///        face, stored canonically with a < b. uint32_t: K <= 256*leafCount stays well below 2^32.
+struct CrossLeafEdge { uint32_t a, b; };
+
+template <typename BuildT>
+class ConnectedComponents
+{
+    using GridT = NanoGrid<BuildT>;
+    using TreeT = NanoTree<BuildT>;
+    using RootT = NanoRoot<BuildT>;
+
+public:
+
+    /// @brief Constructor
+    /// @param d_srcGrid source device indexGrid whose active voxels are to be labeled
+    /// @param stream optional CUDA stream (defaults to CUDA stream 0)
+    ConnectedComponents(const GridT* d_srcGrid, cudaStream_t stream = 0)
+        : mStream(stream), mTimer(stream), mDeviceSrcGrid(d_srcGrid) {}
+
+    /// @brief Toggle on and off verbose mode
+    /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
+    void setVerbose(int level = 1) { mVerbose = level; }
+
+    /// @brief Run the connected-components pipeline and return { d_labels, componentCount }:
+    ///          - d_labels: a device array of activeVoxelCount+1 uint32_t, indexed by leaf.getValue(n)
+    ///            (slot 0 = background, sentinel 0xFFFFFFFF). Each active voxel holds its component's
+    ///            dense id in [0, N), so two active voxels share a value iff they are in the same
+    ///            connected component. This is a non-owning view valid for this object's lifetime.
+    ///          - componentCount: the number of connected components N.
+    std::pair<uint32_t*, uint64_t> getVoxelLabelsAndCount()
+    {
+        processLeafConnectedComponents();
+        processCrossLeafEdges();
+        processComponentLabels();
+        processVoxelLabels();
+        return { static_cast<uint32_t*>(mVoxelLabel.deviceData()), mGlobalComponentCount };
+    }
+
+private:
+
+    // --- Pipeline stages (run in order by getVoxelLabelsAndCount). ---
+
+    // Stage 1: per-leaf 6-connected components (each leaf in isolation) -> per-component count,
+    // prefix-sum offset, active-voxel Mask<3>, and 6 face masks.
+    void processLeafConnectedComponents();
+
+    // Stage 2: emit one edge (a<b) per pair of face-adjacent leaf-local components whose touching
+    // face masks intersect. Unordered.
+    void processCrossLeafEdges();
+
+    // Stage 3: union-find over the edges -> deviceComponentParent()[s] = component s's representative
+    // (its class's minimum global slot).
+    void processComponentLabels();
+
+    // Build the per-voxel label sidecar + component count N from the parent array.
+    void processVoxelLabels();
+
+    // --- Internal device-array accessors (each valid after the stage that fills it). ---
+    auto deviceLeafComponentCounts()    { return static_cast<uint16_t*>(mLeafComponentCounts.deviceData()); }
+    auto deviceLeafComponentOffsets()   { return static_cast<uint64_t*>(mLeafComponentOffsets.deviceData()); }
+    auto deviceLeafComponentMasks()     { return static_cast<nanovdb::Mask<3>*>(mLeafComponentMasks.deviceData()); }
+    auto deviceLeafComponentFaceMasks() { return reinterpret_cast<uint64_t(*)[6]>(mLeafComponentFaceMasks.deviceData()); }
+    auto deviceCrossLeafEdges()         { return static_cast<CrossLeafEdge*>(mCrossLeafEdges.deviceData()); }
+    auto deviceComponentParent()        { return static_cast<uint64_t*>(mComponentParent.deviceData()); }
+
+    cudaStream_t                 mStream{0};
+    util::cuda::Timer            mTimer;
+    int                          mVerbose{0};
+    const GridT                 *mDeviceSrcGrid;
+    nanovdb::cuda::TempDevicePool mTempDevicePool;
+
+    uint64_t                     mLeafComponentAggregateCount{0}; // total leaf-local components across all leaves (= K = offsets[leafCount])
+
+    nanovdb::cuda::DeviceBuffer  mLeafComponentCounts;      // leafCount                    × uint16_t:      per-leaf component count
+    nanovdb::cuda::DeviceBuffer  mLeafComponentOffsets;     // (leafCount+1)                × uint64_t:      exclusive+inclusive prefix sums
+    nanovdb::cuda::DeviceBuffer  mLeafComponentMasks;       // mLeafComponentAggregateCount × Mask<3>:       per-component active-voxel footprint
+    nanovdb::cuda::DeviceBuffer  mLeafComponentFaceMasks;   // mLeafComponentAggregateCount × uint64_t[6]:   per-component face bitmasks (0=-X,1=+X,2=-Y,3=+Y,4=-Z,5=+Z)
+
+    uint64_t                     mCrossLeafEdgeCount{0};    // total cross-leaf edges (E)
+    nanovdb::cuda::DeviceBuffer  mCrossLeafEdgeOffsets;     // (leafCount+1) × uint64_t:  per-leaf edge prefix sums
+    nanovdb::cuda::DeviceBuffer  mCrossLeafEdges;           // E × CrossLeafEdge (a<b)
+
+    nanovdb::cuda::DeviceBuffer  mComponentParent;          // K × uint64_t: per-component global representative
+
+    nanovdb::cuda::DeviceBuffer  mVoxelLabel;               // (activeVoxelCount+1) × uint32_t: per-active-voxel dense component id in [0,N) (index by leaf.getValue(n); slot 0 = background)
+    uint64_t                     mGlobalComponentCount{0};  // number of connected components N (distinct representatives)
+
+}; // tools::cuda::ConnectedComponents<BuildT>
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace cc_detail {
+
+// Per-leaf connected-components via a Shiloach-Vishkin union-find run in shared memory,
+// one CUDA block per leaf, one thread per voxel offset n in [0, 512). The forest is stored
+// as a parent array of leaf-local voxel offsets: parent[n] = n for active roots, a smaller
+// active offset for non-roots, and -1 for inactive voxels. Connectivity is 6-connected and
+// strictly intra-leaf (cross-leaf edges are ignored at this stage).
+//
+// The three primitives are double-buffered (Jacobi): they read the "cur" buffer and write
+// the "nxt" buffer, then swap. Inactive entries (-1) are carried through unchanged. The
+// pointer swap is performed identically by every thread, so the register copies stay in sync.
+
+constexpr int LEAF_DIM  = 8;            // NanoLeaf DIM
+constexpr int LEAF_SIZE = 512;          // 8^3
+constexpr int CC_INACTIVE = -1;         // parent sentinel for inactive voxels
+
+// 3D view over a 512-entry parent buffer. The voxel offset is x-major
+// (n = (x<<6)|(y<<3)|z), so a row-major int[8][8][8] indexed [x][y][z] aliases the flat
+// buffer exactly: element [x][y][z] sits at linear offset x*64 + y*8 + z == n. Accessing
+// individual int elements through this view is well-defined (the storage really is int).
+using ParentsT = int[LEAF_DIM][LEAF_DIM][LEAF_DIM];
+
+// Smallest parent among the (up to 6) active in-leaf face neighbors of offset n, floored at
+// the supplied current value. Offset layout is x-major: n = (x<<6)|(y<<3)|z.
+__device__ inline int ccNeighborMin(const int* parentsPtr, int n, int current)
+{
+    const auto& p = reinterpret_cast<const ParentsT&>(*parentsPtr);
+    const int x =  n >> 6       ;
+    const int y = (n >> 3) & 0x7;
+    const int z =       n  & 0x7;
+    int m = current;
+    if (x > 0 && p[x-1][y][z] != CC_INACTIVE) m = ::min(m, p[x-1][y][z]);   // -X
+    if (x < 7 && p[x+1][y][z] != CC_INACTIVE) m = ::min(m, p[x+1][y][z]);   // +X
+    if (y > 0 && p[x][y-1][z] != CC_INACTIVE) m = ::min(m, p[x][y-1][z]);   // -Y
+    if (y < 7 && p[x][y+1][z] != CC_INACTIVE) m = ::min(m, p[x][y+1][z]);   // +Y
+    if (z > 0 && p[x][y][z-1] != CC_INACTIVE) m = ::min(m, p[x][y][z-1]);   // -Z
+    if (z < 7 && p[x][y][z+1] != CC_INACTIVE) m = ::min(m, p[x][y][z+1]);   // +Z
+    return m;
+}
+
+// SV root hook: every vertex v whose smallest active neighbor label m is below parent[v]
+// lowers the slot of v's *parent* (its tree root, once flattened) toward m, via atomicMin.
+// Sets *changed (when non-null) iff some root slot was actually lowered.
+__device__ inline void ccHook(int*& cur, int*& nxt, int n, int* changed)
+{
+    const int pn = cur[n];
+    nxt[n] = pn;                                  // Phase A: seed nxt = cur (own slot, no race)
+    __syncthreads();
+    if (pn != CC_INACTIVE) {                      // active voxel
+        const int m = ccNeighborMin(cur, n, pn);
+        if (m < pn) {                             // root slot is data-dependent -> atomicMin
+            const int old = atomicMin_block(&nxt[pn], m);  // block scope: nxt[] is shared
+            if (changed && old > m) *changed = 1;
+        }
+    }
+    __syncthreads();
+    int* t = cur; cur = nxt; nxt = t;             // swap (identical on every thread)
+}
+
+// Pointer-jumping compress: parent[v] <- parent[parent[v]]. Halves tree depth per call.
+// Sets *changed (when non-null) iff some entry actually moved.
+__device__ inline void ccCompress(int*& cur, int*& nxt, int n, int* changed)
+{
+    const int pn = cur[n];
+    int v = CC_INACTIVE;
+    if (pn != CC_INACTIVE) {                      // active: grandparent (cur[pn] is valid)
+        v = cur[pn];
+        if (changed && v != pn) *changed = 1;
+    }
+    nxt[n] = v;                                   // own slot, no race
+    __syncthreads();
+    int* t = cur; cur = nxt; nxt = t;             // swap
+}
+
+template <typename BuildT>
+struct LeafComponentCountFunctor
+{
+    static constexpr int MaxThreadsPerBlock         = LEAF_SIZE;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    // Safety cap on the convergence loop, well above the worst case for an 8^3 leaf
+    // (~log2(depth) + log2(#local minima) <= ~18); guards against a non-terminating bug
+    // rather than limiting any legitimate input.
+    static constexpr int MaxConvergenceIters = 64;
+
+    __device__ void operator()(const NanoGrid<BuildT>* d_grid, uint16_t* d_counts)
+    {
+        __shared__ int bufA[LEAF_SIZE];
+        __shared__ int bufB[LEAF_SIZE];
+        __shared__ int changed;
+        __shared__ int compCount;
+
+        const int   leafID = blockIdx.x;
+        const int   tID    = threadIdx.x;
+        const auto& leaf   = d_grid->tree().template getFirstNode<0>()[leafID];
+
+        int* cur = bufA;
+        int* nxt = bufB;
+
+        // Init: active voxels label themselves, inactive get the sentinel.
+        cur[tID] = leaf.isActive(uint32_t(tID)) ? tID : CC_INACTIVE;
+        __syncthreads();
+
+        // Unconditional warm-up: 1 hook + log2(DIM)=3 compresses.
+        ccHook    (cur, nxt, tID, nullptr);
+        ccCompress(cur, nxt, tID, nullptr);
+        ccCompress(cur, nxt, tID, nullptr);
+        ccCompress(cur, nxt, tID, nullptr);
+
+        // Then alternate (hook, compress) until a full iteration changes nothing.
+        for (int it = 0; it < MaxConvergenceIters; ++it) {
+            if (tID == 0) changed = 0;
+            __syncthreads();
+            ccHook    (cur, nxt, tID, &changed);
+            ccCompress(cur, nxt, tID, &changed);
+            __syncthreads();
+            if (changed == 0) break;
+            __syncthreads();  // all threads have read `changed`; safe for thread 0 to reset it next iteration
+        }
+
+        // Component count = number of surviving roots (cur[tID] == tID; inactive entries are -1).
+        if (tID == 0) compCount = 0;
+        __syncthreads();
+        if (cur[tID] == tID) atomicAdd_block(&compCount, 1);  // block scope: compCount is shared
+        __syncthreads();
+        if (tID == 0) d_counts[leafID] = uint16_t(compCount);
+    }
+}; // LeafComponentCountFunctor
+
+template <typename BuildT>
+struct LeafComponentMaskFunctor
+{
+    static constexpr int MaxThreadsPerBlock         = LEAF_SIZE;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+    static constexpr int MaxConvergenceIters        = 64;
+
+    __device__ void operator()(const NanoGrid<BuildT>* d_grid,
+                                const uint64_t*         d_offsets,
+                                nanovdb::Mask<3>*       d_masks,
+                                uint64_t              (*d_faces)[6])
+    {
+        __shared__ int   bufA[LEAF_SIZE];
+        __shared__ int   bufB[LEAF_SIZE];
+        __shared__ typename cub::BlockReduce<uint32_t, LEAF_SIZE>::TempStorage reduceTmp;
+        __shared__ int      changed;
+        __shared__ uint32_t sMinLabel;
+        // Ballot words (u32/warp) aliased to the Mask<3> u64 words. NAMED union: an anonymous
+        // __shared__ union compiled to per-thread local storage, breaking cross-warp sharing.
+        __shared__ union { uint32_t u32[16]; uint64_t u64[8]; } sMaskU;
+        uint32_t* sMaskWords_u32 = sMaskU.u32;
+        uint64_t* sMaskWords     = sMaskU.u64;
+
+        const int   leafID = blockIdx.x;
+        const int   tID    = threadIdx.x;
+        const auto& leaf   = d_grid->tree().template getFirstNode<0>()[leafID];
+
+        int* cur = bufA;
+        int* nxt = bufB;
+
+        // Init + SV convergence: identical schedule to LeafComponentCountFunctor.
+        cur[tID] = leaf.isActive(uint32_t(tID)) ? tID : CC_INACTIVE;
+        __syncthreads();
+
+        ccHook    (cur, nxt, tID, nullptr);
+        ccCompress(cur, nxt, tID, nullptr);
+        ccCompress(cur, nxt, tID, nullptr);
+        ccCompress(cur, nxt, tID, nullptr);
+
+        for (int it = 0; it < MaxConvergenceIters; ++it) {
+            if (tID == 0) changed = 0;
+            __syncthreads();
+            ccHook    (cur, nxt, tID, &changed);
+            ccCompress(cur, nxt, tID, &changed);
+            __syncthreads();
+            if (changed == 0) break;
+            __syncthreads();
+        }
+
+        // Mask-fill: iterate over leaf-local components in ascending root-label order.
+        //
+        // Each iteration finds the smallest unprocessed root label via a block-wide unsigned
+        // min (CC_INACTIVE = -1 recasts to 0xFFFFFFFF and thus never wins), then collects
+        // matching voxels via __ballot_sync and writes the 32-bit result for each warp
+        // directly into the Mask<3> word array recast as uint32_t* (each of the 16 warps
+        // covers exactly one 32-bit word, so all words are written unconditionally).
+        // Processed entries are erased to CC_INACTIVE so they don't win a future min.
+        // localCompIdx tracks the dense component index in lockstep across all threads.
+
+        const uint64_t baseOffset = d_offsets[leafID];
+        const int warpID = tID >> 5;   // tID / 32
+        const int laneID = tID & 31;   // tID % 32
+
+        int localCompIdx = 0;
+
+        while (true) {
+            uint32_t minLabel = cub::BlockReduce<uint32_t, LEAF_SIZE>(reduceTmp)
+                                    .Reduce(uint32_t(cur[tID]), ::cuda::minimum<uint32_t>{});
+            if (tID == 0) sMinLabel = minLabel;
+            __syncthreads();
+            if (sMinLabel == uint32_t(CC_INACTIVE)) break;
+
+            const bool     match  = (uint32_t(cur[tID]) == sMinLabel);
+            const uint32_t ballot = __ballot_sync(0xFFFFFFFF, match);
+            if (laneID == 0) sMaskWords_u32[warpID] = ballot;
+
+            if (match) cur[tID] = CC_INACTIVE;
+            __syncthreads();  // [SYNC1]: sMaskWords_u32 fully written + cur erases visible
+
+            // Coalesced write: first 8 threads store sMaskWords → mask.words(), one uint64_t each.
+            if (tID < 8) {
+                d_masks[baseOffset + localCompIdx].words()[tID] = sMaskWords[tID];
+            }
+
+            // Extract 6 face masks from sMaskWords (uint64_t view) and store them.
+            if (tID == 0) {
+                uint64_t* face = d_faces[baseOffset + localCompIdx];
+
+                // ±X: whole word 0 / word 7 are exactly the minusX / plusX face planes.
+                face[minusX] = sMaskWords[0];
+                face[plusX]  = sMaskWords[7];
+
+                // ±Y: bottom byte (y=0) and top byte (y=7) of each word x;
+                //     shift-accumulate from x=7 down; result bit index = x*8 + z (x major, z minor).
+                uint64_t mY = sMaskWords[7] & 0xFF,  pY = (sMaskWords[7] >> 56) & 0xFF;
+                for (int x = 6; x >= 0; --x) {
+                    mY = (mY << 8) | (sMaskWords[x] & 0xFF);
+                    pY = (pY << 8) | ((sMaskWords[x] >> 56) & 0xFF);
+                }
+                face[minusY] = mY;
+                face[plusY]  = pY;
+
+                // ±Z: bit 0 (z=0) and bit 7 (z=7) of each byte in each word;
+                //     shift-accumulate from x=7 down; result bit index = y*8 + x (y major, x minor).
+                uint64_t mZ = sMaskWords[7] & UINT64_C(0x0101010101010101);
+                uint64_t pZ = (sMaskWords[7] >> 7) & UINT64_C(0x0101010101010101);
+                for (int x = 6; x >= 0; --x) {
+                    mZ = (mZ << 1) | (sMaskWords[x] & UINT64_C(0x0101010101010101));
+                    pZ = (pZ << 1) | ((sMaskWords[x] >> 7) & UINT64_C(0x0101010101010101));
+                }
+                face[minusZ] = mZ;
+                face[plusZ]  = pZ;
+            }
+            __syncthreads();  // [SYNC2]: mask + face writes done; all threads safe for next BlockReduce
+
+            ++localCompIdx;
+        }
+    }
+}; // LeafComponentMaskFunctor
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// Stage 2: cross-leaf connectivity edges.
+//
+// One block per leaf. For each of the leaf's +X/+Y/+Z neighbor leaves (so each undirected leaf-leaf
+// boundary is visited exactly once, from its -side), pair every local component of this leaf with
+// every local component of the neighbor and test whether their touching face masks intersect. The
+// component "global slot" is leafComponentOffsets[leaf] + localIdx.
+
+/// @brief Linear leaf index of leaf's +axis neighbor (axis: 0=+X, 1=+Y, 2=+Z), or -1 if none.
+template <typename BuildT>
+__device__ inline int ccNeighborLeafIndex(const NanoGrid<BuildT>* d_grid,
+                                           const NanoLeaf<BuildT>&  leaf, int axis)
+{
+    const nanovdb::Coord o  = leaf.origin();
+    const nanovdb::Coord no = (axis == 0) ? o.offsetBy(8, 0, 0)
+                            : (axis == 1) ? o.offsetBy(0, 8, 0)
+                                          : o.offsetBy(0, 0, 8);
+    const auto* nptr = d_grid->tree().root().probeLeaf(no);
+    if (!nptr) return -1;
+    const auto* base = d_grid->tree().template getFirstNode<0>();
+    return int(nptr - base);  // leaves are contiguous breadth-first; typed diff = linear index
+}
+
+/// @brief Enumerate this leaf's cross-leaf component pairs whose touching faces intersect, invoking
+///        emit(globalSlotThisLeaf, globalSlotNeighbor) for each. Shared by the count and scatter
+///        passes so their iteration + AND test cannot drift. Threads of the block stride the pair
+///        grid; emit() must be safe under concurrent calls (it uses a block-scoped atomic).
+template <typename BuildT, typename EdgeFn>
+__device__ inline void ccForEachCrossLeafEdge(
+    const NanoGrid<BuildT>* d_grid, const uint64_t* d_offsets, const uint64_t (*d_faces)[6],
+    int leafID, int tID, int nThreads, EdgeFn&& emit)
+{
+    const auto&    leaf   = d_grid->tree().template getFirstNode<0>()[leafID];
+    const uint64_t baseL  = d_offsets[leafID];
+    const int      countL = int(d_offsets[leafID + 1] - baseL);
+    if (countL == 0) return;
+
+    const int faceL[3] = { plusX,  plusY,  plusZ  };  // this leaf's +axis face
+    const int faceN[3] = { minusX, minusY, minusZ };  // neighbor's matching -axis face
+
+    for (int axis = 0; axis < 3; ++axis) {
+        const int N = ccNeighborLeafIndex<BuildT>(d_grid, leaf, axis);
+        if (N < 0) continue;
+        const uint64_t baseN  = d_offsets[N];
+        const int      countN = int(d_offsets[N + 1] - baseN);
+        if (countN == 0) continue;
+        const int fL = faceL[axis], fN = faceN[axis];
+        const int total = countL * countN;
+        for (int p = tID; p < total; p += nThreads) {
+            const int i = p / countN, j = p % countN;
+            if (d_faces[baseL + i][fL] & d_faces[baseN + j][fN])
+                emit(uint32_t(baseL + i), uint32_t(baseN + j));
+        }
+    }
+}
+
+template <typename BuildT>
+struct CrossLeafEdgeCountFunctor
+{
+    static constexpr int MaxThreadsPerBlock         = 128;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    // d_outCount is (leafComponentEdgeOffsets + 1), so writing [leafID] lands at offsets[leafID+1].
+    __device__ void operator()(const NanoGrid<BuildT>* d_grid, const uint64_t* d_offsets,
+                               const uint64_t (*d_faces)[6], uint64_t* d_outCount)
+    {
+        __shared__ int sEdges;
+        const int leafID = blockIdx.x, tID = threadIdx.x;
+        if (tID == 0) sEdges = 0;
+        __syncthreads();
+        ccForEachCrossLeafEdge<BuildT>(d_grid, d_offsets, d_faces, leafID, tID, blockDim.x,
+            [&] __device__ (uint32_t, uint32_t) { atomicAdd_block(&sEdges, 1); });
+        __syncthreads();
+        if (tID == 0) d_outCount[leafID] = uint64_t(sEdges);
+    }
+};
+
+template <typename BuildT>
+struct CrossLeafEdgeScatterFunctor
+{
+    static constexpr int MaxThreadsPerBlock         = 128;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    __device__ void operator()(const NanoGrid<BuildT>* d_grid, const uint64_t* d_offsets,
+                               const uint64_t (*d_faces)[6], const uint64_t* d_edgeOffsets,
+                               CrossLeafEdge* d_edges)
+    {
+        __shared__ unsigned long long sWrite;
+        const int leafID = blockIdx.x, tID = threadIdx.x;
+        if (tID == 0) sWrite = (unsigned long long)d_edgeOffsets[leafID];
+        __syncthreads();
+        ccForEachCrossLeafEdge<BuildT>(d_grid, d_offsets, d_faces, leafID, tID, blockDim.x,
+            [&] __device__ (uint32_t ga, uint32_t gb) {
+                const unsigned long long slot = atomicAdd_block(&sWrite, 1ull);
+                CrossLeafEdge e;
+                e.a = (ga < gb) ? ga : gb;  // canonical a < b
+                e.b = (ga < gb) ? gb : ga;
+                d_edges[slot] = e;
+            });
+        __syncthreads();
+    }
+};
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// Stage 3: global union-find over the cross-leaf edge list (representative = min slot in the class).
+
+/// @brief Walk parent pointers to the root of x. Links always point larger->smaller slot, so the
+///        forest is acyclic and this terminates; the root is the minimum slot in x's class.
+__device__ inline uint64_t ccFind(const uint64_t* parent, uint64_t x)
+{
+    while (parent[x] != x) x = parent[x];
+    return x;
+}
+
+/// @brief Lock-free union of the classes of a and b: find both roots and CAS-link the larger root
+///        under the smaller (parent[hi] : hi -> lo). Retries if hi ceased to be a root meanwhile.
+///        Order-independent result: a class's minimum slot is never the "hi", so it stays the root.
+__device__ inline void ccUnite(uint64_t* parent, uint64_t a, uint64_t b)
+{
+    while (true) {
+        const uint64_t ra = ccFind(parent, a);
+        const uint64_t rb = ccFind(parent, b);
+        if (ra == rb) return;
+        const uint64_t hi = (ra > rb) ? ra : rb;
+        const uint64_t lo = (ra < rb) ? ra : rb;
+        const unsigned long long old = atomicCAS(
+            reinterpret_cast<unsigned long long*>(&parent[hi]),
+            static_cast<unsigned long long>(hi),
+            static_cast<unsigned long long>(lo));
+        if (old == static_cast<unsigned long long>(hi)) return;  // linked; else hi moved -> retry
+    }
+}
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// Small element-wise functors driven by lambdaKernel. These are named structs (rather than inline
+// extended __device__ lambdas) so their enclosing ConnectedComponents member functions can have
+// private access — nvcc forbids extended __device__ lambdas inside private/protected methods — which
+// also matches the sibling operators (PruneGrid/DilateGrid/... drive lambdaKernel with named functors).
+
+// offsets[i+1] = counts[i]: upcast the per-leaf uint16 component counts into the uint64 offset array.
+struct UpcastCountsFunctor {
+    __device__ void operator()(size_t i, const uint16_t* counts, uint64_t* offsets) const {
+        offsets[i + 1] = uint64_t(counts[i]);
+    }
+};
+
+// Union-find init: every component is its own root.
+struct LabelInitFunctor {
+    __device__ void operator()(size_t s, uint64_t* p) const { p[s] = uint64_t(s); }
+};
+
+// Union-find unite: link the two endpoints of cross-leaf edge e (each ccUnite has its own CAS-retry).
+struct LabelUniteFunctor {
+    __device__ void operator()(size_t e, uint64_t* p, const CrossLeafEdge* edges) const {
+        ccUnite(p, uint64_t(edges[e].a), uint64_t(edges[e].b));
+    }
+};
+
+// Union-find flatten: point every component directly at its representative (class minimum slot).
+struct LabelFlattenFunctor {
+    __device__ void operator()(size_t s, uint64_t* p) const { p[s] = ccFind(p, uint64_t(s)); }
+};
+
+// flag[s] = 1 if component s is a self-root (parent[s]==s), else 0. An inclusive scan of these flags
+// gives each root its dense id (scan[root]-1) and, in the last entry, the component count N.
+struct RootFlagFunctor {
+    __device__ void operator()(size_t s, const uint64_t* p, uint32_t* flag) const {
+        flag[s] = (p[s] == uint64_t(s)) ? 1u : 0u;
+    }
+};
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// Voxel-label scatter: write each active voxel's dense component id into the per-voxel sidecar.
+//
+// One block per leaf, one thread per voxel offset n. The leaf's components partition its active
+// voxels, so the short scan over the leaf's slots finds the unique component containing n; its dense
+// id (rank[parent[s]] - 1) is written at leaf.getValue(n).
+
+template <typename BuildT>
+struct VoxelLabelScatterFunctor
+{
+    static constexpr int MaxThreadsPerBlock         = LEAF_SIZE;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    __device__ void operator()(const NanoGrid<BuildT>* d_grid, const uint64_t* d_offsets,
+                               const nanovdb::Mask<3>* d_masks, const uint64_t* d_parent,
+                               const uint32_t* d_rank, uint32_t* d_voxelLabel)
+    {
+        const int   leafID = blockIdx.x, n = threadIdx.x;
+        const auto& leaf   = d_grid->tree().template getFirstNode<0>()[leafID];
+        if (!leaf.isActive(uint32_t(n))) return;
+        const uint64_t base = d_offsets[leafID], end = d_offsets[leafID + 1];
+        for (uint64_t s = base; s < end; ++s)
+            if (d_masks[s].isOn(uint32_t(n))) {
+                d_voxelLabel[leaf.getValue(uint32_t(n))] = d_rank[d_parent[s]] - 1u;  // dense id in [0,N)
+                return;
+            }
+    }
+};
+
+} // namespace cc_detail
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+void ConnectedComponents<BuildT>::processLeafConnectedComponents()
+{
+    const uint32_t leafCount =
+        util::cuda::DeviceGridTraits<BuildT>::getTreeData(mDeviceSrcGrid).mNodeCount[0];
+
+    // Allocate one component-count per leaf (device-only). At most 256 components per 8^3
+    // leaf (6-connected worst case), so uint16_t is sufficient.
+    if (mVerbose==1) mTimer.start("Allocating per-leaf component counts");
+    mLeafComponentCounts = nanovdb::cuda::DeviceBuffer::create(
+        std::size_t(leafCount) * sizeof(uint16_t), nullptr, false);
+    if (mVerbose==1) mTimer.stop();
+
+    if (leafCount == 0) return;
+
+    // One block per leaf, one thread per voxel offset; counts the distinct 6-connected
+    // components of each leaf's active voxels (in isolation) into mLeafComponentCounts.
+    using Op = cc_detail::LeafComponentCountFunctor<BuildT>;
+    if (mVerbose==1) mTimer.start("Per-leaf connected-component counting");
+    util::cuda::operatorKernel<Op>
+        <<<leafCount, Op::MaxThreadsPerBlock, 0, mStream>>>(mDeviceSrcGrid, deviceLeafComponentCounts());
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+
+    // Prefix sum: mLeafComponentOffsets[0]=0, mLeafComponentOffsets[1..leafCount] = inclusive sum
+    // of mLeafComponentCounts. mLeafComponentOffsets[leafCount] = K (total leaf-local components).
+    if (mVerbose==1) mTimer.start("Allocating per-leaf component offsets");
+    mLeafComponentOffsets = nanovdb::cuda::DeviceBuffer::create(
+        (std::size_t(leafCount) + 1) * sizeof(uint64_t), nullptr, false);
+    if (mVerbose==1) mTimer.stop();
+
+    cudaCheck(cudaMemsetAsync(mLeafComponentOffsets.deviceData(), 0, sizeof(uint64_t), mStream));
+
+    // Upcast per-leaf uint16_t counts into offsets[1..leafCount] as uint64_t.
+    uint16_t* d_counts  = deviceLeafComponentCounts();
+    uint64_t* d_offsets = deviceLeafComponentOffsets();
+    util::cuda::lambdaKernel<<<(leafCount + 255) / 256, 256, 0, mStream>>>(
+        leafCount, cc_detail::UpcastCountsFunctor{}, d_counts, d_offsets);
+    cudaCheckError();
+
+    // In-place inclusive sum over offsets[1..leafCount]; offsets[leafCount] = K (total components).
+    if (mVerbose==1) mTimer.start("Per-leaf component offset prefix sum");
+    NANOVDB_CC_CALL_CUBS(DeviceScan::InclusiveSum, d_offsets + 1, d_offsets + 1, int(leafCount));
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+
+    // Read the aggregate count from the sentinel at offsets[leafCount].
+    // Use async copy on mStream (ordered after the scan) + stream sync to avoid
+    // inadvertently synchronizing other streams.
+    cudaCheck(cudaMemcpyAsync(&mLeafComponentAggregateCount, d_offsets + leafCount,
+                              sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
+    cudaCheck(cudaStreamSynchronize(mStream));
+
+    // Allocate mLeafComponentAggregateCount Mask<3> objects — one per leaf-local component.
+    // No zero-init needed: the mask-fill kernel writes all 16 uint32_t words of every mask
+    // unconditionally via warp ballot (zero ballot = no component voxels in that warp).
+    if (mVerbose==1) mTimer.start("Allocating per-component leaf masks");
+    mLeafComponentMasks = nanovdb::cuda::DeviceBuffer::create(
+        mLeafComponentAggregateCount * sizeof(nanovdb::Mask<3>), nullptr, false);
+    if (mVerbose==1) mTimer.stop();
+
+    // Allocate 6 uint64_t face masks per component (one per LeafNeighborTap entry).
+    // The face-extraction kernel fills these; no zero-init needed for the same reason.
+    if (mVerbose==1) mTimer.start("Allocating per-component face masks");
+    mLeafComponentFaceMasks = nanovdb::cuda::DeviceBuffer::create(
+        mLeafComponentAggregateCount * 6 * sizeof(uint64_t), nullptr, false);
+    if (mVerbose==1) mTimer.stop();
+
+    // Re-run SV per leaf and scatter each active voxel's bit into its component's Mask<3>.
+    using MaskOp = cc_detail::LeafComponentMaskFunctor<BuildT>;
+    if (mVerbose==1) mTimer.start("Per-leaf component mask fill");
+    util::cuda::operatorKernel<MaskOp>
+        <<<leafCount, MaskOp::MaxThreadsPerBlock, 0, mStream>>>(
+            mDeviceSrcGrid, deviceLeafComponentOffsets(),
+            deviceLeafComponentMasks(), deviceLeafComponentFaceMasks());
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+}// ConnectedComponents<BuildT>::processLeafConnectedComponents
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+void ConnectedComponents<BuildT>::processCrossLeafEdges()
+{
+    const uint32_t leafCount =
+        util::cuda::DeviceGridTraits<BuildT>::getTreeData(mDeviceSrcGrid).mNodeCount[0];
+    mCrossLeafEdgeCount = 0;
+    if (leafCount == 0) return;
+
+    // Per-leaf edge offsets: offsets[0]=0, offsets[1..leafCount] filled by the count pass then
+    // scanned in place; offsets[leafCount] = E (total cross-leaf edges).
+    mCrossLeafEdgeOffsets = nanovdb::cuda::DeviceBuffer::create(
+        (std::size_t(leafCount) + 1) * sizeof(uint64_t), nullptr, false);
+    uint64_t* d_offsets = static_cast<uint64_t*>(mCrossLeafEdgeOffsets.deviceData());
+    cudaCheck(cudaMemsetAsync(d_offsets, 0, sizeof(uint64_t), mStream));
+
+    // Count pass: one block per leaf, writing each leaf's edge count into offsets[leafID+1].
+    using CountOp = cc_detail::CrossLeafEdgeCountFunctor<BuildT>;
+    if (mVerbose==1) mTimer.start("Cross-leaf edge count");
+    util::cuda::operatorKernel<CountOp>
+        <<<leafCount, CountOp::MaxThreadsPerBlock, 0, mStream>>>(
+            mDeviceSrcGrid, deviceLeafComponentOffsets(), deviceLeafComponentFaceMasks(), d_offsets + 1);
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+
+    // Inclusive prefix sum over offsets[1..leafCount]; offsets[leafCount] = E.
+    if (mVerbose==1) mTimer.start("Cross-leaf edge offset prefix sum");
+    NANOVDB_CC_CALL_CUBS(DeviceScan::InclusiveSum, d_offsets + 1, d_offsets + 1, int(leafCount));
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+
+    cudaCheck(cudaMemcpyAsync(&mCrossLeafEdgeCount, d_offsets + leafCount,
+                              sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
+    cudaCheck(cudaStreamSynchronize(mStream));
+    if (mCrossLeafEdgeCount == 0) return;  // single-leaf grid / no touching components
+
+    // Scatter pass: write each leaf's edges into [offsets[leafID], offsets[leafID+1]).
+    mCrossLeafEdges = nanovdb::cuda::DeviceBuffer::create(
+        mCrossLeafEdgeCount * sizeof(CrossLeafEdge), nullptr, false);
+    using ScatterOp = cc_detail::CrossLeafEdgeScatterFunctor<BuildT>;
+    if (mVerbose==1) mTimer.start("Cross-leaf edge scatter");
+    util::cuda::operatorKernel<ScatterOp>
+        <<<leafCount, ScatterOp::MaxThreadsPerBlock, 0, mStream>>>(
+            mDeviceSrcGrid, deviceLeafComponentOffsets(), deviceLeafComponentFaceMasks(),
+            d_offsets, deviceCrossLeafEdges());
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+}// ConnectedComponents<BuildT>::processCrossLeafEdges
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+void ConnectedComponents<BuildT>::processComponentLabels()
+{
+    const uint64_t K = mLeafComponentAggregateCount;
+    mComponentParent = nanovdb::cuda::DeviceBuffer::create(
+        std::size_t(K ? K : 1) * sizeof(uint64_t), nullptr, false);  // avoid 0-byte alloc
+    if (K == 0) return;
+    uint64_t* d_parent = deviceComponentParent();
+
+    auto blocks = [](uint64_t n) { return (unsigned int)((n + 255) / 256); };
+
+    // (a) init: every component is its own root.
+    if (mVerbose==1) mTimer.start("Component-label init");
+    util::cuda::lambdaKernel<<<blocks(K), 256, 0, mStream>>>(
+        K, cc_detail::LabelInitFunctor{}, d_parent);
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+
+    // (b) unite: one thread per edge; each ccUnite has its own CAS-retry, so one pass suffices.
+    if (mCrossLeafEdgeCount) {
+        if (mVerbose==1) mTimer.start("Component-label unite");
+        util::cuda::lambdaKernel<<<blocks(mCrossLeafEdgeCount), 256, 0, mStream>>>(
+            mCrossLeafEdgeCount, cc_detail::LabelUniteFunctor{}, d_parent, deviceCrossLeafEdges());
+        cudaCheckError();
+        if (mVerbose==1) mTimer.stop();
+    }
+
+    // (c) flatten: point every component directly at its representative (class minimum slot).
+    if (mVerbose==1) mTimer.start("Component-label flatten");
+    util::cuda::lambdaKernel<<<blocks(K), 256, 0, mStream>>>(
+        K, cc_detail::LabelFlattenFunctor{}, d_parent);
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+}// ConnectedComponents<BuildT>::processComponentLabels
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+void ConnectedComponents<BuildT>::processVoxelLabels()
+{
+    const uint32_t leafCount =
+        util::cuda::DeviceGridTraits<BuildT>::getTreeData(mDeviceSrcGrid).mNodeCount[0];
+    const uint64_t activeCount =
+        util::cuda::DeviceGridTraits<BuildT>::getActiveVoxelCount(mDeviceSrcGrid);
+
+    // Per-active-voxel dense-label sidecar (indexed by leaf.getValue(n); slot 0 = background).
+    mVoxelLabel = nanovdb::cuda::DeviceBuffer::create((activeCount + 1) * sizeof(uint32_t), nullptr, false);
+    cudaCheck(cudaMemsetAsync(mVoxelLabel.deviceData(), 0xFF, (activeCount + 1) * sizeof(uint32_t), mStream)); // background = 0xFFFFFFFF
+
+    mGlobalComponentCount = 0;
+    const uint64_t K = mLeafComponentAggregateCount;
+    if (leafCount == 0 || K == 0) return;
+
+    // (a) Assign dense component ids: rank[s] = inclusive count of self-roots in [0,s], so a root's
+    //     dense id is rank[root]-1 and rank[K-1] = N.
+    auto rankBuf = nanovdb::cuda::DeviceBuffer::create(K * sizeof(uint32_t), nullptr, false);
+    auto* d_rank = static_cast<uint32_t*>(rankBuf.deviceData());
+    util::cuda::lambdaKernel<<<(unsigned int)((K + 255) / 256), 256, 0, mStream>>>(
+        K, cc_detail::RootFlagFunctor{}, deviceComponentParent(), d_rank);
+    cudaCheckError();
+    NANOVDB_CC_CALL_CUBS(DeviceScan::InclusiveSum, d_rank, d_rank, int(K));
+    cudaCheckError();
+
+    uint32_t hN = 0;
+    cudaCheck(cudaMemcpyAsync(&hN, d_rank + (K - 1), sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
+    cudaCheck(cudaStreamSynchronize(mStream));
+    mGlobalComponentCount = uint64_t(hN);
+
+    // (b) Scatter: each active voxel's dense component id -> sidecar.
+    using ScatterOp = cc_detail::VoxelLabelScatterFunctor<BuildT>;
+    if (mVerbose==1) mTimer.start("Voxel-label scatter");
+    util::cuda::operatorKernel<ScatterOp>
+        <<<leafCount, ScatterOp::MaxThreadsPerBlock, 0, mStream>>>(
+            mDeviceSrcGrid, deviceLeafComponentOffsets(), deviceLeafComponentMasks(),
+            deviceComponentParent(), d_rank, static_cast<uint32_t*>(mVoxelLabel.deviceData()));
+    cudaCheckError();
+    if (mVerbose==1) mTimer.stop();
+}// ConnectedComponents<BuildT>::processVoxelLabels
+
+} // namespace tools::cuda
+
+} // namespace nanovdb
+
+#undef NANOVDB_CC_CALL_CUBS  // don't leak the private helper macro
+
+#endif // NVIDIA_TOOLS_CUDA_CONNECTEDCOMPONENTS_CUH_HAS_BEEN_INCLUDED

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -13,6 +13,7 @@
 #include <nanovdb/tools/cuda/SignedFloodFill.cuh>
 #include <nanovdb/tools/cuda/PointsToGrid.cuh>
 #include <nanovdb/tools/cuda/IndexToGrid.cuh>
+#include <nanovdb/tools/cuda/ConnectedComponents.cuh>
 #include <nanovdb/tools/cuda/AddBlindData.cuh>
 #include <nanovdb/tools/cuda/GridChecksum.cuh>
 #include <nanovdb/tools/cuda/GridValidator.cuh>
@@ -3978,3 +3979,76 @@ TEST(TestNanoVDBCUDA, MeshToGrid_UnitTetrahedron)
     // getHandle() and getHandleAndUDF() must produce identical grids.
     EXPECT_EQ(grid->mChecksum.full(), topoChecksum);
 }// MeshToGrid_UnitTetrahedron
+
+TEST(TestNanoVDBCUDA, ConnectedComponentsMultiSphere)
+{
+    using BuildT = nanovdb::ValueOnIndex;
+
+    // Run the full CC pipeline on a set of active voxels; return the number of distinct global
+    // components via the public contract (getVoxelLabelsAndCount()).
+    auto globalComponents = [](const std::vector<nanovdb::Coord>& coords) -> uint64_t {
+        nanovdb::Coord* d_coords = nullptr;
+        cudaCheck(cudaMalloc(&d_coords, coords.size() * sizeof(nanovdb::Coord)));
+        cudaCheck(cudaMemcpy(d_coords, coords.data(), coords.size() * sizeof(nanovdb::Coord),
+                             cudaMemcpyHostToDevice));
+        auto handle = nanovdb::tools::cuda::voxelsToGrid<BuildT>(d_coords, coords.size());
+        cudaCheck(cudaFree(d_coords));
+        const auto* d_grid = handle.template deviceGrid<BuildT>();
+
+        nanovdb::tools::cuda::ConnectedComponents<BuildT> cc(d_grid);
+        const uint64_t n = cc.getVoxelLabelsAndCount().second;   // full pipeline; returns component count N
+        cudaCheck(cudaDeviceSynchronize());
+        return n;
+    };
+
+    // Reproduce the connected-components pipeline's CC input: the rasterized *narrow band* of a
+    // closed surface with the surface shell removed. The example prunes voxels whose unsigned
+    // distance to the surface is within sqrt(3)/2 voxels (the barrier), leaving, for a solid sphere,
+    // two disjoint concentric shells (inner + outer) => 2 components. N well-separated spheres each
+    // contribute their own two shells (their narrow bands never touch) => 2N.
+    const float band  = 3.0f;        // narrow-band half-width (voxels), matches the default bandWidth
+    const float shell = 0.8660254f;  // sqrt(3)/2: the barrier shell the example removes
+
+    auto sphereShells = [&](int N, float R, int spacing) {
+        const int margin = int(band) + 2;
+        const int x0 = -int(R) - margin, x1 = (N - 1) * spacing + int(R) + margin;
+        const int yz = int(R) + margin;
+        std::vector<nanovdb::Coord> coords;
+        for (int x = x0; x <= x1; ++x)
+            for (int y = -yz; y <= yz; ++y)
+                for (int z = -yz; z <= yz; ++z)
+                    for (int i = 0; i < N; ++i) {  // a separated voxel is in <=1 sphere's band
+                        const float dx = float(x - i * spacing), dy = float(y), dz = float(z);
+                        const float dd = std::fabs(std::sqrt(dx * dx + dy * dy + dz * dz) - R);
+                        if (dd > shell && dd <= band) { coords.emplace_back(x, y, z); break; }
+                    }
+        return coords;
+    };
+
+    EXPECT_EQ(globalComponents(sphereShells(1, 8.f, 30)), 2u);  // inner shell + outer shell
+    EXPECT_EQ(globalComponents(sphereShells(2, 8.f, 30)), 4u);  // 2 disjoint spheres -> 2*2
+    EXPECT_EQ(globalComponents(sphereShells(3, 8.f, 30)), 6u);  // 3 disjoint spheres -> 2*3
+
+    // Two heavily-overlapping spheres are a single connected solid (a "peanut") with one boundary
+    // surface, so the pruned narrow band of its union is one inner shell + one outer shell => 2.
+    // The overlap merges what would be 4 (two separated spheres) down to 2. The narrow band follows
+    // the *union* surface, i.e. the union SDF min(sdfA,sdfB); a small center separation (D = R) keeps
+    // the neck fat so the inner shell does not pinch.
+    {
+        const float R = 8.f, D = 8.f;  // D < 2R => overlap
+        const int   margin = int(band) + 2;
+        const int   x0 = -int(R) - margin, x1 = int(D) + int(R) + margin;
+        const int   yz = int(R) + margin;
+        std::vector<nanovdb::Coord> coords;
+        for (int x = x0; x <= x1; ++x)
+            for (int y = -yz; y <= yz; ++y)
+                for (int z = -yz; z <= yz; ++z) {
+                    const float dxA = float(x), dxB = float(x) - D, fy = float(y), fz = float(z);
+                    const float sdfA = std::sqrt(dxA*dxA + fy*fy + fz*fz) - R;
+                    const float sdfB = std::sqrt(dxB*dxB + fy*fy + fz*fz) - R;
+                    const float a    = std::fabs(std::min(sdfA, sdfB));  // |union SDF|
+                    if (a > shell && a <= band) coords.emplace_back(x, y, z);
+                }
+        EXPECT_EQ(globalComponents(coords), 2u);  // overlap merges -> inner shell + outer shell
+    }
+}// ConnectedComponentsMultiSphere

--- a/pendingchanges/connectedcomponents.txt
+++ b/pendingchanges/connectedcomponents.txt
@@ -1,0 +1,8 @@
+NanoVDB:
+
+  New Features:
+  - Added nanovdb::tools::cuda::ConnectedComponents, a CUDA connected-components
+    labeling of the active voxels of a NanoVDB ValueOnIndex grid (6-connectivity):
+    a hierarchical per-leaf Shiloach-Vishkin union-find, cross-leaf edge detection,
+    and a global union-find over the resulting component graph. Added a companion
+    ex_connected_components_cuda example and a ConnectedComponentsMultiSphere unit test.


### PR DESCRIPTION
## Summary

Adds `nanovdb::tools::cuda::ConnectedComponents` — a CUDA connected-components labeling of the
active voxels of a NanoVDB `ValueOnIndex` grid (6-connectivity). Two active voxels share a label
iff they are connected through a path of adjacent active voxels. The public
`getVoxelLabelsAndCount()` returns a per-active-voxel dense component id in `[0, N)` plus the
component count `N`.

## Algorithm

Hierarchical, exploiting the 8³ leaf structure:
- **Per-leaf** Shiloach–Vishkin union-find in shared memory (one block per leaf), producing each
  leaf-local component's voxel `Mask<3>` and six face bitmasks.
- **Cross-leaf** edge detection by intersecting the touching face masks over each leaf's +X/+Y/+Z
  neighbours (each undirected boundary visited once).
- **Global** lock-free union-find over the resulting component graph; the representative is each
  class's minimum slot, so the result is order-independent.

## Also included

- `ex_connected_components_cuda` — rasterizes an `.obj` to a narrow band (`MeshToGrid`), drops the
  √3/2-voxel surface shell (`PruneGrid`), then labels; a CPU union-find oracle independently
  verifies the GPU component count and per-voxel partition.
- `ConnectedComponentsMultiSphere` unit test (analytic ground truth: N separated spheres → 2N
  shells; overlapping pair → 2).
- A `pendingchanges/` entry.

## Notes

- Depends only on existing NanoVDB CUDA tools (`MeshToGrid`, `PruneGrid`, `voxelsToGrid`) + CUB;
  no new third-party dependencies, no OpenVDB requirement for the example.
- Branch is based on current `master`.

Opening as a **draft** to run CI and for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)