### PR TITLE
NanoVDB: default Mask's copy constructor

### DIFF
--- a/nanovdb/nanovdb/NanoVDB.h
+++ b/nanovdb/nanovdb/NanoVDB.h
@@ -1182,11 +1182,7 @@ public:
     }
 
     /// @brief Copy constructor
-    __hostdev__ Mask(const Mask& other)
-    {
-        for (uint32_t i = 0; i < WORD_COUNT; ++i)
-            mWords[i] = other.mWords[i];
-    }
+    Mask(const Mask&) = default;
 
     /// @brief Return a pointer to the list of words of the bit mask
     __hostdev__ uint64_t*       words() { return mWords; }

--- a/pendingchanges/maskdefaultedcopyctor.txt
+++ b/pendingchanges/maskdefaultedcopyctor.txt
@@ -1,0 +1,5 @@
+NanoVDB:
+  Improvements:
+  - nanovdb::Mask is now trivially copyable: its copy constructor, which duplicated the
+    implicit memberwise copy of its sole data member, is defaulted like the copy assignment
+    operator beside it.


### PR DESCRIPTION
## Summary

`Mask`'s only data member is `uint64_t mWords[WORD_COUNT]`, and the hand-written copy
constructor's loop copies exactly that range — so it duplicates the implicit memberwise copy.
Defaulting it leaves the semantics unchanged and makes `Mask` trivially copyable. `sizeof` and
standard-layout are unaffected.

Note:

- The copy **assignment** operator immediately below is already `= default`; this just finishes
  the pair.
- `nanovdb::cuda::Buffer<T, R>` requires `std::is_trivially_copyable<T>`, so `Mask` currently
  cannot be a buffer element type. With this change, mask sidecars can be held in a typed
  `Buffer<Mask<N>>` rather than a `Buffer<std::byte>` plus a cast.

## Verification

- `is_trivially_copyable` becomes true for `Mask<3>`/`Mask<4>`/`Mask<5>`; `sizeof` (64/512/4096)
  and `is_standard_layout` are unchanged.
- Copy-construction and assignment still work in device code (the defaulted special member is
  implicitly `__host__ __device__`, as the already-defaulted `operator=` beside it relies on).
