### PR TITLE
Alternative stencil resolvers for VoxelBlockManager

### DIFF
--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -19,7 +19,7 @@
         jumpMap on the GPU from a device-resident NanoGrid.
       - decodeInverseMaps (device): per-block SIMT decode of the inverse maps
         (sequential active-voxel index -> leaf ID + intra-leaf voxel offset),
-        executed cooperatively across a CUDA thread block.
+        with one thread per output slot across a CUDA thread block.
 */
 
 #ifndef NANOVDB_VOXELBLOCKMANAGER_CUH_HAS_BEEN_INCLUDED
@@ -87,42 +87,49 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     {
         // Verify that the nodes can be accessed linearly
         NANOVDB_ASSERT(grid->isSequential());
-
-        int tID = threadIdx.x;
-
-        // Count how many additional leaves (following the one indicated by firstLeafID)
-        // overlap with this voxel block
-        int nExtraLeaves = 0;
-        for (int i = 0; i < JumpMapLength; i++)
-            nExtraLeaves += util::countOn(jumpMap[i]);
-
-        // Initialize leafIndex & voxelOffset to sentinel values
-        // for blocks that extend beyond the last active voxel in the grid
-        if (tID < BlockWidth)
-            #pragma unroll
-            for (int i = 0; i < BlockWidth; i += blockDim.x) {
-                smem_leafIndex[i+tID] = UnusedLeafIndex;
-                smem_voxelOffset[i+tID] = UnusedVoxelOffset;
-            }
-        __syncthreads();
-
         NANOVDB_ASSERT(blockDim.x <= 512);
-        const auto& tree = grid->tree();
-        // Loop through all leafNodes overlapping the voxel block
-        // with all threads in threadblock working collaboratively within each leafNode
-        for (int leafID = firstLeafID; leafID <= firstLeafID + nExtraLeaves; leafID++) {
-            const auto& leaf = tree.template getFirstNode<0>()[leafID];
-            if (leaf.data()->firstOffset() >= blockFirstOffset + BlockWidth) break;
-            const Coord origin = leaf.origin();
-            for (int threadOffset = 0; threadOffset < 512; threadOffset += blockDim.x) {
-                int localOffset = threadOffset + tID;
-                auto index = leaf.data()->getValue(localOffset);
-                if ((index >= blockFirstOffset) && (index < blockFirstOffset + BlockWidth)) {
-                    int blockOffset = index - blockFirstOffset;
-                    // Write inverse map to shared memory; no collisions
-                    smem_leafIndex[blockOffset] = leafID;
-                    smem_voxelOffset[blockOffset] = localOffset;
+
+        // Select-based decode: one thread per OUTPUT slot. Here each
+        // slot ranks itself into its leaf via the jumpMap popcount,
+        // then locates its voxel with the leaf's 9-bit prefix sums
+        // plus an in-word bit select - O(1) per slot.
+        int tID = threadIdx.x;
+        const auto *leaf0 = grid->tree().template getFirstNode<0>();
+        for (int blockOffset = tID; blockOffset < BlockWidth; blockOffset += blockDim.x) {
+            // rank this slot into its leaf: count leaves beginning at in-block positions
+            // [1, blockOffset] (bit 0 is never set) via the jumpMap popcount
+            uint32_t leafRank = 0;
+            const int jumpWord = blockOffset >> 6;
+            #pragma unroll
+            for (int i = 0; i < JumpMapLength; ++i) {
+                if (i < jumpWord) leafRank += util::countOn(jumpMap[i]);
+                else if (i == jumpWord) leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
+            }
+            const uint32_t leafID = firstLeafID + leafRank;
+            const auto& leafData = *leaf0[leafID].data();
+            const uint64_t rankInLeaf = (blockFirstOffset + blockOffset) - leafData.firstOffset();// 0-based rank among the leaf's actives
+            if (rankInLeaf < leafData.valueCount()) {
+                // select the rankInLeaf-th active voxel: find its 64-bit mask word via the
+                // leaf's 9-bit prefix sums, then its bit within that word
+                uint32_t activesBeforeWord = 0;
+                int wordID = 0;
+                #pragma unroll
+                for (int candidateWord = 1; candidateWord < 8; ++candidateWord) {
+                    const uint32_t cumulative = uint32_t(leafData.mPrefixSum >> (9*(candidateWord-1))) & 0x1ffu;
+                    if (cumulative <= rankInLeaf) { wordID = candidateWord; activesBeforeWord = cumulative; }
                 }
+                uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord;
+                const uint64_t maskWord = leafData.mValueMask.words()[wordID];
+                const uint32_t lowHalf = uint32_t(maskWord);
+                const uint32_t lowHalfCount = util::countOn(uint64_t(lowHalf));
+                int bit;
+                if (rankInWord < lowHalfCount) bit = __fns(lowHalf, 0, rankInWord + 1);
+                else                           bit = 32 + __fns(uint32_t(maskWord >> 32), 0, rankInWord - lowHalfCount + 1);
+                smem_leafIndex[blockOffset] = leafID;
+                smem_voxelOffset[blockOffset] = uint16_t((wordID << 6) + bit);
+            } else {// beyond the last active voxel in the grid
+                smem_leafIndex[blockOffset] = UnusedLeafIndex;
+                smem_voxelOffset[blockOffset] = UnusedVoxelOffset;
             }
         }
         __syncthreads();

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -166,6 +166,38 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
             }
         }
     }
+
+    /// @brief Visit each 3x3x3 stencil index without materializing a 27-element array.
+    /// Consumers that reduce or accumulate taps should prefer this streaming form over
+    /// computeBoxStencil: the callback is device-inlined and receives (tap, index) in the
+    /// same deterministic tap order, so lookup and arithmetic stay fused (no 27-element
+    /// per-thread array, no stack spill). Keep computeBoxStencil for callers that need
+    /// random access to all taps. Like computeBoxStencil this accesses shared memory but
+    /// does not synchronize, so it may be called from divergent threads within a block.
+    /// @tparam BuildT Build type of the grid
+    /// @tparam OpT    Device-callable with signature op(int tap, uint64_t index)
+    template <class BuildT, class OpT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    forEachBoxStencil(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t *smem_leafIndex,
+        const uint16_t *smem_voxelOffset,
+        OpT op)
+    {
+        NANOVDB_ASSERT(grid->isSequential());
+        const int tID = threadIdx.x;
+        const auto& tree = grid->tree();
+        if (smem_leafIndex[tID] == UnusedLeafIndex) return;
+        const auto& leaf = tree.template getFirstNode<0>()[smem_leafIndex[tID]];
+        const Coord coord = leaf.offsetToGlobalCoord(smem_voxelOffset[tID]);
+        for (int di = -1; di <= 1; ++di)
+        for (int dj = -1; dj <= 1; ++dj)
+        for (int dk = -1; dk <= 1; ++dk) {
+            const int tap = (di + 1) * 9 + (dj + 1) * 3 + dk + 1;
+            op(tap, tree.getValue(coord.offsetBy(di, dj, dk)));
+        }
+    }
 };
 
 /// @brief This functor calculates the firstLeafID and jumpMap for the

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -89,40 +89,56 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         NANOVDB_ASSERT(grid->isSequential());
         NANOVDB_ASSERT(blockDim.x <= 512);
 
-        // Select-based decode: one thread per OUTPUT slot. Here each
+        // Select-based decode: one thread per output slot. Here each
         // slot ranks itself into its leaf via the jumpMap popcount,
         // then locates its voxel with the leaf's 9-bit prefix sums
         // plus an in-word bit select - O(1) per slot.
-        int tID = threadIdx.x;
+        const int tID = threadIdx.x;
         const auto *leaf0 = grid->tree().template getFirstNode<0>();
         for (int blockOffset = tID; blockOffset < BlockWidth; blockOffset += blockDim.x) {
             // rank this slot into its leaf: count leaves beginning at in-block positions
             // [1, blockOffset] (bit 0 is never set) via the jumpMap popcount
             uint32_t leafRank = 0;
-            const int jumpWord = blockOffset >> 6;
+            const int jumpWord = blockOffset >> 6;  // index into jumpMap
+            // count the number of leaves that begin before blockOffset
             #pragma unroll
             for (int i = 0; i < JumpMapLength; ++i) {
-                if (i < jumpWord) leafRank += util::countOn(jumpMap[i]);
-                else if (i == jumpWord) leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
+                if (i < jumpWord) leafRank += util::countOn(jumpMap[i]); // count leaves before the current jump word
+                else if (i == jumpWord) {
+                    // count leaves in the current jump word, masking those that are before blockOffset
+                    leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
+                }
+
             }
             const uint32_t leafID = firstLeafID + leafRank;
             const auto& leafData = *leaf0[leafID].data();
-            const uint64_t rankInLeaf = (blockFirstOffset + blockOffset) - leafData.firstOffset();// 0-based rank among the leaf's actives
-            if (rankInLeaf < leafData.valueCount()) {
+            // 0-based rank among the leaf's actives
+            const uint64_t rankInLeaf = (blockFirstOffset + blockOffset) - leafData.firstOffset();
+            if (rankInLeaf < leafData.valueCount()) { // if the rank is within the leaf's active voxels (bounds check)
                 // select the rankInLeaf-th active voxel: find its 64-bit mask word via the
                 // leaf's 9-bit prefix sums, then its bit within that word
-                uint32_t activesBeforeWord = 0;
                 int wordID = 0;
+                uint32_t activesBeforeWord = 0;
                 #pragma unroll
                 for (int candidateWord = 1; candidateWord < 8; ++candidateWord) {
+                    // the number of active voxels before the candidateWord's mask word (& 0x1ffu masks to 9 bits)
                     const uint32_t cumulative = uint32_t(leafData.mPrefixSum >> (9*(candidateWord-1))) & 0x1ffu;
-                    if (cumulative <= rankInLeaf) { wordID = candidateWord; activesBeforeWord = cumulative; }
+                    if (cumulative <= rankInLeaf) {
+                        wordID = candidateWord; // word ID of the mask word that contains the rankInLeaf-th active voxel
+                        activesBeforeWord = cumulative; // the number of active voxels before the wordID's mask word
+                    }
                 }
-                uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord;
+
+                uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord; // active voxel's rank within the mask word (0-based)
+                // select the in-word bit position of the voxel using __fns (find n-th set bit)
+                // /__fns(mask, base, k) is the hardware find-nth-set-bit intrinsic - the k-th set bit (1-based) at/after base
+                // but it's a 32-bit op while `maskWord` is 64-bit, so we need to split it into two 32-bit halves
                 const uint64_t maskWord = leafData.mValueMask.words()[wordID];
-                const uint32_t lowHalf = uint32_t(maskWord);
+                const uint32_t lowHalf = uint32_t(maskWord);  // low 32 bits of the mask word
                 const uint32_t lowHalfCount = util::countOn(uint64_t(lowHalf));
                 int bit;
+                // if rank is less than the number of active voxels in the low half, __fns finds the bit in the lower half
+                // otherwise, shift maskWord by 32 bits and __fns finds the bit in the upper half
                 if (rankInWord < lowHalfCount) bit = __fns(lowHalf, 0, rankInWord + 1);
                 else                           bit = 32 + __fns(uint32_t(maskWord >> 32), 0, rankInWord - lowHalfCount + 1);
                 smem_leafIndex[blockOffset] = leafID;

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -17,9 +17,14 @@
       of an OnIndexGrid, independent of occupancy.  This file provides:
       - buildVoxelBlockManager (device): constructs the firstLeafID array and
         jumpMap on the GPU from a device-resident NanoGrid.
-      - decodeInverseMaps (device): per-block SIMT decode of the inverse maps
-        (sequential active-voxel index -> leaf ID + intra-leaf voxel offset),
-        with one thread per output slot across a CUDA thread block.
+      - decodeInverseMap (device): per-slot, thread-local decode of one inverse
+        map entry (sequential active-voxel index -> leaf ID + intra-leaf voxel
+        offset) into registers; no shared memory or synchronization, callable
+        from divergent threads. Block-level facts a cooperative consumer might
+        otherwise read from a materialized map are derivable directly from the
+        VBM metadata: the block's first leaf is firstLeafID, slot p starts a
+        new leaf iff jumpMap bit p is set, and the number of leaves spanned by
+        the block is 1 + the jumpMap popcount.
 */
 
 #ifndef NANOVDB_VOXELBLOCKMANAGER_CUH_HAS_BEEN_INCLUDED
@@ -48,117 +53,134 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     using Base::UnusedLeafIndex;
     using Base::UnusedVoxelOffset;
 
-    // The efficiency of the functions in this class are contingent on
-    // threadblock-level coordination, which manifests either as using shared
-    // memory for synchronization, or warp-level shift operations.
+    // The decode is a rank + select over the VBM's bit-vectors and is
+    // thread-local per output slot: decodeInverseMap requires no threadblock
+    // coordination. Consumers that need cross-slot information derive it from
+    // the VBM metadata (firstLeafID + jumpMap) rather than from a materialized
+    // per-block map.
 
-    /// @brief Decode the inverse maps for a single voxel block on the device.
+    /// @brief Rank one output slot into its leaf: the number of leaves that
+    /// begin at in-block positions [1, blockOffset] (bit 0 is never set),
+    /// counted via popcounts over the block's jumpMap.
+    /// Thread-local; no synchronization.
+    __device__
+    static uint32_t jumpMapRank(const uint64_t *jumpMap, const int blockOffset)
+    {
+        uint32_t leafRank = 0;
+        const int jumpWord = blockOffset >> 6;  // index into jumpMap
+        #pragma unroll
+        for (int i = 0; i < JumpMapLength; ++i) {
+            if (i < jumpWord) leafRank += util::countOn(jumpMap[i]); // count leaves before the current jump word
+            else if (i == jumpWord) {
+                // count leaves in the current jump word, masking those that are at or before blockOffset
+                leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
+            }
+        }
+        return leafRank;
+    }
+
+    /// @brief Select the voxel with sequential index @c globalOffset inside leaf
+    /// @c leafID: find its 64-bit mask word via the leaf's precomputed 9-bit
+    /// prefix sums (mPrefixSum), then its bit within that word via __fns.
+    /// Writes the sentinels if globalOffset lies beyond the leaf's last active
+    /// voxel (i.e. beyond the last active voxel of the grid).
+    /// Thread-local; no synchronization.
+    template <class BuildT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    selectVoxelInLeaf(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t leafID,
+        const uint64_t globalOffset,
+        uint32_t &leafIndex,
+        uint16_t &voxelOffset)
+    {
+        const auto& leafData = *grid->tree().template getFirstNode<0>()[leafID].data();
+        // 0-based rank among the leaf's actives
+        const uint64_t rankInLeaf = globalOffset - leafData.firstOffset();
+        if (rankInLeaf < leafData.valueCount()) { // if the rank is within the leaf's active voxels (bounds check)
+            int wordID = 0;
+            uint32_t activesBeforeWord = 0;
+            #pragma unroll
+            for (int candidateWord = 1; candidateWord < 8; ++candidateWord) {
+                // the number of active voxels before the candidateWord's mask word (& 0x1ffu masks to 9 bits)
+                const uint32_t cumulative = uint32_t(leafData.mPrefixSum >> (9*(candidateWord-1))) & 0x1ffu;
+                if (cumulative <= rankInLeaf) {
+                    wordID = candidateWord; // word ID of the mask word that contains the rankInLeaf-th active voxel
+                    activesBeforeWord = cumulative; // the number of active voxels before the wordID's mask word
+                }
+            }
+            uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord; // active voxel's rank within the mask word (0-based)
+            // select the in-word bit position of the voxel using __fns (find n-th set bit)
+            // __fns(mask, base, k) is the hardware find-nth-set-bit intrinsic - the k-th set bit (1-based) at/after base
+            // but it's a 32-bit op while `maskWord` is 64-bit, so we need to split it into two 32-bit halves
+            const uint64_t maskWord = leafData.mValueMask.words()[wordID];
+            const uint32_t lowHalf = uint32_t(maskWord);  // low 32 bits of the mask word
+            const uint32_t lowHalfCount = __popc(lowHalf);
+            int bit;
+            // if rank is less than the number of active voxels in the low half, __fns finds the bit in the lower half
+            // otherwise, shift maskWord by 32 bits and __fns finds the bit in the upper half
+            if (rankInWord < lowHalfCount) bit = __fns(lowHalf, 0, rankInWord + 1);
+            else                           bit = 32 + __fns(uint32_t(maskWord >> 32), 0, rankInWord - lowHalfCount + 1);
+            leafIndex = leafID;
+            voxelOffset = uint16_t((wordID << 6) + bit);
+        } else { // beyond the last active voxel in the grid
+            leafIndex = UnusedLeafIndex;
+            voxelOffset = UnusedVoxelOffset;
+        }
+    }
+
+    /// @brief Decode a single inverse-map entry into registers on the device.
     ///
     /// Given the VBM metadata for one block (firstLeafID and the block's slice of
-    /// the jumpMap) and the block's base sequential offset, fills smem_leafIndex[]
-    /// and smem_voxelOffset[] in shared memory so that for each position p in
-    /// [0, BlockWidth):
-    ///   - smem_leafIndex[p]   = index of the leaf node containing sequential voxel
-    ///                           (blockFirstOffset + p), or UnusedLeafIndex if that
-    ///                           index is beyond the last active voxel.
-    ///   - smem_voxelOffset[p] = local (0..511) offset of that voxel within its leaf,
-    ///                           or UnusedVoxelOffset.
+    /// the jumpMap), the block's base sequential offset, and a slot position
+    /// blockOffset in [0, BlockWidth), computes:
+    ///   - leafIndex   = index of the leaf node containing sequential voxel
+    ///                   (blockFirstOffset + blockOffset), or UnusedLeafIndex if
+    ///                   that index is beyond the last active voxel.
+    ///   - voxelOffset = local (0..511) offset of that voxel within its leaf,
+    ///                   or UnusedVoxelOffset.
     ///
-    /// Must be called by all threads in the block (uses __syncthreads internally).
-    /// Do not call from divergent threads within a thread block.
+    /// No shared memory or synchronization; may be called from divergent threads.
     ///
     /// @tparam BuildT  Build type of the grid (must be an index type)
     /// @param grid              Device-accessible OnIndex grid
     /// @param firstLeafID       Index of the first leaf overlapping this block
     /// @param jumpMap           Pointer to the JumpMapLength words for this block
     /// @param blockFirstOffset  Sequential index of the first voxel in this block
-    /// @param smem_leafIndex    Output array of length BlockWidth in shared memory
-    /// @param smem_voxelOffset  Output array of length BlockWidth in shared memory
+    /// @param blockOffset       Slot position within the block, in [0, BlockWidth)
+    /// @param leafIndex         Output leaf index (register)
+    /// @param voxelOffset       Output intra-leaf voxel offset (register)
     template <class BuildT>
     __device__
     static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
-    decodeInverseMaps(
+    decodeInverseMap(
         const NanoGrid<BuildT> *grid,
         const uint32_t firstLeafID,
         const uint64_t *jumpMap,
         const uint64_t blockFirstOffset,
-        uint32_t *smem_leafIndex,
-        uint16_t *smem_voxelOffset)
+        const int blockOffset,
+        uint32_t &leafIndex,
+        uint16_t &voxelOffset)
     {
         // Verify that the nodes can be accessed linearly
         NANOVDB_ASSERT(grid->isSequential());
-        NANOVDB_ASSERT(blockDim.x <= 512);
+        NANOVDB_ASSERT(blockOffset >= 0 && blockOffset < BlockWidth);
 
-        // Select-based decode: one thread per output slot. Here each
-        // slot ranks itself into its leaf via the jumpMap popcount,
-        // then locates its voxel with the leaf's 9-bit prefix sums
-        // plus an in-word bit select - O(1) per slot.
-        const int tID = threadIdx.x;
-        const auto *leaf0 = grid->tree().template getFirstNode<0>();
-        for (int blockOffset = tID; blockOffset < BlockWidth; blockOffset += blockDim.x) {
-            // rank this slot into its leaf: count leaves beginning at in-block positions
-            // [1, blockOffset] (bit 0 is never set) via the jumpMap popcount
-            uint32_t leafRank = 0;
-            const int jumpWord = blockOffset >> 6;  // index into jumpMap
-            // count the number of leaves that begin before blockOffset
-            #pragma unroll
-            for (int i = 0; i < JumpMapLength; ++i) {
-                if (i < jumpWord) leafRank += util::countOn(jumpMap[i]); // count leaves before the current jump word
-                else if (i == jumpWord) {
-                    // count leaves in the current jump word, masking those that are before blockOffset
-                    leafRank += util::countOn(jumpMap[i] & ((uint64_t(2) << (blockOffset & 63)) - 1u));
-                }
-
-            }
-            const uint32_t leafID = firstLeafID + leafRank;
-            const auto& leafData = *leaf0[leafID].data();
-            // 0-based rank among the leaf's actives
-            const uint64_t rankInLeaf = (blockFirstOffset + blockOffset) - leafData.firstOffset();
-            if (rankInLeaf < leafData.valueCount()) { // if the rank is within the leaf's active voxels (bounds check)
-                // select the rankInLeaf-th active voxel: find its 64-bit mask word via the
-                // leaf's 9-bit prefix sums, then its bit within that word
-                int wordID = 0;
-                uint32_t activesBeforeWord = 0;
-                #pragma unroll
-                for (int candidateWord = 1; candidateWord < 8; ++candidateWord) {
-                    // the number of active voxels before the candidateWord's mask word (& 0x1ffu masks to 9 bits)
-                    const uint32_t cumulative = uint32_t(leafData.mPrefixSum >> (9*(candidateWord-1))) & 0x1ffu;
-                    if (cumulative <= rankInLeaf) {
-                        wordID = candidateWord; // word ID of the mask word that contains the rankInLeaf-th active voxel
-                        activesBeforeWord = cumulative; // the number of active voxels before the wordID's mask word
-                    }
-                }
-
-                uint32_t rankInWord = uint32_t(rankInLeaf) - activesBeforeWord; // active voxel's rank within the mask word (0-based)
-                // select the in-word bit position of the voxel using __fns (find n-th set bit)
-                // /__fns(mask, base, k) is the hardware find-nth-set-bit intrinsic - the k-th set bit (1-based) at/after base
-                // but it's a 32-bit op while `maskWord` is 64-bit, so we need to split it into two 32-bit halves
-                const uint64_t maskWord = leafData.mValueMask.words()[wordID];
-                const uint32_t lowHalf = uint32_t(maskWord);  // low 32 bits of the mask word
-                const uint32_t lowHalfCount = util::countOn(uint64_t(lowHalf));
-                int bit;
-                // if rank is less than the number of active voxels in the low half, __fns finds the bit in the lower half
-                // otherwise, shift maskWord by 32 bits and __fns finds the bit in the upper half
-                if (rankInWord < lowHalfCount) bit = __fns(lowHalf, 0, rankInWord + 1);
-                else                           bit = 32 + __fns(uint32_t(maskWord >> 32), 0, rankInWord - lowHalfCount + 1);
-                smem_leafIndex[blockOffset] = leafID;
-                smem_voxelOffset[blockOffset] = uint16_t((wordID << 6) + bit);
-            } else {// beyond the last active voxel in the grid
-                smem_leafIndex[blockOffset] = UnusedLeafIndex;
-                smem_voxelOffset[blockOffset] = UnusedVoxelOffset;
-            }
-        }
-        __syncthreads();
+        const uint32_t leafRank = jumpMapRank(jumpMap, blockOffset);
+        selectVoxelInLeaf(grid, firstLeafID + leafRank,
+                          blockFirstOffset + blockOffset, leafIndex, voxelOffset);
     }
 
-    /// @brief Given a grid and its decoded voxel map, compute the stencil.
-    /// This function accesses shared memory but does not synchronize threads
-    /// so it may be called from divergent threads within a thread block.
-    /// offsets for a 3x3x3 box stencil.
+    /// @brief Given a grid and one decoded inverse-map entry (from
+    /// decodeInverseMap), compute the stencil indices for a 3x3x3 box stencil.
+    /// Thread-local: no shared memory, no synchronization; may be called from
+    /// divergent threads within a thread block. Leaves stencilIndices untouched
+    /// when leafIndex is UnusedLeafIndex (a slot beyond the last active voxel).
     /// @tparam BuildT Build type of the grid
-    /// @param grid
-    /// @param smem_leafIndex Leaf indices stored in shared memory
-    /// @param smem_voxelOffset Voxel offsets stored in shared memory
+    /// @param grid         Device-accessible OnIndex grid
+    /// @param leafIndex    This thread's decoded leaf index (or UnusedLeafIndex)
+    /// @param voxelOffset  This thread's decoded intra-leaf voxel offset
     /// @param stencilIndices Pointer to output stencil indices. Must have
     /// length of at least 27 (corresponding to the 3x3x3 stencil)
     template <class BuildT>
@@ -166,20 +188,18 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
     computeBoxStencil(
         const NanoGrid<BuildT> *grid,
-        const uint32_t *smem_leafIndex,
-        const uint16_t *smem_voxelOffset,
+        const uint32_t leafIndex,
+        const uint16_t voxelOffset,
         uint64_t *stencilIndices)
     {
         // Verify that the nodes can be accessed linearly
         NANOVDB_ASSERT(grid->isSequential());
 
-        int tID = threadIdx.x;
         const auto& tree = grid->tree();
-        if (smem_leafIndex[tID] != UnusedLeafIndex) {
+        if (leafIndex != UnusedLeafIndex) {
             // This presumes that leaf nodes are fixed-size and sequentially accessible in memory
-            const auto& leaf = tree.template getFirstNode<0>()[ smem_leafIndex[tID] ];
-            const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
-            const auto index = leaf.getValue( smem_voxelOffset[tID] );
+            const auto& leaf = tree.template getFirstNode<0>()[ leafIndex ];
+            const Coord coord = leaf.offsetToGlobalCoord( voxelOffset );
             for (int di = -1; di <= 1; di++)
             for (int dj = -1; dj <= 1; dj++)
             for (int dk = -1; dk <= 1; dk++) {

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -85,6 +85,41 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         return sSpannedCount < MaxCachedLeaves ? sSpannedCount : MaxCachedLeaves;
     }
 
+    /// @brief Stage the per-spanned-leaf neighbor table shared by the cached resolvers.
+    ///
+    /// Fills table[slot*N + n] with the leaf node lying at neighbor position n of the slot-th
+    /// spanned leaf, or nullptr where no such leaf exists; entry SelfIndex stores the spanned
+    /// leaf itself rather than probing for it. Each resolver supplies the shift from a leaf
+    /// origin to its n-th neighbor's origin, so it keeps whatever indexing its lookup expects.
+    /// The nSpanned x N entries are distributed across ALL threads, so no thread serializes
+    /// the probes.
+    ///
+    /// Must be called by all threads in the block (ends in __syncthreads).
+    ///
+    /// @tparam N          Table entries per spanned leaf
+    /// @tparam SelfIndex  Entry index holding the spanned leaf itself (not probed for)
+    /// @tparam OffsetT    Device-callable (Coord& origin, int n) shifting a leaf origin to the
+    ///                    origin of the leaf at entry n
+    /// @param table     Flattened [MaxCachedLeaves][N] table of leaf pointers in shared memory
+    /// @param nSpanned  Number of spanned leaves (from cachedLeafSpan)
+    template <int N, int SelfIndex, class BuildT, class LeafT, class OffsetT>
+    __device__
+    static void stageLeafTable(const NanoGrid<BuildT> *grid, const LeafT **table,
+                               int nSpanned, uint32_t firstSpanned, OffsetT shiftToNeighbor)
+    {
+        const int tID = threadIdx.x;
+        const auto& tree = grid->tree();
+        const LeafT* leaf0 = tree.template getFirstNode<0>();
+        for (int c = tID; c < nSpanned * N; c += blockDim.x) {
+            const int slot = c / N, n = c % N;
+            if (n == SelfIndex) { table[slot*N + n] = leaf0 + (firstSpanned + slot); continue; }
+            Coord origin = leaf0[firstSpanned + slot].origin();
+            shiftToNeighbor(origin, n);
+            table[slot*N + n] = tree.root().probeLeaf(origin);
+        }
+        __syncthreads();
+    }
+
     /// @brief Decode the inverse maps for a single voxel block on the device.
     ///
     /// Given the VBM metadata for one block (firstLeafID and the block's slice of
@@ -344,14 +379,9 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         const uint32_t firstSpanned = smem_leafIndex[0];
         const uint32_t myLeaf = smem_leafIndex[tID];
         const int nSpanned = cachedLeafSpan<MaxCachedLeaves>(smem_leafIndex, firstSpanned, myLeaf);
-        for (int c = tID; c < nSpanned * 7; c += blockDim.x) {
-            const int slot = c / 7, n = c % 7;
-            if (n == 6) { sFaceLeaves[slot][6] = leaf0 + (firstSpanned + slot); continue; }
-            Coord nOrigin = leaf0[firstSpanned + slot].origin();
-            nOrigin[n >> 1] += (n & 1) ? 8 : -8;
-            sFaceLeaves[slot][n] = tree.root().probeLeaf(nOrigin);
-        }
-        __syncthreads();
+        // Entry order 0..5 is -x,+x,-y,+y,-z,+z (axis*2 + dir), which the lookup below assumes.
+        stageLeafTable<7, 6>(grid, &sFaceLeaves[0][0], nSpanned, firstSpanned,
+            [](Coord &o, int n) { o[n >> 1] += (n & 1) ? 8 : -8; });
 
         if (myLeaf != UnusedLeafIndex) {
             const auto& leaf = leaf0[myLeaf];
@@ -414,14 +444,9 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
 
         // Stage the spannedLeaves x 27 leaf-neighborhood table across ALL threads
         const int nSpanned = cachedLeafSpan<MaxCachedLeaves>(smem_leafIndex, firstSpanned, myLeaf);
-        for (int c = tID; c < nSpanned * 27; c += blockDim.x) {
-            const int slot = c / 27, n = c % 27;
-            if (n == 13) { sNeighborLeaves[slot][13] = leaf0 + (firstSpanned + slot); continue; }
-            const Coord origin = leaf0[firstSpanned + slot].origin();
-            const int di = n/9 - 1, dj = (n/3)%3 - 1, dk = n%3 - 1;
-            sNeighborLeaves[slot][n] = tree.root().probeLeaf(origin.offsetBy(di*8, dj*8, dk*8));
-        }
-        __syncthreads();
+        // The full box neighborhood: entry n is the 3x3x3 spoke n.
+        stageLeafTable<27, 13>(grid, &sNeighborLeaves[0][0], nSpanned, firstSpanned,
+            [](Coord &o, int n) { o = o.offsetBy((n/9-1)*8, ((n/3)%3-1)*8, (n%3-1)*8); });
 
         if (myLeaf == UnusedLeafIndex) return;
         const auto& leaf = leaf0[myLeaf];

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -68,54 +68,58 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     /// to MaxCachedLeaves. Shared preamble of the cached resolvers, which stage one table
     /// entry group per spanned leaf. Must be called by all threads (uses __syncthreads).
     /// @param smem_leafIndex Decoded leaf indices in shared memory
-    /// @param firstSpanned   Leaf index of slot 0, i.e. the first leaf the block spans
+    /// @param firstLeaf      Leaf index of slot 0, i.e. the first leaf the block spans
     /// @param myLeaf         This thread's leaf index (UnusedLeafIndex past the last voxel)
     template <int MaxCachedLeaves>
     __device__
-    static int cachedLeafSpan(const uint32_t *smem_leafIndex, uint32_t firstSpanned, uint32_t myLeaf)
+    static int cachedLeafSpan(const uint32_t *smem_leafIndex, uint32_t firstLeaf, uint32_t myLeaf)
     {
-        __shared__ int sSpannedCount;
+        __shared__ int sSpannedLeafCount;
         const int tID = threadIdx.x;
-        if (tID == 0) sSpannedCount = 0;
+        if (tID == 0) sSpannedLeafCount = 0;
         __syncthreads();
         // one atomicMax per distinct leaf: only the first slot of each run contributes
         if (myLeaf != UnusedLeafIndex && (tID == 0 || smem_leafIndex[tID-1] != myLeaf))
-            atomicMax(&sSpannedCount, int(myLeaf - firstSpanned) + 1);
+            atomicMax(&sSpannedLeafCount, int(myLeaf - firstLeaf) + 1);
         __syncthreads();
-        return sSpannedCount < MaxCachedLeaves ? sSpannedCount : MaxCachedLeaves;
+        return sSpannedLeafCount < MaxCachedLeaves ? sSpannedLeafCount : MaxCachedLeaves;
     }
 
     /// @brief Stage the per-spanned-leaf neighbor table shared by the cached resolvers.
     ///
-    /// Fills table[slot*N + n] with the leaf node lying at neighbor position n of the slot-th
-    /// spanned leaf, or nullptr where no such leaf exists; entry SelfIndex stores the spanned
+    /// Fills table[leafSlot*N + neighborID] with the leaf lying at that neighbor position of
+    /// the leafSlot-th spanned leaf, or nullptr if absent; entry SelfIndex stores the spanned
     /// leaf itself rather than probing for it. Each resolver supplies the shift from a leaf
     /// origin to its n-th neighbor's origin, so it keeps whatever indexing its lookup expects.
-    /// The nSpanned x N entries are distributed across ALL threads, so no thread serializes
+    /// The spannedLeafCount x N entries are distributed across ALL threads, so no thread serializes
     /// the probes.
     ///
     /// Must be called by all threads in the block (ends in __syncthreads).
     ///
     /// @tparam N          Table entries per spanned leaf
     /// @tparam SelfIndex  Entry index holding the spanned leaf itself (not probed for)
-    /// @tparam OffsetT    Device-callable (Coord& origin, int n) shifting a leaf origin to the
-    ///                    origin of the leaf at entry n
-    /// @param table     Flattened [MaxCachedLeaves][N] table of leaf pointers in shared memory
-    /// @param nSpanned  Number of spanned leaves (from cachedLeafSpan)
+    /// @tparam OffsetT    Device-callable (Coord& origin, int neighborID) shifting a leaf origin
+    ///                    to the origin of the leaf at that neighbor position
+    /// @param table            Flattened [MaxCachedLeaves][N] leaf-pointer table in shared memory
+    /// @param spannedLeafCount Number of spanned leaves (from cachedLeafSpan)
+    /// @param firstLeaf        Leaf index of the block's first slot
     template <int N, int SelfIndex, class BuildT, class LeafT, class OffsetT>
     __device__
     static void stageLeafTable(const NanoGrid<BuildT> *grid, const LeafT **table,
-                               int nSpanned, uint32_t firstSpanned, OffsetT shiftToNeighbor)
+                               int spannedLeafCount, uint32_t firstLeaf, OffsetT shiftToNeighbor)
     {
         const int tID = threadIdx.x;
         const auto& tree = grid->tree();
         const LeafT* leaf0 = tree.template getFirstNode<0>();
-        for (int c = tID; c < nSpanned * N; c += blockDim.x) {
-            const int slot = c / N, n = c % N;
-            if (n == SelfIndex) { table[slot*N + n] = leaf0 + (firstSpanned + slot); continue; }
-            Coord origin = leaf0[firstSpanned + slot].origin();
-            shiftToNeighbor(origin, n);
-            table[slot*N + n] = tree.root().probeLeaf(origin);
+        for (int entry = tID; entry < spannedLeafCount * N; entry += blockDim.x) {
+            const int leafSlot = entry / N, neighborID = entry % N;
+            if (neighborID == SelfIndex) {// this spanned leaf itself; no probe needed
+                table[leafSlot*N + neighborID] = leaf0 + (firstLeaf + leafSlot);
+                continue;
+            }
+            Coord neighborOrigin = leaf0[firstLeaf + leafSlot].origin();
+            shiftToNeighbor(neighborOrigin, neighborID);
+            table[leafSlot*N + neighborID] = tree.root().probeLeaf(neighborOrigin);
         }
         __syncthreads();
     }
@@ -376,18 +380,18 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         const auto& tree = grid->tree();
         const LeafT* leaf0 = tree.template getFirstNode<0>();
 
-        const uint32_t firstSpanned = smem_leafIndex[0];
+        const uint32_t firstLeaf = smem_leafIndex[0];// leaf owning the block's first slot
         const uint32_t myLeaf = smem_leafIndex[tID];
-        const int nSpanned = cachedLeafSpan<MaxCachedLeaves>(smem_leafIndex, firstSpanned, myLeaf);
+        const int spannedLeafCount = cachedLeafSpan<MaxCachedLeaves>(smem_leafIndex, firstLeaf, myLeaf);
         // Entry order 0..5 is -x,+x,-y,+y,-z,+z (axis*2 + dir), which the lookup below assumes.
-        stageLeafTable<7, 6>(grid, &sFaceLeaves[0][0], nSpanned, firstSpanned,
+        stageLeafTable<7, 6>(grid, &sFaceLeaves[0][0], spannedLeafCount, firstLeaf,
             [](Coord &o, int n) { o[n >> 1] += (n & 1) ? 8 : -8; });
 
         if (myLeaf != UnusedLeafIndex) {
             const auto& leaf = leaf0[myLeaf];
             const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
-            const uint32_t slot = myLeaf - firstSpanned;
-            const bool cached = slot < MaxCachedLeaves;
+            const uint32_t leafSlot = myLeaf - firstLeaf;
+            const bool isCached = leafSlot < MaxCachedLeaves;
             stencilIndices[13] = leaf.getValue( smem_voxelOffset[tID] );
             for (int n = 0; n < 6; ++n) {
                 const int axis = n >> 1, dir = (n & 1) ? 1 : -1;
@@ -395,10 +399,12 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
                 neighbor[axis] += dir;
                 // Standard 27-slot spoke id for this face tap
                 const int spokeID = 13 + dir * (axis == 0 ? 9 : axis == 1 ? 3 : 1);
-                if (cached) {
-                    const int v = coord[axis] & 7;
-                    const LeafT* nl = ((v + dir) & ~7) ? sFaceLeaves[slot][n] : sFaceLeaves[slot][6];
-                    stencilIndices[spokeID] = nl ? nl->getValue(LeafT::CoordToOffset(neighbor)) : 0;
+                if (isCached) {
+                    const int voxelOnAxis = coord[axis] & 7;// 0..7 within the leaf
+                    // stepping off the leaf on this axis? then use the face neighbor, else self
+                    const LeafT* neighborLeaf = ((voxelOnAxis + dir) & ~7) ? sFaceLeaves[leafSlot][n]
+                                                                          : sFaceLeaves[leafSlot][6];
+                    stencilIndices[spokeID] = neighborLeaf ? neighborLeaf->getValue(LeafT::CoordToOffset(neighbor)) : 0;
                 } else {
                     stencilIndices[spokeID] = tree.getValue( neighbor );
                 }
@@ -439,30 +445,32 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         const int tID = threadIdx.x;
         const auto& tree = grid->tree();
         const LeafT* leaf0 = tree.template getFirstNode<0>();
-        const uint32_t firstSpanned = smem_leafIndex[0];
+        const uint32_t firstLeaf = smem_leafIndex[0];// leaf owning the block's first slot
         const uint32_t myLeaf = smem_leafIndex[tID];
 
         // Stage the spannedLeaves x 27 leaf-neighborhood table across ALL threads
-        const int nSpanned = cachedLeafSpan<MaxCachedLeaves>(smem_leafIndex, firstSpanned, myLeaf);
+        const int spannedLeafCount = cachedLeafSpan<MaxCachedLeaves>(smem_leafIndex, firstLeaf, myLeaf);
         // The full box neighborhood: entry n is the 3x3x3 spoke n.
-        stageLeafTable<27, 13>(grid, &sNeighborLeaves[0][0], nSpanned, firstSpanned,
+        stageLeafTable<27, 13>(grid, &sNeighborLeaves[0][0], spannedLeafCount, firstLeaf,
             [](Coord &o, int n) { o = o.offsetBy((n/9-1)*8, ((n/3)%3-1)*8, (n%3-1)*8); });
 
         if (myLeaf == UnusedLeafIndex) return;
         const auto& leaf = leaf0[myLeaf];
         const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
-        const uint32_t slot = myLeaf - firstSpanned;
-        const bool cached = slot < MaxCachedLeaves;
-        const int vi = coord[0] & 7, vj = coord[1] & 7, vk = coord[2] & 7;
+        const uint32_t leafSlot = myLeaf - firstLeaf;
+        const bool isCached = leafSlot < MaxCachedLeaves;
+        const int voxelX = coord[0] & 7, voxelY = coord[1] & 7, voxelZ = coord[2] & 7;
         for (int di = -1; di <= 1; di++)
         for (int dj = -1; dj <= 1; dj++)
         for (int dk = -1; dk <= 1; dk++) {
             const int spokeID = ( di + 1 ) * 9 + ( dj + 1 ) * 3 + dk + 1;
             const Coord neighbor = coord.offsetBy( di, dj, dk );
-            if (cached) {
-                const int li = ((vi+di)>>3)+1, lj = ((vj+dj)>>3)+1, lk = ((vk+dk)>>3)+1;
-                const LeafT* nl = sNeighborLeaves[slot][li*9+lj*3+lk];
-                op(spokeID, nl ? nl->getValue(LeafT::CoordToOffset(neighbor)) : uint64_t(0));
+            if (isCached) {
+                // which of the 3x3x3 neighboring leaves this tap falls into
+                const int leafX = ((voxelX+di)>>3)+1, leafY = ((voxelY+dj)>>3)+1, leafZ = ((voxelZ+dk)>>3)+1;
+                const LeafT* neighborLeaf = sNeighborLeaves[leafSlot][leafX*9 + leafY*3 + leafZ];
+                op(spokeID, neighborLeaf ? neighborLeaf->getValue(LeafT::CoordToOffset(neighbor))
+                                         : uint64_t(0));
             } else {
                 op(spokeID, tree.getValue( neighbor ));
             }

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -198,6 +198,151 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
             op(tap, tree.getValue(coord.offsetBy(di, dj, dk)));
         }
     }
+
+    /// @brief Like computeBoxStencil, but the block cooperatively stages a leaf-pointer table
+    /// in shared memory: the block's voxels span few distinct (consecutive) leaves, so the
+    /// spannedLeaves x 27 leaf-neighborhood resolutions are distributed across ALL threads and
+    /// each stencil tap becomes a direct in-leaf lookup instead of a root-down tree traversal.
+    /// Blocks spanning more than MaxCachedLeaves leaves fall back to per-tap traversal for the
+    /// uncached leaves. Must be called by all threads in the block (uses __syncthreads).
+    ///
+    /// Use this for consumers that read all 27 taps: measured 1.1-1.6x over the naive per-tap
+    /// resolution on both sparse and dense topology, with the margin widening at larger block
+    /// widths and narrowing as the per-tap payload gather grows. For partial-tap consumers that
+    /// read only a subset of the 27, prefer the naive computeBoxStencil: tap-level dead-code
+    /// elimination already skips resolving the taps that are never read, so a right-sized table
+    /// has less to save (a 19-tap variant measured slower than the DCE'd naive path).
+    /// @tparam BuildT Build type of the grid
+    /// @param stencilIndices Output stencil indices, length >= 27 (the 3x3x3 stencil)
+    template <class BuildT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    computeBoxStencilCached(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t *smem_leafIndex,
+        const uint16_t *smem_voxelOffset,
+        uint64_t *stencilIndices)
+    {
+        // Verify that the nodes can be accessed linearly
+        NANOVDB_ASSERT(grid->isSequential());
+
+        using LeafT = typename NanoTree<BuildT>::LeafNodeType;
+        constexpr int MaxCachedLeaves = 16;
+        __shared__ const LeafT* sNeighborLeaves[MaxCachedLeaves][27];
+
+        int tID = threadIdx.x;
+        const auto& tree = grid->tree();
+        const LeafT* leaf0 = tree.template getFirstNode<0>();
+
+        // Sequential voxels are grouped by (consecutive) leaves; distribute the
+        // spannedLeaves x 27 neighbor resolutions across ALL threads so no
+        // single thread serializes 27 root walks behind the barrier.
+        const uint32_t firstSpanned = smem_leafIndex[0];
+        const uint32_t myLeaf = smem_leafIndex[tID];
+        __shared__ int sSpannedCount;
+        if (tID == 0) sSpannedCount = 0;
+        __syncthreads();
+        if (myLeaf != UnusedLeafIndex && (tID == 0 || smem_leafIndex[tID-1] != myLeaf))
+            atomicMax(&sSpannedCount, int(myLeaf - firstSpanned) + 1);
+        __syncthreads();
+        const int nSpanned = sSpannedCount < MaxCachedLeaves ? sSpannedCount : MaxCachedLeaves;
+        for (int c = tID; c < nSpanned * 27; c += blockDim.x) {
+            const int slot = c / 27, n = c % 27;
+            if (n == 13) { sNeighborLeaves[slot][13] = leaf0 + (firstSpanned + slot); continue; }
+            const Coord origin = leaf0[firstSpanned + slot].origin();
+            const int di = n/9 - 1, dj = (n/3)%3 - 1, dk = n%3 - 1;
+            sNeighborLeaves[slot][n] = tree.root().probeLeaf(origin.offsetBy(di*8, dj*8, dk*8));
+        }
+        __syncthreads();
+
+        if (myLeaf != UnusedLeafIndex) {
+            const auto& leaf = leaf0[myLeaf];
+            const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
+            const uint32_t slot = myLeaf - firstSpanned;
+            const bool cached = slot < MaxCachedLeaves;
+            const int vi = coord[0] & 7, vj = coord[1] & 7, vk = coord[2] & 7;
+            for (int di = -1; di <= 1; di++)
+            for (int dj = -1; dj <= 1; dj++)
+            for (int dk = -1; dk <= 1; dk++) {
+                const int spokeID = ( di + 1 ) * 9 + ( dj + 1 ) * 3 + dk + 1;
+                const Coord neighbor = coord.offsetBy( di, dj, dk );
+                if (cached) {
+                    // Which of the 27 leaf-neighborhood slots this tap lands in
+                    const int li = ((vi+di)>>3)+1, lj = ((vj+dj)>>3)+1, lk = ((vk+dk)>>3)+1;
+                    const LeafT* nl = sNeighborLeaves[slot][li*9+lj*3+lk];
+                    stencilIndices[spokeID] = nl ? nl->getValue(LeafT::CoordToOffset(neighbor)) : 0;
+                } else {
+                    stencilIndices[spokeID] = tree.getValue( neighbor );
+                }
+            }
+        }
+    }
+
+    /// @brief Like computeBoxStencil, but resolves only the 7-point cross (center + 6 face
+    /// neighbors), staging a 7-entry leaf table per spanned leaf (own leaf + 6 face-adjacent
+    /// leaves) - the right-sized variant for Laplacian/upwind-class stencils. Writes the
+    /// face+center slots of the 27-slot array (4, 22, 10, 16, 12, 14 and 13); the rest are left
+    /// untouched. Must be called by all threads in the block (uses __syncthreads).
+    template <class BuildT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    computeCrossStencil(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t *smem_leafIndex,
+        const uint16_t *smem_voxelOffset,
+        uint64_t *stencilIndices)
+    {
+        NANOVDB_ASSERT(grid->isSequential());
+
+        using LeafT = typename NanoTree<BuildT>::LeafNodeType;
+        constexpr int MaxCachedLeaves = 16;
+        // Slots 0..5: -x,+x,-y,+y,-z,+z face neighbors; slot 6: own leaf
+        __shared__ const LeafT* sFaceLeaves[MaxCachedLeaves][7];
+
+        int tID = threadIdx.x;
+        const auto& tree = grid->tree();
+        const LeafT* leaf0 = tree.template getFirstNode<0>();
+
+        const uint32_t firstSpanned = smem_leafIndex[0];
+        const uint32_t myLeaf = smem_leafIndex[tID];
+        __shared__ int sSpannedCount;
+        if (tID == 0) sSpannedCount = 0;
+        __syncthreads();
+        if (myLeaf != UnusedLeafIndex && (tID == 0 || smem_leafIndex[tID-1] != myLeaf))
+            atomicMax(&sSpannedCount, int(myLeaf - firstSpanned) + 1);
+        __syncthreads();
+        const int nSpanned = sSpannedCount < MaxCachedLeaves ? sSpannedCount : MaxCachedLeaves;
+        for (int c = tID; c < nSpanned * 7; c += blockDim.x) {
+            const int slot = c / 7, n = c % 7;
+            if (n == 6) { sFaceLeaves[slot][6] = leaf0 + (firstSpanned + slot); continue; }
+            Coord nOrigin = leaf0[firstSpanned + slot].origin();
+            nOrigin[n >> 1] += (n & 1) ? 8 : -8;
+            sFaceLeaves[slot][n] = tree.root().probeLeaf(nOrigin);
+        }
+        __syncthreads();
+
+        if (myLeaf != UnusedLeafIndex) {
+            const auto& leaf = leaf0[myLeaf];
+            const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
+            const uint32_t slot = myLeaf - firstSpanned;
+            const bool cached = slot < MaxCachedLeaves;
+            stencilIndices[13] = leaf.getValue( smem_voxelOffset[tID] );
+            for (int n = 0; n < 6; ++n) {
+                const int axis = n >> 1, dir = (n & 1) ? 1 : -1;
+                Coord neighbor = coord;
+                neighbor[axis] += dir;
+                // Standard 27-slot spoke id for this face tap
+                const int spokeID = 13 + dir * (axis == 0 ? 9 : axis == 1 ? 3 : 1);
+                if (cached) {
+                    const int v = coord[axis] & 7;
+                    const LeafT* nl = ((v + dir) & ~7) ? sFaceLeaves[slot][n] : sFaceLeaves[slot][6];
+                    stencilIndices[spokeID] = nl ? nl->getValue(LeafT::CoordToOffset(neighbor)) : 0;
+                } else {
+                    stencilIndices[spokeID] = tree.getValue( neighbor );
+                }
+            }
+        }
+    }
 };
 
 /// @brief This functor calculates the firstLeafID and jumpMap for the

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -25,6 +25,9 @@
         VBM metadata: the block's first leaf is firstLeafID, slot p starts a
         new leaf iff jumpMap bit p is set, and the number of leaves spanned by
         the block is 1 + the jumpMap popcount.
+      - decodeInverseMaps (device): cooperative wrapper over decodeInverseMap
+        that materializes all BlockWidth slots into shared memory, preserving
+        the pre-existing signature for consumers that read across slots.
 */
 
 #ifndef NANOVDB_VOXELBLOCKMANAGER_CUH_HAS_BEEN_INCLUDED
@@ -55,9 +58,9 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
 
     // The decode is a rank + select over the VBM's bit-vectors and is
     // thread-local per output slot: decodeInverseMap requires no threadblock
-    // coordination. Consumers that need cross-slot information derive it from
-    // the VBM metadata (firstLeafID + jumpMap) rather than from a materialized
-    // per-block map.
+    // coordination. Consumers that need cross-slot information can derive it
+    // from the VBM metadata (firstLeafID + jumpMap), or materialize all slots
+    // in shared memory via the cooperative decodeInverseMaps wrapper.
 
     /// @brief Rank one output slot into its leaf: the number of leaves that
     /// begin at in-block positions [1, blockOffset] (bit 0 is never set),
@@ -170,6 +173,49 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         const uint32_t leafRank = jumpMapRank(jumpMap, blockOffset);
         selectVoxelInLeaf(grid, firstLeafID + leafRank,
                           blockFirstOffset + blockOffset, leafIndex, voxelOffset);
+    }
+
+    /// @brief Decode the inverse maps for a single voxel block into shared memory.
+    ///
+    /// Cooperative form of decodeInverseMap, preserving the pre-existing signature:
+    /// fills smem_leafIndex[] and smem_voxelOffset[] so that for each position p in
+    /// [0, BlockWidth):
+    ///   - smem_leafIndex[p]   = index of the leaf node containing sequential voxel
+    ///                           (blockFirstOffset + p), or UnusedLeafIndex if that
+    ///                           index is beyond the last active voxel.
+    ///   - smem_voxelOffset[p] = local (0..511) offset of that voxel within its leaf,
+    ///                           or UnusedVoxelOffset.
+    ///
+    /// Each slot is decoded independently by decodeInverseMap; this wrapper only
+    /// materializes the results, striding over the slots so any blockDim.x <= 512
+    /// fills the maps correctly. Must be called by all threads in the block (ends
+    /// in __syncthreads); do not call from divergent threads. Consumers that only
+    /// read their own slot's result should prefer decodeInverseMap, which needs no
+    /// shared memory or barrier.
+    ///
+    /// @tparam BuildT  Build type of the grid (must be an index type)
+    /// @param grid              Device-accessible OnIndex grid
+    /// @param firstLeafID       Index of the first leaf overlapping this block
+    /// @param jumpMap           Pointer to the JumpMapLength words for this block
+    /// @param blockFirstOffset  Sequential index of the first voxel in this block
+    /// @param smem_leafIndex    Output array of length BlockWidth in shared memory
+    /// @param smem_voxelOffset  Output array of length BlockWidth in shared memory
+    template <class BuildT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    decodeInverseMaps(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t firstLeafID,
+        const uint64_t *jumpMap,
+        const uint64_t blockFirstOffset,
+        uint32_t *smem_leafIndex,
+        uint16_t *smem_voxelOffset)
+    {
+        NANOVDB_ASSERT(blockDim.x <= 512);
+        for (int blockOffset = threadIdx.x; blockOffset < BlockWidth; blockOffset += blockDim.x)
+            decodeInverseMap(grid, firstLeafID, jumpMap, blockFirstOffset, blockOffset,
+                             smem_leafIndex[blockOffset], smem_voxelOffset[blockOffset]);
+        __syncthreads();
     }
 
     /// @brief Given a grid and one decoded inverse-map entry (from

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -173,7 +173,9 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     /// same deterministic tap order, so lookup and arithmetic stay fused (no 27-element
     /// per-thread array, no stack spill). Keep computeBoxStencil for callers that need
     /// random access to all taps. Like computeBoxStencil this accesses shared memory but
-    /// does not synchronize, so it may be called from divergent threads within a block.
+    /// does not synchronize, so it may be called from divergent threads within a block -
+    /// which is the reason to use this rather than the faster forEachBoxStencilCached,
+    /// whose cooperative leaf table requires all threads to participate.
     /// @tparam BuildT Build type of the grid
     /// @tparam OpT    Device-callable with signature op(int tap, uint64_t index)
     template <class BuildT, class OpT>
@@ -206,9 +208,12 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     /// Blocks spanning more than MaxCachedLeaves leaves fall back to per-tap traversal for the
     /// uncached leaves. Must be called by all threads in the block (uses __syncthreads).
     ///
-    /// Use this for consumers that read all 27 taps: measured 1.1-1.6x over the naive per-tap
-    /// resolution on both sparse and dense topology, with the margin widening at larger block
-    /// widths and narrowing as the per-tap payload gather grows. For partial-tap consumers that
+    /// Use this for consumers that need all 27 taps materialized (random or repeated access):
+    /// measured 1.1-1.6x over the naive per-tap resolution on both sparse and dense topology,
+    /// with the margin widening at larger block widths and narrowing as the per-tap payload
+    /// gather grows. Consumers that can consume taps in order should prefer
+    /// forEachBoxStencilCached, which adds the streaming output for a larger win. For
+    /// partial-tap consumers that
     /// read only a subset of the 27, prefer the naive computeBoxStencil: tap-level dead-code
     /// elimination already skips resolving the taps that are never read, so a right-sized table
     /// has less to save (a 19-tap variant measured slower than the DCE'd naive path).
@@ -340,6 +345,80 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
                 } else {
                     stencilIndices[spokeID] = tree.getValue( neighbor );
                 }
+            }
+        }
+    }
+
+    /// @brief The cached leaf table of computeBoxStencilCached with the streaming output of
+    /// forEachBoxStencil: taps are resolved through the staged per-leaf neighbor table AND
+    /// handed to a device-inlined callback, so neither the 27 root-down traversals nor the
+    /// 27-element per-thread array is paid. This is the fastest path for consumers that read
+    /// all 27 taps and can consume them in tap order - measured ~1.8x (block width 128) to
+    /// ~2.6x (block width 512) over the naive computeBoxStencil, versus ~1.3-1.9x for either
+    /// technique alone. Blocks spanning more than MaxCachedLeaves leaves fall back to per-tap
+    /// traversal for the uncached leaves.
+    ///
+    /// @warning Unlike forEachBoxStencil, this stages a shared-memory table cooperatively, so
+    /// it must be called by all threads in the block (uses __syncthreads internally). Use
+    /// forEachBoxStencil when the call site may be divergent.
+    ///
+    /// @tparam BuildT Build type of the grid
+    /// @tparam OpT    Device-callable with signature op(int tap, uint64_t index)
+    template <class BuildT, class OpT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    forEachBoxStencilCached(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t *smem_leafIndex,
+        const uint16_t *smem_voxelOffset,
+        OpT op)
+    {
+        NANOVDB_ASSERT(grid->isSequential());
+
+        using LeafT = typename NanoTree<BuildT>::LeafNodeType;
+        constexpr int MaxCachedLeaves = 16;
+        __shared__ const LeafT* sNeighborLeaves[MaxCachedLeaves][27];
+        __shared__ int sSpannedCount;
+
+        const int tID = threadIdx.x;
+        const auto& tree = grid->tree();
+        const LeafT* leaf0 = tree.template getFirstNode<0>();
+        const uint32_t firstSpanned = smem_leafIndex[0];
+        const uint32_t myLeaf = smem_leafIndex[tID];
+
+        // Stage the spannedLeaves x 27 leaf-neighborhood table across ALL threads
+        if (tID == 0) sSpannedCount = 0;
+        __syncthreads();
+        if (myLeaf != UnusedLeafIndex && (tID == 0 || smem_leafIndex[tID-1] != myLeaf))
+            atomicMax(&sSpannedCount, int(myLeaf - firstSpanned) + 1);
+        __syncthreads();
+        const int nSpanned = sSpannedCount < MaxCachedLeaves ? sSpannedCount : MaxCachedLeaves;
+        for (int c = tID; c < nSpanned * 27; c += blockDim.x) {
+            const int slot = c / 27, n = c % 27;
+            if (n == 13) { sNeighborLeaves[slot][13] = leaf0 + (firstSpanned + slot); continue; }
+            const Coord origin = leaf0[firstSpanned + slot].origin();
+            const int di = n/9 - 1, dj = (n/3)%3 - 1, dk = n%3 - 1;
+            sNeighborLeaves[slot][n] = tree.root().probeLeaf(origin.offsetBy(di*8, dj*8, dk*8));
+        }
+        __syncthreads();
+
+        if (myLeaf == UnusedLeafIndex) return;
+        const auto& leaf = leaf0[myLeaf];
+        const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
+        const uint32_t slot = myLeaf - firstSpanned;
+        const bool cached = slot < MaxCachedLeaves;
+        const int vi = coord[0] & 7, vj = coord[1] & 7, vk = coord[2] & 7;
+        for (int di = -1; di <= 1; di++)
+        for (int dj = -1; dj <= 1; dj++)
+        for (int dk = -1; dk <= 1; dk++) {
+            const int spokeID = ( di + 1 ) * 9 + ( dj + 1 ) * 3 + dk + 1;
+            const Coord neighbor = coord.offsetBy( di, dj, dk );
+            if (cached) {
+                const int li = ((vi+di)>>3)+1, lj = ((vj+dj)>>3)+1, lk = ((vk+dk)>>3)+1;
+                const LeafT* nl = sNeighborLeaves[slot][li*9+lj*3+lk];
+                op(spokeID, nl ? nl->getValue(LeafT::CoordToOffset(neighbor)) : uint64_t(0));
+            } else {
+                op(spokeID, tree.getValue( neighbor ));
             }
         }
     }

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -64,6 +64,27 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     // forEach<Name> streams (tap, index) to a device-inlined callback, which avoids the
     // per-thread array entirely for consumers that can take the taps in order.
 
+    /// @brief Number of distinct, consecutive leaves the block's decoded slots span, clamped
+    /// to MaxCachedLeaves. Shared preamble of the cached resolvers, which stage one table
+    /// entry group per spanned leaf. Must be called by all threads (uses __syncthreads).
+    /// @param smem_leafIndex Decoded leaf indices in shared memory
+    /// @param firstSpanned   Leaf index of slot 0, i.e. the first leaf the block spans
+    /// @param myLeaf         This thread's leaf index (UnusedLeafIndex past the last voxel)
+    template <int MaxCachedLeaves>
+    __device__
+    static int cachedLeafSpan(const uint32_t *smem_leafIndex, uint32_t firstSpanned, uint32_t myLeaf)
+    {
+        __shared__ int sSpannedCount;
+        const int tID = threadIdx.x;
+        if (tID == 0) sSpannedCount = 0;
+        __syncthreads();
+        // one atomicMax per distinct leaf: only the first slot of each run contributes
+        if (myLeaf != UnusedLeafIndex && (tID == 0 || smem_leafIndex[tID-1] != myLeaf))
+            atomicMax(&sSpannedCount, int(myLeaf - firstSpanned) + 1);
+        __syncthreads();
+        return sSpannedCount < MaxCachedLeaves ? sSpannedCount : MaxCachedLeaves;
+    }
+
     /// @brief Decode the inverse maps for a single voxel block on the device.
     ///
     /// Given the VBM metadata for one block (firstLeafID and the block's slice of
@@ -240,59 +261,11 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         const uint16_t *smem_voxelOffset,
         uint64_t *stencilIndices)
     {
-        // Verify that the nodes can be accessed linearly
-        NANOVDB_ASSERT(grid->isSequential());
-
-        using LeafT = typename NanoTree<BuildT>::LeafNodeType;
-        constexpr int MaxCachedLeaves = 16;
-        __shared__ const LeafT* sNeighborLeaves[MaxCachedLeaves][27];
-
-        int tID = threadIdx.x;
-        const auto& tree = grid->tree();
-        const LeafT* leaf0 = tree.template getFirstNode<0>();
-
-        // Sequential voxels are grouped by (consecutive) leaves; distribute the
-        // spannedLeaves x 27 neighbor resolutions across ALL threads so no
-        // single thread serializes 27 root walks behind the barrier.
-        const uint32_t firstSpanned = smem_leafIndex[0];
-        const uint32_t myLeaf = smem_leafIndex[tID];
-        __shared__ int sSpannedCount;
-        if (tID == 0) sSpannedCount = 0;
-        __syncthreads();
-        if (myLeaf != UnusedLeafIndex && (tID == 0 || smem_leafIndex[tID-1] != myLeaf))
-            atomicMax(&sSpannedCount, int(myLeaf - firstSpanned) + 1);
-        __syncthreads();
-        const int nSpanned = sSpannedCount < MaxCachedLeaves ? sSpannedCount : MaxCachedLeaves;
-        for (int c = tID; c < nSpanned * 27; c += blockDim.x) {
-            const int slot = c / 27, n = c % 27;
-            if (n == 13) { sNeighborLeaves[slot][13] = leaf0 + (firstSpanned + slot); continue; }
-            const Coord origin = leaf0[firstSpanned + slot].origin();
-            const int di = n/9 - 1, dj = (n/3)%3 - 1, dk = n%3 - 1;
-            sNeighborLeaves[slot][n] = tree.root().probeLeaf(origin.offsetBy(di*8, dj*8, dk*8));
-        }
-        __syncthreads();
-
-        if (myLeaf != UnusedLeafIndex) {
-            const auto& leaf = leaf0[myLeaf];
-            const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
-            const uint32_t slot = myLeaf - firstSpanned;
-            const bool cached = slot < MaxCachedLeaves;
-            const int vi = coord[0] & 7, vj = coord[1] & 7, vk = coord[2] & 7;
-            for (int di = -1; di <= 1; di++)
-            for (int dj = -1; dj <= 1; dj++)
-            for (int dk = -1; dk <= 1; dk++) {
-                const int spokeID = ( di + 1 ) * 9 + ( dj + 1 ) * 3 + dk + 1;
-                const Coord neighbor = coord.offsetBy( di, dj, dk );
-                if (cached) {
-                    // Which of the 27 leaf-neighborhood slots this tap lands in
-                    const int li = ((vi+di)>>3)+1, lj = ((vj+dj)>>3)+1, lk = ((vk+dk)>>3)+1;
-                    const LeafT* nl = sNeighborLeaves[slot][li*9+lj*3+lk];
-                    stencilIndices[spokeID] = nl ? nl->getValue(LeafT::CoordToOffset(neighbor)) : 0;
-                } else {
-                    stencilIndices[spokeID] = tree.getValue( neighbor );
-                }
-            }
-        }
+        // Identical resolution to forEachBoxStencilCached; the only difference is that the
+        // taps are stored rather than streamed, so express it as that traversal with a
+        // storing callback instead of duplicating the table staging and tap loop.
+        forEachBoxStencilCached<BuildT>(grid, smem_leafIndex, smem_voxelOffset,
+            [stencilIndices](int tap, uint64_t index) { stencilIndices[tap] = index; });
     }
 
     /// @brief Like computeBoxStencil, but resolves only the 7-point cross (center + 6 face
@@ -370,13 +343,7 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
 
         const uint32_t firstSpanned = smem_leafIndex[0];
         const uint32_t myLeaf = smem_leafIndex[tID];
-        __shared__ int sSpannedCount;
-        if (tID == 0) sSpannedCount = 0;
-        __syncthreads();
-        if (myLeaf != UnusedLeafIndex && (tID == 0 || smem_leafIndex[tID-1] != myLeaf))
-            atomicMax(&sSpannedCount, int(myLeaf - firstSpanned) + 1);
-        __syncthreads();
-        const int nSpanned = sSpannedCount < MaxCachedLeaves ? sSpannedCount : MaxCachedLeaves;
+        const int nSpanned = cachedLeafSpan<MaxCachedLeaves>(smem_leafIndex, firstSpanned, myLeaf);
         for (int c = tID; c < nSpanned * 7; c += blockDim.x) {
             const int slot = c / 7, n = c % 7;
             if (n == 6) { sFaceLeaves[slot][6] = leaf0 + (firstSpanned + slot); continue; }
@@ -438,7 +405,6 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         using LeafT = typename NanoTree<BuildT>::LeafNodeType;
         constexpr int MaxCachedLeaves = 16;
         __shared__ const LeafT* sNeighborLeaves[MaxCachedLeaves][27];
-        __shared__ int sSpannedCount;
 
         const int tID = threadIdx.x;
         const auto& tree = grid->tree();
@@ -447,12 +413,7 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         const uint32_t myLeaf = smem_leafIndex[tID];
 
         // Stage the spannedLeaves x 27 leaf-neighborhood table across ALL threads
-        if (tID == 0) sSpannedCount = 0;
-        __syncthreads();
-        if (myLeaf != UnusedLeafIndex && (tID == 0 || smem_leafIndex[tID-1] != myLeaf))
-            atomicMax(&sSpannedCount, int(myLeaf - firstSpanned) + 1);
-        __syncthreads();
-        const int nSpanned = sSpannedCount < MaxCachedLeaves ? sSpannedCount : MaxCachedLeaves;
+        const int nSpanned = cachedLeafSpan<MaxCachedLeaves>(smem_leafIndex, firstSpanned, myLeaf);
         for (int c = tID; c < nSpanned * 27; c += blockDim.x) {
             const int slot = c / 27, n = c % 27;
             if (n == 13) { sNeighborLeaves[slot][13] = leaf0 + (firstSpanned + slot); continue; }

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -52,6 +52,18 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     // threadblock-level coordination, which manifests either as using shared
     // memory for synchronization, or warp-level shift operations.
 
+    // Stencil resolver naming. Each stencil shape comes in two forms:
+    //   <name>        - resolves each tap by a root-down tree traversal. Uses no shared
+    //                   memory and does not synchronize, so it is safe to call from
+    //                   divergent threads within a block.
+    //   <name>Cached  - the block cooperatively stages a per-leaf neighbor table in shared
+    //                   memory, turning each tap into a direct in-leaf lookup. Substantially
+    //                   faster, but must be called by all threads in the block (it uses
+    //                   __syncthreads) and costs shared memory.
+    // Independently, compute<Name> materializes the taps into a 27-slot array while
+    // forEach<Name> streams (tap, index) to a device-inlined callback, which avoids the
+    // per-thread array entirely for consumers that can take the taps in order.
+
     /// @brief Decode the inverse maps for a single voxel block on the device.
     ///
     /// Given the VBM metadata for one block (firstLeafID and the block's slice of
@@ -284,14 +296,62 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     }
 
     /// @brief Like computeBoxStencil, but resolves only the 7-point cross (center + 6 face
-    /// neighbors), staging a 7-entry leaf table per spanned leaf (own leaf + 6 face-adjacent
-    /// leaves) - the right-sized variant for Laplacian/upwind-class stencils. Writes the
-    /// face+center slots of the 27-slot array (4, 22, 10, 16, 12, 14 and 13); the rest are left
-    /// untouched. Must be called by all threads in the block (uses __syncthreads).
+    /// neighbors) - the right-sized shape for Laplacian/upwind-class stencils. Writes the
+    /// face+center slots of the 27-slot array (4, 22, 10, 16, 12, 14 and 13); the rest are
+    /// left untouched. Like computeBoxStencil this uses no shared memory and does not
+    /// synchronize, so it may be called from divergent threads within a block; see
+    /// computeCrossStencilCached for the cooperative, leaf-table-accelerated form.
+    ///
+    /// Prefer this over calling computeBoxStencil and reading only the cross slots: resolving
+    /// the 7 taps directly measured 1.6-1.8x faster than relying on the compiler to eliminate
+    /// the 20 unread taps of the full box.
+    /// @tparam BuildT Build type of the grid
+    /// @param stencilIndices Output stencil indices, length >= 27 (the cross slots are written)
     template <class BuildT>
     __device__
     static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
     computeCrossStencil(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t *smem_leafIndex,
+        const uint16_t *smem_voxelOffset,
+        uint64_t *stencilIndices)
+    {
+        // Verify that the nodes can be accessed linearly
+        NANOVDB_ASSERT(grid->isSequential());
+
+        int tID = threadIdx.x;
+        const auto& tree = grid->tree();
+        if (smem_leafIndex[tID] != UnusedLeafIndex) {
+            const auto& leaf = tree.template getFirstNode<0>()[ smem_leafIndex[tID] ];
+            const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
+            stencilIndices[13] = leaf.getValue( smem_voxelOffset[tID] );
+            for (int n = 0; n < 6; ++n) {
+                const int axis = n >> 1, dir = (n & 1) ? 1 : -1;
+                Coord neighbor = coord;
+                neighbor[axis] += dir;
+                // Standard 27-slot spoke id for this face tap
+                const int spokeID = 13 + dir * (axis == 0 ? 9 : axis == 1 ? 3 : 1);
+                stencilIndices[spokeID] = tree.getValue( neighbor );
+            }
+        }
+    }
+
+    /// @brief Like computeCrossStencil, but stages a 7-entry leaf table per spanned leaf (own
+    /// leaf + 6 face-adjacent leaves) so each of the 7 taps becomes a direct in-leaf lookup
+    /// instead of a root-down tree traversal - by a wide margin the fastest way to resolve a
+    /// cross-shaped stencil (measured 4.1-6.8x over the naive form at one sidecar channel,
+    /// still 1.5-2.0x at sixteen). Writes the same slots as computeCrossStencil.
+    ///
+    /// @warning Stages a shared-memory table cooperatively, so it must be called by all threads
+    /// in the block (uses __syncthreads internally). Use computeCrossStencil when the call site
+    /// may be divergent, or when the block cannot spare the shared memory.
+    ///
+    /// @note There is deliberately no streaming (forEach) cross variant: a 7-element stencil is
+    /// cheap enough to materialize that removing the array measured as a wash.
+    template <class BuildT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    computeCrossStencilCached(
         const NanoGrid<BuildT> *grid,
         const uint32_t *smem_leafIndex,
         const uint16_t *smem_voxelOffset,

--- a/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/nanovdb/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -63,6 +63,11 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     // Independently, compute<Name> materializes the taps into a 27-slot array while
     // forEach<Name> streams (tap, index) to a device-inlined callback, which avoids the
     // per-thread array entirely for consumers that can take the taps in order.
+    //
+    // Every resolver resolves the taps of ONE decoded slot per thread - the slot with the
+    // thread's own index - so the block must be launched with blockDim.x == BlockWidth.
+    // (decodeInverseMaps itself is more permissive: it strides over the slots, so it fills
+    // the maps correctly for any blockDim.x.)
 
     /// @brief Number of distinct, consecutive leaves the block's decoded slots span, clamped
     /// to MaxCachedLeaves. Shared preamble of the cached resolvers, which stage one table
@@ -221,6 +226,7 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     {
         // Verify that the nodes can be accessed linearly
         NANOVDB_ASSERT(grid->isSequential());
+        NANOVDB_ASSERT(blockDim.x == BlockWidth);// one thread per decoded slot
 
         int tID = threadIdx.x;
         const auto& tree = grid->tree();
@@ -260,6 +266,7 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         OpT op)
     {
         NANOVDB_ASSERT(grid->isSequential());
+        NANOVDB_ASSERT(blockDim.x == BlockWidth);// one thread per decoded slot
         const int tID = threadIdx.x;
         const auto& tree = grid->tree();
         if (smem_leafIndex[tID] == UnusedLeafIndex) return;
@@ -330,6 +337,7 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
     {
         // Verify that the nodes can be accessed linearly
         NANOVDB_ASSERT(grid->isSequential());
+        NANOVDB_ASSERT(blockDim.x == BlockWidth);// one thread per decoded slot
 
         int tID = threadIdx.x;
         const auto& tree = grid->tree();
@@ -370,6 +378,7 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         uint64_t *stencilIndices)
     {
         NANOVDB_ASSERT(grid->isSequential());
+        NANOVDB_ASSERT(blockDim.x == BlockWidth);// one thread per decoded slot
 
         using LeafT = typename NanoTree<BuildT>::LeafNodeType;
         constexpr int MaxCachedLeaves = 16;
@@ -437,6 +446,7 @@ struct VoxelBlockManager : nanovdb::tools::VoxelBlockManagerBase<Log2BlockWidth>
         OpT op)
     {
         NANOVDB_ASSERT(grid->isSequential());
+        NANOVDB_ASSERT(blockDim.x == BlockWidth);// one thread per decoded slot
 
         using LeafT = typename NanoTree<BuildT>::LeafNodeType;
         constexpr int MaxCachedLeaves = 16;

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -3465,15 +3465,17 @@ __global__ void testComputeStencilNeighborsKernel(
     uint64_t *jumpMap = jumpMapArray + JumpMapLength * bID;
     int firstOffset = 1;
     int blockFirstOffset = firstOffset + bID * BlockWidth;
-    uint32_t leafIndex;
-    uint16_t voxelOffset;
+    // Decode through the cooperative wrapper (which exercises the per-slot
+    // decodeInverseMap internally), then resolve this thread's own slot.
+    __shared__ uint32_t leafIndex[BlockWidth];
+    __shared__ uint16_t voxelOffset[BlockWidth];
 
-    nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::decodeInverseMap(
-        grid, firstLeafID, jumpMap, blockFirstOffset, tID, leafIndex, voxelOffset);
+    nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::decodeInverseMaps(
+        grid, firstLeafID, jumpMap, blockFirstOffset, &leafIndex[0], &voxelOffset[0]);
 
     uint64_t localNeighbors[27] = {};
     nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::computeBoxStencil(
-        grid, leafIndex, voxelOffset, localNeighbors);
+        grid, leafIndex[tID], voxelOffset[tID], localNeighbors);
 
     using StencilNeighborsType = uint64_t (*)[27];
     auto stencilNeighbors = reinterpret_cast<StencilNeighborsType>(stencilNeighborsArray+27*BlockWidth*bID);

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -3465,16 +3465,15 @@ __global__ void testComputeStencilNeighborsKernel(
     uint64_t *jumpMap = jumpMapArray + JumpMapLength * bID;
     int firstOffset = 1;
     int blockFirstOffset = firstOffset + bID * BlockWidth;
-    __shared__ uint32_t leafIndex[BlockWidth];
-    __shared__ uint16_t voxelOffset[BlockWidth];
+    uint32_t leafIndex;
+    uint16_t voxelOffset;
 
-    nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::decodeInverseMaps(
-        grid, firstLeafID, jumpMap, blockFirstOffset, &leafIndex[0], &voxelOffset[0]);
+    nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::decodeInverseMap(
+        grid, firstLeafID, jumpMap, blockFirstOffset, tID, leafIndex, voxelOffset);
 
     uint64_t localNeighbors[27] = {};
     nanovdb::tools::cuda::VoxelBlockManager<Log2BlockWidth>::computeBoxStencil(
-        grid, &leafIndex[0], &voxelOffset[0], localNeighbors);
-    __syncthreads();
+        grid, leafIndex, voxelOffset, localNeighbors);
 
     using StencilNeighborsType = uint64_t (*)[27];
     auto stencilNeighbors = reinterpret_cast<StencilNeighborsType>(stencilNeighborsArray+27*BlockWidth*bID);

--- a/pendingchanges/nanovdbvbmdecode.txt
+++ b/pendingchanges/nanovdbvbmdecode.txt
@@ -1,0 +1,5 @@
+NanoVDB:
+  Improvements:
+  - Replaced the CUDA VoxelBlockManager inverse-map decode's O(nLeaves x 512) per-block
+    sweep with an O(1)-per-slot select (jumpMap popcount rank + the leaf's 9-bit prefix
+    sums + an in-word bit select); byte-identical decode maps and ~2x faster decode.

--- a/pendingchanges/nanovdbvbmdecode.txt
+++ b/pendingchanges/nanovdbvbmdecode.txt
@@ -4,12 +4,14 @@ NanoVDB:
     sweep with an O(1)-per-slot select (jumpMap popcount rank + the leaf's 9-bit prefix
     sums + an in-word bit select); byte-identical decode maps and ~2x faster decode.
   API Changes:
-  - Consolidated the CUDA VoxelBlockManager decode to a single thread-local API:
+  - Restructured the CUDA VoxelBlockManager decode around a thread-local primitive:
     decodeInverseMap decodes one slot into registers (no shared memory or
-    synchronization; callable from divergent threads) and replaces the cooperative
-    shared-memory decodeInverseMaps, which has been removed. computeBoxStencil now
-    takes the decoded (leafIndex, voxelOffset) by value instead of shared-memory
-    arrays. Block-level facts formerly read from the materialized maps derive
+    synchronization; callable from divergent threads). The cooperative
+    decodeInverseMaps keeps its pre-existing signature and is now a thin wrapper
+    that materializes all slots via decodeInverseMap; prefer the per-slot form for
+    consumers that only read their own slot. computeBoxStencil now takes the
+    decoded (leafIndex, voxelOffset) by value instead of shared-memory arrays.
+    Block-level facts formerly read from the materialized maps also derive
     directly from the VBM metadata: the block's first leaf is firstLeafID, slot p
     starts a new leaf iff jumpMap bit p is set, and the spanned-leaf count is
     1 + the jumpMap popcount.

--- a/pendingchanges/nanovdbvbmdecode.txt
+++ b/pendingchanges/nanovdbvbmdecode.txt
@@ -3,3 +3,13 @@ NanoVDB:
   - Replaced the CUDA VoxelBlockManager inverse-map decode's O(nLeaves x 512) per-block
     sweep with an O(1)-per-slot select (jumpMap popcount rank + the leaf's 9-bit prefix
     sums + an in-word bit select); byte-identical decode maps and ~2x faster decode.
+  API Changes:
+  - Consolidated the CUDA VoxelBlockManager decode to a single thread-local API:
+    decodeInverseMap decodes one slot into registers (no shared memory or
+    synchronization; callable from divergent threads) and replaces the cooperative
+    shared-memory decodeInverseMaps, which has been removed. computeBoxStencil now
+    takes the decoded (leafIndex, voxelOffset) by value instead of shared-memory
+    arrays. Block-level facts formerly read from the materialized maps derive
+    directly from the VBM metadata: the block's first leaf is firstLeafID, slot p
+    starts a new leaf iff jumpMap bit p is set, and the spanned-leaf count is
+    1 + the jumpMap popcount.

--- a/pendingchanges/nanovdbvbmstencils.txt
+++ b/pendingchanges/nanovdbvbmstencils.txt
@@ -1,0 +1,12 @@
+NanoVDB:
+  Improvements:
+  - Added stencil resolvers to the CUDA VoxelBlockManager so stencil consumers need not pay a
+    root-down tree traversal per tap. Each shape has a plain form (no shared memory, callable
+    from divergent threads) and a "Cached" form in which the thread block cooperatively stages
+    a per-leaf neighbour table in shared memory and each tap becomes a direct in-leaf lookup:
+    computeBoxStencilCached for the 3x3x3 box, and computeCrossStencil /
+    computeCrossStencilCached for the 7-point cross used by Laplacian and upwind-class stencils.
+  - Added streaming forms of the box stencil, forEachBoxStencil and forEachBoxStencilCached,
+    which hand (tap, index) to a device-inlined callback instead of materializing a 27-element
+    per-thread array. forEachBoxStencilCached combines the cached table with the streaming
+    output and is the fastest way to resolve all 27 taps.


### PR DESCRIPTION
## Summary

This PR focuses on two independent costs that are part of resolving a 3×3×3 stencil through the VoxelBlockManager: 27 root-down tree traversals (one per tap), and a 27-element per-thread index array to hold the result. This PR adds new resolver functions (alongside the existing `computeBoxStencil`) that address each cost, and one that addresses both.

Each stencil shape comes in a plain and a `Cached` form, with a single convention stated on the class:

- **`<name>`** — resolves each tap by a root-down tree traversal. Thread-local like `decodeInverseMap` itself: **no shared memory, no barrier, safe from divergent threads — the entire decode+resolve pipeline is.**
- **`<name>Cached`** — the block cooperatively stages a per-leaf neighbour table in shared memory, so each tap is a direct in-leaf lookup. Substantially faster, but **must be called by all threads** (uses `__syncthreads`) and costs shared memory (the staged table only).

Independently, `compute<Name>` materializes taps into a 27-slot array while `forEach<Name>` streams `(tap, index)` to a device-inlined callback, avoiding the per-thread array entirely.

| method | shape | resolution | output |
|---|---|---|---|
| `computeBoxStencil` *(existing)* | 27-tap | tree walk | materialized |
| **`forEachBoxStencil`** | 27-tap | tree walk | streamed |
| **`computeBoxStencilCached`** | 27-tap | cached table | materialized |
| **`forEachBoxStencilCached`** | 27-tap | cached table | streamed |
| **`computeCrossStencil`** | 7-tap | tree walk | materialized |
| **`computeCrossStencilCached`** | 7-tap | cached table | materialized |

The cached resolvers exploit a structural property of the VBM: a block's voxels span **few distinct, consecutive leaves**, so the block cooperatively stages a per-leaf neighbour table in shared memory (built by *all* threads, not a leader) and each tap becomes a direct in-leaf lookup. A 3×3×3 stencil touches at most 7 neighbouring leaves, not 27 independent lookups. Blocks spanning more than `MaxCachedLeaves` fall back to per-tap traversal.

## Built on the register-decode API (#2258)

This PR now stacks on #2258's consolidated thread-local decode (`decodeInverseMap` into registers; the shared-memory `decodeInverseMaps` is removed there). Every resolver takes the calling thread's decoded `(leafIndex, voxelOffset)` **by value**; the cached forms additionally take the block's `firstLeafID` and `jumpMap` and derive everything the staging needs from that metadata — the block's first leaf **is** `firstLeafID`, and the spanned-leaf count is **1 + popcount(jumpMap)**. Consequences:

- No materialized per-block maps exist anywhere: the leader election over `smem_leafIndex[tID-1]`, its `atomicMax` span counter, and two of the three prologue barriers in the cached forms are gone (`cachedLeafSpan` is now a thread-local popcount).
- Shared memory is the resolver's table alone (`ptxas -v`, width 128): **3456 B** for the cached box (down from 4228 B — the 512 B + 256 B map arrays and 4 B counter are gone), **896 B** for the cached cross (down from 1668 B).
- The plain forms are divergent-safe *end-to-end*, decode included — previously the resolver was divergent-safe but the decode feeding it was cooperative.
- The one-thread-per-slot `blockDim` contract is dropped: resolvers operate on whatever slot the caller passes.

#2258 should merge first; this branch includes its commits via merge.

## Measurements

All six resolvers measured in **one run, on one grid, against one baseline, with the same consumer**: resolve the taps, then accumulate `C` interleaved sidecar channels per tap (box variants accumulate their 27, cross variants their 7). Sparse sphere shell: 1.29M active voxels across 9140 leaves, mean leaf occupancy 141/512. RTX PRO 6000 (sm_120), median of 50 iterations. Output is **byte-exact within each stencil shape**.

### One sidecar channel

| method | shape | resolution | divergent-safe? | smem | output | w128 ms | w128 × | w512 ms | w512 × |
|---|---|---|:--:|--:|---|--:|--:|--:|--:|
| `computeBoxStencil` *(existing)* | 27-tap box | tree walk | **yes** | none | materialized | 0.1856 | 1.00× | 0.2616 | 1.00× |
| **`forEachBoxStencil`** | 27-tap box | tree walk | **yes** | none | streamed | 0.1388 | 1.34× | 0.1428 | 1.83× |
| **`computeBoxStencilCached`** | 27-tap box | cached table | no | 3456 B | materialized | 0.1527 | 1.22× | 0.1427 | 1.83× |
| **`forEachBoxStencilCached`** | 27-tap box | cached table | no | 3456 B | streamed | 0.0844 | **2.20×** | 0.0875 | **2.99×** |
| **`computeCrossStencil`** | 7-pt cross | tree walk | **yes** | none | materialized | 0.0434 | 4.27× | 0.0474 | 5.52× |
| **`computeCrossStencilCached`** | 7-pt cross | cached table | no | 896 B | materialized | 0.0318 | **5.84×** | 0.0394 | **6.64×** |

Speedups share the `computeBoxStencil` baseline — noting that the cross resolvers deliberately resolve 7 taps rather than 27, which is the point of matching the resolver to the stencil shape. Throughout, a pair like **2.20× / 2.99×** means **BlockWidth 128 / BlockWidth 512**.

### What each technique contributes

- **Streaming alone** removes the 27-element index array; **caching alone** removes the tree walks. The costs are independent, so **fusing them beats either** — 2.20× / 2.99× versus 1.34× / 1.83× (streaming) and 1.22× / 1.83× (caching).
- **Matching the resolver to the stencil shape is the largest single lever**: the cross resolvers are 4.3–6.6×.

### Feature width erodes every margin

At 8 sidecar channels the `taps × C` payload gather (identical for all resolvers) starts to dominate: `forEachBoxStencilCached` 1.47× / 2.12×, `computeBoxStencilCached` 1.22× / 1.48×, `computeCrossStencilCached` 4.37× / 4.59×. The ordering is unchanged.

### Register cost of materialization

For the cached 27-tap consumer (`ptxas -v`, sm_120, one channel) the `uint64_t st[27]` array costs **22 registers and a 216-byte stack frame** (62 → 40 registers, 216 B → 0 between `computeBoxStencilCached` and `forEachBoxStencilCached`; the 216 B is exactly `27 × sizeof(uint64_t)`) — the relief the streaming variants capture.

## Validation

- **Byte-exact within each stencil shape, at two levels**: raw taps (all 27 slots of every thread materialized to global and compared bytewise — box resolvers vs `computeBoxStencil`, cross vs cross) and consumer output (the accumulated float channels compared bitwise), at block widths 128/512, on 16%–60% leaf-occupancy topology and at both feature widths measured. The resolvers change *how* a tap index is found, never which index.
- The `TestNanoVDBCUDA.VoxelBlockManager_*` unit tests pass on the merged branch.

## Notes

- The resolvers are additive; `computeBoxStencil`'s move to by-value decoded slots is #2258's API change, which this PR inherits. Callers choose between plain and cached forms on two axes that are genuinely theirs to weigh: whether the call site is uniform, and whether the block can spare the shared memory for the table (16 × 27 leaf pointers for the box, 16 × 7 for the cross — now the *only* shared memory in the pipeline).
- `MaxCachedLeaves` is 16.
- There is deliberately no `forEachCrossStencil`: a 7-element stencil is cheap enough to materialize that removing the array measured as a wash.
- This PR subsumes #2262, left open for comparison until the design discussion concludes.
