### PR TITLE
RasterizeTrilinear Improvements

### DIFF
--- a/openvdb/openvdb/points/PointRasterizeTrilinear.h
+++ b/openvdb/openvdb/points/PointRasterizeTrilinear.h
@@ -5,7 +5,7 @@
 ///
 /// @file PointRasterizeTrilinear.h
 ///
-/// @brief Transfer schemes for rasterizing point data
+/// @brief Weighted trilinear rasterization of point data
 ///
 
 #ifndef OPENVDB_POINTS_RASTERIZE_TRILINEAR_HAS_BEEN_INCLUDED
@@ -19,6 +19,7 @@
 #include <openvdb/tools/Morphology.h>
 #include <openvdb/tree/ValueAccessor.h>
 #include <openvdb/util/Assert.h>
+#include <openvdb/simd/Simd.h>
 
 #include "PointDataGrid.h"
 #include "PointMask.h"
@@ -31,21 +32,42 @@ OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
 namespace points {
 
-///
+/// @brief  Traits for staggered (MAC) trilinear rasterization. This method
+///   only works on scalar or Vec3 attribute types and only ever returns a Vec3
+///   tree. It is typically used for velocity rasterization in fluid
+///   simulations to avoid the pressure-velocity decoupling problem that occurs
+///   on collocated (cell-centered) grids. The resulting Vec3 tree effectively
+///   represents the velocity values on the cell faces rather than the cell
+///   centers.
 template <typename ValueT, bool Staggered = true>
 struct TrilinearTraits
 {
-    using ResultT = typename std::conditional<
-        VecTraits<ValueT>::IsVec, ValueT, math::Vec3<ValueT>>::type;
+private:
+    using FltT = typename types_internal::flt_t<sizeof(typename ValueTraits<ValueT>::ElementType)*CHAR_BIT>::type;
+    static_assert(ValueTraits<ValueT>::IsScalar ||
+        (ValueTraits<ValueT>::IsVec && ValueTraits<ValueT>::Size == 3),
+        "Source attribute type must be scalar or Vec3 for staggered rasterization.");
+public:
+    /// @brief  Resulting rasterized Tree ValueType (always Vec3)
+    using ResultT = math::Vec3<FltT>;
+    /// @brief  Resulting rasterized TreeType
     template <typename PointDataTreeT>
     using TreeT = typename PointDataTreeT::template ValueConverter<ResultT>::Type;
 };
 
-///
+/// @brief  Traits for collocated, cell-centered rasterization. Work for any
+///   scalar, vector or matrix attribute. Note that integer values are
+///   interpolated at their respective floating point precision and returned
+///   as trees at that precision.
 template <typename ValueT>
 struct TrilinearTraits<ValueT, false>
 {
-    using ResultT = ValueT;
+private:
+    using FltT = typename types_internal::flt_t<sizeof(typename ValueTraits<ValueT>::ElementType)*CHAR_BIT>::type;
+public:
+    /// @brief  Resulting rasterized Tree ValueType
+    using ResultT = typename ConvertElementType<ValueT, FltT>::Type;
+    /// @brief  Resulting rasterized TreeType
     template <typename PointDataTreeT>
     using TreeT = typename PointDataTreeT::template ValueConverter<ResultT>::Type;
 };
@@ -65,8 +87,11 @@ struct TrilinearTraits<ValueT, false>
 /// @tparam Staggered whether to perform a staggered or collocated rasterization
 /// @tparam ValueT    the value type of the point attribute to rasterize
 /// @param points     the point tree to be rasterized
-/// @param attribute  the name of the attribute to rasterize. Must be a scalar
-///   or Vec3 attribute.
+/// @param attribute  the name of the attribute to rasterize. Must be a Vec3
+///   attribute for Staggered rasterization. Otherwise, can be any scalar,
+///   Vector or Matrix type. Integer values are interpolated at their float
+///   bitwidth precision and returned as a tree at that precision e.g:
+///     int32 -> float, FloatTree.
 /// @param filter     an optional point filter to use
 template <bool Staggered,
     typename ValueT,

--- a/openvdb/openvdb/points/PointRasterizeTrilinear.h
+++ b/openvdb/openvdb/points/PointRasterizeTrilinear.h
@@ -87,10 +87,10 @@ public:
 /// @tparam Staggered whether to perform a staggered or collocated rasterization
 /// @tparam ValueT    the value type of the point attribute to rasterize
 /// @param points     the point tree to be rasterized
-/// @param attribute  the name of the attribute to rasterize. Must be a Vec3
-///   attribute for Staggered rasterization. Otherwise, can be any scalar,
-///   Vector or Matrix type. Integer values are interpolated at their float
-///   bitwidth precision and returned as a tree at that precision e.g:
+/// @param attribute  the name of the attribute to rasterize. Must be a scalar
+///   or Vec3 attribute for Staggered rasterization. Otherwise, can be any
+///   scalar, Vector or Matrix type. Integer values are interpolated at their
+///   float bitwidth precision and returned as a tree at that precision e.g:
 ///     int32 -> float, FloatTree.
 /// @param filter     an optional point filter to use
 template <bool Staggered,

--- a/openvdb/openvdb/points/impl/PointRasterizeTrilinearImpl.h
+++ b/openvdb/openvdb/points/impl/PointRasterizeTrilinearImpl.h
@@ -18,35 +18,62 @@ namespace points {
 
 namespace rasterize_trilinear_internal {
 
-template <typename TreeType,
-          typename PositionCodecT,
-          typename SourceValueT,
-          typename SourceCodecT,
-          typename FilterT>
-struct TrilinearTransfer :
-    public VolumeTransfer<TreeType>,
-    public FilteredTransfer<FilterT>
+template <bool _Staggered,
+    typename TreeT,
+    typename PositionCodecT,
+    typename SourceValueT,
+    typename SourceCodecT,
+    typename FilterT>
+struct TArgs
 {
-    using BaseT = VolumeTransfer<TreeType>;
-    using FilterTransferT = FilteredTransfer<FilterT>;
-    using WeightT = typename TreeType::ValueType;
-    using PositionHandleT = points::AttributeHandle<Vec3f, PositionCodecT>;
-    using SourceHandleT = points::AttributeHandle<SourceValueT, SourceCodecT>;
+    static constexpr bool Staggered = _Staggered;
+    using TreeType = TreeT;
+    using PositionCodecType = PositionCodecT;
+    using SourceValueType = SourceValueT;
+    using SourceCodecType = SourceCodecT;
+    using FilterType = FilterT;
+};
 
-    // precision of kernel arithmetic - aliased to the floating point
-    // element type of the source attribute.
+//// @note Kernel value evaluator
+template <typename ScalarT>
+static inline ScalarT value(const ScalarT x)
+{
+    const ScalarT abs_x = simd::abs(x);
+    const ScalarT r0 = ScalarT(1.0) - abs_x;
+    return simd::select(abs_x < ScalarT(1.0), r0, ScalarT(0.0));
+}
+
+template <typename DerivedT, typename TArgsT>
+struct TrilinearTransfer :
+    public VolumeTransfer<typename TArgsT::TreeType>,
+    public FilteredTransfer<typename TArgsT::FilterType>
+{
+    using BaseT = VolumeTransfer<typename TArgsT::TreeType>;
+    using FilterType = typename TArgsT::FilterType;
+    using FilterTransferT = FilteredTransfer<FilterType>;
+    using SourceValueT = typename TArgsT::SourceValueType;
+
+    using PositionHandleT = points::AttributeHandle<Vec3f, typename TArgsT::PositionCodecType>;
+    using SourceHandleT = points::AttributeHandle<SourceValueT, typename TArgsT::SourceCodecType>;
+
     using SourceElementT = typename ValueTraits<SourceValueT>::ElementType;
-    using RealT = SourceElementT;
+    static const size_t SourceSize = ValueTraits<SourceValueT>::Elements;
 
-    static_assert(std::is_floating_point<SourceElementT>::value,
-        "Trilinear rasterization only supports floating point values.");
+    // Destination tree expected to always be at floating point precision. Its
+    // floating point type defines the precision of the kernel arithmetic
+    using RealT = typename ValueTraits<typename TArgsT::TreeType::ValueType>::ElementType;
+    static_assert(std::is_floating_point_v<RealT>);
+    using NativeT = typename simd::NativeSimdOrScalar<RealT>::Type;
 
-    static const Index NUM_VALUES = TreeType::LeafNodeType::NUM_VALUES;
+    // Per extent weight for staggered trilinear interpolation, only ever one
+    // weight required for cell centered
+    static constexpr size_t kNumWeights = TArgsT::TreeType::LeafNodeType::NUM_VALUES *
+        (TArgsT::Staggered ? 3 : 1);
 
     TrilinearTransfer(const size_t pidx,
         const size_t sidx,
-        const FilterT& filter,
-        TreeType& tree)
+        const FilterType& filter,
+        typename TArgsT::TreeType& tree)
         : BaseT(tree)
         , FilterTransferT(filter)
         , mPIdx(pidx)
@@ -64,229 +91,429 @@ struct TrilinearTransfer :
         , mSHandle()
         , mWeights() {}
 
-    //// @note Kernel value evaluator
-    static inline RealT value(const RealT x)
-    {
-        const RealT abs_x = std::fabs(x);
-        if (abs_x < RealT(1.0)) return RealT(1.0) - abs_x;
-        return RealT(0.0);
-    }
-
     inline static Int32 range() { return 1; }
+
     inline Int32 range(const Coord&, size_t) const { return this->range(); }
 
     inline void initialize(const Coord& origin, const size_t idx, const CoordBBox& bounds)
     {
         this->BaseT::initialize(origin, idx, bounds);
         this->FilterTransferT::initialize(origin, idx, bounds);
-        mWeights.fill(openvdb::zeroVal<WeightT>());
+        mWeights.fill(NativeT(0));
     }
 
     inline bool startPointLeaf(const PointDataTree::LeafNodeType& leaf)
     {
         this->FilterTransferT::startPointLeaf(leaf);
-        mPHandle.reset(new PositionHandleT(leaf.constAttributeArray(mPIdx)));
-        mSHandle.reset(new SourceHandleT(leaf.constAttributeArray(mSIdx)));
+        mPHandle = std::make_unique<PositionHandleT>(leaf.constAttributeArray(mPIdx));
+        mSHandle = std::make_unique<SourceHandleT>(leaf.constAttributeArray(mSIdx));
         return true;
     }
 
+    /// @brief  Multi point rasterization
+    /// @note   This is the only allowed entry point from the transfer schemes
+    inline void rasterizePoints(const Coord& ijk,
+                    const Index start,
+                    const Index end,
+                    const CoordBBox& bounds)
+    {
+        constexpr auto N2 = simd::SimdTraits<NativeT>::size;
+        if constexpr(N2 == 1) {
+            // Fallback to per point rasterization
+            for (Index i = start; i < end; ++i) {
+                if (!FilterTransferT::filter(i)) continue;
+                this->rasterizePoint(ijk, i, bounds);
+            }
+        }
+        else {
+            // Batched/vectorized rasterization. Expect power of two for
+            // batched size
+            static_assert((N2 > 1) && !(N2 & (N2 - 1)));
+            std::array<int64_t, N2> ids;
+            Index offset = 0;
+            for (Index i = start; i < end; ++i) {
+                if (!FilterTransferT::filter(i)) continue;
+                ids[offset++] = int64_t(i);
+                if (offset == N2) {
+                    this->rasterizeN2<N2>(ijk, ids, bounds);
+                    offset = 0;
+                }
+            }
+            if (offset == 0) return;
+            else {
+                for (; offset < N2; ++offset) ids[offset] = int64_t(-1);
+                this->rasterizeN2<N2>(ijk, ids, bounds);
+            }
+        }
+    }
+
     inline bool endPointLeaf(const PointDataTree::LeafNodeType&) { return true; }
+
+    inline bool finalize(const Coord&, const size_t)
+    {
+        auto* const data = this->buffer();
+        const auto& mask = *(this->mask());
+
+        for (auto iter = mask.beginOn(); iter; ++iter) {
+            const Index offset = iter.pos();
+            auto& v = data[offset];
+
+            if constexpr (TArgsT::Staggered) {
+                const auto* w = &(this->mWeights[offset*3]);
+                auto w0 = simd::horizontal_add(w[0]);
+                if (!math::isZero(w0)) v[0] /= w0;
+                auto w1 = simd::horizontal_add(w[1]);
+                if (!math::isZero(w1)) v[1] /= w1;;
+                auto w2 = simd::horizontal_add(w[2]);
+                if (!math::isZero(w2)) v[2] /= w2;
+            }
+            else {
+                const auto* w = &(this->mWeights[offset]);
+                auto w0 = simd::horizontal_add(*w);
+                if (math::isZero(w0)) continue;
+                if constexpr (SourceSize == 1) v /= w0;
+                else {
+                    for (size_t j = 0; j < SourceSize; ++j) {
+                        v.asPointer()[j] /= w0;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+private:
+    /// @brief  Single point rasterization
+    inline void rasterizePoint(const Coord& ijk,
+                    const Index id,
+                    const CoordBBox& bounds)
+    {
+        const math::Vec3<RealT> P(this->mPHandle->get(id));
+
+        CoordBBox intersection = this->derived().intersection(P.x(), P.y(), P.z(), ijk);
+        intersection.intersect(bounds);
+        if (intersection.empty()) return;
+
+        const auto S(this->mSHandle->get(id));
+        if constexpr(SourceSize == 1) {
+            this->derived().template stamp<RealT>(P.x(), P.y(), P.z(), &S, ijk, intersection);
+        }
+        else {
+            this->derived().template stamp<RealT>(P.x(), P.y(), P.z(), S.asPointer(), ijk, intersection);
+        }
+    }
+
+    template <size_t N2>
+    inline void rasterizeN2(const Coord& ijk,
+        const std::array<int64_t, N2>& points,
+        const CoordBBox& bounds)
+    {
+        static_assert((N2 > 1) && !(N2 & (N2 - 1)));
+        using SimdT  = typename simd::SimdT<RealT, N2>::Type;
+
+        OPENVDB_ASSERT(points[0] != -1);
+
+        std::array<RealT, std::max(size_t(3), SourceSize)*N2> cache;
+        math::Vec3<RealT> tmp;
+        // convert AoS to SoA
+        for (size_t i = 0; i < N2; ++i) {
+            if (points[i] != -1) {
+                tmp = math::Vec3<RealT>(this->mPHandle->get(Index(points[i])));
+            }
+            else {
+                // For positions, if the point is invalid, set it to a value
+                // which corresponds to a voxel space position far enough away
+                // from the kernel range such that all weights evaluate to 0.
+                // Arbitrarily gone with the value of 10
+                // @todo  For cell cnetered rasterization, we should offset in
+                //   the direction of the last position to try and avoid zero
+                //   crossings which icnrease the stencil lookup size.
+                tmp.init(RealT(10.0), RealT(10.0), RealT(10.0));
+            }
+            cache[i+(N2*0)] = tmp[0];
+            cache[i+(N2*1)] = tmp[1];
+            cache[i+(N2*2)] = tmp[2];
+        }
+
+        const SimdT Px = simd::load<N2>(cache.data() + (N2*0));
+        const SimdT Py = simd::load<N2>(cache.data() + (N2*1));
+        const SimdT Pz = simd::load<N2>(cache.data() + (N2*2));
+
+        CoordBBox intersection = this->derived().intersection(Px, Py, Pz, ijk);
+        intersection.intersect(bounds);
+        if (intersection.empty()) return;
+
+#if defined(__GNUC__)  && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+        SourceValueT tmps;
+        for (size_t i = 0; i < N2; ++i) {
+            if (points[i] != -1) {
+                tmps = this->mSHandle->get(Index(points[i]));
+            }
+            if constexpr (SourceSize == 1) {
+                cache[i+(N2*0)] = RealT(tmps);
+            }
+            else {
+                for (size_t j = 0; j < SourceSize; ++j) {
+                    cache[i+(N2*j)] = RealT(tmps.asPointer()[j]);
+                }
+            }
+        }
+#if defined(__GNUC__)  && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+        SimdT S[TArgsT::Staggered ? 3 : SourceSize];
+        for (size_t j = 0; j < SourceSize; ++j) {
+            S[j] = simd::load<N2>(cache.data() + (N2*j));
+        }
+        if constexpr (SourceSize == 1 && TArgsT::Staggered) {
+            S[1] = S[0];
+            S[2] = S[0];
+        }
+        this->derived().stamp(Px, Py, Pz, S, ijk, intersection);
+    }
+
+    inline DerivedT& derived() {
+        return *(static_cast<DerivedT*>(this));
+    }
 
 protected:
     const size_t mPIdx;
     const size_t mSIdx;
     typename PositionHandleT::UniquePtr mPHandle;
     typename SourceHandleT::UniquePtr mSHandle;
-    std::array<WeightT, NUM_VALUES> mWeights;
+    std::array<NativeT, kNumWeights> mWeights;
 };
 
-template <typename TreeType,
-          typename PositionCodecT,
-          typename SourceValueT,
-          typename SourceCodecT,
-          typename FilterT>
+template <typename TArgsT>
 struct StaggeredTransfer :
-    public TrilinearTransfer<TreeType, PositionCodecT, SourceValueT, SourceCodecT, FilterT>
+    public TrilinearTransfer<StaggeredTransfer<TArgsT>, TArgsT>
 {
-    using BaseT = TrilinearTransfer<TreeType, PositionCodecT, SourceValueT, SourceCodecT, FilterT>;
+    using BaseT = TrilinearTransfer<StaggeredTransfer<TArgsT>, TArgsT>;
     using RealT = typename BaseT::RealT;
-    using BaseT::value;
 
-    static_assert(VecTraits<typename TreeType::ValueType>::IsVec,
-        "Target Tree must be a vector tree for staggered rasterization");
+    static_assert(VecTraits<typename TArgsT::TreeType::ValueType>::IsVec &&
+        VecTraits<typename TArgsT::TreeType::ValueType>::Size == 3,
+        "Target Tree must be a Vec3 tree for staggered rasterization");
 
-    static const Index DIM = TreeType::LeafNodeType::DIM;
-    static const Index LOG2DIM = TreeType::LeafNodeType::LOG2DIM;
+    static const Index DIM = TArgsT::TreeType::LeafNodeType::DIM;
+    static const Index LOG2DIM = TArgsT::TreeType::LeafNodeType::LOG2DIM;
 
     StaggeredTransfer(const size_t pidx,
         const size_t sidx,
-        const FilterT& filter,
-        TreeType& tree)
+        const typename TArgsT::FilterType& filter,
+        typename TArgsT::TreeType& tree)
         : BaseT(pidx, sidx, filter, tree) {}
 
-    void rasterizePoint(const Coord& ijk,
-                    const Index id,
-                    const CoordBBox& bounds)
-    {
-        if (!BaseT::filter(id)) return;
+private:
+    friend BaseT;
 
-        CoordBBox intersectBox(ijk.offsetBy(-1), ijk.offsetBy(1));
-        intersectBox.intersect(bounds);
-        if (intersectBox.empty()) return;
+    template<typename ScalarT> /// RealT or SimdT
+    inline CoordBBox intersection(
+        const ScalarT&,
+        const ScalarT&,
+        const ScalarT&,
+        const Coord& ijk)
+    {
+        // Stencil size is always 27
+        return CoordBBox(ijk.offsetBy(-1), ijk.offsetBy(1));
+    }
+
+    template<typename ScalarT> /// RealT or SimdT
+    inline void stamp(const ScalarT& Px,
+                    const ScalarT& Py,
+                    const ScalarT& Pz,
+                    const ScalarT* S,
+                    const Coord& ijk,
+                    const CoordBBox& intersection)
+    {
+        // Some of the arithmetic in this function assumes these are the same,
+        // otherwise we can end up writing scalars to all lanes of a simdt
+        // (e.g. wp[0] += (Pwx * weights), where wp is a simdt and Pwx is
+        // a scalar - this ends up filing all the lanes).
+        static_assert(simd::IsSimdT<ScalarT>::value == simd::IsSimdT<typename BaseT::NativeT>::value);
+        OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(Px)));
+        OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(Py)));
+        OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(Pz)));
 
         auto* const data = this->buffer();
         const auto& mask = *(this->mask());
 
-        const math::Vec3<RealT> P(this->mPHandle->get(id));
-        const SourceValueT s(this->mSHandle->get(id));
+        ScalarT cwx, cwy, cwz, cwxy; // center weights
+        ScalarT mwx, mwxcy, mwycx, mwz; // mac weights
+        ScalarT result;
+        int32_t xoffset, xyoffset, xyzoffset; // voxel offsets
 
-        math::Vec3<RealT> centerw, macw;
-
-        const Coord& a(intersectBox.min());
-        const Coord& b(intersectBox.max());
+        const Coord& a(intersection.min());
+        const Coord& b(intersection.max());
         for (Coord c = a; c.x() <= b.x(); ++c.x()) {
-            // @todo can probably simplify the double call to value() in some way
-            const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
-            const RealT x = static_cast<RealT>(c.x()-ijk.x()); // distance from ijk to c
-            centerw[0] = value(P.x() - x); // center dist
-            macw.x() = value(P.x() - (x-RealT(0.5))); // mac dist
+            xoffset = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
+            // @todo can probably simplify the double call to value() in
+            //   some way, haven't spent too much time attempting too
+            const ScalarT x(static_cast<RealT>(c.x()-ijk.x())); // distance from ijk to c
+            cwx = value(Px - x); // center dist
+            mwx = value(Px - (x - ScalarT(RealT(0.5)))); // mac dist
 
             for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
-                const Index ij = i + ((c.y() & (DIM-1u)) << LOG2DIM);
-                const RealT y = static_cast<RealT>(c.y()-ijk.y());
-                centerw[1] = value(P.y() - y);
-                macw.y() = value(P.y() - (y-RealT(0.5)));
+                xyoffset = xoffset + /*j*/((c.y() & (DIM-1u)) << LOG2DIM);
+                const ScalarT y(static_cast<RealT>(c.y()-ijk.y()));
+                cwy  = value(Py - y);
+                cwxy = cwx * cwy;
+                mwycx = cwx * value(Py - (y - ScalarT(RealT(0.5))));
+                mwxcy = mwx * cwy;
 
                 for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
-                    OPENVDB_ASSERT(bounds.isInside(c));
-                    const Index offset = ij + /*k*/(c.z() & (DIM-1u));
-                    if (!mask.isOn(offset)) continue;
-                    const RealT z = static_cast<RealT>(c.z()-ijk.z());
-                    centerw[2] = value(P.z() - z);
-                    macw.z() = value(P.z() - (z-RealT(0.5)));
+                    OPENVDB_ASSERT(intersection.isInside(c));
+                    xyzoffset = xyoffset + /*k*/(c.z() & (DIM-1u));
+                    if (!mask.isOn(xyzoffset)) continue;
+                    auto& v = data[xyzoffset]; // Must be a Vec3
+                    auto* w = &(this->mWeights[xyzoffset * 3]);
 
-                    const math::Vec3<RealT> r {
-                        (macw[0] * centerw[1] * centerw[2]),
-                        (macw[1] * centerw[0] * centerw[2]),
-                        (macw[2] * centerw[0] * centerw[1])
-                    };
+                    const ScalarT z(static_cast<RealT>(c.z()-ijk.z()));
+                    cwz = value(Pz - z);
+                    mwz = value(Pz - (z - ScalarT(RealT(0.5))));
 
-                    data[offset] += s * r;
-                    this->mWeights[offset] += r;
+                    // @todo  Could remove the last 3 reductions here with another
+                    //   cached array/vector of weighted values
+                    // x
+                    result = mwxcy * cwz;
+                    OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(result)));
+                    OPENVDB_ASSERT(simd::horizontal_min(result) >= 0.0);
+                    OPENVDB_ASSERT(simd::horizontal_max(result) <= 1.0);
+                    w[0] += result;
+                    v[0] += simd::horizontal_add(S[0] * result);
+
+                    // y
+                    result = mwycx * cwz;
+                    OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(result)));
+                    OPENVDB_ASSERT(simd::horizontal_min(result) >= 0.0);
+                    OPENVDB_ASSERT(simd::horizontal_max(result) <= 1.0);
+                    w[1] += result;
+                    v[1] += simd::horizontal_add(S[1] * result);
+
+                    // z
+                    result = cwxy * mwz;
+                    OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(result)));
+                    OPENVDB_ASSERT(simd::horizontal_min(result) >= 0.0);
+                    OPENVDB_ASSERT(simd::horizontal_max(result) <= 1.0);
+                    w[2] += result;
+                    v[2] += simd::horizontal_add(S[2] * result);
                 }
             }
         }
-    }
-
-    inline bool finalize(const Coord&, const size_t)
-    {
-        auto* const data = this->buffer();
-        const auto& mask = *(this->mask());
-
-        for (auto iter = mask.beginOn(); iter; ++iter) {
-            const Index offset = iter.pos();
-            const auto& w = this->mWeights[offset];
-            auto& v = data[offset];
-            if (!math::isZero(w[0])) v[0] /= w[0];
-            if (!math::isZero(w[1])) v[1] /= w[1];
-            if (!math::isZero(w[2])) v[2] /= w[2];
-        }
-
-        return true;
     }
 };
 
-template <typename TreeType,
-          typename PositionCodecT,
-          typename SourceValueT,
-          typename SourceCodecT,
-          typename FilterT>
+template <typename TArgsT>
 struct CellCenteredTransfer :
-    public TrilinearTransfer<TreeType, PositionCodecT, SourceValueT, SourceCodecT, FilterT>
+    public TrilinearTransfer<CellCenteredTransfer<TArgsT>, TArgsT>
 {
-    using BaseT = TrilinearTransfer<TreeType, PositionCodecT, SourceValueT, SourceCodecT, FilterT>;
+    using BaseT = TrilinearTransfer<CellCenteredTransfer<TArgsT>, TArgsT>;
     using RealT = typename BaseT::RealT;
-    using BaseT::value;
 
-    static const Index DIM = TreeType::LeafNodeType::DIM;
-    static const Index LOG2DIM = TreeType::LeafNodeType::LOG2DIM;
+    static const Index DIM = TArgsT::TreeType::LeafNodeType::DIM;
+    static const Index LOG2DIM = TArgsT::TreeType::LeafNodeType::LOG2DIM;
 
     CellCenteredTransfer(const size_t pidx,
         const size_t sidx,
-        const FilterT& filter,
-        TreeType& tree)
+        const typename TArgsT::FilterType& filter,
+        typename TArgsT::TreeType& tree)
         : BaseT(pidx, sidx, filter, tree) {}
 
-    void rasterizePoint(const Coord& ijk,
-                    const Index id,
-                    const CoordBBox& bounds)
+private:
+    friend BaseT;
+
+    template<typename ScalarT> /// RealT or SimdT
+    inline CoordBBox intersection(
+        const ScalarT& Px,
+        const ScalarT& Py,
+        const ScalarT& Pz,
+        const Coord& ijk)
     {
-        if (!BaseT::filter(id)) return;
-
-        const Vec3f P(this->mPHandle->get(id));
-
-        // build area of influence depending on point position
+        // Build area of influence depending on point position
+        // @note  We should only movemask once on a single mask but VCL doesn't
+        //   expose a nice portable way to deal with that. We should introduce
+        //   some kind of zero crossing API method in the simd namespace i.e:
+        //     auto m = movemask(P < 0.0);
+        //     m == 0x0 // all positive
+        //     m == 0xF // all negative
+        //     // else mixed
         CoordBBox intersectBox(ijk, ijk);
-        if (P.x() < 0.0f) intersectBox.min().x() -= 1;
-        else              intersectBox.max().x() += 1;
-        if (P.y() < 0.0f) intersectBox.min().y() -= 1;
-        else              intersectBox.max().y() += 1;
-        if (P.z() < 0.0f) intersectBox.min().z() -= 1;
-        else              intersectBox.max().z() += 1;
-        OPENVDB_ASSERT(intersectBox.volume() == 8);
+        if (simd::horizontal_or(Px <  ScalarT(0.0))) intersectBox.min().x() -= 1;
+        if (simd::horizontal_or(Px >= ScalarT(0.0))) intersectBox.max().x() += 1;
+        if (simd::horizontal_or(Py <  ScalarT(0.0))) intersectBox.min().y() -= 1;
+        if (simd::horizontal_or(Py >= ScalarT(0.0))) intersectBox.max().y() += 1;
+        if (simd::horizontal_or(Pz <  ScalarT(0.0))) intersectBox.min().z() -= 1;
+        if (simd::horizontal_or(Pz >= ScalarT(0.0))) intersectBox.max().z() += 1;
+        return intersectBox;
+    }
 
-        intersectBox.intersect(bounds);
-        if (intersectBox.empty()) return;
+    template<typename ScalarT> /// RealT or SimdT
+    inline void stamp(const ScalarT& Px,
+                    const ScalarT& Py,
+                    const ScalarT& Pz,
+                    const ScalarT* S,
+                    const Coord& ijk,
+                    const CoordBBox& intersection)
+    {
+        // Some of the arithmetic in this function assumes these are the same,
+        // otherwise we can end up writing scalars to all lanes of a simdt
+        // (e.g. wp[0] += (Pwx * weights), where wp is a simdt and Pwx is
+        // a scalar - this ends up filing all the lanes).
+        static_assert(simd::IsSimdT<ScalarT>::value == simd::IsSimdT<typename BaseT::NativeT>::value);
+        OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(Px)));
+        OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(Py)));
+        OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(Pz)));
 
         auto* const data = this->buffer();
         const auto& mask = *(this->mask());
 
-        const SourceValueT s(this->mSHandle->get(id));
-        math::Vec3<RealT> centerw;
+        ScalarT cwx, cwxy, weight; // center weights
+        int32_t xoffset, xyoffset, xyzoffset; // voxel offsets
 
-        const Coord& a(intersectBox.min());
-        const Coord& b(intersectBox.max());
+        const Coord& a(intersection.min());
+        const Coord& b(intersection.max());
         for (Coord c = a; c.x() <= b.x(); ++c.x()) {
-            const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
-            const RealT x = static_cast<RealT>(c.x()-ijk.x()); // distance from ijk to c
-            centerw[0] = value(P.x() - x); // center dist
+            // @todo can probably simplify the double call to value() in
+            //   some way, haven't spent too much time attempting too
+            const ScalarT x(static_cast<RealT>(c.x()-ijk.x())); // distance from ijk to c
+            cwx = value(Px - x); // center dist
+            xoffset = ((c.x() & (DIM-1u)) << 2*LOG2DIM); // unsigned bit shift mult
 
             for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
-                const Index ij = i + ((c.y() & (DIM-1u)) << LOG2DIM);
-                const RealT y = static_cast<RealT>(c.y()-ijk.y());
-                centerw[1] = value(P.y() - y);
+                const ScalarT y(static_cast<RealT>(c.y()-ijk.y()));
+                cwxy = cwx * value(Py - y);
+                xyoffset = xoffset + /*j*/((c.y() & (DIM-1u)) << LOG2DIM);
 
                 for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
-                    OPENVDB_ASSERT(bounds.isInside(c));
-                    const Index offset = ij + /*k*/(c.z() & (DIM-1u));
-                    if (!mask.isOn(offset)) continue;
-                    const RealT z = static_cast<RealT>(c.z()-ijk.z());
-                    centerw[2] = value(P.z() - z);
+                    OPENVDB_ASSERT(intersection.isInside(c));
+                    xyzoffset = xyoffset + /*k*/(c.z() & (DIM-1u));
+                    if (!mask.isOn(xyzoffset)) continue;
+                    auto& v = data[xyzoffset];
+                    auto& w = this->mWeights[xyzoffset];
 
-                    OPENVDB_ASSERT(centerw[0] >= 0.0f && centerw[0] <= 1.0f);
-                    OPENVDB_ASSERT(centerw[1] >= 0.0f && centerw[1] <= 1.0f);
-                    OPENVDB_ASSERT(centerw[2] >= 0.0f && centerw[2] <= 1.0f);
+                    const ScalarT z(static_cast<RealT>(c.z()-ijk.z()));
+                    weight = cwxy * value(Pz - z);
+                    OPENVDB_ASSERT(simd::horizontal_and(simd::is_finite(weight)));
+                    OPENVDB_ASSERT(simd::horizontal_min(weight) >= 0.0);
+                    OPENVDB_ASSERT(simd::horizontal_max(weight) <= 1.0);
 
-                    const RealT weight = centerw.product();
-                    data[offset] += s * weight;
-                    this->mWeights[offset] += weight;
+                    if constexpr (BaseT::SourceSize == 1) {
+                        v += simd::horizontal_add(S[0] * weight);
+                    }
+                    else {
+                        for (size_t j = 0; j < BaseT::SourceSize; ++j) {
+                            v.asPointer()[j] += simd::horizontal_add(S[j] * weight);
+                        }
+                    }
+                    w += weight;
                 }
             }
         }
-    }
-
-    inline bool finalize(const Coord&, const size_t)
-    {
-        auto* const data = this->buffer();
-        const auto& mask = *(this->mask());
-
-        for (auto iter = mask.beginOn(); iter; ++iter) {
-            const Index offset = iter.pos();
-            const auto& w = this->mWeights[offset];
-            auto& v = data[offset];
-            if (!math::isZero(w)) v /= w;
-        }
-        return true;
     }
 };
 
@@ -313,13 +540,14 @@ rasterizeTrilinear(const PointDataTreeT& points,
 {
     using TraitsT = TrilinearTraits<ValueT, Staggered>;
     using TargetTreeT = typename TraitsT::template TreeT<PointDataTree>;
+    using TArgsT = TArgs<Staggered, TargetTreeT, PositionCodecT, ValueT, CodecT, FilterT>;
     using TransferT = typename std::conditional<Staggered,
-            StaggeredTransfer<TargetTreeT, PositionCodecT, ValueT, CodecT, FilterT>,
-            CellCenteredTransfer<TargetTreeT, PositionCodecT, ValueT, CodecT, FilterT>
+            StaggeredTransfer<TArgsT>,
+            CellCenteredTransfer<TArgsT>
         >::type;
 
     typename TargetTreeT::Ptr tree = std::make_shared<TargetTreeT>();
-    if (std::is_same<FilterT, NullFilter>::value) {
+    if constexpr (std::is_same_v<FilterT, NullFilter>) {
         tree->topologyUnion(points);
     }
     else {
@@ -355,7 +583,7 @@ rasterizeTrilinear(const PointDataTreeT& points,
     using TargetTreeT = typename TraitsT::template TreeT<PointDataTree>;
 
     const auto iter = points.cbeginLeaf();
-    if (!iter) return typename TargetTreeT::Ptr(new TargetTreeT);
+    if (!iter) return std::make_shared<TargetTreeT>();
 
     const AttributeSet::Descriptor& descriptor = iter->attributeSet().descriptor();
     const size_t pidx = descriptor.find("P");

--- a/openvdb/openvdb/points/impl/PointRasterizeTrilinearImpl.h
+++ b/openvdb/openvdb/points/impl/PointRasterizeTrilinearImpl.h
@@ -117,8 +117,8 @@ struct TrilinearTransfer :
                     const Index end,
                     const CoordBBox& bounds)
     {
-        constexpr auto N2 = simd::SimdTraits<NativeT>::size;
-        if constexpr(N2 == 1) {
+        constexpr auto kBatchSize = simd::SimdTraits<NativeT>::size;
+        if constexpr(kBatchSize == 1) {
             // Fallback to per point rasterization
             for (Index i = start; i < end; ++i) {
                 if (!FilterTransferT::filter(i)) continue;
@@ -128,22 +128,22 @@ struct TrilinearTransfer :
         else {
             // Batched/vectorized rasterization. Expect power of two for
             // batched size
-            static_assert((N2 > 1) && !(N2 & (N2 - 1)));
-            std::array<int64_t, N2> ids;
+            static_assert((kBatchSize > 1) && !(kBatchSize & (kBatchSize - 1)));
+            std::array<int64_t, kBatchSize> ids;
             Index offset = 0;
             for (Index i = start; i < end; ++i) {
                 if (!FilterTransferT::filter(i)) continue;
                 ids[offset++] = int64_t(i);
-                if (offset == N2) {
-                    this->rasterizeN2<N2>(ijk, ids, bounds);
+                if (offset == kBatchSize) {
+                    this->rasterizeN2<kBatchSize>(ijk, ids, bounds);
                     offset = 0;
                 }
             }
             if (offset == 0) return;
-            else {
-                for (; offset < N2; ++offset) ids[offset] = int64_t(-1);
-                this->rasterizeN2<N2>(ijk, ids, bounds);
+            for (; offset < kBatchSize; ++offset) {
+                ids[offset] = int64_t(-1);
             }
+            this->rasterizeN2<kBatchSize>(ijk, ids, bounds);
         }
     }
 

--- a/openvdb/openvdb/simd/Simd.h
+++ b/openvdb/openvdb/simd/Simd.h
@@ -596,6 +596,7 @@ struct SimdTraits
 
 OPENVDB_ENABLE_IF_ARITHMETIC inline T max(const T& a, const T& b) { return std::max(a, b); }
 OPENVDB_ENABLE_IF_ARITHMETIC inline T min(const T& a, const T& b) { return std::min(a, b); }
+OPENVDB_ENABLE_IF_ARITHMETIC inline auto abs(const T& a) { return std::abs(a); }
 OPENVDB_ENABLE_IF_ARITHMETIC inline auto sqrt(const T& a) { return std::sqrt(a); }
 OPENVDB_ENABLE_IF_ARITHMETIC inline T pow2(const T& a) { return math::Pow2(a); }
 OPENVDB_ENABLE_IF_ARITHMETIC inline T pow3(const T& a) { return math::Pow3(a); }

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -163,6 +163,7 @@ else()
     TestPointSample.cc
     TestPointScatter.cc
     TestPointStatistics.cc
+    TestPointTransfer.cc
     TestPointsToMask.cc
     TestPoissonSolver.cc
     TestPotentialFlow.cc

--- a/openvdb/openvdb/unittest/TestPointRasterizeTrilinear.cc
+++ b/openvdb/openvdb/unittest/TestPointRasterizeTrilinear.cc
@@ -5,9 +5,10 @@
 #include <openvdb/points/PointAttribute.h>
 #include <openvdb/points/PointCount.h>
 #include <openvdb/points/PointConversion.h>
-#include <openvdb/points/PointScatter.h>
 #include <openvdb/points/PointRasterizeTrilinear.h>
 #include <openvdb/util/Assert.h>
+
+#include "PointBuilder.h"
 
 #include <gtest/gtest.h>
 
@@ -20,484 +21,455 @@ public:
     void TearDown() override { openvdb::uninitialize(); }
 }; // class TestPointRasterize
 
-struct DefaultTransfer
+template <bool S, typename V>
+using RasterizeTrilinearT =
+    decltype(points::rasterizeTrilinear<S, V, points::NullFilter, points::PointDataTree>(
+        std::declval<const points::PointDataTree&>(),
+        std::declval<const std::string&>(),
+        std::declval<const points::NullFilter&>()));
+
+// Assert some expected tree types from invoking rasterizeTrilinear
+static_assert(std::is_same_v<RasterizeTrilinearT<false, int32_t>, FloatTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<true,  int32_t>, Vec3fTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<false, int64_t>, DoubleTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<true,  int64_t>, Vec3dTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<false, uint32_t>, FloatTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<true,  uint32_t>, Vec3fTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<false, uint64_t>, DoubleTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<true,  uint64_t>, Vec3dTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<false, float>, FloatTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<true,  float>, Vec3fTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<false, double>, DoubleTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<true,  double>, Vec3dTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<false, Vec3f>, Vec3fTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<true,  Vec3f>, Vec3fTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<false, Vec3d>, Vec3dTree::Ptr>);
+static_assert(std::is_same_v<RasterizeTrilinearT<true,  Vec3d>, Vec3dTree::Ptr>);
+
+inline double kweight(const Vec3d& dist)
 {
-    inline bool startPointLeaf(const points::PointDataTree::LeafNodeType&) { return true; }
-    inline bool endPointLeaf(const points::PointDataTree::LeafNodeType&) { return true; }
-    inline bool finalize(const Coord&, size_t) { return true; }
-};
-
-template <typename T, bool Staggered>
-inline void testTrilinear(const T& v)
-{
-    static constexpr bool IsVec = ValueTraits<T>::IsVec;
-    using VecT = typename std::conditional<IsVec, T, math::Vec3<T>>::type;
-    using ResultValueT = typename std::conditional<Staggered && !IsVec, VecT, T>::type;
-    using ResultTreeT = typename points::PointDataTree::ValueConverter<ResultValueT>::Type;
-
-    std::vector<Vec3f> positions;
-    positions.emplace_back(Vec3f(0.0f));
-
-    const double voxelSize = 0.1;
-    math::Transform::Ptr transform =
-        math::Transform::createLinearTransform(voxelSize);
-
-    points::PointDataGrid::Ptr points =
-        points::createPointDataGrid<points::NullCodec,
-            points::PointDataGrid, Vec3f>(positions, *transform);
-
-    points::appendAttribute<T>(points->tree(), "test", v);
-    TreeBase::Ptr tree =
-        points::rasterizeTrilinear<Staggered, T>(points->tree(), "test");
-
-    EXPECT_TRUE(tree);
-    typename ResultTreeT::Ptr typed = DynamicPtrCast<ResultTreeT>(tree);
-    EXPECT_TRUE(typed);
-
-    const ResultValueT result = typed->getValue(Coord(0,0,0));
-
-    // convert both to vecs even if they are scalars to avoid having
-    // to specialise this method
-    const VecT expected(v);
-    const VecT vec(result);
-    EXPECT_NEAR(expected[0], vec[0], 1e-6);
-    EXPECT_NEAR(expected[1], vec[1], 1e-6);
-    EXPECT_NEAR(expected[2], vec[2], 1e-6);
+    return
+        points::rasterize_trilinear_internal::value(dist[0]) *
+        points::rasterize_trilinear_internal::value(dist[1]) *
+        points::rasterize_trilinear_internal::value(dist[2]);
 }
 
-TEST_F(TestPointRasterize, testTrilinearRasterizeFloat)
+template <typename T>
+inline void TestTrilinearScalar()
 {
-    testTrilinear<float, false>(111.0f);
-    testTrilinear<float, true>(111.0f);
-}
+    using ElemT = typename ValueTraits<T>::ElementType;
+    using FltT = typename types_internal::flt_t<sizeof(ElemT)*CHAR_BIT>::type;
 
-TEST_F(TestPointRasterize, testTrilinearRasterizeDouble)
-{
-    testTrilinear<double, false>(222.0);
-    testTrilinear<double, true>(222.0);
-}
-
-TEST_F(TestPointRasterize, testTrilinearRasterizeVec3f)
-{
-    testTrilinear<Vec3f, false>(Vec3f(111.0f,222.0f,333.0f));
-    testTrilinear<Vec3f, true>(Vec3f(111.0f,222.0f,333.0f));
-}
-
-TEST_F(TestPointRasterize, testTrilinearRasterizeVec3d)
-{
-    testTrilinear<Vec3d, false>(Vec3d(444.0,555.0,666.0));
-    testTrilinear<Vec3d, true>(Vec3d(444.0,555.0,666.0));
-}
-
-TEST_F(TestPointRasterize, testRasterizeWithFilter)
-{
-    struct CountPointsTransferScheme
-        : public DefaultTransfer
-        , public points::VolumeTransfer<Int32Tree>
-        , public points::FilteredTransfer<points::GroupFilter>
+    // Test single point at the origin (center of a voxel)
+    auto points = PointBuilder({Vec3f(0)}).attribute(T(111.0), "test").get();
     {
-        using FilterT = points::FilteredTransfer<points::GroupFilter>;
-        using FilterT::startPointLeaf;
-
-        CountPointsTransferScheme(Int32Tree& tree, const points::GroupFilter& filter)
-            : points::VolumeTransfer<Int32Tree>(&tree)
-            , points::FilteredTransfer<points::GroupFilter>(filter) {}
-
-        inline void initialize(const Coord& origin, const size_t idx, const CoordBBox& bounds)
-        {
-            points::VolumeTransfer<Int32Tree>::initialize(origin, idx, bounds);
-            points::FilteredTransfer<points::GroupFilter>::initialize(origin, idx, bounds);
+        auto tree = points::rasterizeTrilinear<false, T>(points->tree(), "test");
+        static_assert(
+            (sizeof(T) == 4 && std::is_same_v<FloatTree::Ptr, decltype(tree)>) ||
+            (sizeof(T) == 8 && std::is_same_v<DoubleTree::Ptr, decltype(tree)>));
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount()); // should probably by 8 but we don't deactivate
+        for (auto iter = tree->cbeginValueAll(); iter; ++iter) {
+            // we're at the origin, expect either full weight or no weight
+            if (iter.getCoord() == Coord(0,0,0)) EXPECT_NEAR(FltT(111.0), *iter, 1e-6f);
+            else                                 EXPECT_EQ(FltT(0.0), *iter);
         }
-
-        inline Int32 range(const Coord&, size_t) const { return 0; }
-
-        inline void rasterizePoint(const Coord& ijk,
-                        const Index id,
-                        const CoordBBox&)
-        {
-            if (!this->FilterT::filter(id)) return;
-            const Index offset = points::PointDataTree::LeafNodeType::coordToOffset(ijk);
-            auto* const data = this->template buffer<0>();
-            data[offset] += 1;
-        }
-    };
-
-    std::vector<Vec3f> positions;
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-
-    const double voxelSize = 0.1;
-    math::Transform::Ptr transform =
-        math::Transform::createLinearTransform(voxelSize);
-
-    points::PointDataGrid::Ptr points =
-        points::createPointDataGrid<points::NullCodec,
-            points::PointDataGrid>(positions, *transform);
-
-    points::PointDataTree& tree = points->tree();
-    points::appendGroup(tree, "test");
-
-    auto groupHandle = tree.beginLeaf()->groupWriteHandle("test");
-    groupHandle.set(0, true);
-    groupHandle.set(1, false);
-    groupHandle.set(2, true);
-    groupHandle.set(3, false);
-
-    Int32Tree::Ptr intTree(new Int32Tree);
-    intTree->setValueOn(Coord(0,0,0));
-
-    points::GroupFilter filter("test", tree.cbeginLeaf()->attributeSet());
-    CountPointsTransferScheme transfer(*intTree, filter);
-
-    points::rasterize(*points, transfer);
-    const int count = intTree->getValue(Coord(0,0,0));
-    EXPECT_EQ(2, count);
-}
-
-TEST_F(TestPointRasterize, testRasterizeWithInitializeAndFinalize)
-{
-    struct LinearFunctionPointCountTransferScheme
-        : public DefaultTransfer
-        , public points::VolumeTransfer<Int32Tree>
+    }
     {
-        LinearFunctionPointCountTransferScheme(Int32Tree& tree) :
-            points::VolumeTransfer<Int32Tree>(&tree) {}
+        auto tree = points::rasterizeTrilinear<true, T>(points->tree(), "test");
+        static_assert(
+            (sizeof(T) == 4 && std::is_same_v<Vec3fTree::Ptr, decltype(tree)>) ||
+            (sizeof(T) == 8 && std::is_same_v<Vec3dTree::Ptr, decltype(tree)>));
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueOn(); iter; ++iter) {
+            const Vec3d dx = iter.getCoord().asVec3d() - Vec3d(0.5,0,0);
+            const Vec3d dy = iter.getCoord().asVec3d() - Vec3d(0,0.5,0);
+            const Vec3d dz = iter.getCoord().asVec3d() - Vec3d(0,0,0.5);
+            // we know we're at the origin, so we expect a |hat| function
+            // here, where the weight is either exactly zero or one
+            EXPECT_NEAR(kweight(dx) > 0 ? FltT(111.0) : 0.0f, (*iter)[0], 1e-6f);
+            EXPECT_NEAR(kweight(dy) > 0 ? FltT(111.0) : 0.0f, (*iter)[1], 1e-6f);
+            EXPECT_NEAR(kweight(dz) > 0 ? FltT(111.0) : 0.0f, (*iter)[2], 1e-6f);
+        }
+        for (auto iter = tree->cbeginValueOff(); iter; ++iter) EXPECT_EQ(iter->zero(), *iter);
+    }
 
-        inline Int32 range(const Coord&, size_t) const { return 0; }
+    // Test eight point at the origin (all overlapping). Result should be evenly weighted
+    auto positions = getBoxPoints(/*scale*/0.0f); // 8 positions
+    const std::vector<T> values { T(-1.0), T(0.0), T(2.3), T(5.4), T(8.4), T(-9.1), T(0.0), T(0.1) };
+    const FltT expected = [&]() {
+        FltT r = 0;
+        for (auto& v : values) r += FltT(v);
+        return r / FltT(8);
+    }();
 
-        inline void initialize(const Coord& c, size_t i, const CoordBBox& b)
-        {
-            this->points::VolumeTransfer<Int32Tree>::initialize(c,i,b);
-            auto* const data = this->template buffer<0>();
-            const auto& mask = *(this->template mask<0>());
-            for (auto iter = mask.beginOn(); iter; ++iter) {
-                data[iter.pos()] += 10;
+    points = PointBuilder(positions).attribute(values, "test").get();
+    {
+        auto tree = points::rasterizeTrilinear<false, T>(points->tree(), "test");
+        static_assert(
+            (sizeof(T) == 4 && std::is_same_v<FloatTree::Ptr, decltype(tree)>) ||
+            (sizeof(T) == 8 && std::is_same_v<DoubleTree::Ptr, decltype(tree)>));
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueAll(); iter; ++iter) {
+            // we're at the origin, expect either full weight or no weight
+            if (iter.getCoord() == Coord(0,0,0)) EXPECT_NEAR(expected, *iter, 1e-6f);
+            else                                 EXPECT_EQ(FltT(0.0), *iter);
+        }
+    }
+    {
+        auto tree = points::rasterizeTrilinear<true, T>(points->tree(), "test");
+        static_assert(
+            (sizeof(T) == 4 && std::is_same_v<Vec3fTree::Ptr, decltype(tree)>) ||
+            (sizeof(T) == 8 && std::is_same_v<Vec3dTree::Ptr, decltype(tree)>));
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount());
+
+        for (auto iter = tree->cbeginValueOn(); iter; ++iter) {
+            const Vec3d dx = iter.getCoord().asVec3d() - Vec3d(0.5,0,0);
+            const Vec3d dy = iter.getCoord().asVec3d() - Vec3d(0,0.5,0);
+            const Vec3d dz = iter.getCoord().asVec3d() - Vec3d(0,0,0.5);
+            // we know we're at the origin, so we expect a |hat| function
+            // here, where the weight is either exactly zero or one
+            EXPECT_NEAR(kweight(dx) > 0 ? expected : 0.0f, (*iter)[0], 1e-6f);
+            EXPECT_NEAR(kweight(dy) > 0 ? expected : 0.0f, (*iter)[1], 1e-6f);
+            EXPECT_NEAR(kweight(dz) > 0 ? expected : 0.0f, (*iter)[2], 1e-6f);
+        }
+        for (auto iter = tree->cbeginValueOff(); iter; ++iter) EXPECT_EQ(iter->zero(), *iter);
+    }
+
+    // Test eight points
+    positions = getBoxPoints(); // 8 positions
+    points = PointBuilder(positions).attribute(values, "test").get();
+    // positions to index space for the test check
+    for (auto& p : positions) p = Vec3f(points->transform().worldToIndex(p));
+    {
+        auto tree = points::rasterizeTrilinear<false, T>(points->tree(), "test");
+        static_assert(
+            (sizeof(T) == 4 && std::is_same_v<FloatTree::Ptr, decltype(tree)>) ||
+            (sizeof(T) == 8 && std::is_same_v<DoubleTree::Ptr, decltype(tree)>));
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(216), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueOn(); iter; ++iter) {
+            FltT expected(0.0), weight(0.0);
+            for (size_t i = 0; i < 8; ++i) {
+                FltT w = FltT(kweight(positions[i] - iter.getCoord().asVec3d()));
+                weight += w;
+                expected += FltT(values[i]) * w;
             }
+            EXPECT_GE(weight, 0.0);
+            if (bool(weight)) expected /= weight;
+            EXPECT_NEAR(FltT(expected), *iter, 1e-6f);
         }
-
-        inline bool finalize(const Coord&, size_t)
-        {
-            auto* const data = this->template buffer<0>();
-            const auto& mask = *(this->template mask<0>());
-            for (auto iter = mask.beginOn(); iter; ++iter) {
-                data[iter.pos()] *= 2;
-            }
-            return true;
-        }
-
-        inline void rasterizePoint(const Coord& ijk, const Index, const CoordBBox&)
-        {
-            const Index offset = points::PointDataTree::LeafNodeType::coordToOffset(ijk);
-            auto* const data = this->template buffer<0>();
-            data[offset] += 1;
-        }
-    };
-
-    std::vector<Vec3f> positions;
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-
-    const double voxelSize = 0.1;
-    math::Transform::Ptr transform =
-        math::Transform::createLinearTransform(voxelSize);
-
-    points::PointDataGrid::Ptr points =
-        points::createPointDataGrid<points::NullCodec,
-            points::PointDataGrid>(positions, *transform);
-
-    Int32Tree::Ptr intTree(new Int32Tree);
-    intTree->setValueOn(Coord(0,0,0));
-
-    LinearFunctionPointCountTransferScheme transfer(*intTree);
-    points::rasterize(*points, transfer);
-
-    const int value = intTree->getValue(Coord(0,0,0));
-    EXPECT_EQ(/*(10+4)*2*/28, value);
-}
-
-TEST_F(TestPointRasterize, tetsSingleTreeRasterize)
-{
-    struct CountPoints27TransferScheme
-        : public DefaultTransfer
-        , public points::VolumeTransfer<Int32Tree>
+        for (auto iter = tree->cbeginValueOff(); iter; ++iter) EXPECT_EQ(T(0), *iter);
+    }
     {
-        CountPoints27TransferScheme(Int32Tree& tree)
-            : points::VolumeTransfer<Int32Tree>(&tree) {}
-
-        /// @brief  The maximum lookup range of this transfer scheme in voxels.
-        inline Int32 range(const Coord&, size_t) const { return 1; }
-
-        /// @brief  The point stamp function. Each point which contributes to the
-        ///         current leaf that the thread has access to will call this function
-        ///         exactly once.
-        /// @param ijk     The current voxel containing the point being rasterized. May
-        ///                not be inside the destination leaf nodes.
-        /// @param id      The point index being rasterized
-        /// @param bounds  The active bounds of the leaf node(s) being written to.
-        void rasterizePoint(const Coord& ijk, const Index, const CoordBBox& bounds)
-        {
-            static const Index DIM = Int32Tree::LeafNodeType::DIM;
-            static const Index LOG2DIM = Int32Tree::LeafNodeType::LOG2DIM;
-
-            CoordBBox intersectBox(ijk.offsetBy(-1), ijk.offsetBy(1));
-            intersectBox.intersect(bounds);
-            if (intersectBox.empty()) return;
-            auto* const data = this->template buffer<0>();
-            const auto& mask = *(this->template mask<0>());
-
-            // loop over voxels in this leaf which are affected by this point
-
-            const Coord& a(intersectBox.min());
-            const Coord& b(intersectBox.max());
-            for (Coord c = a; c.x() <= b.x(); ++c.x()) {
-                const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM);
-                for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
-                    const Index j = ((c.y() & (DIM-1u)) << LOG2DIM);
-                    for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
-                        OPENVDB_ASSERT(bounds.isInside(c));
-                        const Index offset = i + j + /*k*/(c.z() & (DIM-1u));
-                        if (!mask.isOn(offset)) continue;
-                        data[offset] += 1;
-
-                    }
+        auto tree = points::rasterizeTrilinear<true, T>(points->tree(), "test");
+        static_assert(
+            (sizeof(T) == 4 && std::is_same_v<Vec3fTree::Ptr, decltype(tree)>) ||
+            (sizeof(T) == 8 && std::is_same_v<Vec3dTree::Ptr, decltype(tree)>));
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(216), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ijk = iter.getCoord().asVec3d();
+            math::Vec3<FltT> expected(0.0f), weight(0.0f);
+            for (size_t i = 0; i < 8; ++i) {
+                for (size_t j = 0; j < 3; ++j) {
+                    Vec3d offset(0.0);
+                    offset[j] = 0.5;
+                    FltT w = FltT(kweight(positions[i] - (ijk - offset)));
+                    weight[j] += w;
+                    expected[j] += FltT(values[i]) * w;
                 }
             }
+            for (size_t j = 0; j < 3; ++j) {
+                EXPECT_GE(weight[j], FltT(0.0)) << j;
+                if (bool(weight[j])) expected[j] /= weight[j];
+            }
+            EXPECT_NEAR(expected[0], (*iter)[0], 1e-6f);
+            EXPECT_NEAR(expected[1], (*iter)[1], 1e-6f);
+            EXPECT_NEAR(expected[2], (*iter)[2], 1e-6f);
         }
-    };
-
-    std::vector<Vec3f> positions;
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-    positions.emplace_back(Vec3f(0.1f, 0.1f, 0.1f));
-    positions.emplace_back(Vec3f(0.2f, 0.2f, 0.2f));
-    positions.emplace_back(Vec3f(-0.1f,-0.1f,-0.1f));
-
-    const double voxelSize = 0.1;
-    math::Transform::Ptr transform =
-        math::Transform::createLinearTransform(voxelSize);
-
-    points::PointDataGrid::Ptr points =
-        points::createPointDataGrid<points::NullCodec,
-            points::PointDataGrid>(positions, *transform);
-
-    Int32Tree::Ptr intTree(new Int32Tree);
-    intTree->setValueOn(Coord(0,0,0));
-    intTree->setValueOn(Coord(1,1,1));
-    intTree->setValueOn(Coord(-1,-1,-1));
-
-    CountPoints27TransferScheme transfer(*intTree);
-    points::rasterize(*points, transfer);
-
-    int count = intTree->getValue(Coord(0,0,0));
-    EXPECT_EQ(3, count);
-    count = intTree->getValue(Coord(1,1,1));
-    EXPECT_EQ(3, count);
-    count = intTree->getValue(Coord(-1,-1,-1));
-    EXPECT_EQ(2, count);
+        for (auto iter = tree->cbeginValueOff(); iter; ++iter) EXPECT_EQ(iter->zero(), *iter);
+    }
 }
 
-TEST_F(TestPointRasterize, testMultiTreeRasterize)
+TEST_F(TestPointRasterize, testTrilinearRasterizeScalar)
 {
-    /// @brief  An example multi tree transfer scheme which rasterizes a vector
-    ///         attribute into an int grid using length, and an int attribute
-    ///         into a vector grid. Based on a 27 lookup stencil.
-    ///
-    struct MultiTransferScheme
-        : public DefaultTransfer
-        , public points::VolumeTransfer<Int32Tree, Vec3DTree>
+    TestTrilinearScalar<float>();
+    TestTrilinearScalar<double>();
+    TestTrilinearScalar<int32_t>();
+    TestTrilinearScalar<int64_t>();
+}
+
+
+template <typename Vec3T>
+inline void TestTrilinearVec()
+{
+    using ElemT = typename Vec3T::ValueType;
+    using FltT = typename types_internal::flt_t<sizeof(ElemT)*CHAR_BIT>::type;
+    using TreeT = typename openvdb::points::PointDataGrid::ValueConverter<math::Vec3<FltT>>::Type::TreeType;
+
+    // Test single point at the origin (center of a voxel)
+    auto points = PointBuilder({Vec3T(0)}).attribute(Vec3T(1.0, 2.0, 3.0), "test").get();
     {
-        using BaseT = points::VolumeTransfer<Int32Tree, Vec3DTree>;
-
-        MultiTransferScheme(const size_t vIdx,const size_t iIdx,
-                            Int32Tree& t1, Vec3DTree& t2)
-            : BaseT(t1, t2)
-            , mVIdx(vIdx), mIIdx(iIdx)
-            , mVHandle(), mIHandle() {}
-
-        MultiTransferScheme(const MultiTransferScheme& other)
-            : BaseT(other), mVIdx(other.mVIdx), mIIdx(other.mIIdx)
-            , mVHandle(), mIHandle() {}
-
-        inline Int32 range(const Coord&, size_t) const { return 1; }
-
-        inline bool startPointLeaf(const points::PointDataTree::LeafNodeType& leaf)
-        {
-            mVHandle = points::AttributeHandle<Vec3d>::create(leaf.constAttributeArray(mVIdx));
-            mIHandle = points::AttributeHandle<int>::create(leaf.constAttributeArray(mIIdx));
-            return true;
-        }
-
-        void rasterizePoint(const Coord& ijk, const Index id, const CoordBBox& bounds)
-        {
-            static const Index DIM = Int32Tree::LeafNodeType::DIM;
-            static const Index LOG2DIM = Int32Tree::LeafNodeType::LOG2DIM;
-
-            CoordBBox intersectBox(ijk.offsetBy(-1), ijk.offsetBy(1));
-            intersectBox.intersect(bounds);
-            if (intersectBox.empty()) return;
-
-            auto* const data1 = this->template buffer<0>();
-            auto* const data2 = this->template buffer<1>();
-            const auto& mask = *(this->template mask<0>());
-
-            // loop over voxels in this leaf which are affected by this point
-            const Vec3d& vec = mVHandle->get(id);
-            const int integer = mIHandle->get(id);
-
-            const Coord& a(intersectBox.min());
-            const Coord& b(intersectBox.max());
-            for (Coord c = a; c.x() <= b.x(); ++c.x()) {
-                const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM);
-                for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
-                    const Index j = ((c.y() & (DIM-1u)) << LOG2DIM);
-                    for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
-                        OPENVDB_ASSERT(bounds.isInside(c));
-                        const Index offset = i + j + /*k*/(c.z() & (DIM-1u));
-                        if (!mask.isOn(offset)) continue;
-                        data1[offset] += static_cast<int>(vec.length());
-                        data2[offset] += Vec3d(integer);
-                    }
-                }
+        auto tree = points::rasterizeTrilinear<false, Vec3T>(points->tree(), "test");
+        static_assert(std::is_same_v<typename TreeT::Ptr, decltype(tree)>);
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount()); // should probably by 8 but we don't deactivate
+        for (auto iter = tree->cbeginValueAll(); iter; ++iter) {
+            // we're at the origin, expect either full weight or no weight
+            if (iter.getCoord() == Coord(0,0,0)) {
+                EXPECT_NEAR(1.0f, (*iter)[0], 1e-6f);
+                EXPECT_NEAR(2.0f, (*iter)[1], 1e-6f);
+                EXPECT_NEAR(3.0f, (*iter)[2], 1e-6f);
+            }
+            else {
+                EXPECT_EQ(iter->zero(), *iter);
             }
         }
-
-    private:
-        const size_t mVIdx;
-        const size_t mIIdx;
-        points::AttributeHandle<Vec3d>::Ptr mVHandle;
-        points::AttributeHandle<int>::Ptr mIHandle;
-    };
-
-    std::vector<Vec3f> positions;
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-
-    const double voxelSize = 0.1;
-    math::Transform::Ptr transform =
-        math::Transform::createLinearTransform(voxelSize);
-
-    points::PointDataGrid::Ptr points =
-        points::createPointDataGrid<points::NullCodec,
-            points::PointDataGrid>(positions, *transform);
-
-    points::PointDataTree& tree = points->tree();
-
-    const Vec3d vectorValue(444.0f,555.0f,666.0f);
-    points::appendAttribute<Vec3d>(tree, "testVec3d", vectorValue);
-    points::appendAttribute<int>(tree, "testInt", 7);
-
-    Vec3DTree::Ptr vecTree(new Vec3DTree);
-    Int32Tree::Ptr intTree(new Int32Tree);
-    vecTree->topologyUnion(tree);
-    intTree->topologyUnion(tree);
-
-    const points::PointDataTree::LeafNodeType& leaf = *(tree.cbeginLeaf());
-    const size_t vidx = leaf.attributeSet().descriptor().find("testVec3d");
-    const size_t iidx = leaf.attributeSet().descriptor().find("testInt");
-
-    MultiTransferScheme transfer(vidx, iidx, *intTree, *vecTree);
-    points::rasterize(*points, transfer);
-
-    const Vec3d vecResult = vecTree->getValue(Coord(0,0,0));
-    const int intResult = intTree->getValue(Coord(0,0,0));
-
-    EXPECT_EQ(7.0, vecResult[0]);
-    EXPECT_EQ(7.0, vecResult[1]);
-    EXPECT_EQ(7.0, vecResult[2]);
-    const int expected = static_cast<int>(vectorValue.length());
-    EXPECT_EQ(expected, intResult);
-}
-
-TEST_F(TestPointRasterize, testMultiTreeRasterizeWithMask)
-{
-    struct CountPointsMaskTransferScheme
-        : public DefaultTransfer
-        , public points::VolumeTransfer<BoolTree, Int32Tree>
+    }
     {
-        using BaseT = points::VolumeTransfer<BoolTree, Int32Tree>;
-        CountPointsMaskTransferScheme(BoolTree& t1, Int32Tree& t2)
-            : BaseT(t1, t2) {}
-
-        inline Int32 range(const Coord&, size_t) const { return 0; }
-        inline void rasterizePoint(const Coord& ijk, const Index, const CoordBBox&)
-        {
-            auto* const data = this->template buffer<1>();
-            const Index offset = points::PointDataTree::LeafNodeType::coordToOffset(ijk);
-            data[offset] += 1;
+        auto tree = points::rasterizeTrilinear<true, Vec3T>(points->tree(), "test");
+        static_assert(std::is_same_v<typename TreeT::Ptr, decltype(tree)>);
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueOn(); iter; ++iter) {
+            const Vec3d dx = iter.getCoord().asVec3d() - Vec3d(0.5,0,0);
+            const Vec3d dy = iter.getCoord().asVec3d() - Vec3d(0,0.5,0);
+            const Vec3d dz = iter.getCoord().asVec3d() - Vec3d(0,0,0.5);
+            // we know we're at the origin, so we expect a |hat| function
+            // here, where the weight is either exactly zero or one
+            EXPECT_NEAR(kweight(dx) > 0 ? 1.0f : 0.0f, (*iter)[0], 1e-6f) << iter.getCoord();
+            EXPECT_NEAR(kweight(dy) > 0 ? 2.0f : 0.0f, (*iter)[1], 1e-6f) << iter.getCoord();
+            EXPECT_NEAR(kweight(dz) > 0 ? 3.0f : 0.0f, (*iter)[2], 1e-6f) << iter.getCoord();
         }
+        for (auto iter = tree->cbeginValueOff(); iter; ++iter) EXPECT_EQ(iter->zero(), *iter);
+    }
+
+    // Test eight point at the origin (all overlapping). Result should be evenly weighted
+    auto positions = getBoxPoints(/*scale*/0.0f); // 8 positions
+    const std::vector<Vec3T> values {
+        Vec3T(ElemT(-1.0f), ElemT(0.0f), ElemT(2.3f)),
+        Vec3T(ElemT(5.4f),  ElemT(8.4f), ElemT(-9.1f)),
+        Vec3T(ElemT(0.0f),  ElemT(0.1f), ElemT(0.0f)),
+        Vec3T(ElemT(8.2f),  ElemT(3.1f), ElemT(0.0f)),
+        Vec3T(ElemT(0.0f),  ElemT(0.0f), ElemT(0.0f)),
+        Vec3T(ElemT(-9.0f), ElemT(0.0f), ElemT(-3.0f)),
+        Vec3T(ElemT(0.5f),  ElemT(0.5f), ElemT(0.5f)),
+        Vec3T(ElemT(0.0f),  ElemT(0.1f), ElemT(0.0f))
     };
+    const math::Vec3<FltT> expected = [&]() {
+        math::Vec3<FltT> r(0.0f);
+        for (auto& v : values) r += math::Vec3<FltT>(v);
+        return r / float(8);
+    }();
 
-    // Setup test data
-    std::vector<Vec3f> positions;
-    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
-    positions.emplace_back(Vec3f(1.0f, 1.0f, 1.0f));
+    points = PointBuilder(positions).attribute(values, "test").get();
+    {
+        auto tree = points::rasterizeTrilinear<false, Vec3T>(points->tree(), "test");
+        static_assert(std::is_same_v<typename TreeT::Ptr, decltype(tree)>);
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueAll(); iter; ++iter) {
+            // we're at the origin, expect either full weight or no weight
+            if (iter.getCoord() == Coord(0,0,0)) {
+                EXPECT_NEAR(expected[0], (*iter)[0], 1e-6f);
+                EXPECT_NEAR(expected[1], (*iter)[1], 1e-6f);
+                EXPECT_NEAR(expected[2], (*iter)[2], 1e-6f);
+            }
+            else {
+                EXPECT_EQ(iter->zero(), *iter);
+            }
+        }
+    }
+    {
+        auto tree = points::rasterizeTrilinear<true, Vec3T>(points->tree(), "test");
+        static_assert(std::is_same_v<typename TreeT::Ptr, decltype(tree)>);
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount());
 
-    const double voxelSize = 0.1;
-    math::Transform::Ptr transform =
-        math::Transform::createLinearTransform(voxelSize);
+        for (auto iter = tree->cbeginValueOn(); iter; ++iter) {
+            const Vec3d dx = iter.getCoord().asVec3d() - Vec3d(0.5,0,0);
+            const Vec3d dy = iter.getCoord().asVec3d() - Vec3d(0,0.5,0);
+            const Vec3d dz = iter.getCoord().asVec3d() - Vec3d(0,0,0.5);
+            // we know we're at the origin, so we expect a |hat| function
+            // here, where the weight is either exactly zero or one
+            EXPECT_NEAR(kweight(dx) > 0 ? expected[0] : 0.0f, (*iter)[0], 1e-6f) << iter.getCoord();
+            EXPECT_NEAR(kweight(dy) > 0 ? expected[1] : 0.0f, (*iter)[1], 1e-6f) << iter.getCoord();
+            EXPECT_NEAR(kweight(dz) > 0 ? expected[2] : 0.0f, (*iter)[2], 1e-6f) << iter.getCoord();
+        }
+        for (auto iter = tree->cbeginValueOff(); iter; ++iter) EXPECT_EQ(iter->zero(), *iter);
+    }
 
-    points::PointDataGrid::Ptr points =
-        points::createPointDataGrid<points::NullCodec,
-            points::PointDataGrid>(positions, *transform);
-
-    Int32Tree::Ptr intTree(new Int32Tree);
-    BoolTree::Ptr topology(new BoolTree);
-    intTree->topologyUnion(points->tree());
-    topology->setValueOn(Coord(0,0,0));
-
-    EXPECT_TRUE(intTree->isValueOn(Coord(10,10,10)));
-
-    CountPointsMaskTransferScheme transfer(*topology, *intTree);
-    points::rasterize(*points, transfer);
-
-    int count = intTree->getValue(Coord(0,0,0));
-    EXPECT_EQ(1, count);
-    count = intTree->getValue(Coord(10,10,10));
-    EXPECT_EQ(0, count);
+    // Test eight points
+    positions = getBoxPoints(); // 8 positions
+    points = PointBuilder(positions).attribute(values, "test").get();
+    // positions to index space for the test check
+    for (auto& p : positions) p = Vec3f(points->transform().worldToIndex(p));
+    {
+        auto tree = points::rasterizeTrilinear<false, Vec3T>(points->tree(), "test");
+        static_assert(std::is_same_v<typename TreeT::Ptr, decltype(tree)>);
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(216), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueOn(); iter; ++iter) {
+            math::Vec3<FltT> expected(0.0f);
+            FltT weight = 0.0f;
+            for (size_t i = 0; i < 8; ++i) {
+                FltT w = FltT(kweight(positions[i] - iter.getCoord().asVec3d()));
+                weight += w;
+                expected += values[i] * w;
+            }
+            EXPECT_GE(weight, 0.0f);
+            if (bool(weight)) expected /= weight;
+            EXPECT_NEAR(expected[0], (*iter)[0], 1e-6f);
+            EXPECT_NEAR(expected[1], (*iter)[1], 1e-6f);
+            EXPECT_NEAR(expected[2], (*iter)[2], 1e-6f);
+        }
+        for (auto iter = tree->cbeginValueOff(); iter; ++iter) EXPECT_EQ(iter->zero(), *iter);
+    }
+    {
+        auto tree = points::rasterizeTrilinear<true, Vec3T>(points->tree(), "test");
+        static_assert(std::is_same_v<typename TreeT::Ptr, decltype(tree)>);
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(216), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueOn(); iter; ++iter) {
+            const Vec3d ijk = iter.getCoord().asVec3d();
+            math::Vec3<FltT> expected(0.0f), weight(0.0f);
+            for (size_t i = 0; i < 8; ++i) {
+                for (size_t j = 0; j < 3; ++j) {
+                    Vec3d offset(0.0);
+                    offset[j] = 0.5;
+                    FltT w = FltT(kweight(positions[i] - (ijk - offset)));
+                    weight[j] += w;
+                    expected[j] += FltT(values[i][j]) * w;
+                }
+            }
+            for (size_t j = 0; j < 3; ++j) {
+                EXPECT_GE(weight[j], 0.0f) << j;
+                if (bool(weight[j])) expected[j] /= weight[j];
+            }
+            EXPECT_NEAR(expected[0], (*iter)[0], 1e-6f);
+            EXPECT_NEAR(expected[1], (*iter)[1], 1e-6f);
+            EXPECT_NEAR(expected[2], (*iter)[2], 1e-6f);
+        }
+        for (auto iter = tree->cbeginValueOff(); iter; ++iter) EXPECT_EQ(iter->zero(), *iter);
+    }
 }
 
-// void
-// TestPointRasterize::testMultiTreeRasterizeConstTopology()
-// {
-//     // Test const-ness is respected and works at compile time through
-//     // the points::rasterize function (transfer function signatures should
-//     // respect the const flag of the topology mask leaf nodes)
 
-//     struct CountPointsConstMaskTransferScheme
-//         : public DefaultTransfer,
-//         : public points::VolumeTransfer<const BoolTree, Int32Tree>
-//     {
-//         using VolumeTransferT =
-//             points::rasterize_tree_containers::MultiTreeRasterizer
-//                 <const BoolTree, Int32Tree>;
+TEST_F(TestPointRasterize, testTrilinearRasterizeVec)
+{
+    TestTrilinearVec<Vec3f>();
+    TestTrilinearVec<Vec3i>();
+    TestTrilinearVec<Vec3d>();
+}
 
-//         using BufferT = VolumeTransferT::BufferT;
-//         using NodeMaskT = VolumeTransferT::NodeMaskT;
 
-//         static_assert(std::is_const<NodeMaskT>::value,
-//             "Node mask should be const");
-//         static_assert(std::is_const<VolumeTransferT::TopologyTreeT>::value,
-//             "TopologyTreeT should be const");
+TEST_F(TestPointRasterize, testTrilinearRasterizeMat)
+{
+    using FltT = float;
+    using Mat3sTree = tree::Tree4<Mat3s, 5, 4, 3>::Type;
 
-//         inline Int32 range() const { return 0; }
-//         inline void initialize(BufferT, NodeMaskT&, const Coord&) {}
-//         inline void initLeaf(const points::PointDataTree::LeafNodeType&) {}
-//         inline void finalize(BufferT, NodeMaskT&, const Coord&) {}
-//         inline void rasterizePoint(const Coord&,
-//                         const Index,
-//                         const CoordBBox&,
-//                         BufferT,
-//                         NodeMaskT&) {}
-//     };
+    // Test single point at the origin (center of a voxel)
+    auto points = PointBuilder({Vec3f(0)}).attribute(Mat3s(
+        1.0f, 2.0f, 3.0f,
+        4.0f, 5.0f, 6.0f,
+        7.0f, 8.0f, 9.0f), "test").get();
+    {
+        auto tree = points::rasterizeTrilinear<false, Mat3s>(points->tree(), "test");
+        static_assert(std::is_same_v<Mat3sTree::Ptr, decltype(tree)>);
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount()); // should probably by 8 but we don't deactivate
+        for (auto iter = tree->cbeginValueAll(); iter; ++iter) {
+            // we're at the origin, expect either full weight or no weight
+            if (iter.getCoord() == Coord(0,0,0)) {
+                for (size_t i = 0; i < 9; ++i) EXPECT_NEAR(float(i+1), (*iter).asPointer()[i], 1e-6f);
+            }
+            else {
+                EXPECT_EQ(Mat3s::zero(), *iter);
+            }
+        }
+    }
+    // Test eight point at the origin (all overlapping). Result should be evenly weighted
+    auto positions = getBoxPoints(/*scale*/0.0f); // 8 positions
+    const std::vector<Mat3s> values {
+        Mat3s(-1.0f, 0.0f, 2.3f,  5.4f, 0.0f, -14.0f,  0.24f, 0.2f, 1.0f),
+        Mat3s(5.4f, 8.4f, -9.1f,  0.5f, 0.5f, 0.5f,    0.5f, 0.5f, 0.5f),
+        Mat3s::zero(),
+        Mat3s(8.2f, 3.1f, 0.0f,  -1.0f, 0.0f, 2.3f,    1.0f, 1.0f, 1.0f),
+        Mat3s(0.0f, 0.0f, 0.0f,   5.1f, 7.2f, 9.0f,    0.0f, 0.0f, 0.0f),
+        Mat3s::identity(),
+        Mat3s(0.5f, 0.5f, 0.5f,   0.5f, 0.5f, 0.5f,    0.5f, 0.5f, 0.5f),
+        Mat3s::zero(),
+    };
+    const Mat3s expected = [&]() {
+        Mat3s r = Mat3s::zero();
+        for (auto& v : values) r += v;
+        for (size_t i = 0; i < 9; ++i) r.asPointer()[i] /= float(8);
+        return r;
+    }();
 
-//     points::PointDataTree tree;
-//     Int32Tree::Ptr intTree(new Int32Tree);
-//     BoolTree::Ptr topology(new BoolTree);
-
-//     CountPointsConstMaskTransferScheme transfer;
-//     CountPointsConstMaskTransferScheme::VolumeTransferT::TreeArrayT array = {intTree};
-//     CountPointsConstMaskTransferScheme::VolumeTransferT container(*topology, array);
-//     points::rasterize(tree, transfer, container);
-// }
+    points = PointBuilder(positions).attribute(values, "test").get();
+    {
+        auto tree = points::rasterizeTrilinear<false, Mat3s>(points->tree(), "test");
+        static_assert(std::is_same_v<Mat3sTree::Ptr, decltype(tree)>);
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(27), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueAll(); iter; ++iter) {
+            // we're at the origin, expect either full weight or no weight
+            if (iter.getCoord() == Coord(0,0,0)) {
+                for (size_t i = 0; i < 9; ++i) {
+                    EXPECT_NEAR(expected.asPointer()[i], (*iter).asPointer()[i], 1e-6f);
+                }
+            }
+            else {
+                EXPECT_EQ(Mat3s::zero(), *iter);
+            }
+        }
+    }
+    // Test eight points
+    positions = getBoxPoints(); // 8 positions
+    points = PointBuilder(positions).attribute(values, "test").get();
+    // positions to index space for the test check
+    for (auto& p : positions) p = Vec3f(points->transform().worldToIndex(p));
+    {
+        auto tree = points::rasterizeTrilinear<false, Mat3s>(points->tree(), "test");
+        static_assert(std::is_same_v<Mat3sTree::Ptr, decltype(tree)>);
+        EXPECT_EQ(Index64(8), tree->leafCount());
+        EXPECT_EQ(Index64(0), tree->activeTileCount());
+        EXPECT_EQ(Index64(216), tree->activeVoxelCount());
+        for (auto iter = tree->cbeginValueOn(); iter; ++iter) {
+            Mat3s expected = Mat3s::zero();
+            float weight = 0.0f;
+            for (size_t i = 0; i < 8; ++i) {
+                FltT w = FltT(kweight(positions[i] - iter.getCoord().asVec3d()));
+                weight += w;
+                expected += values[i] * w;
+            }
+            EXPECT_GE(weight, 0.0f);
+            if (bool(weight)) {
+                for (size_t i = 0; i < 9; ++i) expected.asPointer()[i] /= weight;
+            }
+            for (size_t i = 0; i < 9; ++i) {
+                EXPECT_NEAR(expected.asPointer()[i], (*iter).asPointer()[i], 1e-6f);
+            }
+        }
+        for (auto iter = tree->cbeginValueOff(); iter; ++iter) EXPECT_EQ(Mat3s::zero(), *iter);
+    }
+}

--- a/openvdb/openvdb/unittest/TestPointTransfer.cc
+++ b/openvdb/openvdb/unittest/TestPointTransfer.cc
@@ -1,0 +1,397 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+#include <openvdb/openvdb.h>
+#include <openvdb/points/PointAttribute.h>
+#include <openvdb/points/PointCount.h>
+#include <openvdb/points/PointConversion.h>
+#include <openvdb/points/PointScatter.h>
+#include <openvdb/points/PointTransfer.h>
+#include <openvdb/util/Assert.h>
+
+#include <gtest/gtest.h>
+
+using namespace openvdb;
+
+class TestPointTransfer: public ::testing::Test
+{
+public:
+    void SetUp() override { openvdb::initialize(); }
+    void TearDown() override { openvdb::uninitialize(); }
+}; // class TestPointTransfer
+
+struct DefaultTransfer
+{
+    inline bool startPointLeaf(const points::PointDataTree::LeafNodeType&) { return true; }
+    inline bool endPointLeaf(const points::PointDataTree::LeafNodeType&) { return true; }
+    inline bool finalize(const Coord&, size_t) { return true; }
+};
+
+TEST_F(TestPointTransfer, testRasterizeWithFilter)
+{
+    struct CountPointsTransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<Int32Tree>
+        , public points::FilteredTransfer<points::GroupFilter>
+    {
+        using FilterT = points::FilteredTransfer<points::GroupFilter>;
+        using FilterT::startPointLeaf;
+
+        CountPointsTransferScheme(Int32Tree& tree, const points::GroupFilter& filter)
+            : points::VolumeTransfer<Int32Tree>(&tree)
+            , points::FilteredTransfer<points::GroupFilter>(filter) {}
+
+        inline void initialize(const Coord& origin, const size_t idx, const CoordBBox& bounds)
+        {
+            points::VolumeTransfer<Int32Tree>::initialize(origin, idx, bounds);
+            points::FilteredTransfer<points::GroupFilter>::initialize(origin, idx, bounds);
+        }
+
+        inline Int32 range(const Coord&, size_t) const { return 0; }
+
+        inline void rasterizePoint(const Coord& ijk,
+                        const Index id,
+                        const CoordBBox&)
+        {
+            if (!this->FilterT::filter(id)) return;
+            const Index offset = points::PointDataTree::LeafNodeType::coordToOffset(ijk);
+            auto* const data = this->template buffer<0>();
+            data[offset] += 1;
+        }
+    };
+
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    points::PointDataTree& tree = points->tree();
+    points::appendGroup(tree, "test");
+
+    auto groupHandle = tree.beginLeaf()->groupWriteHandle("test");
+    groupHandle.set(0, true);
+    groupHandle.set(1, false);
+    groupHandle.set(2, true);
+    groupHandle.set(3, false);
+
+    Int32Tree::Ptr intTree(new Int32Tree);
+    intTree->setValueOn(Coord(0,0,0));
+
+    points::GroupFilter filter("test", tree.cbeginLeaf()->attributeSet());
+    CountPointsTransferScheme transfer(*intTree, filter);
+
+    points::rasterize(*points, transfer);
+    const int count = intTree->getValue(Coord(0,0,0));
+    EXPECT_EQ(2, count);
+}
+
+TEST_F(TestPointTransfer, testRasterizeWithInitializeAndFinalize)
+{
+    struct LinearFunctionPointCountTransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<Int32Tree>
+    {
+        LinearFunctionPointCountTransferScheme(Int32Tree& tree) :
+            points::VolumeTransfer<Int32Tree>(&tree) {}
+
+        inline Int32 range(const Coord&, size_t) const { return 0; }
+
+        inline void initialize(const Coord& c, size_t i, const CoordBBox& b)
+        {
+            this->points::VolumeTransfer<Int32Tree>::initialize(c,i,b);
+            auto* const data = this->template buffer<0>();
+            const auto& mask = *(this->template mask<0>());
+            for (auto iter = mask.beginOn(); iter; ++iter) {
+                data[iter.pos()] += 10;
+            }
+        }
+
+        inline bool finalize(const Coord&, size_t)
+        {
+            auto* const data = this->template buffer<0>();
+            const auto& mask = *(this->template mask<0>());
+            for (auto iter = mask.beginOn(); iter; ++iter) {
+                data[iter.pos()] *= 2;
+            }
+            return true;
+        }
+
+        inline void rasterizePoint(const Coord& ijk, const Index, const CoordBBox&)
+        {
+            const Index offset = points::PointDataTree::LeafNodeType::coordToOffset(ijk);
+            auto* const data = this->template buffer<0>();
+            data[offset] += 1;
+        }
+    };
+
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    Int32Tree::Ptr intTree(new Int32Tree);
+    intTree->setValueOn(Coord(0,0,0));
+
+    LinearFunctionPointCountTransferScheme transfer(*intTree);
+    points::rasterize(*points, transfer);
+
+    const int value = intTree->getValue(Coord(0,0,0));
+    EXPECT_EQ(/*(10+4)*2*/28, value);
+}
+
+TEST_F(TestPointTransfer, tetsSingleTreeRasterize)
+{
+    struct CountPoints27TransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<Int32Tree>
+    {
+        CountPoints27TransferScheme(Int32Tree& tree)
+            : points::VolumeTransfer<Int32Tree>(&tree) {}
+
+        /// @brief  The maximum lookup range of this transfer scheme in voxels.
+        inline Int32 range(const Coord&, size_t) const { return 1; }
+
+        /// @brief  The point stamp function. Each point which contributes to the
+        ///         current leaf that the thread has access to will call this function
+        ///         exactly once.
+        /// @param ijk     The current voxel containing the point being rasterized. May
+        ///                not be inside the destination leaf nodes.
+        /// @param id      The point index being rasterized
+        /// @param bounds  The active bounds of the leaf node(s) being written to.
+        void rasterizePoint(const Coord& ijk, const Index, const CoordBBox& bounds)
+        {
+            static const Index DIM = Int32Tree::LeafNodeType::DIM;
+            static const Index LOG2DIM = Int32Tree::LeafNodeType::LOG2DIM;
+
+            CoordBBox intersectBox(ijk.offsetBy(-1), ijk.offsetBy(1));
+            intersectBox.intersect(bounds);
+            if (intersectBox.empty()) return;
+            auto* const data = this->template buffer<0>();
+            const auto& mask = *(this->template mask<0>());
+
+            // loop over voxels in this leaf which are affected by this point
+
+            const Coord& a(intersectBox.min());
+            const Coord& b(intersectBox.max());
+            for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+                const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM);
+                for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                    const Index j = ((c.y() & (DIM-1u)) << LOG2DIM);
+                    for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                        OPENVDB_ASSERT(bounds.isInside(c));
+                        const Index offset = i + j + /*k*/(c.z() & (DIM-1u));
+                        if (!mask.isOn(offset)) continue;
+                        data[offset] += 1;
+
+                    }
+                }
+            }
+        }
+    };
+
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(0.1f, 0.1f, 0.1f));
+    positions.emplace_back(Vec3f(0.2f, 0.2f, 0.2f));
+    positions.emplace_back(Vec3f(-0.1f,-0.1f,-0.1f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    Int32Tree::Ptr intTree(new Int32Tree);
+    intTree->setValueOn(Coord(0,0,0));
+    intTree->setValueOn(Coord(1,1,1));
+    intTree->setValueOn(Coord(-1,-1,-1));
+
+    CountPoints27TransferScheme transfer(*intTree);
+    points::rasterize(*points, transfer);
+
+    int count = intTree->getValue(Coord(0,0,0));
+    EXPECT_EQ(3, count);
+    count = intTree->getValue(Coord(1,1,1));
+    EXPECT_EQ(3, count);
+    count = intTree->getValue(Coord(-1,-1,-1));
+    EXPECT_EQ(2, count);
+}
+
+TEST_F(TestPointTransfer, testMultiTreeRasterize)
+{
+    /// @brief  An example multi tree transfer scheme which rasterizes a vector
+    ///         attribute into an int grid using length, and an int attribute
+    ///         into a vector grid. Based on a 27 lookup stencil.
+    ///
+    struct MultiTransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<Int32Tree, Vec3DTree>
+    {
+        using BaseT = points::VolumeTransfer<Int32Tree, Vec3DTree>;
+
+        MultiTransferScheme(const size_t vIdx,const size_t iIdx,
+                            Int32Tree& t1, Vec3DTree& t2)
+            : BaseT(t1, t2)
+            , mVIdx(vIdx), mIIdx(iIdx)
+            , mVHandle(), mIHandle() {}
+
+        MultiTransferScheme(const MultiTransferScheme& other)
+            : BaseT(other), mVIdx(other.mVIdx), mIIdx(other.mIIdx)
+            , mVHandle(), mIHandle() {}
+
+        inline Int32 range(const Coord&, size_t) const { return 1; }
+
+        inline bool startPointLeaf(const points::PointDataTree::LeafNodeType& leaf)
+        {
+            mVHandle = points::AttributeHandle<Vec3d>::create(leaf.constAttributeArray(mVIdx));
+            mIHandle = points::AttributeHandle<int>::create(leaf.constAttributeArray(mIIdx));
+            return true;
+        }
+
+        void rasterizePoint(const Coord& ijk, const Index id, const CoordBBox& bounds)
+        {
+            static const Index DIM = Int32Tree::LeafNodeType::DIM;
+            static const Index LOG2DIM = Int32Tree::LeafNodeType::LOG2DIM;
+
+            CoordBBox intersectBox(ijk.offsetBy(-1), ijk.offsetBy(1));
+            intersectBox.intersect(bounds);
+            if (intersectBox.empty()) return;
+
+            auto* const data1 = this->template buffer<0>();
+            auto* const data2 = this->template buffer<1>();
+            const auto& mask = *(this->template mask<0>());
+
+            // loop over voxels in this leaf which are affected by this point
+            const Vec3d& vec = mVHandle->get(id);
+            const int integer = mIHandle->get(id);
+
+            const Coord& a(intersectBox.min());
+            const Coord& b(intersectBox.max());
+            for (Coord c = a; c.x() <= b.x(); ++c.x()) {
+                const Index i = ((c.x() & (DIM-1u)) << 2*LOG2DIM);
+                for (c.y() = a.y(); c.y() <= b.y(); ++c.y()) {
+                    const Index j = ((c.y() & (DIM-1u)) << LOG2DIM);
+                    for (c.z() = a.z(); c.z() <= b.z(); ++c.z()) {
+                        OPENVDB_ASSERT(bounds.isInside(c));
+                        const Index offset = i + j + /*k*/(c.z() & (DIM-1u));
+                        if (!mask.isOn(offset)) continue;
+                        data1[offset] += static_cast<int>(vec.length());
+                        data2[offset] += Vec3d(integer);
+                    }
+                }
+            }
+        }
+
+    private:
+        const size_t mVIdx;
+        const size_t mIIdx;
+        points::AttributeHandle<Vec3d>::Ptr mVHandle;
+        points::AttributeHandle<int>::Ptr mIHandle;
+    };
+
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    points::PointDataTree& tree = points->tree();
+
+    const Vec3d vectorValue(444.0f,555.0f,666.0f);
+    points::appendAttribute<Vec3d>(tree, "testVec3d", vectorValue);
+    points::appendAttribute<int>(tree, "testInt", 7);
+
+    Vec3DTree::Ptr vecTree(new Vec3DTree);
+    Int32Tree::Ptr intTree(new Int32Tree);
+    vecTree->topologyUnion(tree);
+    intTree->topologyUnion(tree);
+
+    const points::PointDataTree::LeafNodeType& leaf = *(tree.cbeginLeaf());
+    const size_t vidx = leaf.attributeSet().descriptor().find("testVec3d");
+    const size_t iidx = leaf.attributeSet().descriptor().find("testInt");
+
+    MultiTransferScheme transfer(vidx, iidx, *intTree, *vecTree);
+    points::rasterize(*points, transfer);
+
+    const Vec3d vecResult = vecTree->getValue(Coord(0,0,0));
+    const int intResult = intTree->getValue(Coord(0,0,0));
+
+    EXPECT_EQ(7.0, vecResult[0]);
+    EXPECT_EQ(7.0, vecResult[1]);
+    EXPECT_EQ(7.0, vecResult[2]);
+    const int expected = static_cast<int>(vectorValue.length());
+    EXPECT_EQ(expected, intResult);
+}
+
+TEST_F(TestPointTransfer, testMultiTreeRasterizeWithMask)
+{
+    struct CountPointsMaskTransferScheme
+        : public DefaultTransfer
+        , public points::VolumeTransfer<BoolTree, Int32Tree>
+    {
+        using BaseT = points::VolumeTransfer<BoolTree, Int32Tree>;
+        CountPointsMaskTransferScheme(BoolTree& t1, Int32Tree& t2)
+            : BaseT(t1, t2) {}
+
+        inline Int32 range(const Coord&, size_t) const { return 0; }
+        inline void rasterizePoint(const Coord& ijk, const Index, const CoordBBox&)
+        {
+            auto* const data = this->template buffer<1>();
+            const Index offset = points::PointDataTree::LeafNodeType::coordToOffset(ijk);
+            data[offset] += 1;
+        }
+    };
+
+    // Setup test data
+    std::vector<Vec3f> positions;
+    positions.emplace_back(Vec3f(0.0f, 0.0f, 0.0f));
+    positions.emplace_back(Vec3f(1.0f, 1.0f, 1.0f));
+
+    const double voxelSize = 0.1;
+    math::Transform::Ptr transform =
+        math::Transform::createLinearTransform(voxelSize);
+
+    points::PointDataGrid::Ptr points =
+        points::createPointDataGrid<points::NullCodec,
+            points::PointDataGrid>(positions, *transform);
+
+    Int32Tree::Ptr intTree(new Int32Tree);
+    BoolTree::Ptr topology(new BoolTree);
+    intTree->topologyUnion(points->tree());
+    topology->setValueOn(Coord(0,0,0));
+
+    EXPECT_TRUE(intTree->isValueOn(Coord(10,10,10)));
+
+    CountPointsMaskTransferScheme transfer(*topology, *intTree);
+    points::rasterize(*points, transfer);
+
+    int count = intTree->getValue(Coord(0,0,0));
+    EXPECT_EQ(1, count);
+    count = intTree->getValue(Coord(10,10,10));
+    EXPECT_EQ(0, count);
+}

--- a/pendingchanges/simd.txt
+++ b/pendingchanges/simd.txt
@@ -9,7 +9,8 @@ OpenVDB:
     vectorized math library. See https://github.com/vectorclass/version2.
 
     Using VCL can be controlled via the USE_VCL build option. The desired x86
-    ISA can be provided via OPENVDB_X86_INSTRSET.
+    ISA can be provided via OPENVDB_X86_INSTRSET (OpenVDB does not perform
+    automatic host ISA selection).
 
     To support other platforms and plan for future transitions, a generic SIMD
     interface has been introduced in simd/Simd.h. When VCL is not in use, this
@@ -18,11 +19,16 @@ OpenVDB:
     code which can be auto-vectorized, regardless of the underlying SIMD
     acceleration library in use.
 
+    More tools and algorithms will continue to be instrumented with the new
+    simd tooling in future releases.
+
   Improvements:
   - Vectorized points::rasterizeSdf(SphereSettings), improving performance
-    upwards of 2x on x86 and 1.5x on other platforms.
-  - Vectorized points::pca, improving performance upwards of 2x on x86 and
-    1.5x on other platforms.
+    upwards of 2x on x86 with VCL and 1.5x otherwise.
+  - Vectorized points::pca, improving performance upwards of 2x on x86 with
+    VCL or 1.5x otherwise.
+  - Vectorized points::rasterizeTrilinear, improving performance upwards of
+    2x on x86 with VCL, and 1.5x otherwise.
   - Introduced new component wise arithmetic and relational operators for
     math::Tuple instantiations for use with fallback SIMD support.
   - Using Limiter::CLAMP when advecting vector fields through VolumeAdvect now

--- a/pendingchanges/trilinear.txt
+++ b/pendingchanges/trilinear.txt
@@ -1,0 +1,3 @@
+Improvements:
+  - points::rasterizeTrilinear now supports integer and arbitrary sized openvdb 
+    vector and matrix attributes (for collocated transfers).


### PR DESCRIPTION
  - Vectorized rasterizeTrilinear
  - Added support for integer and arbitrary sized openvdb vector and matrix attributes (for collocated transfers)
  - Split out PointTransfer tests from TestPointRasterizeTrilinear into TestPointTransfer
  - Improved the tests for RasterizeTrilinear