### PR TITLE
CI: speed up the NanoVDB Windows job

### DIFF
--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -103,6 +103,9 @@ jobs:
     runs-on: ${{ (github.repository_owner == 'AcademySoftwareFoundation' && 'windows-2022-8c-32g-300h') || 'windows-latest' }}
     env:
       VCPKG_DEFAULT_TRIPLET: 'x64-windows'
+      # Cache built vcpkg packages in the GitHub Actions cache to avoid
+      # rebuilding every dependency from source on every run.
+      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
       visual_studio: "Visual Studio 17 2022"
       cuda: "12.4.0"
     strategy:
@@ -114,12 +117,46 @@ jobs:
         # note: system path must be modified in a previous step to it's use
         echo "$Env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "${{github.workspace}}\build\openvdb\openvdb\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    # Expose the Actions cache endpoint/token to vcpkg for its x-gha
+    # binary caching backend (they are only available to javascript actions).
+    - name: export_gha_cache_env
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+    # Cache the CUDA toolkit install to skip the (slow) NVIDIA network
+    # installer on cache hits.
+    - name: cache_cuda
+      id: cache-cuda
+      uses: actions/cache@v4
+      with:
+        path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA
+        key: ${{ runner.os }}-cuda-${{ env.cuda }}-${{ hashFiles('ci/install_windows_cuda.ps1') }}
     - name: install_cuda
+      if: steps.cache-cuda.outputs.cache-hit != 'true'
       shell: powershell
       run: .\ci\install_windows_cuda.ps1
+    # On a cache hit the installer didn't run, so recreate what it would
+    # have done outside of the toolkit directory: the environment variables
+    # and the Visual Studio CUDA build customizations.
+    - name: restore_cuda_env
+      if: steps.cache-cuda.outputs.cache-hit == 'true'
+      shell: powershell
+      run: |
+        $ver = $env:cuda -replace '^([0-9]+)\.([0-9]+).*$','$1.$2'
+        $cudaPath = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$ver"
+        echo "CUDA_PATH=$cudaPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "CUDA_PATH_V$($ver -replace '\.','_')=$cudaPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "$cudaPath\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+        Copy-Item "$cudaPath\extras\visual_studio_integration\MSBuildExtensions\*" "$vsPath\MSBuild\Microsoft\VC\v170\BuildCustomizations" -Force
+    # Only install the dependencies this job's components actually need
+    # (e.g. no openexr, cppunit, glfw3, glew, jemalloc or libpng).
     - name: install
       shell: powershell
-      run: .\ci\install_windows.ps1
+      run: .\ci\install_windows.ps1 -Packages zlib,blosc,tbb,gtest,boost-iostreams,boost-interprocess,boost-algorithm,python3,nanobind
     - name: install_numpy
       shell: powershell
       run: .\ci\install_windows_numpy.ps1

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -153,10 +153,10 @@ jobs:
         $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
         Copy-Item "$cudaPath\extras\visual_studio_integration\MSBuildExtensions\*" "$vsPath\MSBuild\Microsoft\VC\v170\BuildCustomizations" -Force
     # Only install the dependencies this job's components actually need
-    # (e.g. no openexr, cppunit, glfw3, glew, jemalloc or libpng).
+    # (e.g. no openexr, cppunit, glfw3, glew or libpng).
     - name: install
       shell: powershell
-      run: .\ci\install_windows.ps1 -Packages zlib,blosc,tbb,gtest,boost-iostreams,boost-interprocess,boost-algorithm,python3,nanobind
+      run: .\ci\install_windows.ps1 -Packages zlib,blosc,tbb,gtest,jemalloc,boost-iostreams,boost-interprocess,boost-algorithm,python3,nanobind
     - name: install_numpy
       shell: powershell
       run: .\ci\install_windows_numpy.ps1

--- a/ci/install_windows.ps1
+++ b/ci/install_windows.ps1
@@ -1,3 +1,9 @@
+param(
+    # Optional subset of packages to install. Defaults to the full OpenVDB
+    # dependency list below when not provided.
+    [string[]]$Packages
+)
+
 # Enable verbose and stop on error
 $ErrorActionPreference = "Stop"
 $VerbosePreference = "Continue"
@@ -21,12 +27,17 @@ $vcpkgPackages = @(
     "nanobind"
 )
 
+if (-not $Packages) {
+    $Packages = $vcpkgPackages
+}
+Write-Host "Installing vcpkg packages: $Packages"
+
 # Update vcpkg
 vcpkg update
 
 # Allow the vcpkg command to fail once so we can retry with the latest
 try {
-    vcpkg install $vcpkgPackages
+    vcpkg install $Packages
 } catch {
     Write-Host "vcpkg install failed, retrying with latest ports..."
     # Retry the installation with updated ports
@@ -34,7 +45,7 @@ try {
     git pull
     Pop-Location
     vcpkg update
-    vcpkg install $vcpkgPackages
+    vcpkg install $Packages
 }
 
 Write-Host "vcpkg install completed successfully"


### PR DESCRIPTION
The windows-nanovdb job spends ~37 of its ~52 minutes installing dependencies from scratch on every run (e.g. [this run](https://github.com/AcademySoftwareFoundation/openvdb/actions/runs/32346743423): install_cuda 13 min, vcpkg install 24 min). This PR:

- **Enables vcpkg's GitHub Actions binary caching** (`x-gha`) so dependency builds are reused across runs instead of compiled from source (~24 min → ~1-2 min on a cache hit). A `github-script` step exports the Actions cache URL/token, which are only visible to JavaScript actions.
- **Caches the CUDA toolkit directory** and skips the NVIDIA network installer on a hit, restoring the environment variables and the Visual Studio build customizations the installer would have set up (~13 min → ~1 min).
- **Trims the vcpkg package list** to what this job's components actually need, dropping openexr, cppunit, glfw3, glew and libpng (NanoVDB has no glfw/glew usage).

`ci/install_windows.ps1` gains an optional `-Packages` parameter that defaults to the existing full list, so `build.yml` and `weekly.yml` are unaffected.

Notes:
- The first run after merge is no faster (cold caches, plus cache-save time); steady state should be roughly 52 min → ~20 min, with the build step becoming the long pole (sccache would be a follow-up).
- Caches invalidate when the runner image updates vcpkg's port baseline, so occasional slow runs are expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
