### PR TITLE
added build support on Ampere

### DIFF
--- a/nanovdb/nanovdb/examples/CMakeLists.txt
+++ b/nanovdb/nanovdb/examples/CMakeLists.txt
@@ -117,8 +117,17 @@ nanovdb_example(NAME "ex_coarsen_nanovdb_cuda" OPENVDB)
 nanovdb_example(NAME "ex_mesh_to_grid_cuda" OPENVDB)
 
 if(CUDAToolkit_FOUND)
-  nanovdb_example(NAME "ex_make_mgpu_nanovdb") # requires cuRAND
-  target_link_libraries(ex_make_mgpu_nanovdb PRIVATE CUDA::curand)
+  # ex_make_mgpu_nanovdb uses TF32 WMMA which requires SM_80+ (Ampere or newer)
+  execute_process(
+    COMMAND bash -c "nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | sort -n | tail -1 | tr -d '.'"
+    OUTPUT_VARIABLE _max_cuda_arch OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(_max_cuda_arch GREATER_EQUAL 80)
+    nanovdb_example(NAME "ex_make_mgpu_nanovdb") # requires cuRAND and SM_80+ (TF32 WMMA)
+    target_link_libraries(ex_make_mgpu_nanovdb PRIVATE CUDA::curand)
+  else()
+    message(STATUS "Skipping ex_make_mgpu_nanovdb: requires SM_80+ (TF32), detected SM_${_max_cuda_arch}")
+  endif()
+  unset(_max_cuda_arch)
 endif()
 
 if(NANOVDB_USE_MAGICAVOXEL)

--- a/nanovdb/nanovdb/examples/CMakeLists.txt
+++ b/nanovdb/nanovdb/examples/CMakeLists.txt
@@ -117,17 +117,28 @@ nanovdb_example(NAME "ex_coarsen_nanovdb_cuda" OPENVDB)
 nanovdb_example(NAME "ex_mesh_to_grid_cuda" OPENVDB)
 
 if(CUDAToolkit_FOUND)
-  # ex_make_mgpu_nanovdb uses TF32 WMMA which requires SM_80+ (Ampere or newer)
-  execute_process(
-    COMMAND bash -c "nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | sort -n | tail -1 | tr -d '.'"
-    OUTPUT_VARIABLE _max_cuda_arch OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if(_max_cuda_arch GREATER_EQUAL 80)
+  # ex_make_mgpu_nanovdb uses TF32 WMMA which requires SM_80+ (Ampere or newer).
+  # Gate on CMAKE_CUDA_ARCHITECTURES (what the build actually targets) rather than
+  # probing the configure-time machine's GPU: the two can differ (cross-compiling,
+  # building on one machine to run on another, CI runners without a GPU), and
+  # probing via "bash -c nvidia-smi ..." isn't portable to Windows either way.
+  set(_nanovdb_has_sm80 OFF)
+  foreach(_cuda_arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
+    string(REGEX MATCH "^[0-9]+" _cuda_arch_number "${_cuda_arch}")
+    if(_cuda_arch_number GREATER_EQUAL 80)
+      set(_nanovdb_has_sm80 ON)
+    endif()
+  endforeach()
+
+  if(_nanovdb_has_sm80)
     nanovdb_example(NAME "ex_make_mgpu_nanovdb") # requires cuRAND and SM_80+ (TF32 WMMA)
     target_link_libraries(ex_make_mgpu_nanovdb PRIVATE CUDA::curand)
   else()
-    message(STATUS "Skipping ex_make_mgpu_nanovdb: requires SM_80+ (TF32), detected SM_${_max_cuda_arch}")
+    message(STATUS "Skipping ex_make_mgpu_nanovdb: requires CUDA architecture 80 or newer (CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES})")
   endif()
-  unset(_max_cuda_arch)
+  unset(_nanovdb_has_sm80)
+  unset(_cuda_arch_number)
+  unset(_cuda_arch)
 endif()
 
 if(NANOVDB_USE_MAGICAVOXEL)

--- a/openvdb_cmd/vdb_tool/CMakeLists.txt
+++ b/openvdb_cmd/vdb_tool/CMakeLists.txt
@@ -256,6 +256,9 @@ if(OPENVDB_BUILD_VDB_TOOL_UNITTESTS)
 
   add_executable(vdb_tool_test src/unittest.cpp)
   target_include_directories(vdb_tool_test PRIVATE vdb_tool_common)
-  target_link_libraries(vdb_tool_test PRIVATE vdb_tool_common GTest::gmock GTest::gtest GTest::gmock_main GTest::gtest_main)
+  # The test provides its own main() and uses only gtest (no gmock), so link just
+  # GTest::gtest. Listing gmock / *_main as well pulls gtest/gmock onto the link
+  # line multiple times, which the macOS linker flags as "ignoring duplicate libraries".
+  target_link_libraries(vdb_tool_test PRIVATE vdb_tool_common GTest::gtest)
   add_test(vdb_tool_unit_test vdb_tool_test)
 endif()


### PR DESCRIPTION
 ex_make_mgpu_nanovdb uses TF32 WMMA which requires SM_80+ (Ampere or newer)

changed cmake to address this issue