### PR TITLE
Remove all reference to Boost in CI and docs

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -201,7 +201,7 @@ jobs:
       - name: install_deps
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get -q install -y libboost-dev libboost-iostreams-dev libtbb-dev libblosc-dev libgtest-dev libgmock-dev python3-numpy
+            sudo apt-get -q install -y libtbb-dev libblosc-dev libgtest-dev libgmock-dev python3-numpy
             ./ci/install_nanobind.sh 2.5.0
           elif [ "$RUNNER_OS" == "macOS" ]; then
             ./ci/install_macos.sh 20
@@ -560,7 +560,7 @@ jobs:
         echo "Using major version: ${VDB_MAJOR_VERSION}"
         echo "VDB_MAJOR_VERSION=${VDB_MAJOR_VERSION}" >> "$GITHUB_ENV"
     - name: install_deps
-      run: sudo apt-get -q install -y libboost-iostreams-dev libtbb-dev libblosc-dev elfutils
+      run: sudo apt-get -q install -y libtbb-dev libblosc-dev elfutils
     - name: install_abi_checker
       run: sudo apt-get -q install -y abi-dumper abi-compliance-checker
     - name: build_new

--- a/README.md
+++ b/README.md
@@ -59,14 +59,12 @@ for help with installations.
 # Linux
 # @note If your distribution does not have required versions, consider using
 #   apt pinning. See the dependency documentation for more details.
-apt-get install -y libboost-iostreams-dev
 apt-get install -y libtbb-dev
 apt-get install -y libblosc-dev
 
 # MacOS
 # @note We are using homebrew in this example to install requried dependencies
 #  https://brew.sh/
-brew install boost
 brew install tbb
 brew install c-blosc
 ```
@@ -94,8 +92,6 @@ dependencies.
 vcpkg install zlib:x64-windows
 vcpkg install blosc:x64-windows
 vcpkg install tbb:x64-windows
-vcpkg install boost-iostreams:x64-windows
-vcpkg install boost-interprocess:x64-windows
 ```
 
 ```bash

--- a/ci/install_windows.ps1
+++ b/ci/install_windows.ps1
@@ -15,9 +15,6 @@ $vcpkgPackages = @(
     "glew",
     "python3",
     "jemalloc",
-    "boost-iostreams",
-    "boost-interprocess",
-    "boost-algorithm",
     "nanobind"
 )
 

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -299,15 +299,12 @@ Optional:
   - @b USE_DEFAULT_HOUDINI_INSTALL =`ON` # Use the above default locations if
   @b OPENVDB_HOUDINI_INSTALL_PREFIX is not specified. If `OFF`, uses the value
   of @b CMAKE_INSTALL_PREFIX.
-  - @b BOOST_ROOT =`/path/to/boost/install` # Path to boost. May not be required,
- CMake may find it automatically
 
 For example on MacOS and where the build folder has been created inside the
 OpenVDB source root:
 
 @code
-cmake -D BOOST_ROOT=/path/to/boost/install \
-      -D Houdini_ROOT=/Applications/Houdini/Houdini17.0.506/ \
+cmake -D Houdini_ROOT=/Applications/Houdini/Houdini17.0.506/ \
       -D USE_HOUDINI=ON \
       ../
 @endcode
@@ -343,7 +340,6 @@ Package        | Description                                                    
 -------------- | ---------------------------------------------------------------   | -------------------------------- |
 CMake          | Cross-platform family of tools designed to help build software    | All                              |
 C++17 Compiler | Matching Houdini compiler and version                             | All                              |
-Boost          | Components: iostreams                                             | All                              |
 ZLIB           | Compression library for disk serialization compression            | All                              |
 Blosc          | Recommended dependency for improved disk compression              | All*                             |
 GoogleTest     | A unit testing framework module for C++                           | Unit Tests                       |
@@ -358,7 +354,7 @@ LLVM           | Target-independent code generation                             
 
 * See [blosc support](@ref buildBloscSupport)
 
-At a minimum, boost, a matching C++17 compiler, ZLIB, blosc and CMake will be
+At a minimum, a matching C++17 compiler, ZLIB, blosc and CMake will be
 required. See the full [dependency list](@ref dependencies) for help with
 downloading and installing the above software.
 
@@ -386,15 +382,12 @@ Optional:
  the link for default values.
   - @b OPENVDB_MAYA_INSTALL_PREFIX =`/path/to/install/dir` # The location to
  install the Maya plugin to. Defaults to the value of `${CMAKE_INSTALL_PREFIX}/maya${Maya_VERSION}`
-  - @b BOOST_ROOT =`/path/to/boost/install` # Path to boost. May not be required,
- CMake may find it automatically
 
 For example on MacOS and where the build folder has been created inside the
 OpenVDB source root:
 
 @code
-cmake -D BOOST_ROOT=/path/to/boost/install \
-      -D Maya_ROOT=/Applications/Autodesk/maya2019/ \
+cmake -D Maya_ROOT=/Applications/Autodesk/maya2019/ \
       -D USE_MAYA=ON \
       ../
 @endcode

--- a/doc/dependencies.txt
+++ b/doc/dependencies.txt
@@ -73,7 +73,6 @@ Imath           | 3.2     | >= 3.3      | Half precision floating points        
 OpenEXR         | 3.2     | >= 3.3      | EXR serialization support                                         | Y       | Y        | http://www.openexr.com
 TBB             | 2020.3  | >= 2021     | Threading Building Blocks - template library for task parallelism | Y       | Y        | https://www.threadingbuildingblocks.org
 ZLIB            | 1.2.7   | Latest      | Compression library for disk serialization compression            | Y       | Y        | https://www.zlib.net
-Boost           | 1.82    | >= 1.85     | Components: iostreams                                             | Y       | Y        | https://www.boost.org
 VCL             | 2.02.0  | >= 2.02.0   | x86 intrinsics and SIMD class wrappers and                        | Y       | Y        | https://github.com/vectorclass/version2
 LLVM            | 15.0.0* | 18.0.0      | Target-independent code generation                                | Y       | Y        | https://llvm.org/
 Bison           | 3.7.0   | 3.7.0       | General-purpose parser generator                                  | Y       | Y        | https://www.gnu.org/software/gcc
@@ -153,7 +152,6 @@ other package managers.
 apt-get install cmake                   # CMake
 apt-get install libtbb-dev              # TBB
 apt-get install zlibc                   # zlib
-apt-get install libboost-iostreams-dev  # Boost::iostream
 apt-get install libblosc-dev            # Blosc
 # AX
 apt-get install llvm-15-dev             # LLVM
@@ -184,7 +182,6 @@ an alternative to apt-get or manual installation from source.
 brew install cmake                     # CMake
 brew install tbb                       # TBB
 brew install zlib                      # zlib
-brew install boost                     # Boost
 brew install c-blosc                   # blosc
 # AX
 brew install llvm                      # LLVM

--- a/doc/nanovdb/FAQ.md
+++ b/doc/nanovdb/FAQ.md
@@ -30,7 +30,7 @@
 
 * **How does the data structure of NanoVDB compare to that of OpenVDB?**
 
-  Conceptually they are essentially identical (NanoVDB uses the exact same tree configuration), but there are some implementation differences to minimize dependencies on external libraries in NanoVDB (e.g. no boost and std containers), and more importantly, NanoVDB has additional meta-data encoded in tree nodes specifically to accelerate ray-tracing (e.g. min/max values and AABB of active values). Also, NanoVDB is pointer-less and occupies a contiguous block of memory, i.e. de-fragmentized relative to OpenVDB. Effectively, NanoVDB is a linearized version of the well-known OpenVDB data structure with a few additional information baked into the tree nodes!
+  Conceptually they are essentially identical (NanoVDB uses the exact same tree configuration), but there are some implementation differences to minimize dependencies on external libraries in NanoVDB (e.g. no std containers), and more importantly, NanoVDB has additional meta-data encoded in tree nodes specifically to accelerate ray-tracing (e.g. min/max values and AABB of active values). Also, NanoVDB is pointer-less and occupies a contiguous block of memory, i.e. de-fragmentized relative to OpenVDB. Effectively, NanoVDB is a linearized version of the well-known OpenVDB data structure with a few additional information baked into the tree nodes!
 
 * **Are there known issues with NanoVDB?**
 

--- a/doc/nanovdb/HowToBuild.md
+++ b/doc/nanovdb/HowToBuild.md
@@ -16,7 +16,7 @@ NanoVDB is now a module of the larger OpenVDB project. A user can build both lib
   ```console
   foo@bar:~$ mkdir build
   foo@bar:~$ cd build
-  foo@bar:~$ cmake .. -DUSE_NANOVDB=ON -DTBB_ROOT=/path/to/tbb -DBOOST_ROOT=/path/to/boost -DBLOSC_ROOT=/path/to/blosc -DCMAKE_INSTALL_PREFIX=/install/path
+  foo@bar:~$ cmake .. -DUSE_NANOVDB=ON -DTBB_ROOT=/path/to/tbb -DBLOSC_ROOT=/path/to/blosc -DCMAKE_INSTALL_PREFIX=/install/path
   foo@bar:~$ make -j 4 && make install
   ```
 Note that the default value of `NANOVDB_USE_OPENVDB` is linked to `OPENVDB_BUILD_CORE` option and can be overriden by passing on `-DNANOVDB_USE_OPENVDB=OFF`. The `Boost` library is included because it is a requirement for building OpenVDB.
@@ -49,7 +49,7 @@ From the root OpenVDB directory:
   ```console
   foo@bar:~$ mkdir build
   foo@bar:~$ cd build
-  foo@bar:~$ cmake .. -DUSE_NANOVDB=ON -DNANOVDB_BUILD_UNITTESTS=ON -DNANOVDB_BUILD_EXAMPLES=ON -DNANOVDB_BUILD_BENCHMARK=ON -DNANOVDB_USE_INTRINSICS=ON -DNANOVDB_USE_CUDA=ON -DNANOVDB_CUDA_KEEP_PTX=ON -DTBB_ROOT=/path/to/tbb -DBOOST_ROOT=/path/to/boost -DBLOSC_ROOT=/path/to/blosc -DGTEST_ROOT=/path/to/gtest -DCMAKE_INSTALL_PREFIX=/install/path
+  foo@bar:~$ cmake .. -DUSE_NANOVDB=ON -DNANOVDB_BUILD_UNITTESTS=ON -DNANOVDB_BUILD_EXAMPLES=ON -DNANOVDB_BUILD_BENCHMARK=ON -DNANOVDB_USE_INTRINSICS=ON -DNANOVDB_USE_CUDA=ON -DNANOVDB_CUDA_KEEP_PTX=ON -DTBB_ROOT=/path/to/tbb -DBLOSC_ROOT=/path/to/blosc -DGTEST_ROOT=/path/to/gtest -DCMAKE_INSTALL_PREFIX=/install/path
   foo@bar:~$ make -j 4 && make install
   ```
 Note that if you already have the correct version of OpenVDB pre-installed, you can configure CMake to link against that library by passing the arguments `-DOPENVDB_BUILD_CORE=OFF -DOPENVDB_BUILD_BINARIES=OFF -DOPENVDB_ROOT=/path/to/openvdb` when invoking `cmake`.

--- a/openvdb/openvdb/io/File.cc
+++ b/openvdb/openvdb/io/File.cc
@@ -121,10 +121,6 @@ File::inputStream() const
 Index64
 File::getSize() const
 {
-    /// @internal boost::filesystem::file_size() would be a more portable alternative,
-    /// but as of 9/2014, Houdini ships without the Boost.Filesystem library,
-    /// which makes it much less convenient to use that library.
-
     Index64 result = std::numeric_limits<Index64>::max();
 
     std::string mesg = "could not get size of file " + mFilename;

--- a/openvdb/openvdb/tree/Tree.h
+++ b/openvdb/openvdb/tree/Tree.h
@@ -1990,7 +1990,6 @@ Tree<RootNodeType>::print(std::ostream& os, int verboseLevel) const
 {
     if (verboseLevel <= 0) return;
 
-    /// @todo Consider using boost::io::ios_precision_saver instead.
     struct OnExit {
         std::ostream& os;
         std::streamsize savedPrecision;


### PR DESCRIPTION
Strip out all remaining references to Boost in the CI and the documentation, it is no longer a dependency.