### PR TITLE
Add the missing NanoVDB namespaces to the doxygen input

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -315,7 +315,13 @@ if(OPENVDB_DOXYGEN_NANOVDB)
     doc/nanovdb/HowToBuild.md
     doc/nanovdb/HelloWorld.md
     nanovdb/nanovdb
+    nanovdb/nanovdb/cuda
+    nanovdb/nanovdb/io
+    nanovdb/nanovdb/math
+    nanovdb/nanovdb/putil
+    nanovdb/nanovdb/tools
     nanovdb/nanovdb/util
+    nanovdb/nanovdb/util/cuda
     nanovdb/nanovdb/examples/ex_bump_pool_buffer
     nanovdb/nanovdb/examples/ex_collide_level_set
     nanovdb/nanovdb/examples/ex_make_custom_nanovdb

--- a/nanovdb/nanovdb/cuda/DeviceBuffer.h
+++ b/nanovdb/nanovdb/cuda/DeviceBuffer.h
@@ -247,6 +247,7 @@ public:
     /// @brief Returns an offset pointer of a specific type from the allocated host memory
     /// @tparam T Type of the pointer returned
     /// @param count Numbers of elements of @c parameter type T to skip
+    /// @param device Device whose buffer is returned, or cudaCpuDeviceId for the host buffer
     /// @warning might return NULL
     template <typename T>
     T* data(ptrdiff_t count = 0, int device = cudaCpuDeviceId) const
@@ -258,6 +259,7 @@ public:
 
     /// @brief Returns a byte offset void pointer from the allocated host memory
     /// @param byteOffset offset of return pointer in units of bytes
+    /// @param device Device whose buffer is returned, or cudaCpuDeviceId for the host buffer
     /// @warning assumes that this instance is not empty!
     void* data(ptrdiff_t byteOffset, int device = cudaCpuDeviceId) const
     {

--- a/nanovdb/nanovdb/cuda/DeviceMesh.h
+++ b/nanovdb/nanovdb/cuda/DeviceMesh.h
@@ -66,12 +66,12 @@ public:
     /// @brief Disallow copy-construction
     DeviceMesh(const DeviceMesh&) = delete;
     /// @brief Move constructor.  Underlying CUDA streams and NCCL communicators are not reinitialized.
-    /// @param DeviceMesh instance that will be moved into this DeviceMesh.
+    /// @param other DeviceMesh instance that will be moved into this DeviceMesh.
     DeviceMesh(DeviceMesh&&) noexcept;
     /// @brief Disallow copy-assignment
     DeviceMesh& operator=(const DeviceMesh&) = delete;
     /// @brief Move assignment. Underlying CUDA streams and NCCL communicators are not reinitialized.
-    /// @param DeviceMesh instance that will be moved into this DeviceMesh.
+    /// @param other DeviceMesh instance that will be moved into this DeviceMesh.
     DeviceMesh& operator=(DeviceMesh&&) noexcept;
 
     /// @brief Returns the number of devices

--- a/nanovdb/nanovdb/cuda/DeviceResource.h
+++ b/nanovdb/nanovdb/cuda/DeviceResource.h
@@ -61,6 +61,8 @@ public:
     /// @brief Synchronous deallocation; the caller guarantees that device
     ///        work touching the memory has completed.
     /// @param p pointer previously returned by allocate or allocate_async
+    /// @param bytes size of the allocation in bytes
+    /// @param alignment alignment of the allocation in bytes
     void deallocate(void* p, size_t bytes, size_t alignment) {
         this->deallocate_async(p, bytes, alignment, cudaStream_t(0));
     }

--- a/nanovdb/nanovdb/cuda/UnifiedBuffer.h
+++ b/nanovdb/nanovdb/cuda/UnifiedBuffer.h
@@ -104,13 +104,13 @@ public:
 
     ///////////////////////////////////////////////////////////////////////
 
-    //@{
+    ///@{
     /// @brief Factory methods that create an DualUnifiedBuffer instance and returns it with move semantics
     static DualUnifiedBuffer create(size_t size, size_t capacity) {return DualUnifiedBuffer(size, capacity);}
     static DualUnifiedBuffer create(size_t size) {return DualUnifiedBuffer(size);}
     ///@}
 
-    //@{
+    ///@{
     /// @brief Factory methods that create a shared pointer to an DualUnifiedBuffer instance
     static PtrT createPtr(size_t size, size_t capacity) {return std::make_shared<DualUnifiedBuffer>(size, capacity);}
     static PtrT createPtr(size_t size) {return std::make_shared<DualUnifiedBuffer>(size);}
@@ -120,7 +120,7 @@ public:
     ///        If a reference buffer is provided and its non-empty, it is used to defined the capacity of the new buffer
     /// @param size Size on bytes of the new buffer
     /// @param reference reference buffer optionally used to define the capacity
-    /// @param host Ignored for now
+    /// @param device Device whose preferred memory location is set for the new buffer
     /// @param stream cuda stream
     /// @return An instance of a new DualUnifiedBuffer using move semantics
     static DualUnifiedBuffer create(size_t size, const DualUnifiedBuffer* reference, int device, cudaStream_t stream)

--- a/nanovdb/nanovdb/io/IO.h
+++ b/nanovdb/nanovdb/io/IO.h
@@ -125,6 +125,7 @@ using fileSize_t = uint64_t;
 /// @brief Internal functions for compressed read/write of a NanoVDB GridHandle into a stream
 ///
 /// @warning These functions should never be called directly by client code
+/// @cond
 namespace Internal {
 static constexpr fileSize_t MAX_SIZE = 1UL << 30; // size is 1 GB
 
@@ -136,6 +137,7 @@ static void read(std::istream& is, BufferT& buffer, Codec codec);
 
 static void read(std::istream& is, char* data, fileSize_t size, Codec codec);
 } // namespace Internal
+/// @endcond
 
 /// @brief Standard hash function to use on strings; std::hash may vary by
 ///        platform/implementation and is know to produce frequent collisions.
@@ -210,6 +212,8 @@ std::vector<FileGridMetaData> readGridMetaData(const std::string& fileName);
 std::vector<FileGridMetaData> readGridMetaData(std::istream& is);
 
 // --------------------------> Implementations for Internal <------------------------------------
+
+/// @cond
 
 template<typename BufferT>
 fileSize_t Internal::write(std::ostream& os, const GridHandle<BufferT>& handle, Codec codec, unsigned int n)
@@ -315,6 +319,7 @@ void Internal::read(std::istream& is, char* data, fileSize_t residual, Codec cod
     }
     if (!is) throw std::runtime_error("Failed to read Tree from file");
 } // Internal::read
+/// @endcond
 
 // --------------------------> Implementations for FileGridMetaData <------------------------------------
 

--- a/nanovdb/nanovdb/tools/CreateNanoGrid.h
+++ b/nanovdb/nanovdb/tools/CreateNanoGrid.h
@@ -172,6 +172,7 @@ createNanoGrid(const SrcGridT &srcGrid,
 /// @tparam DstBuildT If ValueIndex all (active and inactive) values are indexed and if
 ///         it is ValueOnIndex only active values are indexed.
 /// @tparam BufferT BufferT Type of the buffer used ti allocate the destination grid
+/// @param srcGrid Input (source) grid to be converted
 /// @param channels If non-zero the values (active or all) in @c srcGrid are encoded as blind
 ///                 data in the output index grid. @c channels indicates the number of copies
 ///                 of these blind data
@@ -859,7 +860,7 @@ struct CreateNanoGrid<SrcGridT>::OrderedBlindMetaData
         return type;
     }
     /// @brief Maps from string names of point attributes in openvdb to GridBlindDataSemantic
-    /// @param String name, typically used for point attributes in OpenVDB
+    /// @param name Attribute name, typically used for point attributes in OpenVDB
     /// @return GridBlindDataSemantic
     static GridBlindDataSemantic mapToSemantics(const std::string& name)
     {

--- a/nanovdb/nanovdb/tools/CreatePrimitives.h
+++ b/nanovdb/nanovdb/tools/CreatePrimitives.h
@@ -36,13 +36,13 @@ namespace tools {// ===================================================
 /// @param name      Name of the grid
 /// @param sMode     Mode of computation for the statistics.
 /// @param cMode     Mode of computation for the checksum.
-/// @param tolerance Global error tolerance use when VoxelT = FpN
-/// @param ditherOn  If true dithering will be applied when VoxelT = {Fp4,Fp8,Fp16,FpN}
 /// @param buffer    Buffer used for memory allocation by the handle
 ///
 /// @details The @c BuildT template parameter must be one of the following:
-///          float (default), double, Fp4, Fp8, Fp16 or FpN. The @c tolerance
-///          argument is only used when BuildT is set to FpN.
+///          float (default), double, Fp4, Fp8, Fp16 or FpN. The Fp4, Fp8,
+///          Fp16 and FpN overloads take an extra @c ditherOn argument, and the
+///          FpN overload also takes a @c tolerance argument that sets the
+///          global error tolerance.
 template<typename BuildT = float, typename BufferT = HostBuffer>
 typename util::enable_if<util::is_same<BuildT, float,  double>::value, GridHandle<BufferT>>::type
 createLevelSetSphere(double              radius = 100.0,
@@ -97,13 +97,13 @@ createLevelSetSphere(double              radius = 100.0,
 /// @param name      Name of the grid
 /// @param sMode     Mode of computation for the statistics.
 /// @param cMode     Mode of computation for the checksum.
-/// @param tolerance Global error tolerance use when VoxelT = FpN
-/// @param ditherOn  If true dithering will be applied when BuildT = {Fp4,Fp8,Fp16,FpN}
 /// @param buffer    Buffer used for memory allocation by the handle
 ///
 /// @details The @c BuildT template parameter must be one of the following:
-///          float (default), double, Fp4, Fp8, Fp16 or FpN. The @c tolerance
-///          argument is only used when BuildT is set to FpN.
+///          float (default), double, Fp4, Fp8, Fp16 or FpN. The Fp4, Fp8,
+///          Fp16 and FpN overloads take an extra @c ditherOn argument, and the
+///          FpN overload also takes a @c tolerance argument that sets the
+///          global error tolerance.
 template<typename BuildT = float, typename BufferT = HostBuffer>
 typename util::disable_if<util::is_same<FpN, BuildT>::value, GridHandle<BufferT>>::type
 createFogVolumeSphere(double              radius = 100.0,
@@ -169,13 +169,13 @@ createPointSphere(int                 pointsPerVoxel = 1,
 /// @param name        Name of the grid
 /// @param sMode       Mode of computation for the statistics.
 /// @param cMode       Mode of computation for the checksum.
-/// @param tolerance   Global error tolerance use when VoxelT = FpN
-/// @param ditherOn    If true dithering will be applied when VoxelT = {Fp4,Fp8,Fp16,FpN}
 /// @param buffer      Buffer used for memory allocation by the handle
 ///
 /// @details The @c BuildT template parameter must be one of the following:
-///          float (default), double, Fp4, Fp8, Fp16 or FpN. The @c tolerance
-///          argument is only used when BuildT is set to FpN.
+///          float (default), double, Fp4, Fp8, Fp16 or FpN. The Fp4, Fp8,
+///          Fp16 and FpN overloads take an extra @c ditherOn argument, and the
+///          FpN overload also takes a @c tolerance argument that sets the
+///          global error tolerance.
 template<typename BuildT = float, typename BufferT = HostBuffer>
 typename util::disable_if<util::is_same<FpN, BuildT>::value, GridHandle<BufferT>>::type
 createLevelSetTorus(double              majorRadius = 100.0,
@@ -220,13 +220,13 @@ createLevelSetTorus(double              majorRadius = 100.0,
 /// @param name        Name of the grid
 /// @param sMode       Mode of computation for the statistics.
 /// @param cMode       Mode of computation for the checksum.
-/// @param tolerance   Global error tolerance use when VoxelT = FpN
-/// @param ditherOn    If true dithering will be applied when VoxelT = {Fp4,Fp8,Fp16,FpN}
 /// @param buffer      Buffer used for memory allocation by the handle
 ///
 /// @details The @c BuildT template parameter must be one of the following:
-///          float (default), double, Fp4, Fp8, Fp16 or FpN. The @c tolerance
-///          argument is only used when BuildT is set to FpN.
+///          float (default), double, Fp4, Fp8, Fp16 or FpN. The Fp4, Fp8,
+///          Fp16 and FpN overloads take an extra @c ditherOn argument, and the
+///          FpN overload also takes a @c tolerance argument that sets the
+///          global error tolerance.
 template<typename BuildT = float, typename BufferT = HostBuffer>
 typename util::disable_if<util::is_same<FpN, BuildT>::value, GridHandle<BufferT>>::type
 createFogVolumeTorus(double              majorRadius = 100.0,
@@ -297,13 +297,13 @@ createPointTorus(int                 pointsPerVoxel = 1, // half-width of narrow
 /// @param name      Name of the grid
 /// @param sMode     Mode of computation for the statistics.
 /// @param cMode     Mode of computation for the checksum.
-/// @param tolerance Global error tolerance use when VoxelT = FpN
-/// @param ditherOn  If true dithering will be applied when VoxelT = {Fp4,Fp8,Fp16,FpN}
 /// @param buffer    Buffer used for memory allocation by the handle
 ///
 /// @details The @c BuildT template parameter must be one of the following:
-///          float (default), double, Fp4, Fp8, Fp16 or FpN. The @c tolerance
-///          argument is only used when BuildT is set to FpN.
+///          float (default), double, Fp4, Fp8, Fp16 or FpN. The Fp4, Fp8,
+///          Fp16 and FpN overloads take an extra @c ditherOn argument, and the
+///          FpN overload also takes a @c tolerance argument that sets the
+///          global error tolerance.
 template<typename BuildT = float, typename BufferT = HostBuffer>
 typename util::disable_if<util::is_same<FpN, BuildT>::value, GridHandle<BufferT>>::type
 createLevelSetBox(double              width = 40.0,
@@ -351,13 +351,13 @@ createLevelSetBox(double              width = 40.0,
 /// @param name      Name of the grid
 /// @param sMode     Mode of computation for the statistics.
 /// @param cMode     Mode of computation for the checksum.
-/// @param tolerance Global error tolerance use when VoxelT = FpN
-/// @param ditherOn  If true dithering will be applied when VoxelT = {Fp4,Fp8,Fp16,FpN}
 /// @param buffer    Buffer used for memory allocation by the handle
 ///
 /// @details The @c BuildT template parameter must be one of the following:
-///          float (default), double, Fp4, Fp8, Fp16 or FpN. The @c tolerance
-///          argument is only used when BuildT is set to FpN.
+///          float (default), double, Fp4, Fp8, Fp16 or FpN. The Fp4, Fp8,
+///          Fp16 and FpN overloads take an extra @c ditherOn argument, and the
+///          FpN overload also takes a @c tolerance argument that sets the
+///          global error tolerance.
 template<typename BuildT = float, typename BufferT = HostBuffer>
 typename util::disable_if<util::is_same<FpN, BuildT>::value, GridHandle<BufferT>>::type
 createFogVolumeBox(double              width = 40.0,
@@ -400,13 +400,13 @@ createFogVolumeBox(double              width = 40.0,
 /// @param name      Name of the grid
 /// @param sMode     Mode of computation for the statistics.
 /// @param cMode     Mode of computation for the checksum.
-/// @param tolerance Global error tolerance use when VoxelT = FpN
-/// @param ditherOn  If true dithering will be applied when VoxelT = {Fp4,Fp8,Fp16,FpN}
 /// @param buffer    Buffer used for memory allocation by the handle
 ///
 /// @details The @c BuildT template parameter must be one of the following:
-///          float (default), double, Fp4, Fp8, Fp16 or FpN. The @c tolerance
-///          argument is only used when BuildT is set to FpN.
+///          float (default), double, Fp4, Fp8, Fp16 or FpN. The Fp4, Fp8,
+///          Fp16 and FpN overloads take an extra @c ditherOn argument, and the
+///          FpN overload also takes a @c tolerance argument that sets the
+///          global error tolerance.
 template<typename BuildT = float, typename BufferT = HostBuffer>
 typename util::disable_if<util::is_same<FpN, BuildT>::value, GridHandle<BufferT>>::type
 createLevelSetOctahedron(double              scale = 100.0,
@@ -448,13 +448,13 @@ createLevelSetOctahedron(double              scale = 100.0,
 /// @param name      Name of the grid
 /// @param sMode     Mode of computation for the statistics.
 /// @param cMode     Mode of computation for the checksum.
-/// @param tolerance Global error tolerance use when VoxelT = FpN
-/// @param ditherOn  If true dithering will be applied when VoxelT = {Fp4,Fp8,Fp16,FpN}
 /// @param buffer    Buffer used for memory allocation by the handle
 ///
 /// @details The @c BuildT template parameter must be one of the following:
-///          float (default), double, Fp4, Fp8, Fp16 or FpN. The @c tolerance
-///          argument is only used when BuildT is set to FpN.
+///          float (default), double, Fp4, Fp8, Fp16 or FpN. The Fp4, Fp8,
+///          Fp16 and FpN overloads take an extra @c ditherOn argument, and the
+///          FpN overload also takes a @c tolerance argument that sets the
+///          global error tolerance.
 template<typename BuildT = float, typename BufferT = HostBuffer>
 typename util::disable_if<util::is_same<FpN, BuildT>::value, GridHandle<BufferT>>::type
 createFogVolumeOctahedron(double              scale = 100.0,
@@ -496,13 +496,13 @@ createFogVolumeOctahedron(double              scale = 100.0,
 /// @param name      Name of the grid
 /// @param sMode     Mode of computation for the statistics.
 /// @param cMode     Mode of computation for the checksum.
-/// @param tolerance Global error tolerance use when VoxelT = FpN
-/// @param ditherOn  If true dithering will be applied when VoxelT = {Fp4,Fp8,Fp16,FpN}
 /// @param buffer    Buffer used for memory allocation by the handle
 ///
 /// @details The @c BuildT template parameter must be one of the following:
-///          float (default), double, Fp4, Fp8, Fp16 or FpN. The @c tolerance
-///          argument is only used when BuildT is set to FpN.
+///          float (default), double, Fp4, Fp8, Fp16 or FpN. The Fp4, Fp8,
+///          Fp16 and FpN overloads take an extra @c ditherOn argument, and the
+///          FpN overload also takes a @c tolerance argument that sets the
+///          global error tolerance.
 template<typename BuildT = float, typename BufferT = HostBuffer>
 typename util::disable_if<util::is_same<FpN, BuildT>::value, GridHandle<BufferT>>::type
 createLevelSetBBox(double              width = 40.0,

--- a/nanovdb/nanovdb/tools/GridChecksum.h
+++ b/nanovdb/nanovdb/tools/GridChecksum.h
@@ -61,13 +61,12 @@ inline Checksum getChecksum(const GridData *gridData)
 
 /// @brief Return true if the checksum of @c gridData matches the expected
 ///        value already encoded into the grid's meta data.
-/// @tparam BuildT Template parameter used to build NanoVDB grid.
-/// @param grid Grid whose checksum is validated.
+/// @param gridData Base pointer to the grid whose checksum is validated.
 /// @param mode Defines the mode of computation for the checksum.
 bool validateChecksum(const GridData *gridData, CheckMode mode = CheckMode::Default);
 
 /// @brief Updates the checksum of a grid
-/// @param grid Grid whose checksum will be updated.
+/// @param gridData Base pointer to the grid whose checksum will be updated.
 /// @param mode Defines the mode of computation for the checksum.
 inline void updateChecksum(GridData *gridData, CheckMode mode)
 {
@@ -127,7 +126,7 @@ inline __hostdev__ uint32_t crc32(const void* data, size_t size, uint32_t crc = 
 
 /// @brief Compute crc32 checksum of data between @c begin and @c end
 /// @param begin points to beginning of data
-/// @param end points to end of @data, (exclusive)
+/// @param end points to end of @c data, (exclusive)
 /// @param crc initial value of crc32 checksum
 /// @return return crc32 checksum
 inline __hostdev__ uint32_t crc32(const void *begin, const void *end, uint32_t crc = 0)
@@ -153,7 +152,7 @@ inline __hostdev__ uint32_t crc32(const void *data, size_t size, const uint32_t 
 
 /// @brief Compute crc32 checksum of data between @c begin and @c end using a lookup table
 /// @param begin points to beginning of data
-/// @param end points to end of @data, (exclusive)
+/// @param end points to end of @c data, (exclusive)
 /// @param lut pointer to loopup table for accelerated crc32 computation
 /// @param crc initial value of crc32 checksum
 /// @return return crc32 checksum
@@ -205,11 +204,12 @@ namespace tools {// ============================================================
 
 // ----------------------------> crc32Head <--------------------------------------
 
-/// @brief
-/// @tparam ValueT
-/// @param grid
-/// @param mode
-/// @return
+/// @brief Compute the crc32 checksum of a grid's head, i.e. its GridData and
+///        TreeData, using a lookup table. GridData::mMagic and
+///        GridData::mChecksum are excluded.
+/// @param gridData Base pointer to the grid.
+/// @param lut Pointer to the lookup table for accelerated crc32 computation.
+/// @return crc32 checksum of the grid's head.
 inline __hostdev__ uint32_t crc32Head(const GridData *gridData, const uint32_t *lut)
 {
     NANOVDB_ASSERT(gridData);
@@ -365,11 +365,6 @@ bool validateChecksum(const NanoGrid<ValueT> *grid, CheckMode mode)
     }
 }
 
-/// @brief
-/// @tparam ValueT
-/// @param grid
-/// @param mode
-/// @return
 inline bool validateChecksum(const GridData *gridData, CheckMode mode)
 {
     if (gridData->mChecksum.isEmpty()|| mode == CheckMode::Empty) return true;

--- a/nanovdb/nanovdb/util/cuda/Timer.h
+++ b/nanovdb/nanovdb/util/cuda/Timer.h
@@ -65,8 +65,6 @@ public:
     }
 
     /// @brief Start the timer
-    /// @param stream CUDA stream to be timed (defaults to stream 0)
-    /// @param os output stream for the message above
     /// @warning @c cudaEventRecord requires that the event and stream are
     ///          associated with the same device. So it's important to call
     ///          @c cudaSetDevice(device) so @c device matches the one used
@@ -75,7 +73,6 @@ public:
 
     /// @brief Start the timer
     /// @param msg string message to be printed when timer is started
-
     /// @param os output stream for the message above
     void start(const std::string &msg, std::ostream& os = std::cerr)
     {
@@ -148,6 +145,7 @@ public:
 
     /// @brief stop and start the timer
     /// @param msg string message to be printed when timer is started
+    /// @param os output stream for the message above
     /// @warning Remember to call start before restart
     inline void restart(const std::string &msg, std::ostream& os = std::cerr)
     {

--- a/nanovdb/nanovdb/util/cuda/Util.h
+++ b/nanovdb/nanovdb/util/cuda/Util.h
@@ -112,15 +112,17 @@ inline bool memoryPoolsSupported(int device)
 #if (CUDART_VERSION < 11020) || defined(NANOVDB_USE_SYNC_CUDA_MALLOC) // 11.2 introduced cudaMallocAsync and cudaFreeAsync
 
 /// @brief Wrapper forced to synchronous cudaMalloc; see the mode comment above.
+///        The trailing stream argument is accepted for signature compatibility
+///        and ignored.
 /// @param d_ptr Device pointer to allocated device memory
 /// @param size  Number of bytes to allocate
-/// @param dummy The stream establishing the stream ordering contract and the memory pool to allocate from (ignored)
 /// @return Cuda error code
 inline cudaError_t mallocAsync(void** d_ptr, size_t size, cudaStream_t){return cudaMalloc(d_ptr, size);}
 
 /// @brief Wrapper forced to synchronous cudaFree; see the mode comment above.
+///        The trailing stream argument is accepted for signature compatibility
+///        and ignored.
 /// @param d_ptr Device pointer that will be freed
-/// @param dummy The stream establishing the stream ordering promise (ignored)
 /// @return Cuda error code
 inline cudaError_t freeAsync(void* d_ptr, cudaStream_t){return cudaFree(d_ptr);}
 

--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -1571,7 +1571,7 @@ InternalNode<ChildT, Log2Dim>::addLeafAndCache(LeafNodeType* leaf, AccessorT& ac
 
 template<typename ChildT, Index Log2Dim>
 inline bool
-InternalNode<ChildT, Log2Dim>::addChild(ChildT* child)
+InternalNode<ChildT, Log2Dim>::addChild(ChildNodeType* child)
 {
     OPENVDB_ASSERT(child);
     const Coord& xyz = child->origin();

--- a/openvdb/openvdb/tree/RootNode.h
+++ b/openvdb/openvdb/tree/RootNode.h
@@ -696,7 +696,7 @@ public:
     /// the new node in its place (i.e. ownership of the new child node is transferred
     /// to this RootNode).
     /// @return @c true (for consistency with InternalNode::addChild)
-    bool addChild(ChildType* child);
+    bool addChild(ChildNodeType* child);
 
     /// @brief Add a tile containing voxel (x, y, z) at the root level,
     /// deleting the existing branch if necessary.
@@ -2621,7 +2621,7 @@ RootNode<ChildT>::addLeafAndCache(LeafNodeType* leaf, AccessorT& acc)
 
 template<typename ChildT>
 inline bool
-RootNode<ChildT>::addChild(ChildT* child)
+RootNode<ChildT>::addChild(ChildNodeType* child)
 {
     if (!child) return false;
     const Coord& xyz = child->origin();


### PR DESCRIPTION
Fixes #2324.

## The bug

`nanovdb::cuda`, `::io`, `::math`, `::putil`, `::tools` and `::util::cuda` are missing from the API docs on openvdb.org. Searching for `ZeroCrossing` finds only `openvdb::math::ZeroCrossing`.

`doc/CMakeLists.txt` lists only `nanovdb/nanovdb` and `nanovdb/nanovdb/util`, and `DOXYGEN_RECURSIVE` is `NO`. When NanoVDB was reorganised into per-namespace directories the list was never extended. @Idclip's list on the issue names four directories; `nanovdb/nanovdb/cuda` and `nanovdb/nanovdb/util/cuda` are missing too, so this adds six.

## Why it isn't a six-line change

Adding the directories surfaces 53 doxygen diagnostics in headers the docs build has never parsed, and `WARN_AS_ERROR` turns those into a red docs job. They are fixed here rather than suppressed:

| File | Fix |
|---|---|
| `tools/CreatePrimitives.h` | Nine shared doc blocks document `@param tolerance`/`@param ditherOn`, which exist only on the Fp overloads the block does not attach to. Moved into `@details`. |
| `tools/GridChecksum.h` | `@param grid` -> `gridData`; filled in the empty `crc32Head` stub; dropped a duplicate stub on `validateChecksum`; `@data` -> `@c data`. |
| `tools/CreateNanoGrid.h` | Added missing `@param srcGrid`; `@param String` -> `@param name`. |
| `cuda/DeviceMesh.h` | `@param DeviceMesh` -> `@param other`. |
| `cuda/DeviceBuffer.h`, `cuda/DeviceResource.h` | Documented `device`, `bytes`, `alignment`. |
| `cuda/UnifiedBuffer.h` | Two `//@{` openers are not doc comments, leaving their `///@}` unbalanced; both become `///@{`. `@param host` -> `@param device`. |
| `util/cuda/Timer.h` | `start()` takes no arguments, so its stale `@param`s go; a blank line splitting a doc block is closed up; `restart()` documents `os`. |
| `util/cuda/Util.h` | The ignored trailing stream parameter is unnamed, so `@param dummy` cannot bind; folded into the brief. |
| `io/IO.h` | `namespace Internal` wrapped in `@cond` -- the header already warns it must never be called by client code, and doxygen cannot match its `static` declarations to their definitions. |

Every NanoVDB change above is comment-only.

## The one code change (3 lines)

`RootNode::addChild` and `InternalNode::addChild` spelt their parameter type `ChildT` in the out-of-line definitions but `ChildType`/`ChildNodeType` in the declarations. Doxygen matches these textually. It coped while only OpenVDB's nodes were documented, but `nanovdb::tools::build` supplies identically named `RootNode` and `InternalNode` with their own `addChild`, and the definitions then resolve ambiguously.

Both definitions now spell the parameter type `ChildNodeType`, the public alias, and `RootNode`'s declaration does the same -- so the two classes agree with each other as well as with their own definitions. `ChildNodeType` aliases the template parameter in both classes, so no types change.

## Test plan

- [x] Built doxygen 1.14.0 (the version `ci/install_doxygen.sh` pins) and ran the CMake `doc` target with `-DOPENVDB_DOXYGEN_WARN_AS_ERROR=ON`: exit 0, empty warning log. Baseline on master is also 0, so nothing regressed.
- [x] `nanovdb::math::ZeroCrossing` now appears in the search index; namespace pages exist for `nanovdb::cuda`, `::io`, `::math`, `::tools`, `::util`. `nanovdb::io::Internal` is absent, as intended.
- [x] `ci/validate_docs_references.py` passes; `g++ -fsyntax-only` on a TU calling both `addChild` overloads.

## For reviewers

`nanovdb::tools::build` now documents its own `RootNode`, `InternalNode` and `LeafNode`, which sit alongside OpenVDB's identically named classes. That may be more confusing than helpful -- happy to `@cond` the builder's node classes if you agree.
