### PR TITLE
Disable Tree I/O for ABI=14

### DIFF
--- a/openvdb/openvdb/Grid.h
+++ b/openvdb/openvdb/Grid.h
@@ -443,10 +443,10 @@ public:
 
     /// @}
 
-
     /// @name I/O
     /// @{
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     /// @brief Read the grid topology from a stream.
     /// This will read only the grid structure, not the actual data buffers.
     virtual void readTopology(std::istream&) = 0;
@@ -459,13 +459,12 @@ public:
     /// Read all of this grid's data buffers that intersect the given index-space bounding box.
     virtual void readBuffers(std::istream&, const CoordBBox&) = 0;
 
-#if OPENVDB_ABI_VERSION_NUMBER < 14
     OPENVDB_DEPRECATED_MESSAGE("This method is deprecated and will be removed. Delayed loading is no longer supported.")
     virtual void readNonresidentBuffers() const = 0;
-#endif
 
     /// Write out all data buffers for this grid.
     virtual void writeBuffers(std::ostream&) const = 0;
+#endif
 
     /// Read in the transform for this grid.
     void readTransform(std::istream& is) { transform().read(is); }
@@ -931,6 +930,7 @@ public:
     /// @name I/O
     /// @{
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     /// @brief Read the grid topology from a stream.
     /// This will read only the grid structure, not the actual data buffers.
     void readTopology(std::istream&) override;
@@ -943,13 +943,13 @@ public:
     /// Read all of this grid's data buffers that intersect the given index-space bounding box.
     void readBuffers(std::istream&, const CoordBBox&) override;
 
-#if OPENVDB_ABI_VERSION_NUMBER < 14
     OPENVDB_DEPRECATED_MESSAGE("This method is deprecated and will be removed. Delayed loading is no longer supported.")
     void readNonresidentBuffers() const override { }
-#endif
 
     /// Write out all data buffers for this grid.
     void writeBuffers(std::ostream&) const override;
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
     /// Output a human-readable description of this grid.
     void print(std::ostream& = std::cout, int verboseLevel = 1) const override;
@@ -1624,6 +1624,7 @@ Grid<TreeT>::evalActiveVoxelDim() const
 
 ////////////////////////////////////////
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
 
 /// @internal Consider using the stream tagging mechanism (see io::Archive)
 /// to specify the float precision, but note that the setting is per-grid.
@@ -1741,6 +1742,8 @@ Grid<TreeT>::writeBuffers(std::ostream& os) const
         }
     }
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 //static

--- a/openvdb/openvdb/codecs/PointDataCodec.h
+++ b/openvdb/openvdb/codecs/PointDataCodec.h
@@ -8,6 +8,7 @@
 
 #include <openvdb/tools/Clip.h>
 
+#include <openvdb/points/PointDataIO.h> // io::readCompressedValues(), io::writeCompressedValues(), io::writeCompressedValuesSize()
 #include <openvdb/points/PointDataGrid.h>
 #include <openvdb/points/AttributeSet.h>
 #include <openvdb/points/StreamCompression.h>
@@ -181,7 +182,14 @@ inline Index countPointDataPasses(const std::vector<const LeafT*>& leaves)
 {
     Index maxRequiredPasses = 0;
     for (const auto* leaf : leaves) {
-        const Index requiredPasses = leaf->buffers();
+        const Index attributes = leaf->attributeSet().size();
+        const Index requiredPasses =
+            /*voxel buffer sizes*/          1 +
+            /*voxel buffers*/               1 +
+            /*attribute metadata*/          1 +
+            /*attribute uniform values*/    attributes +
+            /*attribute buffers*/           attributes +
+            /*cleanup*/                     1;
         if (requiredPasses > maxRequiredPasses) {
             maxRequiredPasses = requiredPasses;
         }

--- a/openvdb/openvdb/codecs/PointDataCodec.h
+++ b/openvdb/openvdb/codecs/PointDataCodec.h
@@ -182,7 +182,7 @@ inline Index countPointDataPasses(const std::vector<const LeafT*>& leaves)
 {
     Index maxRequiredPasses = 0;
     for (const auto* leaf : leaves) {
-        const Index attributes = leaf->attributeSet().size();
+        const Index attributes = static_cast<Index>(leaf->attributeSet().size());
         const Index requiredPasses =
             /*voxel buffer sizes*/          1 +
             /*voxel buffers*/               1 +

--- a/openvdb/openvdb/io/Archive.cc
+++ b/openvdb/openvdb/io/Archive.cc
@@ -1021,6 +1021,7 @@ Archive::readGrid(const GridDescriptor& gd, std::istream& is, const io::ReadOpti
         if (codec) {
             codec->readTopology(is, *codecData, readOptions, diagnostics);
         } else {
+#if OPENVDB_ABI_VERSION_NUMBER < 14
             io::StreamMetadata::Ptr allocateLeafBuffersMeta;
             if (readOptions.readMode == io::ReadMode::TopologyOnly) {
                 // Signal Grid<TreeT>::readTopology to allocate leaf buffers and
@@ -1040,6 +1041,7 @@ Archive::readGrid(const GridDescriptor& gd, std::istream& is, const io::ReadOpti
                 }
                 throw;
             }
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
         }
     }
     if (readBuffers) {
@@ -1049,6 +1051,7 @@ Archive::readGrid(const GridDescriptor& gd, std::istream& is, const io::ReadOpti
             const Index64 size = static_cast<Index64>(gd.getEndPos() - gd.getGridPos());
             codec->readBuffers(is, size, *codecData, readOptions, diagnostics);
         } else {
+#if OPENVDB_ABI_VERSION_NUMBER < 14
             const auto& worldBBox = readOptions.clipBBox;
             const bool clip = worldBBox.isSorted();
             if (clip) {
@@ -1057,6 +1060,7 @@ Archive::readGrid(const GridDescriptor& gd, std::istream& is, const io::ReadOpti
             } else {
                 grid->readBuffers(is);
             }
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
         }
     }
 
@@ -1242,7 +1246,9 @@ Archive::writeGrid(GridDescriptor& gd, GridBase::ConstPtr grid,
     if (codec) {
         codec->writeTopology(os, *grid, writeOptions);
     } else {
+#if OPENVDB_ABI_VERSION_NUMBER < 14
         grid->writeTopology(os);
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
     }
 
     // Now we know the grid block storage position.
@@ -1252,7 +1258,9 @@ Archive::writeGrid(GridDescriptor& gd, GridBase::ConstPtr grid,
     if (codec) {
         codec->writeBuffers(os, *grid, writeOptions);
     } else {
+#if OPENVDB_ABI_VERSION_NUMBER < 14
         grid->writeBuffers(os);
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
     }
 
     // Now we know the end position of this grid.

--- a/openvdb/openvdb/points/PointDataGrid.h
+++ b/openvdb/openvdb/points/PointDataGrid.h
@@ -31,7 +31,11 @@
 #include <utility> // std::pair, std::make_pair
 #include <vector>
 
+// This header is only needed when PointData I/O methods are present (ie ABI<14)
+// otherwise, this header is included in the PointDataCodec instead.
+#if OPENVDB_ABI_VERSION_NUMBER < 14
 #include <openvdb/points/PointDataIO.h> // io::readCompressedValues(), io::writeCompressedValues(), io::writeCompressedValuesSize()
+#endif
 
 class TestPointDataLeaf;
 
@@ -363,6 +367,7 @@ public:
 
     // I/O methods
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     void readTopology(std::istream& is, bool fromHalf = false);
     void writeTopology(std::ostream& os, bool toHalf = false) const;
 
@@ -372,10 +377,11 @@ public:
     void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
     void writeBuffers(std::ostream& os, bool toHalf = false) const;
 
-
-    Index64 memUsage() const;
     OPENVDB_DEPRECATED_MESSAGE("Use memUsage() instead. This method is deprecated and will be removed. Delayed loading is no longer supported.")
     Index64 memUsageIfLoaded() const { return memUsage(); }
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
+
+    Index64 memUsage() const;
 
     void evalActiveBoundingBox(CoordBBox& bbox, bool visitVoxels = true) const;
 
@@ -987,6 +993,8 @@ PointDataLeafNode<T, Log2Dim>::setOffsetOnly(Index offset, const ValueType& val)
     this->buffer().setValue(offset, val);
 }
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 template<typename T, Index Log2Dim>
 inline void
 PointDataLeafNode<T, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
@@ -1385,6 +1393,8 @@ PointDataLeafNode<T, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
         Local::destroyPagedStream(meta->auxData(), attributeIndex);
     }
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 template<typename T, Index Log2Dim>
 inline Index64

--- a/openvdb/openvdb/points/PointDataIO.h
+++ b/openvdb/openvdb/points/PointDataIO.h
@@ -4,6 +4,10 @@
 #ifndef OPENVDB_POINTS_POINT_DATA_IO_HAS_BEEN_INCLUDED
 #define OPENVDB_POINTS_POINT_DATA_IO_HAS_BEEN_INCLUDED
 
+#include <openvdb/io/Compression.h> // for io::readCompressedValues(), etc
+#include <openvdb/points/StreamCompression.h>
+#include <openvdb/util/NodeMasks.h>
+
 
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE

--- a/openvdb/openvdb/tree/InternalNode.h
+++ b/openvdb/openvdb/tree/InternalNode.h
@@ -458,6 +458,7 @@ public:
     /// Mark all values (both tiles and voxels) as active.
     void setValuesOn();
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     //
     // I/O
     //
@@ -466,7 +467,7 @@ public:
     void writeBuffers(std::ostream&, bool toHalf = false) const;
     void readBuffers(std::istream&, bool fromHalf = false);
     void readBuffers(std::istream&, const CoordBBox&, bool fromHalf = false);
-
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
     //
     // Unsafe methods
@@ -2394,6 +2395,8 @@ InternalNode<ChildT, Log2Dim>::copyToDense(const CoordBBox& bbox, DenseT& dense)
 ////////////////////////////////////////
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 template<typename ChildT, Index Log2Dim>
 inline void
 InternalNode<ChildT, Log2Dim>::writeTopology(std::ostream& os, bool toHalf) const
@@ -2462,6 +2465,8 @@ InternalNode<ChildT, Log2Dim>::readTopology(std::istream& is, bool fromHalf)
         child->readTopology(is, fromHalf);
     }
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 ////////////////////////////////////////
@@ -3218,6 +3223,8 @@ InternalNode<ChildT, Log2Dim>::combine2(const InternalNode& other, const OtherVa
 ////////////////////////////////////////
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 template<typename ChildT, Index Log2Dim>
 inline void
 InternalNode<ChildT, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
@@ -3258,6 +3265,8 @@ InternalNode<ChildT, Log2Dim>::readBuffers(std::istream& is,
     }
     this->clip(clipBBox, background);
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tree/LeafNode.h
+++ b/openvdb/openvdb/tree/LeafNode.h
@@ -381,6 +381,7 @@ public:
     const Buffer& buffer() const { return mBuffer; }
     Buffer& buffer() { return mBuffer; }
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     //
     // I/O methods
     //
@@ -406,6 +407,7 @@ public:
     /// @param os      the stream to which to write
     /// @param toHalf  if true, output floating-point values as 16-bit half floats
     void writeBuffers(std::ostream& os, bool toHalf = false) const;
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
     size_t streamingSize(bool toHalf = false) const;
 
@@ -924,7 +926,10 @@ protected:
     void setValueMaskOn(Index n)  { mValueMask.setOn(n); }
     void setValueMaskOff(Index n) { mValueMask.setOff(n); }
 
+
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     inline void skipCompressedValues(bool seekable, std::istream&, bool fromHalf);
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
     /// Compute the origin of the leaf node that contains the voxel with the given coordinates.
     static void evalNodeOrigin(Coord& xyz) { xyz &= ~(DIM - 1); }
@@ -1326,6 +1331,8 @@ LeafNode<T, Log2Dim>::copyFromDense(const CoordBBox& bbox, const DenseT& dense,
 ////////////////////////////////////////
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 template<typename T, Index Log2Dim>
 inline void
 LeafNode<T, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
@@ -1340,10 +1347,6 @@ LeafNode<T, Log2Dim>::writeTopology(std::ostream& os, bool /*toHalf*/) const
 {
     mValueMask.save(os);
 }
-
-
-////////////////////////////////////////
-
 
 
 template<typename T, Index Log2Dim>
@@ -1439,6 +1442,8 @@ LeafNode<T, Log2Dim>::writeBuffers(std::ostream& os, bool toHalf) const
     io::writeCompressedValues(os, mBuffer.mData, SIZE,
         mValueMask, /*childMask=*/NodeMaskType(), toHalf);
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tree/LeafNodeBool.h
+++ b/openvdb/openvdb/tree/LeafNodeBool.h
@@ -200,6 +200,7 @@ public:
     const Buffer& buffer() const { return mBuffer; }
     Buffer& buffer() { return mBuffer; }
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     //
     // I/O methods
     //
@@ -213,6 +214,7 @@ public:
     void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
     /// Write out the topology and the origin.
     void writeBuffers(std::ostream&, bool toHalf = false) const;
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
     //
     // Accessor methods
@@ -976,6 +978,8 @@ LeafNode<bool, Log2Dim>::offsetToGlobalCoord(Index n) const
 ////////////////////////////////////////
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 template<Index Log2Dim>
 inline void
 LeafNode<bool, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
@@ -1037,6 +1041,8 @@ LeafNode<bool, Log2Dim>::writeBuffers(std::ostream& os, bool /*toHalf*/) const
     // Write out the voxel values.
     mBuffer.mData.save(os);
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tree/LeafNodeMask.h
+++ b/openvdb/openvdb/tree/LeafNodeMask.h
@@ -199,6 +199,7 @@ public:
     const Buffer& buffer() const { return mBuffer; }
     Buffer& buffer() { return mBuffer; }
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     //
     // I/O methods
     //
@@ -212,6 +213,7 @@ public:
     void readBuffers(std::istream& is, const CoordBBox&, bool fromHalf = false);
     /// Write out the topology and the origin.
     void writeBuffers(std::ostream&, bool toHalf = false) const;
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
     //
     // Accessor methods
@@ -962,6 +964,8 @@ LeafNode<ValueMask, Log2Dim>::offsetToGlobalCoord(Index n) const
 ////////////////////////////////////////
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 template<Index Log2Dim>
 inline void
 LeafNode<ValueMask, Log2Dim>::readTopology(std::istream& is, bool /*fromHalf*/)
@@ -1016,6 +1020,8 @@ LeafNode<ValueMask, Log2Dim>::writeBuffers(std::ostream& os, bool /*toHalf*/) co
     // Write out the origin.
     os.write(reinterpret_cast<const char*>(&mOrigin), sizeof(Coord::ValueType) * 3);
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tree/RootNode.h
+++ b/openvdb/openvdb/tree/RootNode.h
@@ -13,7 +13,6 @@
 #include <openvdb/io/Compression.h> // for truncateRealToHalf()
 #include <openvdb/math/Math.h> // for isZero(), isExactlyEqual(), etc.
 #include <openvdb/math/BBox.h>
-#include <openvdb/util/NodeMasks.h> // for backward compatibility only (see readTopology())
 #include <openvdb/util/Assert.h>
 #include <openvdb/version.h>
 #include <tbb/parallel_for.h>
@@ -575,6 +574,7 @@ public:
     void copyToDense(const CoordBBox& bbox, DenseT& dense) const;
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     //
     // I/O
     //
@@ -584,6 +584,7 @@ public:
     void writeBuffers(std::ostream&, bool toHalf = false) const;
     void readBuffers(std::istream&, bool fromHalf = false);
     void readBuffers(std::istream&, const CoordBBox&, bool fromHalf = false);
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
     //
@@ -2347,6 +2348,8 @@ RootNode<ChildT>::copyToDense(const CoordBBox& bbox, DenseT& dense) const
 ////////////////////////////////////////
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 template<typename ChildT>
 inline bool
 RootNode<ChildT>::writeTopology(std::ostream& os, bool toHalf) const
@@ -2467,6 +2470,8 @@ RootNode<ChildT>::readBuffers(std::istream& is, const CoordBBox& clipBBox, bool 
     // Clip root-level tiles and prune children that were clipped.
     this->clip(clipBBox);
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 ////////////////////////////////////////

--- a/openvdb/openvdb/tree/Tree.h
+++ b/openvdb/openvdb/tree/Tree.h
@@ -144,7 +144,7 @@ public:
     /// Return the total amount of memory in bytes occupied by this tree.
     virtual Index64 memUsage() const { return 0; }
 
-
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     //
     // I/O methods
     //
@@ -162,12 +162,12 @@ public:
     /// Read all of this tree's data buffers that intersect the given bounding box.
     virtual void readBuffers(std::istream&, const CoordBBox&, bool saveFloatAsHalf = false) = 0;
 
-#if OPENVDB_ABI_VERSION_NUMBER < 14
     OPENVDB_DEPRECATED_MESSAGE("This method is deprecated and will be removed. Delayed loading is no longer supported.")
     virtual void readNonresidentBuffers() const = 0;
-#endif
+
     /// Write out all the data buffers for this tree.
     virtual void writeBuffers(std::ostream&, bool saveFloatAsHalf = false) const = 0;
+#endif
 
     /// @brief Print statistics, memory usage and other information about this tree.
     /// @param os            a stream to which to write textual information
@@ -316,7 +316,7 @@ public:
     /// @note Because RootNodes are resizable, the RootNode Log2Dim is 0 for all trees.
     static void getNodeLog2Dims(std::vector<Index>& dims);
 
-
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     //
     // I/O methods
     //
@@ -333,13 +333,12 @@ public:
     /// Read all of this tree's data buffers that intersect the given bounding box.
     void readBuffers(std::istream&, const CoordBBox&, bool saveFloatAsHalf = false) override;
 
-#if OPENVDB_ABI_VERSION_NUMBER < 14
     OPENVDB_DEPRECATED_MESSAGE("This method is deprecated and will be removed. Delayed loading is no longer supported.")
     void readNonresidentBuffers() const override { }
-#endif
 
     /// Write out all data buffers for this tree.
     void writeBuffers(std::ostream&, bool saveFloatAsHalf = false) const override;
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
     void print(std::ostream& os = std::cout, int verboseLevel = 1) const override;
 
@@ -1251,6 +1250,8 @@ Tree<RootNodeType>::cbegin() const
 ////////////////////////////////////////
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 template<typename RootNodeType>
 void
 Tree<RootNodeType>::readTopology(std::istream& is, bool saveFloatAsHalf)
@@ -1297,6 +1298,8 @@ Tree<RootNodeType>::writeBuffers(std::ostream &os, bool saveFloatAsHalf) const
 {
     mRoot.writeBuffers(os, saveFloatAsHalf);
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 template<typename RootNodeType>

--- a/openvdb/openvdb/unittest/TestCodec.cc
+++ b/openvdb/openvdb/unittest/TestCodec.cc
@@ -271,12 +271,15 @@ void testCodecIOImpl(
     ASSERT_TRUE(openvdb::io::CodecRegistry::isRegistered(GridT::gridType()));
     // test the io implementation (codec)
     testIOImpl<GridT>(gridName, bgValue, fillValue);
+
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     // clear the codec registry (now read/write falls back to Tree I/O)
     openvdb::io::CodecRegistry::clear();
     // ensure the codec is not registered
     ASSERT_FALSE(openvdb::io::CodecRegistry::isRegistered(GridT::gridType()));
     // test the io implementation (tree I/O)
     testIOImpl<GridT>(gridName, bgValue, fillValue);
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 }
 
 TEST_F(TestCodec, testFloatCodecIO) { testCodecIOImpl<openvdb::FloatGrid>("float_grid", 0.0f, 1.0f); }
@@ -472,6 +475,8 @@ TEST_F(TestCodec, testBoolAndMaskConversionNoGridOffsets)
     runCase(ReadMode::Mask);
 }
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 TEST_F(TestCodec, testVec3FallsBackWithWarningNoGridOffsets)
 {
     using namespace openvdb;
@@ -529,6 +534,8 @@ TEST_F(TestCodec, testVec3FallsBackWithWarningNoGridOffsets)
 
     std::remove(path.c_str());
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 TEST_F(TestCodec, testOffsetsAndNoOffsetsParity)
 {

--- a/openvdb/openvdb/unittest/TestGrid.cc
+++ b/openvdb/openvdb/unittest/TestGrid.cc
@@ -60,17 +60,19 @@ public:
 
     TreeBasePtr copy() const override { return TreeBasePtr(new ProxyTree(*this)); }
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     void readTopology(std::istream& is, bool = false) override { is.seekg(0, std::ios::beg); }
     void writeTopology(std::ostream& os, bool = false) const override { os.seekp(0); }
 
     void readBuffers(std::istream& is,
         const openvdb::CoordBBox&, bool /*saveFloatAsHalf*/=false) override { is.seekg(0); }
-#if OPENVDB_ABI_VERSION_NUMBER < 14
+
     void readNonresidentBuffers() const override {}
-#endif
+
     void readBuffers(std::istream& is, bool /*saveFloatAsHalf*/=false) override { is.seekg(0); }
     void writeBuffers(std::ostream& os, bool /*saveFloatAsHalf*/=false) const override
         { os.seekp(0, std::ios::beg); }
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
     bool empty() const { return true; }
     void clear() {}

--- a/openvdb/openvdb/unittest/TestLeafBool.cc
+++ b/openvdb/openvdb/unittest/TestLeafBool.cc
@@ -340,6 +340,8 @@ TEST_F(TestLeafBool, testIO)
 }
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 TEST_F(TestLeafBool, testTreeIO)
 {
     LeafType leaf(openvdb::Coord(1, 3, 5));
@@ -367,6 +369,8 @@ TEST_F(TestLeafBool, testTreeIO)
 
     EXPECT_TRUE(leaf.onVoxelCount() == 2);
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 TEST_F(TestLeafBool, testConstructors)

--- a/openvdb/openvdb/unittest/TestLeafIO.cc
+++ b/openvdb/openvdb/unittest/TestLeafIO.cc
@@ -115,6 +115,11 @@ public:
 };
 
 
+// These tests round-trip through Archive using an ad hoc grid type built directly
+// from tree/node templates, so no codec is ever registered for it and the read/write
+// falls back to raw Tree I/O, which is disabled for ABI >= 14.
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 TEST_F(TestLeafIOTest, testBufferInt) { TestLeafIO<int>::testBuffer(); }
 TEST_F(TestLeafIOTest, testBufferFloat) { TestLeafIO<float>::testBuffer(); }
 TEST_F(TestLeafIOTest, testBufferDouble) { TestLeafIO<double>::testBuffer(); }
@@ -175,6 +180,7 @@ TEST_F(TestLeafIOTest, testBufferVec3R)
     }
 }
 
+
 TEST_F(TestLeafIOTest, testTreeIOInt) { TestLeafIO<int>::testTreeIO(); }
 TEST_F(TestLeafIOTest, testTreeIOFloat) { TestLeafIO<float>::testTreeIO(); }
 TEST_F(TestLeafIOTest, testTreeIODouble) { TestLeafIO<double>::testTreeIO(); }
@@ -207,3 +213,5 @@ TEST_F(TestLeafIOTest, testTreeIOVec3R)
 
     EXPECT_TRUE(leaf.onVoxelCount() == 2);
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14

--- a/openvdb/openvdb/unittest/TestLeafMask.cc
+++ b/openvdb/openvdb/unittest/TestLeafMask.cc
@@ -338,6 +338,8 @@ TEST_F(TestLeafMask, testIO)
 }
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 TEST_F(TestLeafMask, testTreeIO)
 {
     LeafType leaf(openvdb::Coord(1, 3, 5));
@@ -365,6 +367,8 @@ TEST_F(TestLeafMask, testTreeIO)
 
     EXPECT_TRUE(leaf.onVoxelCount() == 2);
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 TEST_F(TestLeafMask, testTopologyCopy)

--- a/openvdb/openvdb/unittest/TestPointCodec.cc
+++ b/openvdb/openvdb/unittest/TestPointCodec.cc
@@ -55,7 +55,9 @@ TEST_F(TestPointCodec, testPointIndexCodecIO)
 
     const std::string rawPath = "testPointIndexCodec_raw.vdb";
 
-    // Phase 1: write/read without codec
+    // Phase 1: write/read without codec. This falls back to raw Tree I/O,
+    // which is disabled for ABI >= 14, so this phase is skipped there.
+#if OPENVDB_ABI_VERSION_NUMBER < 14
     {
         io::File f(rawPath);
         f.write(GridPtrVec{srcGrid});
@@ -84,6 +86,7 @@ TEST_F(TestPointCodec, testPointIndexCodecIO)
     EXPECT_EQ(rawTopo->getName(), std::string("point_index_grid"));
 
     std::remove(rawPath.c_str());
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
     const std::string codecPath = "testPointIndexCodec_codec.vdb";
 
@@ -208,7 +211,9 @@ TEST_F(TestPointCodec, testPointDataCodecIO)
 
         const std::string rawPath = "testPDG_A_raw.vdb";
 
-        // Phase 1: write/read without codec
+        // Phase 1: write/read without codec. This falls back to raw Tree I/O,
+        // which is disabled for ABI >= 14, so this phase is skipped there.
+#if OPENVDB_ABI_VERSION_NUMBER < 14
         {
             io::File f(rawPath);
             f.write(GridPtrVec{srcGrid});
@@ -237,6 +242,7 @@ TEST_F(TestPointCodec, testPointDataCodecIO)
         EXPECT_EQ(rawTopo->activeVoxelCount(), Index64(4));
 
         std::remove(rawPath.c_str());
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
         const std::string codecPath = "testPDG_A_codec.vdb";
 

--- a/openvdb/openvdb/unittest/TestPointDataLeaf.cc
+++ b/openvdb/openvdb/unittest/TestPointDataLeaf.cc
@@ -1,6 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 
+#include <openvdb/points/PointDataIO.h>
 #include <openvdb/points/PointDataGrid.h>
 #include <openvdb/openvdb.h>
 #include <openvdb/io/io.h>
@@ -1276,6 +1277,8 @@ TEST_F(TestPointDataLeaf, testIO)
 }
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 TEST_F(TestPointDataLeaf, testTreeIO)
 {
     using AttributeVec3s    = TypedAttributeArray<openvdb::Vec3s>;
@@ -1365,6 +1368,8 @@ TEST_F(TestPointDataLeaf, testTreeIO)
         EXPECT_EQ(leaf2.attributeSet().size(), size_t(2));
     }
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 TEST_F(TestPointDataLeaf, testSwap)

--- a/openvdb/openvdb/unittest/TestTree.cc
+++ b/openvdb/openvdb/unittest/TestTree.cc
@@ -831,6 +831,8 @@ TEST_F(TestTree, testIO)
 }
 
 
+#if OPENVDB_ABI_VERSION_NUMBER < 14
+
 TEST_F(TestTree, testTreeIO)
 {
     const char* filename = "testTreeIO.dbg";
@@ -881,6 +883,8 @@ TEST_F(TestTree, testTreeIO)
         ASSERT_DOUBLES_EXACTLY_EQUAL(sum, (0.234f + 4.5678f));
     }
 }
+
+#endif // OPENVDB_ABI_VERSION_NUMBER < 14
 
 
 TEST_F(TestTree, testNegativeIndexing)


### PR DESCRIPTION
This is all the remaining `ABI=14` changes I have planned for VDB 14.0.

Grid ABI changes:
```
Virtual Function - GridBase::readTopology()
Virtual Function - GridBase::readBuffers()
Virtual Function - GridBase::writeTopology()
Virtual Function - GridBase::writeBuffers()
Virtual Function - TreeBase::readTopology()
Virtual Function - TreeBase::readBuffers()
Virtual Function - TreeBase::writeTopology()
Virtual Function - TreeBase::writeBuffers()
```

Everything else is fallout from these changes - disabling the same I/O methods on RootNode, InternalNode and LeafNode, disabling unit tests, some minor refactoring (moving a few header includes to codecs and lifting an extra routine up into the codec).