### PR TITLE
Houdini 22 Weekly

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -70,6 +70,7 @@ jobs:
     strategy:
       matrix:
         config:
+          - { houdini_version: '22.0', platform: 'linux_x86_64_gcc14.2', hou_hash: '22_0' }
           - { houdini_version: '21.0', platform: 'linux_x86_64_gcc11.2', hou_hash: '21_0' }
           - { houdini_version: '20.5', platform: 'linux_x86_64_gcc11.2', hou_hash: '20_5' }
       fail-fast: false

--- a/ci/download_houdini.sh
+++ b/ci/download_houdini.sh
@@ -46,7 +46,7 @@ if [[ $PLATFORM =~ "linux" ]]; then
     mv dsolib/libz* ../hou/dsolib/.
     mv dsolib/libbz2* ../hou/dsolib/.
     mv dsolib/libtbb* ../hou/dsolib/.
-    mv dsolib/libjemalloc* ../hou/dsolib/.
+    mv dsolib/libjemalloc* ../hou/dsolib/. || :
     mv dsolib/liblzma* ../hou/dsolib/.
     mv dsolib/libIex* ../hou/dsolib/.
     mv dsolib/libImath* ../hou/dsolib/.
@@ -54,7 +54,7 @@ if [[ $PLATFORM =~ "linux" ]]; then
     cd ..
 
 elif [[ $PLATFORM =~ "macos" ]]; then
-    # Exract files by mounting the downloaded dmg (we only really want to
+    # Extract files by mounting the downloaded dmg (we only really want to
     # expand Houdini.framework)
     hdiutil attach hou.dmg
     pkgutil --expand-full /Volumes/Houdini/Houdini.pkg Houdini


### PR DESCRIPTION
Add Houdini 22 to the weekly CI. Once this has run, I will follow up and add H22 builds, then finally drop H20.5.

Only small caveat here is that jemalloc no longer ships with Houdini. It might be wise to download/build/install it ourselves for Houdini.

(@jmlait)