### PR TITLE
Update NanoVDB CI Platform

### DIFF
--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -92,7 +92,7 @@ jobs:
           -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           \'
       - name: test
-        run: cd build && sudo ctest -V -E ".*cuda.*|.*mgpu.*"
+        run: cd build && ctest -V -E ".*cuda.*|.*mgpu.*"
 
   windows-nanovdb:
     if: |

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -62,17 +62,17 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cxx: g++,     image: '2024-clang17.2', build: 'Release' }
-          - { cxx: g++,     image: '2024-clang17.2', build: 'Debug' }
-          - { cxx: clang++, image: '2024-clang17.2', build: 'Release' }
-          - { cxx: clang++, image: '2024-clang17.2', build: 'Debug' }
+          - { cxx: g++,       image: '2026', build: 'Release' }
+          - { cxx: clang++,   image: '2026', build: 'Release' }
+          - { cxx: clang++,   image: '2026', build: 'Debug' }
+          - { cxx: clang++,   image: '2024-clang17.2', build: 'Release' }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - name: setup_cuda_12
+      - name: setup_cuda
         run: |
-          echo "/usr/local/cuda-12/bin" >> $GITHUB_PATH
-          echo "LD_LIBRARY_PATH=/usr/local/cuda-12/lib64:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "/usr/local/cuda/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - name: nanobind
         run: ./ci/install_nanobind.sh 2.5.0
       - name: build
@@ -104,7 +104,7 @@ jobs:
     env:
       VCPKG_DEFAULT_TRIPLET: 'x64-windows'
       visual_studio: "Visual Studio 17 2022"
-      cuda: "12.4.0"
+      cuda: "12.9.2"
     strategy:
       fail-fast: false
     steps:
@@ -154,8 +154,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - { runner: 'macos-14', cxx: 'clang++', build: 'Release' }
-          - { runner: 'macos-14', cxx: 'clang++', build: 'Debug'   }
+          - { runner: 'macos-26', cxx: 'clang++', build: 'Release' }
+          - { runner: 'macos-26', cxx: 'clang++', build: 'Debug'   }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -180,7 +180,7 @@ jobs:
         (github.event.inputs.type == 'all' || github.event.inputs.type == 'linux')))
     runs-on: ${{ (github.repository_owner == 'AcademySoftwareFoundation' && 'ubuntu-22.04-8c-32g-300h') || 'ubuntu-latest' }}
     container:
-      image: aswf/ci-openvdb:2024-clang17.2
+      image: aswf/ci-openvdb:2026
     steps:
       - uses: actions/checkout@v3
       - name: install_gtest

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -104,7 +104,7 @@ jobs:
     env:
       VCPKG_DEFAULT_TRIPLET: 'x64-windows'
       visual_studio: "Visual Studio 17 2022"
-      cuda: "12.9.2"
+      cuda: "12.9.1"
     strategy:
       fail-fast: false
     steps:
@@ -188,8 +188,9 @@ jobs:
       - name: build_and_test
         run: |
           cd nanovdb/nanovdb
-          sudo mkdir .build
+          mkdir .build
           cd .build
-          sudo cmake -DUSE_EXPLICIT_INSTANTIATION=OFF -DNANOVDB_BUILD_UNITTESTS=ON -DNANOVDB_USE_OPENVDB=OFF -DNANOVDB_USE_CUDA=OFF ../
-          sudo make -j8 install
-          sudo ctest -V
+          cmake -DUSE_EXPLICIT_INSTANTIATION=OFF -DNANOVDB_BUILD_UNITTESTS=ON -DNANOVDB_USE_OPENVDB=OFF -DNANOVDB_USE_CUDA=OFF ../
+          make -j8
+          sudo make install
+          ctest -V

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -58,15 +58,22 @@ jobs:
     container:
       image: aswf/ci-openvdb:${{ matrix.config.image }}
     env:
+      # nvcc defaults to g++ regardless of CXX, and clang and g++ mangle
+      # GridHandle's dual-buffer constructor differently, so the .cu and .cc
+      # halves of the python module stop agreeing. Point nvcc at CXX.
+      CUDAHOSTCXX: ${{ matrix.config.cudahostcxx }}
       CXX: ${{ matrix.config.cxx }}
-      CUDAHOSTCXX: ${{ matrix.config.cxx }}
     strategy:
       matrix:
         config:
-          - { cxx: g++,       image: '2026-clang19.6', build: 'Release' }
-          - { cxx: clang++,   image: '2026-clang19.6', build: 'Release' }
-          - { cxx: clang++,   image: '2026-clang19.6', build: 'Debug' }
-          - { cxx: clang++,   image: '2024-clang17.2', build: 'Release' }
+          - { cxx: g++,       cudahostcxx: g++,     image: '2026-clang19.6', build: 'Release' }
+          - { cxx: clang++,   cudahostcxx: clang++, image: '2026-clang19.6', build: 'Release' }
+          - { cxx: clang++,   cudahostcxx: clang++, image: '2026-clang19.6', build: 'Debug' }
+          # nvcc 12.6's front end has no __is_scoped_enum (12.8 adds it), but
+          # under a clang host CCCL's __is_identifier probe decides it exists
+          # and the CCCL headers stop parsing. g++ as the nvcc host sidesteps
+          # the probe, and clang 17 mangles as g++ does, so python still links.
+          - { cxx: clang++,   cudahostcxx: g++,     image: '2024-clang17.2', build: 'Release' }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -59,6 +59,7 @@ jobs:
       image: aswf/ci-openvdb:${{ matrix.config.image }}
     env:
       CXX: ${{ matrix.config.cxx }}
+      CUDAHOSTCXX: ${{ matrix.config.cxx }}
     strategy:
       matrix:
         config:

--- a/.github/workflows/nanovdb.yml
+++ b/.github/workflows/nanovdb.yml
@@ -63,9 +63,9 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cxx: g++,       image: '2026', build: 'Release' }
-          - { cxx: clang++,   image: '2026', build: 'Release' }
-          - { cxx: clang++,   image: '2026', build: 'Debug' }
+          - { cxx: g++,       image: '2026-clang19.6', build: 'Release' }
+          - { cxx: clang++,   image: '2026-clang19.6', build: 'Release' }
+          - { cxx: clang++,   image: '2026-clang19.6', build: 'Debug' }
           - { cxx: clang++,   image: '2024-clang17.2', build: 'Release' }
       fail-fast: false
     steps:
@@ -181,7 +181,7 @@ jobs:
         (github.event.inputs.type == 'all' || github.event.inputs.type == 'linux')))
     runs-on: ${{ (github.repository_owner == 'AcademySoftwareFoundation' && 'ubuntu-22.04-8c-32g-300h') || 'ubuntu-latest' }}
     container:
-      image: aswf/ci-openvdb:2026
+      image: aswf/ci-openvdb:2026-clang19.6
     steps:
       - uses: actions/checkout@v3
       - name: install_gtest

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -455,7 +455,7 @@ jobs:
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.config.vc }}
       visual_studio: "Visual Studio 17 2022"
-      cuda: "12.4.0"
+      cuda: "12.9.1"
     strategy:
       matrix:
         config:
@@ -528,7 +528,7 @@ jobs:
         --build-type=Release
         --components=\"core,test\"
     - name: test
-      run: cd build && sudo ctest -V
+      run: cd build && ctest -V
 
   #############################################################################
   ################################## ABI ######################################

--- a/ci/install_windows_cuda.ps1
+++ b/ci/install_windows_cuda.ps1
@@ -28,7 +28,7 @@ $CUDA_KNOWN_URLS = @{
     "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe";
     "11.6.2" = "https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe";
     "12.4.0" = "https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe";
-    "12.9.2" = "https://developer.download.nvidia.com/compute/cuda/12.9.2/network_installers/cuda_12.9.2_windows_network.exe";
+    "12.9.1" = "https://developer.download.nvidia.com/compute/cuda/12.9.1/network_installers/cuda_12.9.1_windows_network.exe";
     "13.2.2" = "https://developer.download.nvidia.com/compute/cuda/13.2.2/network_installers/cuda_13.2.2_windows_network.exe"
 }
 

--- a/ci/install_windows_cuda.ps1
+++ b/ci/install_windows_cuda.ps1
@@ -27,7 +27,9 @@ $CUDA_KNOWN_URLS = @{
     "11.2.2" = "https://developer.download.nvidia.com/compute/cuda/11.2.2/network_installers/cuda_11.2.2_win10_network.exe";
     "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe";
     "11.6.2" = "https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe";
-    "12.4.0" = "https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe"
+    "12.4.0" = "https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe";
+    "12.9.2" = "https://developer.download.nvidia.com/compute/cuda/12.9.2/network_installers/cuda_12.9.2_windows_network.exe";
+    "13.2.2" = "https://developer.download.nvidia.com/compute/cuda/13.2.2/network_installers/cuda_13.2.2_windows_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?

--- a/nanovdb/nanovdb/CMakeLists.txt
+++ b/nanovdb/nanovdb/CMakeLists.txt
@@ -136,11 +136,14 @@ if(NANOVDB_USE_CUDA)
 
   include(../../cmake/CPM.cmake)
 
-  # This will automatically clone CCCL from GitHub and make the exported cmake targets available
+  # Clones CCCL from GitHub and makes the exported cmake targets available.
+  # Pinned to a release so an upstream commit cannot change what CI builds;
+  # bump it deliberately.
+  set(NANOVDB_CCCL_TAG "v3.4.2" CACHE STRING "Git tag of the CCCL release to build against")
   CPMAddPackage(
       NAME CCCL
       GITHUB_REPOSITORY nvidia/cccl
-      GIT_TAG main # Fetches the latest commit on the main branch
+      GIT_TAG ${NANOVDB_CCCL_TAG}
   )
 
   find_package(NCCL)

--- a/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
+++ b/nanovdb/nanovdb/python/cuda/PyDeviceGridHandle.cu
@@ -5,7 +5,7 @@
 #include "../PyGridHandle.h"
 #include <nanobind/ndarray.h>
 
-#include <nanovdb/cuda/DeviceBuffer.h>
+#include <nanovdb/cuda/GridHandle.cuh>
 
 namespace nb = nanobind;
 using namespace nb::literals;

--- a/nanovdb/nanovdb/unittest/CMakeLists.txt
+++ b/nanovdb/nanovdb/unittest/CMakeLists.txt
@@ -79,18 +79,6 @@ if(NANOVDB_USE_CUDA)
   target_link_libraries(nanovdb_test_cuda_buffer PRIVATE nanovdb GTest::GTest GTest::Main)
   set_target_properties(nanovdb_test_cuda_buffer PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
   add_test(nanovdb_cuda_buffer_unit_test nanovdb_test_cuda_buffer)
-
-  if(WIN32)
-    # gtest's TEST macro declares each test's static test_info_ member with an
-    # unused-attribute on GCC/Clang but not under MSVC, so for tests defined
-    # inside an anonymous namespace the CUDA front end can prove it
-    # unreferenced and reports #177, which NANOVDB_CUDA_WERROR promotes to an
-    # error. Suppress #177 for the CUDA test sources that use that style.
-    foreach(_cuda_gtest nanovdb_test_cuda_buffer nanovdb_test_cuda_memory_resource
-            nanovdb_test_cuda_util nanovdb_test_cuda_util_sync)
-      target_compile_options(${_cuda_gtest} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--diag-suppress=177>")
-    endforeach()
-  endif()
 endif()
 
 # -----------------------------------------------------------------------------

--- a/nanovdb/nanovdb/unittest/TestBuffer.cu
+++ b/nanovdb/nanovdb/unittest/TestBuffer.cu
@@ -28,7 +28,11 @@
 #include <utility>
 #include <vector>
 
-namespace {
+// Named rather than anonymous: gtest marks each test class's static test_info_
+// [[maybe_unused]], an attribute the CUDA front end ignores. Under internal
+// linkage it proves the member unreferenced and reports #177, which
+// NANOVDB_CUDA_WERROR promotes to an error.
+namespace nanovdb_test {
 
 //======================================================================
 // Shared test doubles
@@ -1372,4 +1376,4 @@ TEST(TestBuffer, SingleSpaceVoxelBlockManager)
     ASSERT_EQ(cudaSuccess, cudaFree(d_coords));
 }
 
-} // unnamed namespace
+} // namespace nanovdb_test

--- a/nanovdb/nanovdb/unittest/TestMemoryResource.cu
+++ b/nanovdb/nanovdb/unittest/TestMemoryResource.cu
@@ -42,7 +42,11 @@
 #endif
 
 
-namespace {
+// Named rather than anonymous: gtest marks each test class's static test_info_
+// [[maybe_unused]], an attribute the CUDA front end ignores. Under internal
+// linkage it proves the member unreferenced and reports #177, which
+// NANOVDB_CUDA_WERROR promotes to an error.
+namespace nanovdb_test {
 
 //======================================================================
 // Shared test doubles
@@ -583,4 +587,4 @@ TEST(TestMemoryResource, AddBlindData_InjectedResourceSeam)
     ASSERT_EQ(cudaFree(d_blind), cudaSuccess);
 }
 
-} // unnamed namespace
+} // namespace nanovdb_test

--- a/nanovdb/nanovdb/unittest/TestNanoVDB.cu
+++ b/nanovdb/nanovdb/unittest/TestNanoVDB.cu
@@ -2859,7 +2859,6 @@ TEST(TestNanoVDBCUDA, compareNodeOrdering)
     //EXPECT_FALSE(grid1->isLexicographic());
 
     {// check that nodes are arranged breath-first in memory
-        float min = std::numeric_limits<float>::max(), max = -min;
         int n2=0, n1=0, n0=0;
         for (auto it2 = grid1->tree().root().beginChild(); it2; ++it2) {
             EXPECT_EQ(grid1->tree().getFirstUpper() + n2++, &(*it2));

--- a/nanovdb/nanovdb/unittest/TestUtilCuda.cu
+++ b/nanovdb/nanovdb/unittest/TestUtilCuda.cu
@@ -19,7 +19,11 @@
 
 #include <vector>
 
-namespace {
+// Named rather than anonymous: gtest marks each test class's static test_info_
+// [[maybe_unused]], an attribute the CUDA front end ignores. Under internal
+// linkage it proves the member unreferenced and reports #177, which
+// NANOVDB_CUDA_WERROR promotes to an error.
+namespace nanovdb_test {
 
 TEST(TestUtilCuda, MemoryPoolsSupportedMatchesAttribute)
 {
@@ -68,4 +72,4 @@ TEST(TestUtilCuda, MallocAsyncRoundTrip)
     ASSERT_EQ(cudaStreamDestroy(s), cudaSuccess);
 }
 
-} // unnamed namespace
+} // namespace nanovdb_test


### PR DESCRIPTION
Updates NanoVDB's CI job definition to:

- VFX Platform 2026 (with 2024 lower-bound build mirroring OpenVDB)
- Upgrade macos to 26
- Upgrade CUDA to 12.9 (VFX Platform 2026 docker image version)
- **nvcc ignores gtest's `[[maybe_unused]]` on `test_info_` in clang-host mode** and reports `#177`, which `--Werror=all-warnings` makes fatal.  The CUDA test classes now live in a named namespace so the front end can't prove the member unreferenced. This also retires the `--diag-suppress=177` workaround MSVC hosts needed for the same reason.
- **nvcc was silently using GCC as its host compiler** while `CXX` was clang.  Clang 18 and later mangle`GridHandle`'s dual-buffer move constructor differently from GCC (the non-type template parameter has a dependent type), so the definition emitted by the `.cu` object never matched the reference from the `.cc` objects and the Python module failed at import. `CUDAHOSTCXX` now points nvcc at `CXX`, per matrix entry. The 2024 image keeps g++ as the nvcc host: its clang 17 still mangles the way g++ does, and CUDA 12.6's front end has no `__is_scoped_enum`, which the CCCL headers assume under a clang host. CCCL is also pinned to v3.4.2 rather than tracking `main`.