### PR TITLE
CI: pin nanobind to 2.5.0 on Windows

### DIFF
--- a/ci/install_windows.ps1
+++ b/ci/install_windows.ps1
@@ -17,8 +17,7 @@ $vcpkgPackages = @(
     "jemalloc",
     "boost-iostreams",
     "boost-interprocess",
-    "boost-algorithm",
-    "nanobind"
+    "boost-algorithm"
 )
 
 # Update vcpkg
@@ -38,3 +37,17 @@ try {
 }
 
 Write-Host "vcpkg install completed successfully"
+
+# nanobind comes from source rather than vcpkg: the vcpkg port floats with the
+# runner's baseline (nanobind 3.0 broke the CUDA python bindings under
+# --Werror=all-warnings), while every other CI platform pins the version
+# through ci/install_nanobind.sh. Pin the same version here, installed into
+# the vcpkg tree so the toolchain finds it exactly as it found the port.
+$nanobindVersion = "2.5.0"
+git clone --recurse-submodules --depth 1 --branch "v$nanobindVersion" https://github.com/wjakob/nanobind.git
+cmake -S nanobind -B nanobind\build -DNB_TEST=OFF "-DCMAKE_INSTALL_PREFIX=$env:VCPKG_INSTALLATION_ROOT\installed\$env:VCPKG_DEFAULT_TRIPLET"
+if ($LASTEXITCODE -ne 0) { throw "nanobind configure failed" }
+cmake --install nanobind\build
+if ($LASTEXITCODE -ne 0) { throw "nanobind install failed" }
+
+Write-Host "nanobind $nanobindVersion install completed successfully"


### PR DESCRIPTION
## What

Pins the Windows CI's nanobind to 2.5.0 — the version every other CI platform already pins through `ci/install_nanobind.sh` — by building it from source at that tag instead of taking the floating vcpkg port. It installs into the vcpkg tree (nanobind's install layout matches the port's), so CMake discovery through the vcpkg toolchain is unchanged and no workflow files are touched.

## Why

The Windows runners' vcpkg baseline rolled to nanobind 3.0.0 this week. Its headers trip nvcc front-end diagnostics (#177/#550 in `nb_func.h`) that `--Werror=all-warnings` turns into errors, so every PR's `windows-nanovdb` job now fails in the python-binding CUDA translation units (first seen on #2301, but any PR triggering that job reproduces it, and master will on its next run). Pinning restores the version parity the other platforms already have.

Migrating all platforms to nanobind 3.x is deliberate future work, tracked separately.

## Test plan

The `windows-nanovdb` job on this PR is the test: it exercises the modified install script and must come back green where current PRs fail.