### PR TITLE
NanoVDB: install six missing public headers

### DIFF
--- a/nanovdb/nanovdb/CMakeLists.txt
+++ b/nanovdb/nanovdb/CMakeLists.txt
@@ -199,12 +199,14 @@ set(NANOVDB_INCLUDE_FILES
 
 # NanoVDB cuda header files
 set(NANOVDB_INCLUDE_CUDA_FILES
+  cuda/Buffer.h
   cuda/DeviceBuffer.h
   cuda/DeviceMesh.h
   cuda/DeviceResource.h
   cuda/DeviceStreamMap.h
   cuda/GridHandle.cuh
   cuda/NodeManager.cuh
+  cuda/PinnedResource.h
   cuda/TempPool.h
   cuda/UnifiedBuffer.h
 )
@@ -220,6 +222,7 @@ set(NANOVDB_INCLUDE_MATH_FILES
   math/DitherLUT.h
   math/HDDA.h
   math/Math.h
+  math/Proximity.h
   math/Ray.h
   math/SampleFromVoxels.h
   math/Stencils.h
@@ -254,6 +257,7 @@ set(NANOVDB_INCLUDE_TOOLS_CUDA_FILES
   tools/cuda/DilateGrid.cuh
   tools/cuda/CoarsenGrid.cuh
   tools/cuda/VoxelBlockManager.cuh
+  tools/cuda/MeshToGrid.cuh
 )
 
 # NanoVDB util header files
@@ -283,6 +287,7 @@ set(NANOVDB_INCLUDE_UTIL_FILES
   util/Timer.h
   util/Util.h
   util/MorphologyHelpers.h
+  util/MaskPrefixSum.h
 )
 
 # NanoVDB util/cuda header files
@@ -305,6 +310,7 @@ set(NANOVDB_INCLUDE_UTIL_CUDA_FILES
   util/cuda/MorphologyHelpers.cuh
   util/cuda/DeviceGridTraits.cuh
   util/cuda/Injection.cuh
+  util/cuda/Rasterization.cuh
 )
 
 add_library(nanovdb INTERFACE)

--- a/pendingchanges/missinginstallheaders.txt
+++ b/pendingchanges/missinginstallheaders.txt
@@ -1,0 +1,7 @@
+NanoVDB:
+  Bug Fixes:
+  - Fixed six public headers missing from the install lists in nanovdb/CMakeLists.txt:
+    cuda/Buffer.h, cuda/PinnedResource.h, math/Proximity.h, tools/cuda/MeshToGrid.cuh,
+    util/MaskPrefixSum.h and util/cuda/Rasterization.cuh. Installed headers included two of
+    them, so including a header such as nanovdb/cuda/GridHandle.cuh from an installed
+    NanoVDB failed to compile.


### PR DESCRIPTION
Six headers live in the source tree but are absent from the `set(NANOVDB_INCLUDE_*_FILES)` lists
that `install(FILES ...)` copies, so `make install` produces a tree containing headers that
reference files it did not ship:

| header | list it belongs in |
|---|---|
| `cuda/Buffer.h` | `NANOVDB_INCLUDE_CUDA_FILES` |
| `cuda/PinnedResource.h` | `NANOVDB_INCLUDE_CUDA_FILES` |
| `math/Proximity.h` | `NANOVDB_INCLUDE_MATH_FILES` |
| `tools/cuda/MeshToGrid.cuh` | `NANOVDB_INCLUDE_TOOLS_CUDA_FILES` |
| `util/MaskPrefixSum.h` | `NANOVDB_INCLUDE_UTIL_FILES` |
| `util/cuda/Rasterization.cuh` | `NANOVDB_INCLUDE_UTIL_CUDA_FILES` |

Two of them are reached by installed headers, which makes this a hard failure rather than a
missing convenience — 42 installed headers transitively include `cuda/Buffer.h` and two include
`util/MaskPrefixSum.h`:

```
install-prefix/include/nanovdb/cuda/GridHandle.cuh:20:10: fatal error:
    nanovdb/cuda/Buffer.h: No such file or directory
install-prefix/include/nanovdb/tools/VoxelBlockManager.h:32:10: fatal error:
    nanovdb/util/MaskPrefixSum.h: No such file or directory
```

`tools/cuda/MeshToGrid.cuh` is not reached by an installed header, so it produces no error — it is
simply unavailable from an installed NanoVDB. `math/Proximity.h` and `util/cuda/Rasterization.cuh`
are its transitive dependencies, so all three are needed for it to be usable.

In-tree builds compile against the source directory, where every header exists, so none of this is
visible until the headers are installed.

This is the same class of drift fixed by #2117 ("Fix missing nanovdb install files"), which added
eight entries in one sweep — including `tools/cuda/DilateGrid.cuh`, which had been in the tree
since 2025-09-04 and was installed only from 2025-10-22.

