### PR TITLE
tools: fix wrong voxel offset in MeshToVolume checkNeighbours

### DIFF
--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -1645,7 +1645,7 @@ checkNeighbours(const Index pos, const typename LeafNodeType::ValueType * data, 
     // i + 1, j, k
     if (mask[0] && Compare::check(data[pos + NodeT::DIM * NodeT::DIM]))                   return true;
     // i+1, j, k-1
-    if (mask[6] && Compare::check(data[pos + NodeT::DIM * NodeT::DIM]))                   return true;
+    if (mask[6] && Compare::check(data[pos + NodeT::DIM * NodeT::DIM - 1]))               return true;
     // i-1, j, k-1
     if (mask[7] && Compare::check(data[pos - NodeT::DIM * NodeT::DIM - 1]))               return true;
     // i+1, j, k+1

--- a/pendingchanges/meshtovolumecheckneighboursoffset.txt
+++ b/pendingchanges/meshtovolumecheckneighboursoffset.txt
@@ -1,0 +1,5 @@
+OpenVDB:
+  Bug Fixes:
+  - Fixed an incorrect voxel offset in MeshToVolume.h's checkNeighbours() that caused the
+    (i+1, j, k-1) edge-adjacent neighbor to be checked at the wrong location, duplicating
+    the (i+1, j, k) neighbor instead.


### PR DESCRIPTION
## Summary
- In `openvdb/openvdb/tools/MeshToVolume.h`, the `checkNeighbours()` overload that scans a leaf node's raw `data` array has a `mask[6]` branch labeled `i+1, j, k-1` that checks `data[pos + NodeT::DIM * NodeT::DIM]` — the same offset used by the `mask[0]` (`i+1, j, k`) branch two lines above, missing the `- 1` for the `k-1` step.
- The analogous edge-adjacent branches immediately below (`mask[7]`, `mask[8]`, `mask[9]`) all correctly include the `±1` z-offset, confirming this is a copy/paste slip rather than intentional.
- Fixed the offset to `data[pos + NodeT::DIM * NodeT::DIM - 1]` so the correct voxel is checked.

## Test plan
- [ ] CI build/tests for `openvdb` core