### PR TITLE
added fix to unit-test related to NaN on Ubuntu 26.04

### DIFF
--- a/openvdb_cmd/vdb_tool/src/unittest.cpp
+++ b/openvdb_cmd/vdb_tool/src/unittest.cpp
@@ -2729,11 +2729,14 @@ TEST_F(Test_vdb_tool, Processor)
     EXPECT_EQ(std::to_string(tan(2.0f)), proc("{2:tan}"));
     EXPECT_EQ(std::to_string(tan(2.0f)), proc("{2.0:tan}"));
 
-    EXPECT_EQ(std::to_string(asin(2.0f)), proc("{2:asin}"));
-    EXPECT_EQ(std::to_string(asin(2.0f)), proc("{2.0:asin}"));
+    // asin(2)/acos(2) are domain errors; libm does not guarantee the sign bit of the
+    // resulting NaN, so strip a leading '-' before comparing (e.g. "-nan" vs "nan").
+    auto stripNegNan = [](std::string s) { return s == "-nan" ? s.substr(1) : s; };
+    EXPECT_EQ(stripNegNan(std::to_string(asin(2.0f))), stripNegNan(proc("{2:asin}")));
+    EXPECT_EQ(stripNegNan(std::to_string(asin(2.0f))), stripNegNan(proc("{2.0:asin}")));
 
-    EXPECT_EQ(std::to_string(acos(2.0f)), proc("{2:acos}"));
-    EXPECT_EQ(std::to_string(acos(2.0f)), proc("{2.0:acos}"));
+    EXPECT_EQ(stripNegNan(std::to_string(acos(2.0f))), stripNegNan(proc("{2:acos}")));
+    EXPECT_EQ(stripNegNan(std::to_string(acos(2.0f))), stripNegNan(proc("{2.0:acos}")));
 
     EXPECT_EQ(std::to_string(atan(2.0f)), proc("{2:atan}"));
     EXPECT_EQ(std::to_string(atan(2.0f)), proc("{2.0:atan}"));


### PR DESCRIPTION
Fix flaky asin/acos unit test assertions on NaN sign bit

asin(2)/acos(2) are domain errors, and IEEE 754 doesn't specify the sign bit libm sets on the resulting NaN. On Ubuntu 26.04 the calculator's std::asin/std::acos path returns -nan while the test's asin(2.0f)/acos(2.0f) reference returns nan, failing four EXPECT_EQ string comparisons in unittest.cpp. Strip the sign before comparing so the test only checks for NaN, not a platform-dependent bit pattern.