### PR TITLE
NanoVDB: inject a resource into TopologyBuilder scratch, and align cuda::Buffer with cuda::buffer (CUDA)

### DIFF
--- a/nanovdb/nanovdb/cuda/Buffer.h
+++ b/nanovdb/nanovdb/cuda/Buffer.h
@@ -275,6 +275,10 @@ public:
     }
 
     /// @brief Frees the buffer memory (if any) and resets to the empty state.
+    /// @deprecated Use destroy(). Documentation-level only for now: the
+    ///             [[deprecated]] attribute would fire from GridHandle::reset
+    ///             and NodeManager::reset, which must keep calling clear()
+    ///             until every buffer type provides destroy().
     /// @note Transitional, and not the name to use: it exists only because
     ///       GridHandle::reset still calls clear() on its buffer. It goes away
     ///       when the legacy dual buffers do and GridHandle moves to destroy().

--- a/nanovdb/nanovdb/cuda/Buffer.h
+++ b/nanovdb/nanovdb/cuda/Buffer.h
@@ -50,7 +50,7 @@ struct StreamHolder<true> { cudaStream_t mStream = 0; };
 ///         is_resource). When @c R provides both interfaces the stream-ordered
 ///         one is used.
 /// @details With a stream-ordered resource the Buffer retains the stream of
-///          the most recent allocation (or the one supplied via setStream)
+///          the most recent allocation (or the one supplied via set_stream)
 ///          and orders its deallocation on that stream. Buffer is move-only.
 template<typename T, typename R = DeviceResource>
 class Buffer : private detail::StreamHolder<is_async_resource<R>::value>
@@ -133,7 +133,7 @@ public:
     Buffer& operator=(Buffer&& other) noexcept
     {
         if (this != &other) {
-            this->clear();
+            this->destroy();
             static_cast<detail::StreamHolder<IsAsync>&>(*this) = other;
             mResource = std::move(other.mResource);
             mData = other.mData;
@@ -168,7 +168,7 @@ public:
 
     /// @brief D-tor. A stream-ordered resource frees on the retained stream;
     ///        a synchronous resource frees immediately.
-    ~Buffer() { this->clear(); }
+    ~Buffer() { this->destroy(); }
 
     /// @brief Returns the retained stream, i.e. the stream the buffer's memory
     ///        will be freed on.
@@ -179,9 +179,11 @@ public:
     ///        deallocation (and destruction) is ordered on @c stream instead.
     /// @param stream cuda stream subsequent deallocation is ordered on
     /// @warning The caller is responsible for ordering @c stream after any
-    ///          in-flight work that uses the buffer's memory.
+    ///          in-flight work that uses the buffer's memory. This deliberately
+    ///          does not synchronize, matching cuda::buffer's
+    ///          set_stream_unsynchronized rather than its set_stream.
     template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
-    void setStream(cudaStream_t stream) { this->mStream = stream; }
+    void set_stream(cudaStream_t stream) { this->mStream = stream; }
 
     /// @brief Resizes the buffer to @c count elements, preserving the leading
     ///        min(old, new) elements. Every operation — the new allocation, the
@@ -219,7 +221,7 @@ public:
             mSize = count;
         }
         else {
-            this->mStream = stream; // no reallocation: setStream semantics
+            this->mStream = stream; // no reallocation: set_stream semantics
         }
     }
 
@@ -263,11 +265,44 @@ public:
     bool empty() const { return mSize == 0; }
 
     /// @brief Frees the buffer memory (if any) and resets to the empty state.
-    void clear()
+    ///        A stream-ordered resource frees on the retained stream.
+    /// @note Spelled destroy to match cuda::buffer. This is the name to use.
+    void destroy()
     {
         this->deallocate(mData, mSize);
         mData = nullptr;
         mSize = 0;
+    }
+
+    /// @brief Frees the buffer memory (if any) and resets to the empty state.
+    /// @note Transitional, and not the name to use: it exists only because
+    ///       GridHandle::reset still calls clear() on its buffer. It goes away
+    ///       when the legacy dual buffers do and GridHandle moves to destroy().
+    void clear() { this->destroy(); }
+
+    /// @brief Frees the buffer memory (if any) on @c stream and resets to the
+    ///        empty state. @c stream becomes the retained stream.
+    /// @param stream cuda stream the deallocation is ordered on
+    /// @warning The caller is responsible for ordering @c stream after any
+    ///          in-flight work that uses the buffer's memory.
+    template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
+    void destroy(cudaStream_t stream)
+    {
+        this->mStream = stream;
+        this->destroy();
+    }
+
+    /// @brief Exchanges the contents of this buffer with @c other. Neither
+    ///        buffer allocates, frees, or copies element data.
+    /// @param other buffer to exchange contents with
+    void swap(Buffer& other) noexcept
+    {
+        auto& lhs = static_cast<detail::StreamHolder<IsAsync>&>(*this);
+        auto& rhs = static_cast<detail::StreamHolder<IsAsync>&>(other);
+        std::swap(lhs, rhs);
+        std::swap(mResource, other.mResource);
+        std::swap(mData, other.mData);
+        std::swap(mSize, other.mSize);
     }
 
 private:

--- a/nanovdb/nanovdb/cuda/Buffer.h
+++ b/nanovdb/nanovdb/cuda/Buffer.h
@@ -180,8 +180,8 @@ public:
     /// @param stream cuda stream subsequent deallocation is ordered on
     /// @warning The caller is responsible for ordering @c stream after any
     ///          in-flight work that uses the buffer's memory. This deliberately
-    ///          does not synchronize, matching cuda::buffer's
-    ///          set_stream_unsynchronized rather than its set_stream.
+    ///          does not synchronize, matching cuda::buffer's set_stream, which
+    ///          avoids implicit synchronization in fundamental primitives.
     template<typename S = R, std::enable_if_t<is_async_resource<S>::value, int> = 0>
     void set_stream(cudaStream_t stream) { this->mStream = stream; }
 

--- a/nanovdb/nanovdb/tools/cuda/CoarsenGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/CoarsenGrid.cuh
@@ -210,7 +210,7 @@ void CoarsenGrid<BuildT>::coarsenInternalNodes()
     if (auto srcLeafCount = mSrcTreeData.mNodeCount[0]) { // Unless it's an empty grid
         util::cuda::lambdaKernel<<<numBlocks(srcLeafCount), mNumThreads, 0, mStream>>>(
             srcLeafCount, util::morphology::cuda::CoarsenInternalNodesFunctor<BuildT>(),
-            mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.mUpperMasks.deviceData(), mBuilder.mLowerMasks.deviceData() );
+            mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.mUpperMasks.data(), mBuilder.mLowerMasks.data() );
     }
 }// CoarsenGrid<BuildT>::coarsenInternalNodes
 

--- a/nanovdb/nanovdb/tools/cuda/PruneGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/PruneGrid.cuh
@@ -213,7 +213,7 @@ void PruneGrid<BuildT>::pruneInternalNodes()
     if (auto srcLeafCount = mSrcTreeData.mNodeCount[0]) { // Unless it's an empty grid
         util::cuda::lambdaKernel<<<numBlocks(srcLeafCount), mNumThreads, 0, mStream>>>(
             srcLeafCount, util::morphology::cuda::PruneInternalNodesFunctor<BuildT>(),
-            mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mDeviceSrcLeafMask, mBuilder.mUpperMasks.deviceData(), mBuilder.mLowerMasks.deviceData() );
+            mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mDeviceSrcLeafMask, mBuilder.mUpperMasks.data(), mBuilder.mLowerMasks.data() );
     }
 }// PruneGrid<BuildT>::pruneInternalNodes
 

--- a/nanovdb/nanovdb/tools/cuda/RefineGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/RefineGrid.cuh
@@ -225,7 +225,7 @@ void RefineGrid<BuildT>::refineInternalNodes()
     if (auto srcLeafCount = mSrcTreeData.mNodeCount[0]) { // Unless it's an empty grid
         util::cuda::lambdaKernel<<<numBlocks(srcLeafCount), mNumThreads, 0, mStream>>>(
             srcLeafCount, util::morphology::cuda::RefineInternalNodesFunctor<BuildT>(),
-            mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.mUpperMasks.deviceData(), mBuilder.mLowerMasks.deviceData() );
+            mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.mUpperMasks.data(), mBuilder.mLowerMasks.data() );
     }
 }// RefineGrid<BuildT>::refineInternalNodes
 

--- a/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
+++ b/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
@@ -17,6 +17,8 @@
 
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/cuda/TempPool.h>
+#include <nanovdb/cuda/Buffer.h>
+#include <nanovdb/cuda/DeviceResource.h>
 #include <nanovdb/cuda/DeviceBuffer.h>
 #include <nanovdb/util/cuda/Morphology.cuh>
 
@@ -24,7 +26,25 @@ namespace nanovdb {
 
 namespace tools::cuda {
 
+/// @brief Shared grid/tree offsets and node counts handed to the device
+///        functors. Independent of the resource the builder allocates from,
+///        so it lives outside TopologyBuilder and stays one type across every
+///        ResourceT instantiation.
 template <typename BuildT>
+struct TopologyBuilderData {
+    void     *d_bufferPtr;
+    uint64_t grid, tree, root, upper, lower, leaf, size;// byte offsets to nodes in buffer
+    uint32_t nodeCount[3];// 0=leaf,1=lower, 2=upper
+    uint32_t *d_upperOffsets;
+    __hostdev__ NanoGrid<BuildT>&  getGrid() const {return *util::PtrAdd<NanoGrid<BuildT>>(d_bufferPtr, grid);}
+    __hostdev__ NanoTree<BuildT>&  getTree() const {return *util::PtrAdd<NanoTree<BuildT>>(d_bufferPtr, tree);}
+    __hostdev__ NanoRoot<BuildT>&  getRoot() const {return *util::PtrAdd<NanoRoot<BuildT>>(d_bufferPtr, root);}
+    __hostdev__ NanoUpper<BuildT>& getUpper(int i) const {return *(util::PtrAdd<NanoUpper<BuildT>>(d_bufferPtr, upper)+i);}
+    __hostdev__ NanoLower<BuildT>& getLower(int i) const {return *(util::PtrAdd<NanoLower<BuildT>>(d_bufferPtr, lower)+i);}
+    __hostdev__ NanoLeaf<BuildT>&  getLeaf(int i) const {return *(util::PtrAdd<NanoLeaf<BuildT>>(d_bufferPtr, leaf)+i);}
+};// TopologyBuilderData
+
+template <typename BuildT, typename ResourceT = nanovdb::cuda::DeviceResource>
 class TopologyBuilder
 {
     static_assert(nanovdb::BuildTraits<BuildT>::is_onindex);// For now, only OnIndexGrids supported
@@ -36,25 +56,25 @@ class TopologyBuilder
     using LowerT = NanoLower<BuildT>;
     using LeafT  = NanoLeaf<BuildT>;
 
+    /// @brief Device-only scratch storage, allocated from the injected
+    ///        resource. These buffers are never read on the host, so they use
+    ///        the single-space Buffer rather than the dual DeviceBuffer, whose
+    ///        host pointer and per-device array they would leave unused.
+    using ScratchT = nanovdb::cuda::Buffer<std::byte, ResourceT>;
+
 public:
 
-    TopologyBuilder(cudaStream_t stream)
+    /// @param stream cuda stream the scratch allocations are ordered on
+    /// @param resource resource instance all device scratch is allocated from;
+    ///        must outlive this builder
+    TopologyBuilder(cudaStream_t stream, ResourceT& resource = nanovdb::cuda::default_resource<ResourceT>())
+        : mResource(&resource)
+        , mTempDevicePool(resource)
     {
         mData = nanovdb::cuda::DeviceBuffer::create(sizeof(Data));
     }
 
-    struct Data {
-        void     *d_bufferPtr;
-        uint64_t grid, tree, root, upper, lower, leaf, size;// byte offsets to nodes in buffer
-        uint32_t nodeCount[3];// 0=leaf,1=lower, 2=upper
-        uint32_t *d_upperOffsets;
-        __hostdev__ GridT&  getGrid() const {return *util::PtrAdd<GridT>(d_bufferPtr, grid);}
-        __hostdev__ TreeT&  getTree() const {return *util::PtrAdd<TreeT>(d_bufferPtr, tree);}
-        __hostdev__ RootT&  getRoot() const {return *util::PtrAdd<RootT>(d_bufferPtr, root);}
-        __hostdev__ UpperT& getUpper(int i) const {return *(util::PtrAdd<UpperT>(d_bufferPtr, upper)+i);}
-        __hostdev__ LowerT& getLower(int i) const {return *(util::PtrAdd<LowerT>(d_bufferPtr, lower)+i);}
-        __hostdev__ LeafT&  getLeaf(int i) const {return *(util::PtrAdd<LeafT>(d_bufferPtr, leaf)+i);}
-    };// Data
+    using Data = TopologyBuilderData<BuildT>;
 
     void allocateInternalMaskBuffers(cudaStream_t stream);
 
@@ -74,21 +94,21 @@ public:
     void postProcessGridTree(cudaStream_t stream);
 
     nanovdb::cuda::DeviceBuffer  mProcessedRoot;
-    nanovdb::cuda::DeviceBuffer  mUpperMasks;
-    nanovdb::cuda::DeviceBuffer  mLowerMasks;
-    nanovdb::cuda::DeviceBuffer  mUpperOffsets;
-    nanovdb::cuda::DeviceBuffer  mLowerOffsets;
-    nanovdb::cuda::DeviceBuffer  mLeafOffsets;
-    nanovdb::cuda::DeviceBuffer  mVoxelOffsets;
-    nanovdb::cuda::DeviceBuffer  mLowerParents;
-    nanovdb::cuda::DeviceBuffer  mLeafParents;
+    ScratchT                     mUpperMasks;
+    ScratchT                     mLowerMasks;
+    ScratchT                     mUpperOffsets;
+    ScratchT                     mLowerOffsets;
+    ScratchT                     mLeafOffsets;
+    ScratchT                     mVoxelOffsets;
+    ScratchT                     mLowerParents;
+    ScratchT                     mLeafParents;
     nanovdb::cuda::DeviceBuffer  mData;
     CheckMode                    mChecksum{CheckMode::Disable};
 
     auto deviceProcessedRoot() { return static_cast<RootT*>(mProcessedRoot.deviceData()); }
     auto hostProcessedRoot()   { return static_cast<RootT*>(mProcessedRoot.data()); }
-    void* deviceUpperMasks() { return mUpperMasks.deviceData(); }
-    void* deviceLowerMasks() { return mLowerMasks.deviceData(); }
+    void* deviceUpperMasks() { return mUpperMasks.data(); }
+    void* deviceLowerMasks() { return mLowerMasks.data(); }
     Data* data()             { return static_cast<Data*>(mData.data()); }
     Data* deviceData()       { return static_cast<Data*>(mData.deviceData()); }
 
@@ -96,8 +116,9 @@ private:
     static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
     static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
 
-    nanovdb::cuda::TempDevicePool mTempDevicePool;
-};// tools::cuda::TopologyBuilder<BuildT>
+    ResourceT*                        mResource;// non-owning; all device scratch routes through this instance
+    nanovdb::cuda::TempPool<ResourceT> mTempDevicePool;
+};// tools::cuda::TopologyBuilder<BuildT, ResourceT>
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -118,8 +139,8 @@ private:
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void TopologyBuilder<BuildT>::allocateInternalMaskBuffers(cudaStream_t stream)
+template<typename BuildT, typename ResourceT>
+void TopologyBuilder<BuildT, ResourceT>::allocateInternalMaskBuffers(cudaStream_t stream)
 {
     if (hostProcessedRoot()->tileCount() == 0) return; // Processing empty grid(s); nothing to allocate
 
@@ -130,18 +151,18 @@ void TopologyBuilder<BuildT>::allocateInternalMaskBuffers(cudaStream_t stream)
     cudaGetDevice(&device);
     uint64_t upperSize = hostProcessedRoot()->tileCount() * sizeof(Mask<5>);
     uint64_t lowerSize = hostProcessedRoot()->tileCount() * Mask<5>::SIZE * sizeof(Mask<4>);
-    mUpperMasks = nanovdb::cuda::DeviceBuffer::create(upperSize, nullptr, device, stream);
-    if (mUpperMasks.deviceData() == nullptr) throw std::runtime_error("Failed to allocate upper mask buffer on device");
-    cudaCheck(cudaMemsetAsync(mUpperMasks.deviceData(), 0, upperSize, stream));
-    mLowerMasks = nanovdb::cuda::DeviceBuffer::create( lowerSize, nullptr, device, stream );
-    if (mLowerMasks.deviceData() == nullptr) throw std::runtime_error("Failed to allocate lower mask buffer on device");
-    cudaCheck(cudaMemsetAsync(mLowerMasks.deviceData(), 0, lowerSize, stream));
-}// TopologyBuilder<BuildT>::allocateInternalMaskBuffers
+    mUpperMasks = ScratchT(stream, *mResource, upperSize, nanovdb::cuda::noInit);
+    if (mUpperMasks.data() == nullptr) throw std::runtime_error("Failed to allocate upper mask buffer on device");
+    cudaCheck(cudaMemsetAsync(mUpperMasks.data(), 0, upperSize, stream));
+    mLowerMasks = ScratchT(stream, *mResource, lowerSize, nanovdb::cuda::noInit);
+    if (mLowerMasks.data() == nullptr) throw std::runtime_error("Failed to allocate lower mask buffer on device");
+    cudaCheck(cudaMemsetAsync(mLowerMasks.data(), 0, lowerSize, stream));
+}// TopologyBuilder<BuildT, ResourceT>::allocateInternalMaskBuffers
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT>
-void TopologyBuilder<BuildT>::countNodes(cudaStream_t stream)
+template<typename BuildT, typename ResourceT>
+void TopologyBuilder<BuildT, ResourceT>::countNodes(cudaStream_t stream)
 {
     auto processedTileCount = hostProcessedRoot()->tileCount();
     if (processedTileCount == 0) { // Processing empty grid(s); zero nodes at all levels
@@ -157,57 +178,57 @@ void TopologyBuilder<BuildT>::countNodes(cudaStream_t stream)
 
     int device = 0;
     cudaGetDevice(&device);
-    nanovdb::cuda::DeviceBuffer upperCountsBuffer = nanovdb::cuda::DeviceBuffer::create(processedTileCount*sizeof(uint32_t), nullptr, device, stream);
-    nanovdb::cuda::DeviceBuffer lowerCountsBuffer = nanovdb::cuda::DeviceBuffer::create(size*sizeof(uint32_t), nullptr, device, stream);
-    nanovdb::cuda::DeviceBuffer leafCountsBuffer = nanovdb::cuda::DeviceBuffer::create(size*sizeof(uint32_t), nullptr, device, stream);
+    ScratchT upperCountsBuffer = ScratchT(stream, *mResource, processedTileCount*sizeof(uint32_t), nanovdb::cuda::noInit);
+    ScratchT lowerCountsBuffer = ScratchT(stream, *mResource, size*sizeof(uint32_t), nanovdb::cuda::noInit);
+    ScratchT leafCountsBuffer = ScratchT(stream, *mResource, size*sizeof(uint32_t), nanovdb::cuda::noInit);
 
     using CountType = uint32_t (*)[Mask<5>::SIZE];
-    auto lowerCounts = reinterpret_cast<CountType>( lowerCountsBuffer.deviceData() );
-    auto leafCounts = reinterpret_cast<CountType>( leafCountsBuffer.deviceData() );
+    auto lowerCounts = reinterpret_cast<CountType>(lowerCountsBuffer.data());
+    auto leafCounts = reinterpret_cast<CountType>(leafCountsBuffer.data());
 
     using Op = util::morphology::cuda::EnumerateNodesFunctor;
     util::cuda::operatorKernel<Op>
         <<<dim3(processedTileCount, Op::SlicesPerUpperNode, 1), Op::MaxThreadsPerBlock, 0, stream>>>
         (deviceUpperMasks(), deviceLowerMasks(), lowerCounts, leafCounts);
 
-    mUpperOffsets = nanovdb::cuda::DeviceBuffer::create((processedTileCount+1)*sizeof(uint32_t), nullptr, device, stream);
-    mLowerOffsets = nanovdb::cuda::DeviceBuffer::create((size+1)*sizeof(uint32_t), nullptr, device, stream);
-    mLeafOffsets = nanovdb::cuda::DeviceBuffer::create((size+1)*sizeof(uint32_t), nullptr, device, stream);
+    mUpperOffsets = ScratchT(stream, *mResource, (processedTileCount+1)*sizeof(uint32_t), nanovdb::cuda::noInit);
+    mLowerOffsets = ScratchT(stream, *mResource, (size+1)*sizeof(uint32_t), nanovdb::cuda::noInit);
+    mLeafOffsets = ScratchT(stream, *mResource, (size+1)*sizeof(uint32_t), nanovdb::cuda::noInit);
 
-    cudaCheck(cudaMemsetAsync(mLowerOffsets.deviceData(), 0, sizeof(uint32_t), stream));
+    cudaCheck(cudaMemsetAsync(mLowerOffsets.data(), 0, sizeof(uint32_t), stream));
     CALL_CUBS(DeviceScan::InclusiveSum,
-        static_cast<uint32_t*>(lowerCountsBuffer.deviceData()),
-        static_cast<uint32_t*>(mLowerOffsets.deviceData())+1,
+        reinterpret_cast<uint32_t*>(lowerCountsBuffer.data()),
+        reinterpret_cast<uint32_t*>(mLowerOffsets.data())+1,
         size);
-    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[1], static_cast<uint32_t*>(mLowerOffsets.deviceData())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[1], reinterpret_cast<uint32_t*>(mLowerOffsets.data())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
 
-    cudaCheck(cudaMemsetAsync(mLeafOffsets.deviceData(), 0, sizeof(uint32_t), stream));
+    cudaCheck(cudaMemsetAsync(mLeafOffsets.data(), 0, sizeof(uint32_t), stream));
     CALL_CUBS(DeviceScan::InclusiveSum,
-        static_cast<uint32_t*>(leafCountsBuffer.deviceData()),
-        static_cast<uint32_t*>(mLeafOffsets.deviceData())+1,
+        reinterpret_cast<uint32_t*>(leafCountsBuffer.data()),
+        reinterpret_cast<uint32_t*>(mLeafOffsets.data())+1,
         size);
-    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[0], static_cast<uint32_t*>(mLeafOffsets.deviceData())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[0], reinterpret_cast<uint32_t*>(mLeafOffsets.data())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
 
     util::cuda::lambdaKernel<<<numBlocks(processedTileCount), mNumThreads, 0, stream>>>(
         processedTileCount,
         [] __device__(size_t tileID, CountType lowerOffsets, uint32_t* upperCounts)
             { upperCounts[tileID] = (lowerOffsets[tileID+1][0] > lowerOffsets[tileID][0]) ? 1 : 0; },
-        static_cast<CountType>(mLowerOffsets.deviceData()),
-        static_cast<uint32_t*>(upperCountsBuffer.deviceData()));
+        reinterpret_cast<CountType>(mLowerOffsets.data()),
+        reinterpret_cast<uint32_t*>(upperCountsBuffer.data()));
 
-    cudaCheck(cudaMemsetAsync( mUpperOffsets.deviceData(), 0, sizeof(uint32_t), stream));
+    cudaCheck(cudaMemsetAsync( mUpperOffsets.data(), 0, sizeof(uint32_t), stream));
     CALL_CUBS(DeviceScan::InclusiveSum,
-        static_cast<uint32_t*>(upperCountsBuffer.deviceData()),
-        static_cast<uint32_t*>(mUpperOffsets.deviceData())+1,
+        reinterpret_cast<uint32_t*>(upperCountsBuffer.data()),
+        reinterpret_cast<uint32_t*>(mUpperOffsets.data())+1,
         processedTileCount);
-    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[2], static_cast<uint32_t*>(mUpperOffsets.deviceData())+processedTileCount, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
-}// TopologyBuilder<BuildT>::countNodes
+    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[2], reinterpret_cast<uint32_t*>(mUpperOffsets.data())+processedTileCount, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+}// TopologyBuilder<BuildT, ResourceT>::countNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT>
+template <typename BuildT, typename ResourceT>
 template <typename BufferT>
-BufferT TopologyBuilder<BuildT>::getBuffer(const BufferT &pool, cudaStream_t stream)
+BufferT TopologyBuilder<BuildT, ResourceT>::getBuffer(const BufferT &pool, cudaStream_t stream)
 {
     // Allocates a device buffer for the destination grid, once the topology/size of the tree is known
     data()->grid  = 0;// grid is always stored at the start of the buffer!
@@ -226,11 +247,11 @@ BufferT TopologyBuilder<BuildT>::getBuffer(const BufferT &pool, cudaStream_t str
     data()->d_bufferPtr = buffer.deviceData();
     if (data()->d_bufferPtr == nullptr) throw std::runtime_error("Failed to allocate grid buffer on the device");
     if (data()->nodeCount[2] != 0) // Unless the result is an empty grid
-        data()->d_upperOffsets = static_cast<uint32_t*>(mUpperOffsets.deviceData());
+        data()->d_upperOffsets = reinterpret_cast<uint32_t*>(mUpperOffsets.data());
     mData.deviceUpload(device, stream, false);
 
     return buffer;
-}// TopologyBuilder<BuildT>::getBuffer
+}// TopologyBuilder<BuildT, ResourceT>::getBuffer
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -240,7 +261,7 @@ template <typename BuildT>
 struct BuildGridTreeRootFunctor
 {
     __device__
-    void operator()(size_t, typename TopologyBuilder<BuildT>::Data *d_data) {
+    void operator()(size_t, TopologyBuilderData<BuildT> *d_data) {
 
         // process Root
         auto &root = d_data->getRoot();
@@ -320,7 +341,7 @@ struct InitGridTreeRootFunctor
     Map map; // transform to embed in the output grid
 
     __device__
-    void operator()(size_t, typename TopologyBuilder<BuildT>::Data *d_data) {
+    void operator()(size_t, TopologyBuilderData<BuildT> *d_data) {
 
         // process Root (identical to BuildGridTreeRootFunctor)
         auto &root = d_data->getRoot();
@@ -389,7 +410,7 @@ template <typename BuildT>
 struct BuildUpperNodesFunctor
 {
     __device__
-    void operator()(size_t processedTileID, typename TopologyBuilder<BuildT>::Data *d_data, NanoRoot<BuildT> *d_processedRoot) {
+    void operator()(size_t processedTileID, TopologyBuilderData<BuildT> *d_data, NanoRoot<BuildT> *d_processedRoot) {
         uint32_t tileID = d_data->d_upperOffsets[processedTileID];
         if (tileID != d_data->d_upperOffsets[processedTileID+1]) // if the offsets are the same, this was a speculatively introduced tile which was not necessary
         {
@@ -406,8 +427,8 @@ struct BuildUpperNodesFunctor
 
 }// namespace topology::detail
 
-template <typename BuildT>
-inline void TopologyBuilder<BuildT>::processUpperNodes(cudaStream_t stream)
+template<typename BuildT, typename ResourceT>
+inline void TopologyBuilder<BuildT, ResourceT>::processUpperNodes(cudaStream_t stream)
 {
     // Connect all newly allocated upper nodes to their respective tiles
     // Also fill in any necessary part of the preamble (in InternalData) of upper nodes
@@ -418,12 +439,12 @@ inline void TopologyBuilder<BuildT>::processUpperNodes(cudaStream_t stream)
             processedTileCount, topology::detail::BuildUpperNodesFunctor<BuildT>(), deviceData(), deviceProcessedRoot());
         cudaCheckError();
     }
-}// TopologyBuilder<BuildT>::processUpperNodes
+}// TopologyBuilder<BuildT, ResourceT>::processUpperNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT>
-inline void TopologyBuilder<BuildT>::processLowerNodes(cudaStream_t stream)
+template<typename BuildT, typename ResourceT>
+inline void TopologyBuilder<BuildT, ResourceT>::processLowerNodes(cudaStream_t stream)
 {
     // Fill out the contents of all newly allocated lower nodes (using the densified upper/lower mask arrays)
     // Also fill in the preamble (most of LeafData) for their leaf children
@@ -434,31 +455,31 @@ inline void TopologyBuilder<BuildT>::processLowerNodes(cudaStream_t stream)
         int device = 0;
         cudaGetDevice(&device);
         std::size_t lowerCount = data()->nodeCount[1];
-        mLowerParents = nanovdb::cuda::DeviceBuffer::create(lowerCount*sizeof(uint32_t), nullptr, device, stream);
+        mLowerParents = ScratchT(stream, *mResource, lowerCount*sizeof(uint32_t), nanovdb::cuda::noInit);
         std::size_t leafCount = data()->nodeCount[0];
-        mLeafParents = nanovdb::cuda::DeviceBuffer::create(leafCount*sizeof(uint32_t), nullptr, device, stream);
+        mLeafParents = ScratchT(stream, *mResource, leafCount*sizeof(uint32_t), nanovdb::cuda::noInit);
 
         using Op = util::morphology::cuda::ProcessLowerNodesFunctor<BuildT>;
         util::cuda::operatorKernel<Op>
             <<<dim3(processedTileCount, Op::SlicesPerUpperNode, 1), Op::MaxThreadsPerBlock, 0, stream>>>(
                 deviceUpperMasks(),
                 deviceLowerMasks(),
-                static_cast<uint32_t*>(mUpperOffsets.deviceData()),
-                static_cast<CountType>(mLowerOffsets.deviceData()),
-                static_cast<CountType>(mLeafOffsets.deviceData()),
+                reinterpret_cast<uint32_t*>(mUpperOffsets.data()),
+                reinterpret_cast<CountType>(mLowerOffsets.data()),
+                reinterpret_cast<CountType>(mLeafOffsets.data()),
                 static_cast<GridT*>(data()->d_bufferPtr),
-                static_cast<uint32_t*>(mLowerParents.deviceData()),
-                static_cast<uint32_t*>(mLeafParents.deviceData())
+                reinterpret_cast<uint32_t*>(mLowerParents.data()),
+                reinterpret_cast<uint32_t*>(mLeafParents.data())
             );
         cudaCheckError();
     }
 
     mProcessedRoot.clear(stream);
-    mUpperMasks.clear(stream);
-    mLowerMasks.clear(stream);
-    mLowerOffsets.clear(stream);
-    mLeafOffsets.clear(stream);
-}// TopologyBuilder<BuildT>::processLowerNodes
+    mUpperMasks.destroy();
+    mLowerMasks.destroy();
+    mLowerOffsets.destroy();
+    mLeafOffsets.destroy();
+}// TopologyBuilder<BuildT, ResourceT>::processLowerNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -468,7 +489,7 @@ template <typename BuildT>
 struct UpdateLeafVoxelCountsAndPrefixSumFunctor
 {
     __device__
-    void operator()(size_t leafID, typename TopologyBuilder<BuildT>::Data *d_data, uint64_t *d_voxelCounts) {
+    void operator()(size_t leafID, TopologyBuilderData<BuildT> *d_data, uint64_t *d_voxelCounts) {
         auto &leaf = d_data->getGrid().tree().template getFirstNode<0>()[leafID];
         const uint64_t *w = leaf.mValueMask.words();
         uint64_t prefixSum = 0, sum = util::countOn(*w++);
@@ -485,32 +506,32 @@ template <typename BuildT>
 struct UpdateLeafVoxelOffsetsFunctor
 {
     __device__
-    void operator()(size_t leafID, typename TopologyBuilder<BuildT>::Data *d_data, uint64_t *d_voxelOffsets) {
+    void operator()(size_t leafID, TopologyBuilderData<BuildT> *d_data, uint64_t *d_voxelOffsets) {
         auto &leaf = d_data->getGrid().tree().template getFirstNode<0>()[leafID];
         leaf.mOffset = d_voxelOffsets[leafID]+1; }
 };
 
 }// namespace topology::detail
 
-template<typename BuildT>
-inline void TopologyBuilder<BuildT>::processLeafOffsets(cudaStream_t stream)
+template<typename BuildT, typename ResourceT>
+inline void TopologyBuilder<BuildT, ResourceT>::processLeafOffsets(cudaStream_t stream)
 {
     int device = 0;
     cudaGetDevice(&device);
     std::size_t leafCount = data()->nodeCount[0];
     if (leafCount) { // Unless output grid is empty
-        mVoxelOffsets = nanovdb::cuda::DeviceBuffer::create((leafCount+1)*sizeof(uint64_t), nullptr, device, stream);
-        cudaCheck(cudaMemsetAsync(mVoxelOffsets.deviceData(), 0, sizeof(uint64_t), stream));
+        mVoxelOffsets = ScratchT(stream, *mResource, (leafCount+1)*sizeof(uint64_t), nanovdb::cuda::noInit);
+        cudaCheck(cudaMemsetAsync(mVoxelOffsets.data(), 0, sizeof(uint64_t), stream));
         util::cuda::lambdaKernel<<<numBlocks(leafCount), mNumThreads, 0, stream>>>(
-            leafCount, topology::detail::UpdateLeafVoxelCountsAndPrefixSumFunctor<BuildT>(), deviceData(), static_cast<uint64_t*>(mVoxelOffsets.deviceData())+1);
+            leafCount, topology::detail::UpdateLeafVoxelCountsAndPrefixSumFunctor<BuildT>(), deviceData(), reinterpret_cast<uint64_t*>(mVoxelOffsets.data())+1);
         CALL_CUBS(DeviceScan::InclusiveSum,
-            static_cast<uint64_t*>(mVoxelOffsets.deviceData())+1,
-            static_cast<uint64_t*>(mVoxelOffsets.deviceData())+1,
+            reinterpret_cast<uint64_t*>(mVoxelOffsets.data())+1,
+            reinterpret_cast<uint64_t*>(mVoxelOffsets.data())+1,
             leafCount);
         util::cuda::lambdaKernel<<<numBlocks(leafCount), mNumThreads, 0, stream>>>(
-            leafCount, topology::detail::UpdateLeafVoxelOffsetsFunctor<BuildT>(), deviceData(), static_cast<uint64_t*>(mVoxelOffsets.deviceData()));
+            leafCount, topology::detail::UpdateLeafVoxelOffsetsFunctor<BuildT>(), deviceData(), reinterpret_cast<uint64_t*>(mVoxelOffsets.data()));
     }
-}// TopologyBuilder<BuildT>::processLeafOffsets
+}// TopologyBuilder<BuildT, ResourceT>::processLeafOffsets
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -527,7 +548,7 @@ template <typename BuildT>
 struct UpdateAndPropagateLeafBBoxFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data, const uint32_t* leafParents) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data, const uint32_t* leafParents) {
         auto &lower = d_data->getLower(leafParents[tid]);
         auto &leaf = d_data->getLeaf(tid);
         leaf.updateBBox();
@@ -539,7 +560,7 @@ template <typename BuildT>
 struct PropagateLowerBBoxFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data, const uint32_t* lowerParents) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data, const uint32_t* lowerParents) {
         auto &upper = d_data->getUpper(lowerParents[tid]);
         auto &lower = d_data->getLower(tid);
         upper.mBBox.expandAtomic(lower.bbox()); }
@@ -549,7 +570,7 @@ template <typename BuildT>
 struct PropagateUpperBBoxFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data) {
         d_data->getRoot().mBBox.expandAtomic(d_data->getUpper(tid).bbox());
     }
 };
@@ -558,7 +579,7 @@ template <typename BuildT>
 struct UpdateRootWorldBBoxFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data) {
         // TODO: check that the correct semantics are followed in this transformation
         auto BBox = d_data->getRoot().mBBox;
         BBox.max() += 1;
@@ -569,8 +590,8 @@ struct UpdateRootWorldBBoxFunctor
 
 }// namespace topology::detail
 
-template <typename BuildT>
-inline void TopologyBuilder<BuildT>::processBBox(cudaStream_t stream)
+template<typename BuildT, typename ResourceT>
+inline void TopologyBuilder<BuildT, ResourceT>::processBBox(cudaStream_t stream)
 {
     if (data()->nodeCount[0] == 0) return; // Output grid is empty; retain empty bounding box
 
@@ -578,14 +599,14 @@ inline void TopologyBuilder<BuildT>::processBBox(cudaStream_t stream)
 
     // update and propagate bbox from leaf -> lower/parent nodes
     util::cuda::lambdaKernel<<<numBlocks(data()->nodeCount[0]), mNumThreads, 0, stream>>>(
-        data()->nodeCount[0], topology::detail::UpdateAndPropagateLeafBBoxFunctor<BuildT>(), deviceData(), static_cast<uint32_t*>(mLeafParents.deviceData()));
-    mLeafParents.clear(stream);
+        data()->nodeCount[0], topology::detail::UpdateAndPropagateLeafBBoxFunctor<BuildT>(), deviceData(), reinterpret_cast<uint32_t*>(mLeafParents.data()));
+    mLeafParents.destroy();
     cudaCheckError();
 
     // propagate bbox from lower -> upper/parent node
     util::cuda::lambdaKernel<<<numBlocks(data()->nodeCount[1]), mNumThreads, 0, stream>>>(
-        data()->nodeCount[1], topology::detail::PropagateLowerBBoxFunctor<BuildT>(), deviceData(), static_cast<uint32_t*>(mLowerParents.deviceData()));
-    mLowerParents.clear(stream);
+        data()->nodeCount[1], topology::detail::PropagateLowerBBoxFunctor<BuildT>(), deviceData(), reinterpret_cast<uint32_t*>(mLowerParents.data()));
+    mLowerParents.destroy();
     cudaCheckError();
 
     // propagate bbox from upper -> root/parent node
@@ -595,7 +616,7 @@ inline void TopologyBuilder<BuildT>::processBBox(cudaStream_t stream)
     // update the world-bbox in the root node
     util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, topology::detail::UpdateRootWorldBBoxFunctor<BuildT>(), deviceData());
     cudaCheckError();
-}// TopologyBuilder<BuildT>::processBBox
+}// TopologyBuilder<BuildT, ResourceT>::processBBox
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -605,7 +626,7 @@ template <typename BuildT>
 struct PostProcessGridTreeFunctor
 {
     __device__
-    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data, uint64_t* d_voxelOffsets) {
+    void operator()(size_t tid, TopologyBuilderData<BuildT> *d_data, uint64_t* d_voxelOffsets) {
         auto& grid = d_data->getGrid();
         auto& tree = grid.tree();
         auto leafCount = tree.mNodeCount[0];
@@ -616,17 +637,17 @@ struct PostProcessGridTreeFunctor
 
 }// namespace topology::detail
 
-template <typename BuildT>
-inline void TopologyBuilder<BuildT>::postProcessGridTree(cudaStream_t stream)
+template<typename BuildT, typename ResourceT>
+inline void TopologyBuilder<BuildT, ResourceT>::postProcessGridTree(cudaStream_t stream)
 {
     // Finish updates to GridData/TreeData and (optionally) update checksum
     if (data()->nodeCount[0]) // if grid is empty, the default values are correct
-        util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, topology::detail::PostProcessGridTreeFunctor<BuildT>(), deviceData(), static_cast<uint64_t*>(mVoxelOffsets.deviceData()));
+        util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, topology::detail::PostProcessGridTreeFunctor<BuildT>(), deviceData(), reinterpret_cast<uint64_t*>(mVoxelOffsets.data()));
     cudaCheckError();
-    mVoxelOffsets.clear(stream);
+    mVoxelOffsets.destroy();
 
     tools::cuda::updateChecksum((GridData*)data()->d_bufferPtr, mChecksum, stream);
-}// TopologyBuilder<BuildT>::postProcessGridTree
+}// TopologyBuilder<BuildT, ResourceT>::postProcessGridTree
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
+++ b/nanovdb/nanovdb/tools/cuda/TopologyBuilder.cuh
@@ -147,8 +147,6 @@ void TopologyBuilder<BuildT, ResourceT>::allocateInternalMaskBuffers(cudaStream_
     // Allocate (and zero-fill) buffers large enough to hold:
     // (a) The serialized masks of all upper nodes, for all tiles in the updated root node, and
     // (b) The serialized masks of all densified lower nodes, as if every upper node had a full set of 32^3 lower children
-    int device = 0;
-    cudaGetDevice(&device);
     uint64_t upperSize = hostProcessedRoot()->tileCount() * sizeof(Mask<5>);
     uint64_t lowerSize = hostProcessedRoot()->tileCount() * Mask<5>::SIZE * sizeof(Mask<4>);
     mUpperMasks = ScratchT(stream, *mResource, upperSize, nanovdb::cuda::noInit);
@@ -176,8 +174,6 @@ void TopologyBuilder<BuildT, ResourceT>::countNodes(cudaStream_t stream)
     // as well as the tile table at the root.
     std::size_t size = processedTileCount*Mask<5>::SIZE;
 
-    int device = 0;
-    cudaGetDevice(&device);
     ScratchT upperCountsBuffer = ScratchT(stream, *mResource, processedTileCount*sizeof(uint32_t), nanovdb::cuda::noInit);
     ScratchT lowerCountsBuffer = ScratchT(stream, *mResource, size*sizeof(uint32_t), nanovdb::cuda::noInit);
     ScratchT leafCountsBuffer = ScratchT(stream, *mResource, size*sizeof(uint32_t), nanovdb::cuda::noInit);
@@ -452,8 +448,6 @@ inline void TopologyBuilder<BuildT, ResourceT>::processLowerNodes(cudaStream_t s
     using CountType = uint32_t (*)[Mask<5>::SIZE];
  
     if (processedTileCount) { // Unless output grid is empty
-        int device = 0;
-        cudaGetDevice(&device);
         std::size_t lowerCount = data()->nodeCount[1];
         mLowerParents = ScratchT(stream, *mResource, lowerCount*sizeof(uint32_t), nanovdb::cuda::noInit);
         std::size_t leafCount = data()->nodeCount[0];
@@ -475,10 +469,10 @@ inline void TopologyBuilder<BuildT, ResourceT>::processLowerNodes(cudaStream_t s
     }
 
     mProcessedRoot.clear(stream);
-    mUpperMasks.destroy();
-    mLowerMasks.destroy();
-    mLowerOffsets.destroy();
-    mLeafOffsets.destroy();
+    mUpperMasks.destroy(stream);
+    mLowerMasks.destroy(stream);
+    mLowerOffsets.destroy(stream);
+    mLeafOffsets.destroy(stream);
 }// TopologyBuilder<BuildT, ResourceT>::processLowerNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -516,8 +510,6 @@ struct UpdateLeafVoxelOffsetsFunctor
 template<typename BuildT, typename ResourceT>
 inline void TopologyBuilder<BuildT, ResourceT>::processLeafOffsets(cudaStream_t stream)
 {
-    int device = 0;
-    cudaGetDevice(&device);
     std::size_t leafCount = data()->nodeCount[0];
     if (leafCount) { // Unless output grid is empty
         mVoxelOffsets = ScratchT(stream, *mResource, (leafCount+1)*sizeof(uint64_t), nanovdb::cuda::noInit);
@@ -600,13 +592,13 @@ inline void TopologyBuilder<BuildT, ResourceT>::processBBox(cudaStream_t stream)
     // update and propagate bbox from leaf -> lower/parent nodes
     util::cuda::lambdaKernel<<<numBlocks(data()->nodeCount[0]), mNumThreads, 0, stream>>>(
         data()->nodeCount[0], topology::detail::UpdateAndPropagateLeafBBoxFunctor<BuildT>(), deviceData(), reinterpret_cast<uint32_t*>(mLeafParents.data()));
-    mLeafParents.destroy();
+    mLeafParents.destroy(stream);
     cudaCheckError();
 
     // propagate bbox from lower -> upper/parent node
     util::cuda::lambdaKernel<<<numBlocks(data()->nodeCount[1]), mNumThreads, 0, stream>>>(
         data()->nodeCount[1], topology::detail::PropagateLowerBBoxFunctor<BuildT>(), deviceData(), reinterpret_cast<uint32_t*>(mLowerParents.data()));
-    mLowerParents.destroy();
+    mLowerParents.destroy(stream);
     cudaCheckError();
 
     // propagate bbox from upper -> root/parent node
@@ -644,7 +636,7 @@ inline void TopologyBuilder<BuildT, ResourceT>::postProcessGridTree(cudaStream_t
     if (data()->nodeCount[0]) // if grid is empty, the default values are correct
         util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, topology::detail::PostProcessGridTreeFunctor<BuildT>(), deviceData(), reinterpret_cast<uint64_t*>(mVoxelOffsets.data()));
     cudaCheckError();
-    mVoxelOffsets.destroy();
+    mVoxelOffsets.destroy(stream);
 
     tools::cuda::updateChecksum((GridData*)data()->d_bufferPtr, mChecksum, stream);
 }// TopologyBuilder<BuildT, ResourceT>::postProcessGridTree

--- a/nanovdb/nanovdb/unittest/TestBuffer.cu
+++ b/nanovdb/nanovdb/unittest/TestBuffer.cu
@@ -258,9 +258,65 @@ TEST(TestBuffer, ClearFreesAndEmpties)
     ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
 }
 
+TEST(TestBuffer, DestroyIsTheSpellingClearDelegatesTo)
+{
+    Counters c;
+    nanovdb::cuda::Buffer<float, CountingResource> buf(0, CountingResource{&c}, 64, nanovdb::cuda::noInit);
+    ASSERT_EQ(c.allocs, 1);
+    buf.destroy();               // cuda::buffer's spelling
+    EXPECT_EQ(buf.data(), nullptr);
+    EXPECT_EQ(buf.size(), 0u);
+    EXPECT_EQ(c.deallocs, 1);
+    buf.destroy();               // idempotent
+    EXPECT_EQ(c.deallocs, 1);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
+TEST(TestBuffer, DestroyOnStreamRetargetsTheFree)
+{
+    cudaStream_t a, b;
+    ASSERT_EQ(cudaStreamCreate(&a), cudaSuccess);
+    ASSERT_EQ(cudaStreamCreate(&b), cudaSuccess);
+    {
+        StreamLog log;
+        nanovdb::cuda::Buffer<float, StreamRecordingResource> buf(a, StreamRecordingResource{&log}, 32, nanovdb::cuda::noInit);
+        ASSERT_EQ(log.allocStreams.size(), 1u);
+        EXPECT_EQ(log.allocStreams[0], a);   // allocated on a
+        buf.destroy(b);                      // explicit stream overload
+        ASSERT_EQ(log.deallocStreams.size(), 1u);
+        EXPECT_EQ(log.deallocStreams[0], b); // freed on b, not the retained stream a
+        EXPECT_EQ(buf.stream(), b);          // b is retained afterwards
+    }
+    ASSERT_EQ(cudaStreamSynchronize(a), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(b), cudaSuccess);
+    cudaStreamDestroy(a);
+    cudaStreamDestroy(b);
+}
+
+TEST(TestBuffer, SwapExchangesWithoutAllocatingOrFreeing)
+{
+    Counters c;
+    nanovdb::cuda::Buffer<int, CountingResource> x(0, CountingResource{&c}, 128, nanovdb::cuda::noInit);
+    nanovdb::cuda::Buffer<int, CountingResource> y(0, CountingResource{&c},  64, nanovdb::cuda::noInit);
+    ASSERT_EQ(c.allocs, 2);
+    auto* px = x.data();
+    auto* py = y.data();
+    const int allocs = c.allocs, deallocs = c.deallocs;
+
+    x.swap(y);
+
+    EXPECT_EQ(c.allocs,   allocs);  // no allocation
+    EXPECT_EQ(c.deallocs, deallocs);// no free
+    EXPECT_EQ(x.data(), py);
+    EXPECT_EQ(y.data(), px);
+    EXPECT_EQ(x.size(), 64u);
+    EXPECT_EQ(y.size(), 128u);
+    ASSERT_EQ(cudaStreamSynchronize(0), cudaSuccess);
+}
+
 //======================================================================
 // Stream retention: the destructor and resize free on the retained stream
-// (stream of the most recent allocation, or the one supplied via setStream)
+// (stream of the most recent allocation, or the one supplied via set_stream)
 //======================================================================
 
 TEST(TestBuffer, DestructorFreesOnAllocationStream)
@@ -288,7 +344,7 @@ TEST(TestBuffer, SetStreamRedirectsTheFree)
     StreamLog log;
     {
         nanovdb::cuda::Buffer<float, StreamRecordingResource> buf(a, StreamRecordingResource{&log}, 32, nanovdb::cuda::noInit);
-        buf.setStream(b); // member update only, no synchronization
+        buf.set_stream(b); // member update only, no synchronization
         EXPECT_EQ(buf.stream(), b);
     }
     ASSERT_EQ(log.allocStreams.size(), 1u);
@@ -473,7 +529,7 @@ TEST(TestBuffer, AsyncPathIsGraphCapturable)
 template<class B, class = void>
 struct HasSetStream : std::false_type {};
 template<class B>
-struct HasSetStream<B, std::void_t<decltype(std::declval<B&>().setStream(cudaStream_t{0}))>> : std::true_type {};
+struct HasSetStream<B, std::void_t<decltype(std::declval<B&>().set_stream(cudaStream_t{0}))>> : std::true_type {};
 
 template<class B, class = void>
 struct HasStreamGetter : std::false_type {};
@@ -484,9 +540,9 @@ using PinnedBufferF = nanovdb::cuda::Buffer<float, nanovdb::cuda::PinnedResource
 using DeviceBufferF = nanovdb::cuda::Buffer<float, nanovdb::cuda::DeviceResource>;
 
 // A Buffer over a synchronous resource exposes no stream API at all.
-static_assert(!HasSetStream<PinnedBufferF>::value, "sync-resource Buffer must not expose setStream");
+static_assert(!HasSetStream<PinnedBufferF>::value, "sync-resource Buffer must not expose set_stream");
 static_assert(!HasStreamGetter<PinnedBufferF>::value, "sync-resource Buffer must not expose stream()");
-static_assert(HasSetStream<DeviceBufferF>::value, "async-resource Buffer exposes setStream");
+static_assert(HasSetStream<DeviceBufferF>::value, "async-resource Buffer exposes set_stream");
 static_assert(HasStreamGetter<DeviceBufferF>::value, "async-resource Buffer exposes stream()");
 
 TEST(TestBuffer, PinnedBufferIsPageLocked)

--- a/nanovdb/nanovdb/unittest/TestBuffer.cu
+++ b/nanovdb/nanovdb/unittest/TestBuffer.cu
@@ -151,6 +151,50 @@ static_assert(nanovdb::cuda::is_resource<DualResource>::value,
 static_assert(nanovdb::cuda::is_async_resource<DualResource>::value,
               "DualResource must satisfy the AsyncResource concept");
 
+//======================================================================
+// The members required by the concepts are exercised directly: the trait
+// checks above detect them without odr-using them, and an unreferenced
+// member of a file-local struct is dead code to the compiler.
+
+TEST(TestBuffer, TestResourcesSynchronousPair)
+{
+    // The synchronous halves of the counting and stream-recording doubles are
+    // required by the AsyncResource refinement; verify they behave like their
+    // stream-ordered halves.
+    Counters c;
+    CountingResource counting{&c};
+    void* p = counting.allocate(256, CountingResource::DEFAULT_ALIGNMENT);
+    EXPECT_NE(p, nullptr);
+    EXPECT_EQ(c.allocs, 1);
+    counting.deallocate(p, 256, CountingResource::DEFAULT_ALIGNMENT);
+    EXPECT_EQ(c.deallocs, 1);
+
+    StreamLog log;
+    StreamRecordingResource recording{&log};
+    p = recording.allocate(256, StreamRecordingResource::DEFAULT_ALIGNMENT);
+    EXPECT_NE(p, nullptr);
+    ASSERT_EQ(log.allocStreams.size(), 1u);
+    EXPECT_EQ(log.allocStreams[0], cudaStream_t(0));// sync pair delegates through the null stream
+    recording.deallocate(p, 256, StreamRecordingResource::DEFAULT_ALIGNMENT);
+    ASSERT_EQ(log.deallocStreams.size(), 1u);
+    EXPECT_EQ(log.deallocStreams[0], cudaStream_t(0));
+}
+
+TEST(TestBuffer, TraitDoubleStubs)
+{
+    // DualResource and AsyncOnlyResource exist as concept probes; their stub
+    // members allocate nothing and are safe to call with null arguments.
+    DualResource dual;
+    EXPECT_EQ(dual.allocate(0, DualResource::DEFAULT_ALIGNMENT), nullptr);
+    dual.deallocate(nullptr, 0, DualResource::DEFAULT_ALIGNMENT);
+    EXPECT_EQ(dual.allocate_async(0, DualResource::DEFAULT_ALIGNMENT, cudaStream_t(0)), nullptr);
+    dual.deallocate_async(nullptr, 0, DualResource::DEFAULT_ALIGNMENT, cudaStream_t(0));
+
+    AsyncOnlyResource asyncOnly;
+    EXPECT_EQ(asyncOnly.allocate_async(0, AsyncOnlyResource::DEFAULT_ALIGNMENT, cudaStream_t(0)), nullptr);
+    asyncOnly.deallocate_async(nullptr, 0, AsyncOnlyResource::DEFAULT_ALIGNMENT, cudaStream_t(0));
+}
+
 TEST(TestBuffer, ResourceTraits)
 {
     // The static_asserts above are the real test; this anchors them in a

--- a/pendingchanges/nanovdb.txt
+++ b/pendingchanges/nanovdb.txt
@@ -2,6 +2,7 @@ NanoVDB:
 
   New Features:
   - Added new _hostdev_ function named nanovdb::math::isoCrossing, which intersects a ray against a user-defined iso-surface.
+  - Added nanovdb::cuda::Buffer and nanovdb::cuda::BufferView (CUDA): a typed, resource-aware, stream-ordered container that allocates from an injectable memory resource and frees on its retained stream, and a non-owning view over externally managed memory that a GridHandle can wrap without copying. Member names follow cuda::buffer (destroy, set_stream, swap). Also added the synchronous resource concept nanovdb::cuda::is_resource alongside is_async_resource.
 
   Improvements:
   - The bug-fix to the nanovdb::ReadAccessor (see below) improves random-access performance in some use-cases (especially on the CPU).


### PR DESCRIPTION
Follow-up to #2231 and #2251, part of #2232 (NanoVDB injectable CUDA memory resources). This is **B1** of step 2's retrofit; see the roadmap for the B1/B2/B3 split.

Two related changes: the `TopologyBuilder` scratch retrofit, and the `cuda::Buffer` naming alignment that the retrofit surfaced.

## 1. TopologyBuilder scratch from an injected resource

`tools::cuda::TopologyBuilder` gains a `ResourceT` template parameter, and its device-only scratch moves from the dual `cuda::DeviceBuffer` to the single-space `cuda::Buffer` added in #2251. This is an injectability and ownership change, not a performance one — see below.

An audit of host (`.data()`) vs device (`.deviceData()`) use across the builder's ten buffers:

Counts are call sites of `.data()` (host pointer) and `.deviceData()` (device pointer) on each member:

| member | host uses | device uses | converted |
|---|---|---|---|
| `mUpperMasks`   | 0 | 3 | yes |
| `mLowerMasks`   | 0 | 3 | yes |
| `mUpperOffsets` | 0 | 5 | yes |
| `mLowerOffsets` | 0 | 5 | yes |
| `mLeafOffsets`  | 0 | 4 | yes |
| `mVoxelOffsets` | 0 | 6 | yes |
| `mLowerParents` | 0 | 2 | yes |
| `mLeafParents`  | 0 | 2 | yes |
| `mProcessedRoot`| 1 | 1 | no — dual-space |
| `mData`         | 1 | 1 | no — dual-space |

The eight with **zero** host uses are converted (plus three function-local buffers, eleven `DeviceBuffer::create` calls in total). `mProcessedRoot` and `mData` are genuinely dual-space and are left alone; they are step 3's problem, when `DeviceBuffer` is re-implemented as a composition of two `cuda::Buffer`s.

### This is not a performance change

An earlier revision of this description claimed the conversion removes a synchronous `cudaMallocHost` per buffer. **That was wrong, and I have measured it.** `DeviceBuffer::init` allocates host memory *or* device memory, never both:

```cpp
if (device == cudaCpuDeviceId) {
    cudaCheck(cudaMallocHost((void**)&mCpuData, size));            // host only
} else {
    cudaCheck(util::cuda::mallocAsync(mGpuData+device, size, stream)); // device only
}
```

`TopologyBuilder` always passed a real device id from `cudaGetDevice()`, so every one of these buffers took the `else` branch. There was no host allocation on this path to remove.

Dilate benchmark, 50 iterations per run, three runs each, RTX 6000 Ada / CUDA 12.6:

| points | baseline (ms/dilate) | this PR (ms/dilate) |
|---|---|---|
| 1,000 | 4.304 / 4.113 / 4.101 | 4.322 / 4.091 / 4.095 |
| 20,000 | 4.233 / 4.243 / 4.276 | 4.226 / 4.232 / 4.210 |
| 200,000 | 5.178 / 5.189 / 5.253 | 5.207 / 5.215 / 5.211 |

Within run-to-run noise at every size, as expected once the above is understood.

### What it is worth

- **Injectability** — the eleven allocation sites now route through `ResourceT` instead of a hard-wired `DeviceResource`. That is the actual step 2 goal, and `TopologyBuilder` was the last builder without the seam.
- **Ownership** — scratch is freed by scope rather than by seven hand-written `clear(stream)` calls.
- **Dropping unused dual-space state** — each of these buffers carried a host pointer and a `new void*[deviceCount]` array it never used.

The builder's `TempPool` also becomes `TempPool<ResourceT>`, so cub scratch honors the injected resource too.

**Why `Data` moved.** `TopologyBuilder::Data` is hoisted to namespace scope as `TopologyBuilderData<BuildT>`, with an in-class alias so existing uses read unchanged. It carries no dependence on the resource, and leaving it nested would give every `ResourceT` instantiation its own incompatible `Data` type — which the device functors, templated on `BuildT` alone, could not name.

**Compatibility.** `ResourceT` defaults to `nanovdb::cuda::DeviceResource`, matching how `PointsToGrid` took its resource parameter in #2231, so all six existing consumers — `DilateGrid`, `MergeGrids`, `MeshToGrid`, `PruneGrid`, `RefineGrid`, `CoarsenGrid` — compile unchanged. Three of them reach into `mBuilder.mUpperMasks` / `mLowerMasks` directly and needed `.deviceData()` -> `.data()`.

`DeviceBuffer::clear(stream)` takes a stream where `cuda::Buffer` frees on its retained stream. These are the same stream on every path: the builder is constructed with the operator's stream and every subsequent call uses that same stream, so the translation preserves ordering exactly.

## 2. cuda::Buffer naming alignment

Translating those `clear(stream)` calls surfaced a gap, so this PR also closes it. A member-by-member comparison against `cuda::buffer` is written up on #2232; the actionable parts:

- **`destroy()` / `destroy(stream)`** — `cuda::buffer` names the free operation `destroy` and provides both a retained-stream and an explicit-stream overload. We had only the no-argument form, under a different name, which is why the `clear(stream)` translation above needed hand-verification. `clear()` stays as a **transitional** delegate to `destroy()`, and is marked as such in the header. It exists only because `GridHandle::reset()` still calls `clear()` on its buffer; it goes away in step 3's removal phase, when the legacy dual buffers are deleted and `GridHandle` moves to `destroy()`. `cuda::Buffer` is the type those buffers are being replaced by, so its interface should be the one we want to keep, not an accretion of theirs.
- **`setStream` -> `set_stream`** — member names cannot be aliased, which is the stated reason the resource concept kept `allocate_async` in snake_case against house style; the same argument applies here.
- **`swap`** — the generic `std::swap` already behaves correctly through the move operations (verified: no allocation, no free, pointers and sizes exchanged), but `std::vector` and `rmm::device_buffer` both provide a dedicated one, and the B3 retrofit leans on swapping owners as its central idiom.

Note on `set_stream` semantics: ours deliberately does not synchronize — and that matches `cuda::buffer::set_stream` in both name and contract. NVIDIA/cccl#5697 removed the synchronization deliberately (*"avoid implicit synchronization in fundamental primitives"*) but left the earlier "always synchronizes" `@note` in place; that stale doc is what NVIDIA/cccl#10649 reports. No divergence, no revisit needed.

## Testing

Three new tests in `TestBuffer.cu` cover the added API: `destroy()` frees and is idempotent; `destroy(stream)` frees on the given stream rather than the retained one and retains it afterwards; `swap` exchanges pointers and sizes with no allocation or free. The `TopologyBuilder` conversion itself is behavior-preserving and is already covered by the existing suite through all six consumers.

Verified locally on an RTX 6000 Ada, CUDA 12.6:

- `nanovdb_cuda_buffer_unit_test` — **23/23 pass** (20 existing + 3 new)
- `nanovdb_test_cuda` — **52/53 pass**. The single failure, `UnifiedBuffer_IO`, is a missing test-data file (`data/3_spheres.nvdb`) in an unrelated component; the unmodified baseline fails identically, so it is pre-existing and environmental.

Per #2264 the CUDA tests are excluded from CI (`ctest -E ".*cuda.*|.*mgpu.*"`), so CI will build this but not run it — the numbers above are from a local GPU run.

## Follow-ups

- **B2** — `TempPool`'s own bytes onto `Buffer`, and a `SyncFromAsync` mixin so a custom resource is two methods rather than four.
- **B3** — `PointsToGrid`'s 48 allocation sites, which need an ownership design first (device-visible raw pointers in an uploaded struct, ownership moved by `std::swap`, a `goto` retry loop).
- `DistributedPointsToGrid` stays deferred; #2248 should land before any work there.
