### PR TITLE
Fix CUDA 12.8 build with bundled CCCL

### DIFF
--- a/nanovdb/nanovdb/tools/cuda/DistributedPointsToGrid.cuh
+++ b/nanovdb/nanovdb/tools/cuda/DistributedPointsToGrid.cuh
@@ -339,7 +339,7 @@ void exclusiveSumAsync(const nanovdb::cuda::DeviceMesh& deviceMesh, nanovdb::cud
         if (counts[deviceId]) {
             auto segmentExclusiveSum = deviceOut[counts[deviceId] - 1] + deviceIn[counts[deviceId] - 1];
 
-            unsigned int numBlocks = ::cuda::ceil_div(counts[deviceId], NumThreads);
+            unsigned int numBlocks = ::cuda::ceil_div<int>(counts[deviceId], NumThreads);
             util::cuda::lambdaKernel<<<numBlocks, NumThreads, 0, stream>>>(counts[deviceId], [=] __device__ (size_t tid) { deviceOut[tid] += partialExclusiveSum; });
             cudaCheckError();
 
@@ -382,7 +382,7 @@ void inclusiveSumAsync(const nanovdb::cuda::DeviceMesh& deviceMesh, nanovdb::cud
         if (counts[deviceId]) {
             auto segmentInclusiveSum = deviceOut[counts[deviceId] - 1];
 
-            unsigned int numBlocks = ::cuda::ceil_div(counts[deviceId], NumThreads);
+            unsigned int numBlocks = ::cuda::ceil_div<int>(counts[deviceId], NumThreads);
             util::cuda::lambdaKernel<<<numBlocks, NumThreads, 0, stream>>>(counts[deviceId], [=] __device__ (size_t tid) { deviceOut[tid] += partialInclusiveSum; });
             cudaCheckError();
 


### PR DESCRIPTION
The version of CCCL bundled with CUDA 12.9 and later adds mixed type `cuda::ceil_div` overloads. Since NanoVDB's CMakeLists.txt pulls in the latest CCCL and builds with that, a CUDA 12.8 build using NanoVDB's build system does not exhibit this problem.

The problem arises when including NanoVDB in another build system with CUDA 12.8 that does not use the latest CCCL (e.g. fVDB). In this case, the missing mixed type overload results in a compile error.

The solution is to provide a promoted mixed use dtype specifically (`int` in this case due to the `int` and `uint32_t` inputs) via the templated `ceil_div` call. This is forward compatible with later version of CUDA/CCCL as well.

Verified via a build of NanoVDB in a CUDA 12.8 Docker container (disabling the latest CCCL download in NanoVDB's CMakeLists.txt)