### PR TITLE
Simd Improvements & Docs

### DIFF
--- a/doc/build.txt
+++ b/doc/build.txt
@@ -10,6 +10,7 @@
   - @ref buildBloscSupport
   - @ref buildZLibSupport
   - @ref buildVCPKG
+  - @ref buildSimd
 - @ref buildComponents
 - @ref buildGuide
   - @ref buildBuildTypes
@@ -169,6 +170,49 @@ You can disable ZLib using `-D USE_ZLIB=OFF` if Blosc is also disabled using `-D
 It is recommended to set the VCPKG_DEFAULT_TRIPLET=x64-windows environment
 variable to use 64-bit libraries by default as even on a 64-bit Windows OS,
 VCPKG builds and installs 32-bit libraries by default.
+
+@subsection buildSimd Building With Target ISA Support
+
+@warning OpenVDB does not perform host CPU ISA detection during configuration
+or build. The selected ISA is treated as a deployment target and must be chosen
+explicitly by the user.
+
+OpenVDB currently only natively supports targeted ISA selection on x86. You can
+continue to provide any flags you like via `-DCXXFLAGS`, but we recommend using
+the available options to better specify intent, when building for a specific
+x86 ISA. The following table lists the available x86 ISA controls.
+
+Build Flag                    | Description                                               |
+----------------------------- | --------------------------------------------------------- |
+`-DUSE_VCL=ON`                | Use the internal copy of Agner Fog's VCL                  |
+`-DOPENVDB_X86_INSTRSET=0`    | Unknown or unspecified                                    |
+`-DOPENVDB_X86_INSTRSET=1`    | SSE, `-msse`                                              |
+`-DOPENVDB_X86_INSTRSET=2`    | ^, SSE2, `-msse2` # Minimum on x86_64                     |
+`-DOPENVDB_X86_INSTRSET=3`    | ^, SSE3, `-msse3`                                         |
+`-DOPENVDB_X86_INSTRSET=4`    | ^, SSSE3, `-mssse3`                                       |
+`-DOPENVDB_X86_INSTRSET=5`    | ^, SSE4.1, `-msse4.1`                                     |
+`-DOPENVDB_X86_INSTRSET=6`    | ^, SSE4.2, `-msse4.2`                                     |
+`-DOPENVDB_X86_INSTRSET=7`    | ^, AVX, `-mavx`                                           |
+`-DOPENVDB_X86_INSTRSET=8`    | ^, AVX2, `-mavx2`                                         |
+`-DOPENVDB_X86_INSTRSET=9`    | ^, AVX512F, `-mavx512f`                                   |
+`-DOPENVDB_X86_INSTRSET=10`   | ^, AVX512BW/DQ/VL, `-mavx512bw` `-mavx512dq` `-mavx512vl` |
+
+The recommended configuration depends on the intended deployment target. See also the
+section on [SIMD in OpenVDB](@ref simdInOpenVDB) for more details.
+
+Deployment Target                        | Recommended Options                        |
+---------------------------------------- | -------------------------------------------|
+Maximum runtime deployment compatibility | Default configuration                      |
+Modern x86 CPUs                          | `-DOPENVDB_X86_INSTRSET=6`                 |
+Explicit SIMD on x86                     | `-DUSE_VCL=ON` `-DOPENVDB_X86_INSTRSET=6`  |
+Explicit SIMD on AVX hardware            | `-DUSE_VCL=ON` `-DOPENVDB_X86_INSTRSET=7`  |
+Explicit SIMD on AVX2 hardware           | `-DUSE_VCL=ON` `-DOPENVDB_X86_INSTRSET=8`  |
+Explicit SIMD on AVX512 hardware         | `-DUSE_VCL=ON` `-DOPENVDB_X86_INSTRSET=10` |
+
+In general, users are encouraged to target the oldest ISA that is known to be
+available on all deployment systems. Building for a newer ISA than is supported
+by the target CPU may result in illegal instruction at runtime.
+
 
 @section buildComponents OpenVDB Components
 

--- a/doc/doc.txt
+++ b/doc/doc.txt
@@ -66,7 +66,7 @@ Contributors, please familiarize yourselves with our
   - @ref subsecTreeIter
   - @ref subsecNodeIter
   - @ref subsecValueAccessor
-  - @ref subsecTraversal
+- @ref simdInOpenVDB
 - @subpage transformsAndMaps "Transforms and Maps"
 
 
@@ -529,8 +529,60 @@ a callback mechanism, but developers must be careful to call
 whenever deleting nodes directly.
 
 
-@subsection subsecTraversal Tree Traversal
+@section simdInOpenVDB SIMD in OpenVDB
 
-<I>To be written</I>
+Many data structures and tools provided with OpenVDB either inherently exhibit
+Single Instruction Multiple Data (SIMD) control flow patterns or are
+purposefully written in such a way that allows them to utilize SIMD
+instructions. OpenVDB provides a unified interface that encourages algorithms
+to be written in a vectorization-friendly manner such that SIMD instructions
+can be heavily utilized. However, to support all hardware and platforms, this
+interface allows for aliasing to the underlying ISA in use. This provides a
+common point of entry for targeted SIMD emission while allowing the underlying
+implementation to vary between scalar code paths and ISA specific SIMD
+implementations. In other words, tools can be written once while generating
+code for the most appropriate instruction set, depending on the target
+hardware.
+
+In this way, OpenVDB targets SIMD instruction generation both implicitly and
+explicitly. The implicit approach simply relies entirely on the compiler's
+auto-vectorizer. However, because use of the SIMD interface is inherently
+auto-vectorizable, improved code generation can often be observed in tools that
+utilize said interface. You can then simply provide your desired ISA flags
+at compile time, with the idea being that C++ compilers can often recognise the
+vectorization patterns exposed by the SIMD interface and can generate efficient
+instructions when appropriate ISA flags are enabled.
+
+This works well for simple usage and typically guarantees a speed-up for tools
+that are already very easy to vectorize. It falls down for more complicated
+programs, especially for programs that rely on more involved mathematical
+operations. For the best performance possible, the SIMD interface also allows
+for explicit instruction set implementations. This means directly calling the inbuilt
+intrinsics that are provided from the various vendors to achieve the most
+optimal code generation possible for the desired ISA.
+
+OpenVDB currently only supports explicit SIMD emission on x86 via the use of
+Agner Fog's Vectorclass (VCL) library. This library provides an extensive set
+of SIMD compatible vector types and mathematical operations that automatically
+map to the selected x86 instruction set at compile time. For example, the
+table below demonstrates what a simd::Vec4f (4 x floats) and a simd::Vec8f
+(8 x floats) represent with various build configurations.
+
+Build Flags                                | OPENVDB_X86_INSTRSET  | simd::Vec4f            | simd::Vec8f            | Notes                                       |
+------------------------------------------ | --------------------- | ---------------------- | ---------------------- | ------------------------------------------- |
+Vanilla CMake Build                        | 0 (Unspecified)       | `math::Tuple<4,float>` | `math::Tuple<8,float>` | No targeting, relies on auto-vectorizer     |
+`-DOPENVDB_X86_INSTRSET=6`                 | 6 (SSE42)             | `math::Tuple<4,float>` | `math::Tuple<8,float>` | `-msse42` relies on auto-vectorizer         |
+`-DUSE_VCL=ON`                             | 2 (SSE2)              | VCL's Vec4f            | VCL's Vec8f (emulated) | `-msse` `-msse2`                            |
+`-DUSE_VCL=ON` `-DOPENVDB_X86_INSTRSET=6`  | 6 (SSE42)             | VCL's Vec4f            | VCL's Vec8f (emulated) | ^, `-msse3` `-mssse3` `-msse4.1` `-msse4.2` |
+`-DUSE_VCL=ON` `-DOPENVDB_X86_INSTRSET=7`  | 7 (AVX)               | VCL's Vec4f            | VCL's Vec8f            | ^, `-mavx`                                  |
+
+Importantly, OpenVDB's CMake performs @b NO host ISA detection at build time.
+It is expected that the user selects the x86 ISA they know to be compatible for
+their deployment and provide it via the `OPENVDB_X86_INSTRSET` enumerated type.
+USE_VCL is OFF by default. When enabled, OpenVDB's CMake will determine the
+available ISA from either the value of `OPENVDB_X86_INSTRSET` or any manually
+provided CXXFLAGS. Note that `OPENVDB_X86_INSTRSET` is never automatically
+inferred and is only defined when explicitly supplied.
+
 
 */

--- a/ext/THIRD-PARTY.md
+++ b/ext/THIRD-PARTY.md
@@ -81,9 +81,13 @@ Apache 2.0
 * VCL (c) Copyright 2012-2022 Agner Fog.
   https://github.com/vectorclass/version2
 
-  OpenVDB includes a copy of vectorclass for x86 SIMD intrinsic usage. Usage
-  of VCL is disabled by default and requires the VCL headers to be shipped with
-  OpenVDB installations. This behaviour and usage of VCL can be controlled
+  OpenVDB includes a copy of vectorclass for x86 SIMD intrinsic usage. It
+  includes the following modifications:
+    > Header guards and namespaces have been renamed or prefixed with
+      OPENVDB_VCL defines.
+    > Examples and runtime instruction set detection have been removed.
+  Use of VCL is disabled by default and requires the VCL headers to be shipped
+  with OpenVDB installations. This behaviour and usage of VCL can be controlled
   during OpenVDB configuration. See the full LICENSE terms in:
 
     vcl/openvdb/ext/vcl/LICENSE

--- a/ext/vcl/openvdb/ext/vcl/instrset.h
+++ b/ext/vcl/openvdb/ext/vcl/instrset.h
@@ -18,10 +18,19 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 ******************************************************************************/
 
-#ifndef INSTRSET_H
-#define INSTRSET_H 20200
+#ifndef OPENVDB_VCL_INSTRSET_H
+#define OPENVDB_VCL_INSTRSET_H 20200
 
 // check if compiled for C++17
 #if defined(_MSVC_LANG)  // MS compiler has its own version of __cplusplus with different value
@@ -172,9 +181,7 @@ We need different version checks with and whithout __apple_build_version__
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 // Constant for indicating don't care in permute and blend functions.
 // V_DC is -256 in Vector class library version 1.xx
@@ -361,16 +368,10 @@ constexpr int bit_scan_reverse_const(uint64_t const n) {
 *
 *****************************************************************************/
 
-#ifdef VCL_NAMESPACE
-#define NAMESPACEPREFIX VCL_NAMESPACE::
-#else 
-#define NAMESPACEPREFIX
-#endif
-
 template <int32_t  n> class Const_int_t {};                // represent compile-time signed integer constant
 template <uint32_t n> class Const_uint_t {};               // represent compile-time unsigned integer constant
-#define const_int(n)  (NAMESPACEPREFIX Const_int_t <n>())  // n must be compile-time integer constant
-#define const_uint(n) (NAMESPACEPREFIX Const_uint_t<n>())  // n must be compile-time unsigned integer constant
+#define const_int(n)  (OPENVDB_VCL_NAMESPACE:: Const_int_t <n>())  // n must be compile-time integer constant
+#define const_uint(n) (OPENVDB_VCL_NAMESPACE:: Const_uint_t<n>())  // n must be compile-time unsigned integer constant
 
 
 // template for producing quiet NAN
@@ -1446,9 +1447,7 @@ auto blend_half(W const& a, W const& b) {
 }
 
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
 
-#endif // INSTRSET_H
+#endif // OPENVDB_VCL_INSTRSET_H

--- a/ext/vcl/openvdb/ext/vcl/vector_convert.h
+++ b/ext/vcl/openvdb/ext/vcl/vector_convert.h
@@ -10,22 +10,29 @@
 *
 * (c) Copyright 2012-2022 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTOR_CONVERT_H
-#define VECTOR_CONVERT_H
+#ifndef OPENVDB_VCL_VECTOR_CONVERT_H
+#define OPENVDB_VCL_VECTOR_CONVERT_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 #if MAX_VECTOR_SIZE >= 256
 
@@ -821,8 +828,6 @@ static inline V fmodulo(V const numerator, double const denominator) {
     }
 }
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTOR_CONVERT_H
+#endif // OPENVDB_VCL_VECTOR_CONVERT_H

--- a/ext/vcl/openvdb/ext/vcl/vectorclass.h
+++ b/ext/vcl/openvdb/ext/vcl/vectorclass.h
@@ -24,10 +24,19 @@
 *
 * (c) Copyright 2012-2026 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 ******************************************************************************/
 
-#ifndef VECTORCLASS_H
-#define VECTORCLASS_H  20203
+#ifndef OPENVDB_VCL_VECTORCLASS_H
+#define OPENVDB_VCL_VECTORCLASS_H  20203
 
 // Maximum vector size, bits. Allowed values are 128, 256, 512
 #ifndef MAX_VECTOR_SIZE
@@ -78,10 +87,10 @@
 #endif  // INSTRSET >= 2
 
 
-#else   // VECTORCLASS_H
+#else   // OPENVDB_VCL_VECTORCLASS_H
 
-#if VECTORCLASS_H < 20000
+#if OPENVDB_VCL_VECTORCLASS_H < 20000
 #error Mixed versions of vector class library
 #endif
 
-#endif  // VECTORCLASS_H
+#endif  // OPENVDB_VCL_VECTORCLASS_H

--- a/ext/vcl/openvdb/ext/vcl/vectorf128.h
+++ b/ext/vcl/openvdb/ext/vcl/vectorf128.h
@@ -20,23 +20,30 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORF128_H
-#define VECTORF128_H
+#ifndef OPENVDB_VCL_VECTORF128_H
+#define OPENVDB_VCL_VECTORF128_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 /*****************************************************************************
 *
@@ -1180,11 +1187,7 @@ static inline Vec4f pow(Vec4f const a, Const_int_t<n>) {
 }
 
 // implement the same as macro pow_const(vector, int)
-#ifdef VCL_NAMESPACE
-#define pow_const(x,n) pow(x, VCL_NAMESPACE::Const_int_t<n>())
-#else
-#define pow_const(x,n) pow(x,Const_int_t<n>())
-#endif
+#define pow_const(x,n) pow(x, OPENVDB_VCL_NAMESPACE::Const_int_t<n>())
 
 static inline Vec4f round(Vec4f const a) {
 #if INSTRSET >= 5   // SSE4.1 supported
@@ -2974,8 +2977,6 @@ static inline uint8_t to_bits(Vec2db const x) {
 #endif  // INSTRSET < 10
 
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORF128_H
+#endif // OPENVDB_VCL_VECTORF128_H

--- a/ext/vcl/openvdb/ext/vcl/vectorf256.h
+++ b/ext/vcl/openvdb/ext/vcl/vectorf256.h
@@ -20,27 +20,34 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORF256_H
-#define VECTORF256_H  1
+#ifndef OPENVDB_VCL_VECTORF256_H
+#define OPENVDB_VCL_VECTORF256_H  1
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
-#ifdef VECTORF256E_H
+#ifdef OPENVDB_VCL_VECTORF256E_H
 #error Two different versions of vectorf256.h included
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 
 /*****************************************************************************
@@ -3051,8 +3058,6 @@ static inline void scatter(Vec4i const index, uint32_t limit, Vec4d const data, 
 }
 
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORF256_H
+#endif // OPENVDB_VCL_VECTORF256_H

--- a/ext/vcl/openvdb/ext/vcl/vectorf256e.h
+++ b/ext/vcl/openvdb/ext/vcl/vectorf256e.h
@@ -21,27 +21,34 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORF256E_H
-#define VECTORF256E_H  1
+#ifndef OPENVDB_VCL_VECTORF256E_H
+#define OPENVDB_VCL_VECTORF256E_H  1
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
-#ifdef VECTORF256_H
+#ifdef OPENVDB_VCL_VECTORF256_H
 #error Two different versions of vectorf256.h included
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 /*****************************************************************************
 *
@@ -1961,8 +1968,6 @@ static inline uint8_t to_bits(Vec4db const x) {
     return to_bits(Vec4qb(reinterpret_i(x)));
 }
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORF256E_H
+#endif // OPENVDB_VCL_VECTORF256E_H

--- a/ext/vcl/openvdb/ext/vcl/vectorf512.h
+++ b/ext/vcl/openvdb/ext/vcl/vectorf512.h
@@ -20,28 +20,35 @@
 *
 * (c) Copyright 2014-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORF512_H
-#define VECTORF512_H
+#ifndef OPENVDB_VCL_VECTORF512_H
+#define OPENVDB_VCL_VECTORF512_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
-#ifdef VECTORF512E_H
+#ifdef OPENVDB_VCL_VECTORF512E_H
 #error Two different versions of vectorf512.h included
 #endif
 
 #include "vectori512.h"
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 
 /*****************************************************************************
@@ -2045,8 +2052,6 @@ static inline void scatter(Vec8i const index, uint32_t limit, Vec8d const data, 
 }
 
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORF512_H
+#endif // OPENVDB_VCL_VECTORF512_H

--- a/ext/vcl/openvdb/ext/vcl/vectorf512e.h
+++ b/ext/vcl/openvdb/ext/vcl/vectorf512e.h
@@ -21,28 +21,35 @@
 *
 * (c) Copyright 2014-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORF512E_H
-#define VECTORF512E_H
+#ifndef OPENVDB_VCL_VECTORF512E_H
+#define OPENVDB_VCL_VECTORF512E_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
-#if defined (VECTORF512_H)
+#if defined (OPENVDB_VCL_VECTORF512_H)
 #error Two different versions of vectorf512.h included
 #endif
 
 #include "vectori512e.h"
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 /*****************************************************************************
 *
@@ -1938,8 +1945,6 @@ static inline uint8_t to_bits(Vec8db const x) {
     return to_bits(Vec8qb(x));
 }
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORF512E_H
+#endif // OPENVDB_VCL_VECTORF512E_H

--- a/ext/vcl/openvdb/ext/vcl/vectorfp16.h
+++ b/ext/vcl/openvdb/ext/vcl/vectorfp16.h
@@ -25,16 +25,25 @@
 *
 * (c) Copyright 2012-2026 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORFP16_H
-#define VECTORFP16_H
+#ifndef OPENVDB_VCL_VECTORFP16_H
+#define OPENVDB_VCL_VECTORFP16_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
@@ -43,9 +52,7 @@
 #include "vectorfp16e.h"
 #else
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 // type Float16 emulates _Float16 in vectorfp16e.h if _Float16 not defined
 #ifdef __STDCPP_FLOAT16_T__
@@ -2663,10 +2670,8 @@ static inline Vec32h tanpi(Vec32h const x) {
 #endif  // MAX_VECTOR_SIZE >= 512
 
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
 #endif // defined(__AVX512FP16__)
 
-#endif // VECTORFP16_H
+#endif // OPENVDB_VCL_VECTORFP16_H

--- a/ext/vcl/openvdb/ext/vcl/vectorfp16e.h
+++ b/ext/vcl/openvdb/ext/vcl/vectorfp16e.h
@@ -19,16 +19,25 @@
 *
 * (c) Copyright 2012-2026 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORFP16E_H
-#define VECTORFP16E_H
+#ifndef OPENVDB_VCL_VECTORFP16E_H
+#define OPENVDB_VCL_VECTORFP16E_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
@@ -36,9 +45,7 @@
 #error Emulation of half precision floating point not supported for MAX_VECTOR_SIZE < 256
 #endif
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 
 /*****************************************************************************
@@ -3295,8 +3302,6 @@ static inline Vec32h tanpi(Vec32h const x) {
 
 #endif  // MAX_VECTOR_SIZE >= 512
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORFP16_H
+#endif // OPENVDB_VCL_VECTORFP16E_H

--- a/ext/vcl/openvdb/ext/vcl/vectori128.h
+++ b/ext/vcl/openvdb/ext/vcl/vectori128.h
@@ -29,22 +29,29 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORI128_H
-#define VECTORI128_H
+#ifndef OPENVDB_VCL_VECTORI128_H
+#define OPENVDB_VCL_VECTORI128_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
-#ifdef VCL_NAMESPACE         // optional namespace
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 
 // Generate a constant vector of 4 integers stored in memory.
@@ -6975,8 +6982,6 @@ static inline uint8_t to_bits(Vec2qb const x) {
 
 #endif
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif  // VECTORI128_H
+#endif  // OPENVDB_VCL_VECTORI128_H

--- a/ext/vcl/openvdb/ext/vcl/vectori256.h
+++ b/ext/vcl/openvdb/ext/vcl/vectori256.h
@@ -30,28 +30,35 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORI256_H
-#define VECTORI256_H 1
+#ifndef OPENVDB_VCL_VECTORI256_H
+#define OPENVDB_VCL_VECTORI256_H 1
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
 // check combination of header files
-#if defined (VECTORI256E_H)
+#if defined (OPENVDB_VCL_VECTORI256E_H)
 #error Two different versions of vectori256.h included
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 // Generate a constant vector of 8 integers stored in memory.
 template <uint32_t i0, uint32_t i1, uint32_t i2, uint32_t i3, uint32_t i4, uint32_t i5, uint32_t i6, uint32_t i7 >
@@ -5848,8 +5855,6 @@ static inline uint8_t to_bits(Vec4qb const x) {
 
 #endif
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORI256_H
+#endif // OPENVDB_VCL_VECTORI256_H

--- a/ext/vcl/openvdb/ext/vcl/vectori256e.h
+++ b/ext/vcl/openvdb/ext/vcl/vectori256e.h
@@ -30,28 +30,35 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORI256E_H
-#define VECTORI256E_H 1
+#ifndef OPENVDB_VCL_VECTORI256E_H
+#define OPENVDB_VCL_VECTORI256E_H 1
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
 // check combination of header files
-#if defined (VECTORI256_H)
+#if defined (OPENVDB_VCL_VECTORI256_H)
 #error Two different versions of vectori256.h included
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 
 /*****************************************************************************
@@ -3986,8 +3993,6 @@ static inline uint8_t to_bits(Vec4qb const x) {
     return uint8_t(to_bits(x.get_low()) | to_bits(x.get_high()) << 2);
 }
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORI256E_H
+#endif // OPENVDB_VCL_VECTORI256E_H

--- a/ext/vcl/openvdb/ext/vcl/vectori512.h
+++ b/ext/vcl/openvdb/ext/vcl/vectori512.h
@@ -24,28 +24,35 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORI512_H
-#define VECTORI512_H
+#ifndef OPENVDB_VCL_VECTORI512_H
+#define OPENVDB_VCL_VECTORI512_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
 // check combination of header files
-#ifdef VECTORI512E_H
+#ifdef OPENVDB_VCL_VECTORI512E_H
 #error Two different versions of vectori512.h included
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 // Generate a constant vector of 16 integers stored in memory.
 // Can be converted to any integer vector type
@@ -2149,8 +2156,6 @@ static inline Vec16ui & operator /= (Vec16ui & a, Const_int_t<d> b) {
     return a;
 }
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORI512_H
+#endif // OPENVDB_VCL_VECTORI512_H

--- a/ext/vcl/openvdb/ext/vcl/vectori512e.h
+++ b/ext/vcl/openvdb/ext/vcl/vectori512e.h
@@ -23,28 +23,35 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 *****************************************************************************/
 
-#ifndef VECTORI512E_H
-#define VECTORI512E_H
+#ifndef OPENVDB_VCL_VECTORI512E_H
+#define OPENVDB_VCL_VECTORI512E_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
 // check combination of header files
-#if defined (VECTORI512_H)
+#if defined (OPENVDB_VCL_VECTORI512_H)
 #error Two different versions of vectori512.h included
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 
 /*****************************************************************************
@@ -2355,8 +2362,6 @@ static inline uint8_t to_bits(Vec8b const a) {
 }
 
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORI512E_H
+#endif // OPENVDB_VCL_VECTORI512E_H

--- a/ext/vcl/openvdb/ext/vcl/vectori512s.h
+++ b/ext/vcl/openvdb/ext/vcl/vectori512s.h
@@ -24,28 +24,35 @@
 *
 * (c) Copyright 2012-2023 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 ******************************************************************************/
 
-#ifndef VECTORI512S_H
-#define VECTORI512S_H
+#ifndef OPENVDB_VCL_VECTORI512S_H
+#define OPENVDB_VCL_VECTORI512S_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
 // check combination of header files
-#ifdef VECTORI512SE_H
+#ifdef OPENVDB_VCL_VECTORI512SE_H
 #error Two different versions of vectorf256.h included
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 
 /*****************************************************************************
@@ -2325,8 +2332,6 @@ static inline Vec64uc & operator /= (Vec64uc & a, Const_int_t<d> b) {
     return a;
 }
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORI512S_H
+#endif // OPENVDB_VCL_VECTORI512S_H

--- a/ext/vcl/openvdb/ext/vcl/vectori512se.h
+++ b/ext/vcl/openvdb/ext/vcl/vectori512se.h
@@ -24,28 +24,35 @@
 *
 * (c) Copyright 2012-2022 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 ******************************************************************************/
 
-#ifndef VECTORI512SE_H
-#define VECTORI512SE_H
+#ifndef OPENVDB_VCL_VECTORI512SE_H
+#define OPENVDB_VCL_VECTORI512SE_H
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
 // check combination of header files
-#ifdef VECTORI512S_H
+#ifdef OPENVDB_VCL_VECTORI512S_H
 #error Two different versions of vectorf256.h included
 #endif
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 
 /*****************************************************************************
@@ -2088,8 +2095,6 @@ static inline Vec64uc & operator /= (Vec64uc & a, Const_int_t<d> b) {
     return a;
 }
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif // VECTORI512S_H
+#endif // OPENVDB_VCL_VECTORI512S_H

--- a/ext/vcl/openvdb/ext/vcl/vectormath_common.h
+++ b/ext/vcl/openvdb/ext/vcl/vectormath_common.h
@@ -11,22 +11,31 @@
 *
 * (c) Copyright 2014-2022 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 ******************************************************************************/
 
-#ifndef VECTORMATH_COMMON_H
-#define VECTORMATH_COMMON_H  2
+#ifndef OPENVDB_VCL_VECTORMATH_COMMON_H
+#define OPENVDB_VCL_VECTORMATH_COMMON_H  2
 
-#ifdef VECTORMATH_LIB_H
+#ifdef OPENVDB_VCL_VECTORMATH_LIB_H
 #error conflicting header files. More than one implementation of mathematical functions included
 #endif
 
 #include <cmath>
 
-#ifndef VECTORCLASS_H
+#ifndef OPENVDB_VCL_VECTORCLASS_H
 #include "vectorclass.h"
 #endif
 
-#if VECTORCLASS_H < 20200
+#if OPENVDB_VCL_VECTORCLASS_H < 20200
 #error Incompatible versions of vector class library mixed
 #endif
 
@@ -55,9 +64,7 @@
 #define VM_SMALLEST_NORMALF 1.17549435E-38f          // smallest normal number, float
 
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 /******************************************************************************
       templates for producing infinite and nan in desired vector type
@@ -320,8 +327,6 @@ static inline VTYPE polynomial_13m(VTYPE const x, CTYPE c2, CTYPE c3, CTYPE c4, 
         mul_add(mul_add(mul_add(c7, x, c6), x2, mul_add(c5, x, c4)), x4, mul_add(mul_add(c3, x, c2), x2, x)));
 }
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
 #endif

--- a/ext/vcl/openvdb/ext/vcl/vectormath_exp.h
+++ b/ext/vcl/openvdb/ext/vcl/vectormath_exp.h
@@ -31,16 +31,23 @@
 *
 * (c) Copyright 2014-2022 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 ******************************************************************************/
 
-#ifndef VECTORMATH_EXP_H
-#define VECTORMATH_EXP_H  202
+#ifndef OPENVDB_VCL_VECTORMATH_EXP_H
+#define OPENVDB_VCL_VECTORMATH_EXP_H  202
 
 #include "vectormath_common.h"
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 /******************************************************************************
 *                 Exponential functions
@@ -2166,8 +2173,6 @@ V power_rational (V const x) {
 }
 
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
-#endif  // VECTORMATH_EXP_H
+#endif  // OPENVDB_VCL_VECTORMATH_EXP_H

--- a/ext/vcl/openvdb/ext/vcl/vectormath_hyp.h
+++ b/ext/vcl/openvdb/ext/vcl/vectormath_hyp.h
@@ -26,16 +26,23 @@
 *
 * (c) Copyright 2014-2022 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 ******************************************************************************/
 
-#ifndef VECTORMATH_HYP_H
-#define VECTORMATH_HYP_H  202
+#ifndef OPENVDB_VCL_VECTORMATH_HYP_H
+#define OPENVDB_VCL_VECTORMATH_HYP_H  202
 
 #include "vectormath_exp.h"
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 /******************************************************************************
 *                 Hyperbolic functions
@@ -710,8 +717,6 @@ static inline Vec16f atanh(Vec16f const x) {
 }
 #endif // MAX_VECTOR_SIZE >= 512
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
 #endif

--- a/ext/vcl/openvdb/ext/vcl/vectormath_lib.h
+++ b/ext/vcl/openvdb/ext/vcl/vectormath_lib.h
@@ -19,21 +19,28 @@
 *
 * (c) Copyright 2012-2022 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 \*****************************************************************************/
 
 // check combination of header files
-#ifndef VECTORMATH_LIB_H
-#define VECTORMATH_LIB_H  202
+#ifndef OPENVDB_VCL_VECTORMATH_LIB_H
+#define OPENVDB_VCL_VECTORMATH_LIB_H  202
 
-#ifdef VECTORMATH_COMMON_H
+#ifdef OPENVDB_VCL_VECTORMATH_COMMON_H
 #error conflicting header files. More than one implementation of mathematical functions included
 #else
 
 #include "vectorclass.h"     // make sure vector classes are defined first
 
-#ifdef   VCL_NAMESPACE
-namespace VCL_NAMESPACE {    // optional name space
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 #if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 #define USE_SVML_INTRINSICS  // Intel compilers have intrinsic functions of access to SVML library
@@ -2202,10 +2209,8 @@ static inline Vec8d cdfnorminv (Vec8d const x) {  // inverse cumulative normal d
 
 #endif   // MAX_VECTOR_SIZE >= 512
 
-#ifdef   VCL_NAMESPACE
-}
-#endif   // VCL_NAMESPACE
+} // namespace OPENVDB_VCL_NAMESPACE
 
-#endif   // VECTORMATH_COMMON_H
+#endif   // OPENVDB_VCL_VECTORMATH_COMMON_H
 
-#endif   // VECTORMATH_LIB_H
+#endif   // OPENVDB_VCL_VECTORMATH_LIB_H

--- a/ext/vcl/openvdb/ext/vcl/vectormath_trig.h
+++ b/ext/vcl/openvdb/ext/vcl/vectormath_trig.h
@@ -22,16 +22,23 @@
 *
 * (c) Copyright 2014-2022 Agner Fog.
 * Apache License version 2.0 or later.
+*
+* -----------------------------------------------------------------------------
+*
+* This file has been modified from the original in the following ways:
+*  > Various defines and guards have been prefixed with OPENVDB_VCL_.
+*  > VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
+* Copyright Contributors to the OpenVDB Project
+* SPDX-License-Identifier: Apache-2.0*
+*
 ******************************************************************************/
 
-#ifndef VECTORMATH_TRIG_H
-#define VECTORMATH_TRIG_H  202
+#ifndef OPENVDB_VCL_VECTORMATH_TRIG_H
+#define OPENVDB_VCL_VECTORMATH_TRIG_H  202
 
 #include "vectormath_common.h"
 
-#ifdef VCL_NAMESPACE
-namespace VCL_NAMESPACE {
-#endif
+namespace OPENVDB_VCL_NAMESPACE {
 
 
 // *************************************************************
@@ -1033,8 +1040,6 @@ static inline Vec16f atan(Vec16f const y) {
 
 #endif // MAX_VECTOR_SIZE >= 512
 
-#ifdef VCL_NAMESPACE
 }
-#endif
 
 #endif

--- a/openvdb/openvdb/simd/Simd.h
+++ b/openvdb/openvdb/simd/Simd.h
@@ -12,13 +12,15 @@
 ///   openvdb::simd namespace.
 ///
 /// @note OpenVDB currently supports SIMD usage of intel x86 intrinsics via
-///   Agner Fog's VCL wrapper library.
+///   Agner Fog's VCL wrapper library. If not in use, SIMD usage relies on
+///   autovectorization of the aliased Tuple containers.
 ///
 
 #ifndef OPENVDB_SIMD_SIMD_HAS_BEEN_INCLUDED
 #define OPENVDB_SIMD_SIMD_HAS_BEEN_INCLUDED
 
 #include <openvdb/version.h>
+#include <openvdb/Platform.h>
 #include <openvdb/math/Tuple.h>
 #include <openvdb/math/Math.h>
 #include <openvdb/math/HalfDecl.h>
@@ -46,7 +48,7 @@
 #include <openvdb/ext/vcl/vectorclass.h>
 #include <openvdb/ext/vcl/vectorfp16.h>
 #else
-/// SIMD Intrinsic Headers
+/// No VCL, just import SIMD Intrinsic Headers
 #if OPENVDB_X86_INSTRSET > 0
     #if defined(_WIN32)
         #include <intrin.h>
@@ -67,37 +69,40 @@ OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
 namespace simd {
 
+/// Simd type selection macro, aliasing between vcl and Tuple types
 #ifdef OPENVDB_USE_VCL
 #define OPENVDB_SELECT_SIMD_T(A, ...) A
-static inline constexpr size_t OPENVDB_MAX_REGISTER_SIZE =
-    (OPENVDB_X86_INSTRSET < 7 ? 128 : // no AVX, SSE __m128 registers
-        (OPENVDB_X86_INSTRSET < 9 ? 256 : // AVX/AVX2 __m256 registers
-            (OPENVDB_X86_INSTRSET >= 9 ? 512 : 0))); // AVX512  __m512 registers
 #else
 #define OPENVDB_SELECT_SIMD_T(A, ...) __VA_ARGS__
-// @note  In this case VCL will not have been used to determine any requested ISA.
-//   Branch on the supported OPENVDB_SIMD x86 flags, if any.
-#ifdef OPENVDB_USE_AVX
-static inline constexpr size_t OPENVDB_MAX_REGISTER_SIZE = 256;
-#else
-static inline constexpr size_t OPENVDB_MAX_REGISTER_SIZE = 128;
-#endif
 #endif
 
-static_assert(OPENVDB_MAX_REGISTER_SIZE >= 128 &&
-    (OPENVDB_MAX_REGISTER_SIZE % 128 == 0));
+/// Cofigure the default bit size for our simd vectors based on the configured
+/// X86 instruction set. If no specific x86 set has been specified, then we
+/// fallback to the assumption of 128 registers. Note that this decision only
+/// impacts code using the openvdb::simd API and, if VCL is OFF, simply
+/// configures the default (native) Tuple types to fit into this default size.
+#if   OPENVDB_X86_INSTRSET >= 9
+static inline constexpr size_t OPENVDB_DEFAULT_VECTOR_SIZE = 512; // AVX512
+#elif OPENVDB_X86_INSTRSET >= 7
+static inline constexpr size_t OPENVDB_DEFAULT_VECTOR_SIZE = 256; // AVX
+#else
+static inline constexpr size_t OPENVDB_DEFAULT_VECTOR_SIZE = 128; // fallback
+#endif
+
+static_assert(OPENVDB_DEFAULT_VECTOR_SIZE >= 128 &&
+    (OPENVDB_DEFAULT_VECTOR_SIZE % 128 == 0));
 
 /// @brief  Type selection based on if VCL is enabled. If so, all simd::Vec
 ///   types alias to representative VCL classes. Otherwise, types are
 ///   represented by contiguous tuples with elements of matching precision
 
 // Compact boolean vectors
-#if defined(OPENVDB_USE_VCL) && OPENVDB_X86_INSTRSET >= 10
+#if defined(OPENVDB_USE_VCL) && INSTRSET >= 10
 // These types only exist with AVX512
-using Vec2b   = openvdb_ext_vcl::Vec2b;
-using Vec4b   = openvdb_ext_vcl::Vec4b;
-using Vec32b  = openvdb_ext_vcl::Vec32b;
-using Vec64b  = openvdb_ext_vcl::Vec64b;
+using Vec2b   = OPENVDB_VCL_NAMESPACE::Vec2b;
+using Vec4b   = OPENVDB_VCL_NAMESPACE::Vec4b;
+using Vec32b  = OPENVDB_VCL_NAMESPACE::Vec32b;
+using Vec64b  = OPENVDB_VCL_NAMESPACE::Vec64b;
 #else
 // We have to define these as these types are used as broad masks for boolean
 // logic when VCL is not in use.
@@ -107,74 +112,80 @@ using Vec32b  = math::Tuple<32, bool>;
 using Vec64b  = math::Tuple<64, bool>;
 #endif
 
-using Vec8b   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8b,   math::Tuple<8, bool>);
-using Vec16b  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16b,  math::Tuple<16, bool>);
-using Vec128b = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec128b, math::Tuple<128, bool>);
-using Vec256b = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec256b, math::Tuple<256, bool>);
-using Vec512b = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec512b, math::Tuple<512, bool>);
+using Vec8b   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8b,   math::Tuple<8, bool>);
+using Vec16b  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16b,  math::Tuple<16, bool>);
+/*
+Don't expose internal bit types for now
+using Vec128b = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec128b, math::Tuple<128, bool>);
+using Vec256b = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec256b, math::Tuple<256, bool>);
+using Vec512b = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec512b, math::Tuple<512, bool>);
+*/
 
 //  Broad boolean vectors
-using Vec16cb = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16cb, math::Tuple<16, bool>);
-using Vec16fb = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16fb, math::Tuple<16, bool>);
-using Vec16ib = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16ib, math::Tuple<16, bool>);
-using Vec16sb = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16sb, math::Tuple<16, bool>);
-using Vec2db  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec2db, math::Tuple<2, bool>);
-using Vec2qb  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec2qb, math::Tuple<2, bool>);
-using Vec32cb = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec32cb, math::Tuple<32, bool>);
-using Vec32sb = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec32sb, math::Tuple<32, bool>);
-using Vec4db  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4db, math::Tuple<4, bool>);
-using Vec4fb  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4fb, math::Tuple<4, bool>);
-using Vec4ib  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4ib, math::Tuple<4, bool>);
-using Vec4qb  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4qb, math::Tuple<4, bool>);
-using Vec64cb = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec64cb, math::Tuple<64, bool>);
-using Vec8db  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8db, math::Tuple<8, bool>);
-using Vec8fb  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8fb, math::Tuple<8, bool>);
-using Vec8ib  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8ib, math::Tuple<8, bool>);
-using Vec8qb  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8qb, math::Tuple<8, bool>);
-using Vec8sb  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8sb, math::Tuple<8, bool>);
+using Vec16cb = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16cb, math::Tuple<16, bool>);
+using Vec16fb = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16fb, math::Tuple<16, bool>);
+using Vec16ib = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16ib, math::Tuple<16, bool>);
+using Vec16sb = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16sb, math::Tuple<16, bool>);
+using Vec2db  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec2db, math::Tuple<2, bool>);
+using Vec2qb  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec2qb, math::Tuple<2, bool>);
+using Vec32cb = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec32cb, math::Tuple<32, bool>);
+using Vec32sb = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec32sb, math::Tuple<32, bool>);
+using Vec4db  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4db, math::Tuple<4, bool>);
+using Vec4fb  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4fb, math::Tuple<4, bool>);
+using Vec4ib  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4ib, math::Tuple<4, bool>);
+using Vec4qb  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4qb, math::Tuple<4, bool>);
+using Vec64cb = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec64cb, math::Tuple<64, bool>);
+using Vec8db  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8db, math::Tuple<8, bool>);
+using Vec8fb  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8fb, math::Tuple<8, bool>);
+using Vec8ib  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8ib, math::Tuple<8, bool>);
+using Vec8qb  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8qb, math::Tuple<8, bool>);
+using Vec8sb  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8sb, math::Tuple<8, bool>);
 
 // Signed integer vectors
-using Vec16c  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16c, math::Tuple<16, int8_t>);
-using Vec32c  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec32c, math::Tuple<32, int8_t>);
-using Vec64c  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec64c, math::Tuple<64, int8_t>);
-using Vec8s   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8s,  math::Tuple<8, int16_t>);
-using Vec16s  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16s, math::Tuple<16, int16_t>);
-using Vec32s  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec32s, math::Tuple<32, int16_t>);
-using Vec4i   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4i,  math::Tuple<4, int32_t>);
-using Vec8i   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8i,  math::Tuple<8, int32_t>);
-using Vec16i  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16i, math::Tuple<16, int32_t>);
-using Vec2q   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec2q,  math::Tuple<2, int64_t>);
-using Vec4q   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4q,  math::Tuple<4, int64_t>);
-using Vec8q   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8q,  math::Tuple<8, int64_t>);
+using Vec16c  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16c, math::Tuple<16, int8_t>);
+using Vec32c  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec32c, math::Tuple<32, int8_t>);
+using Vec64c  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec64c, math::Tuple<64, int8_t>);
+using Vec8s   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8s,  math::Tuple<8, int16_t>);
+using Vec16s  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16s, math::Tuple<16, int16_t>);
+using Vec32s  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec32s, math::Tuple<32, int16_t>);
+using Vec4i   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4i,  math::Tuple<4, int32_t>);
+using Vec8i   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8i,  math::Tuple<8, int32_t>);
+using Vec16i  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16i, math::Tuple<16, int32_t>);
+using Vec2q   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec2q,  math::Tuple<2, int64_t>);
+using Vec4q   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4q,  math::Tuple<4, int64_t>);
+using Vec8q   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8q,  math::Tuple<8, int64_t>);
 
 // Unsigned integer vectors
-using Vec16uc = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16uc, math::Tuple<16, uint8_t>);
-using Vec32uc = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec32uc, math::Tuple<32, uint8_t>);
-using Vec64uc = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec64uc, math::Tuple<64, uint8_t>);
-using Vec8us  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8us,  math::Tuple<8, uint16_t>);
-using Vec16us = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16us, math::Tuple<16, uint16_t>);
-using Vec32us = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec32us, math::Tuple<32, uint16_t>);
-using Vec4ui  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4ui,  math::Tuple<4, uint32_t>);
-using Vec8ui  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8ui,  math::Tuple<8, uint32_t>);
-using Vec16ui = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16ui, math::Tuple<16, uint32_t>);
-using Vec2uq  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec2uq,  math::Tuple<2, uint64_t>);
-using Vec4uq  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4uq,  math::Tuple<4, uint64_t>);
-using Vec8uq  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8uq,  math::Tuple<8, uint64_t>);
+using Vec16uc = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16uc, math::Tuple<16, uint8_t>);
+using Vec32uc = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec32uc, math::Tuple<32, uint8_t>);
+using Vec64uc = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec64uc, math::Tuple<64, uint8_t>);
+using Vec8us  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8us,  math::Tuple<8, uint16_t>);
+using Vec16us = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16us, math::Tuple<16, uint16_t>);
+using Vec32us = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec32us, math::Tuple<32, uint16_t>);
+using Vec4ui  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4ui,  math::Tuple<4, uint32_t>);
+using Vec8ui  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8ui,  math::Tuple<8, uint32_t>);
+using Vec16ui = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16ui, math::Tuple<16, uint32_t>);
+using Vec2uq  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec2uq,  math::Tuple<2, uint64_t>);
+using Vec4uq  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4uq,  math::Tuple<4, uint64_t>);
+using Vec8uq  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8uq,  math::Tuple<8, uint64_t>);
 
+/*
 // half precision vectors
-using Vec8h   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8h,  math::Tuple<8, math::half>);
-using Vec16h  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16h, math::Tuple<16, math::half>);
-using Vec32h  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec32h, math::Tuple<32, math::half>);
+// @TODO  Figure out nice type mapping with OPENVDB_VCL_NAMESPACE::Float16 and math::half
+using Vec8h   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8h,  math::Tuple<8, math::half>);
+using Vec16h  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16h, math::Tuple<16, math::half>);
+using Vec32h  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec32h, math::Tuple<32, math::half>);
+*/
 
 // float precision vectors
-using Vec4f   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4f,  math::Tuple<4, float>);
-using Vec8f   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8f,  math::Tuple<8, float>);
-using Vec16f  = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec16f, math::Tuple<16, float>);
+using Vec4f   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4f,  math::Tuple<4, float>);
+using Vec8f   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8f,  math::Tuple<8, float>);
+using Vec16f  = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec16f, math::Tuple<16, float>);
 
 // double precision vectors
-using Vec2d   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec2d,  math::Tuple<2, double>);
-using Vec4d   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec4d,  math::Tuple<4, double>);
-using Vec8d   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8d,  math::Tuple<8, double>);
+using Vec2d   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec2d,  math::Tuple<2, double>);
+using Vec4d   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec4d,  math::Tuple<4, double>);
+using Vec8d   = OPENVDB_SELECT_SIMD_T(OPENVDB_VCL_NAMESPACE::Vec8d,  math::Tuple<8, double>);
 
 #undef OPENVDB_SELECT_SIMD_T
 
@@ -182,7 +193,7 @@ using Vec8d   = OPENVDB_SELECT_SIMD_T(openvdb_ext_vcl::Vec8d,  math::Tuple<8, do
 ///   will simply represent canonical tuple types
 template <typename T, size_t S> struct SimdT;
 
-#if !defined(OPENVDB_USE_VCL) || OPENVDB_X86_INSTRSET >= 10
+#if !defined(OPENVDB_USE_VCL) || INSTRSET >= 10
 template <> struct SimdT<bool, 2>    { using Type = simd::Vec2b; };
 template <> struct SimdT<bool, 4>    { using Type = simd::Vec4b; };
 template <> struct SimdT<bool, 32>   { using Type = simd::Vec32b; };
@@ -191,10 +202,11 @@ template <> struct SimdT<bool, 64>   { using Type = simd::Vec64b; };
 
 template <> struct SimdT<bool, 8>    { using Type = simd::Vec8b; };
 template <> struct SimdT<bool, 16>   { using Type = simd::Vec16b; };
+/*
 template <> struct SimdT<bool, 128>  { using Type = simd::Vec128b; };
 template <> struct SimdT<bool, 256>  { using Type = simd::Vec256b; };
 template <> struct SimdT<bool, 512>  { using Type = simd::Vec512b; };
-
+*/
 template <> struct SimdT<int8_t, 16>  { using Type = simd::Vec16c; };
 template <> struct SimdT<int8_t, 32>  { using Type = simd::Vec32c; };
 template <> struct SimdT<int8_t, 64>  { using Type = simd::Vec64c; };
@@ -221,9 +233,11 @@ template <> struct SimdT<uint64_t, 2>  { using Type = simd::Vec2uq; };
 template <> struct SimdT<uint64_t, 4>  { using Type = simd::Vec4uq; };
 template <> struct SimdT<uint64_t, 8>  { using Type = simd::Vec8uq; };
 
+/*
 template <> struct SimdT<math::half, 8>  { using Type = simd::Vec8h; };
 template <> struct SimdT<math::half, 16> { using Type = simd::Vec16h; };
 template <> struct SimdT<math::half, 32> { using Type = simd::Vec32h; };
+*/
 
 template <> struct SimdT<float, 4>  { using Type = simd::Vec4f; };
 template <> struct SimdT<float, 8>  { using Type = simd::Vec8f; };
@@ -237,7 +251,7 @@ template <> struct SimdT<double, 8> { using Type = simd::Vec8d; };
 ///   intrinsics, select the best (in this case largest) SIMD container
 ///   type.
 template <typename T>
-using SimdNativeT = SimdT<T, OPENVDB_MAX_REGISTER_SIZE/(sizeof(T)*CHAR_BIT)>;
+using SimdNativeT = SimdT<T, OPENVDB_DEFAULT_VECTOR_SIZE/(sizeof(T)*CHAR_BIT)>;
 
 /// @brief  Native type selection for compatible POD types when there
 ///   may not be an available Simd type. For example:
@@ -245,6 +259,8 @@ using SimdNativeT = SimdT<T, OPENVDB_MAX_REGISTER_SIZE/(sizeof(T)*CHAR_BIT)>;
 /// @code
 ///    // compiled WITHOUT -msse2 (or higher)
 ///    static_assert(std::is_same_v<NativeSimdOrScalar<double>::Type, double>);
+///    // default behaviour with __m128
+///    static_assert(std::is_same_v<NativeSimdOrScalar<double>::Type, SimdT<double, 2>>);
 ///    // compiled WITH -mavx
 ///    static_assert(std::is_same_v<NativeSimdOrScalar<double>::Type, SimdT<double, 4>>);
 ///@endcode
@@ -266,47 +282,52 @@ struct NativeSimdOrScalar<T, std::void_t<typename SimdNativeT<T>::Type>>
 #endif
 };
 
+/// @{
 /// @brief  Traits for determining if a type is a SIMD type
-template <typename T> struct IsSimdMaskT : std::false_type {};
+template <typename T> struct IsSimdBroadMaskT : std::false_type {};
+template <typename T> struct IsSimdCompactMaskT : std::false_type {};
 template <typename T> struct IsSimdIntT : std::false_type {};
 template <typename T> struct IsSimdFloatT : std::false_type {};
+/// }@
 
 // compact bool vectors
-#if !defined(OPENVDB_USE_VCL) || OPENVDB_X86_INSTRSET >= 10
-template <> struct IsSimdMaskT<simd::Vec2b> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec4b> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec32b> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec64b> : std::true_type {};
+#if !defined(OPENVDB_USE_VCL) || INSTRSET >= 10
+template <> struct IsSimdCompactMaskT<simd::Vec2b> : std::true_type {};
+template <> struct IsSimdCompactMaskT<simd::Vec4b> : std::true_type {};
+template <> struct IsSimdCompactMaskT<simd::Vec32b> : std::true_type {};
+template <> struct IsSimdCompactMaskT<simd::Vec64b> : std::true_type {};
 #endif
-template <> struct IsSimdMaskT<simd::Vec8b> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec16b> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec128b> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec256b> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec512b> : std::true_type {};
+template <> struct IsSimdCompactMaskT<simd::Vec8b> : std::true_type {};
+template <> struct IsSimdCompactMaskT<simd::Vec16b> : std::true_type {};
+/*
+template <> struct IsSimdCompactMaskT<simd::Vec128b> : std::true_type {};
+template <> struct IsSimdCompactMaskT<simd::Vec256b> : std::true_type {};
+template <> struct IsSimdCompactMaskT<simd::Vec512b> : std::true_type {};
+*/
 
 // broad bool masks
 #ifdef OPENVDB_USE_VCL // Duplicate specializations when VCL is NOT in use
-#if OPENVDB_X86_INSTRSET < 9 // These alias to corresponding VecNb containers with AVX512f
-template <> struct IsSimdMaskT<simd::Vec16fb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec8db> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec8qb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec16ib> : std::true_type {};
+#if INSTRSET < 9 // These alias to corresponding VecNb containers with AVX512f
+template <> struct IsSimdBroadMaskT<simd::Vec16fb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec8db> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec8qb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec16ib> : std::true_type {};
 #endif
-#if OPENVDB_X86_INSTRSET < 10  // These alias to corresponding VecNb containers with AVX512+
-template <> struct IsSimdMaskT<simd::Vec16cb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec16sb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec2db> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec2qb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec32cb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec4fb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec4db> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec4ib> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec64cb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec4qb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec8fb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec8ib> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec8sb> : std::true_type {};
-template <> struct IsSimdMaskT<simd::Vec32sb> : std::true_type {};
+#if INSTRSET < 10  // These alias to corresponding VecNb containers with AVX512+
+template <> struct IsSimdBroadMaskT<simd::Vec16cb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec16sb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec2db> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec2qb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec32cb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec4fb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec4db> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec4ib> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec64cb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec4qb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec8fb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec8ib> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec8sb> : std::true_type {};
+template <> struct IsSimdBroadMaskT<simd::Vec32sb> : std::true_type {};
 #endif
 #endif
 
@@ -344,10 +365,12 @@ template <> struct IsSimdIntT<simd::Vec2uq> : std::true_type {};
 template <> struct IsSimdIntT<simd::Vec4uq> : std::true_type {};
 template <> struct IsSimdIntT<simd::Vec8uq> : std::true_type {};
 
+/*
 // 16-bit float vectors
 template <> struct IsSimdFloatT<simd::Vec8h> : std::true_type {};
 template <> struct IsSimdFloatT<simd::Vec16h> : std::true_type {};
 template <> struct IsSimdFloatT<simd::Vec32h> : std::true_type {};
+*/
 // 32-bit float vectors
 template <> struct IsSimdFloatT<simd::Vec4f> : std::true_type {};
 template <> struct IsSimdFloatT<simd::Vec8f> : std::true_type {};
@@ -362,7 +385,7 @@ template <> struct IsSimdFloatT<simd::Vec8d> : std::true_type {};
 ///   types, when VCL is DISABLED, allowing code to be written for containers
 ///   of multiple scalars, regardless whether VCL is enabled or not.
 template <typename T> struct IsSimdT :
-    std::conditional<(IsSimdFloatT<T>::value || IsSimdMaskT<T>::value || IsSimdIntT<T>::value),
+    std::conditional<(IsSimdFloatT<T>::value || IsSimdCompactMaskT<T>::value || IsSimdBroadMaskT<T>::value || IsSimdIntT<T>::value),
         std::true_type,
         std::false_type>::type {};
 
@@ -376,13 +399,61 @@ template<int N, typename T> struct IsTupleT<math::Tuple<N, T>> : std::true_type 
 #define OPENVDB_ENABLE_IF_TUPLE \
     template<typename T, typename std::enable_if<IsTupleT<T>::value>::type* = nullptr>
 #define OPENVDB_ENABLE_IF_TUPLE_MASK \
-    template<typename T, typename std::enable_if<IsTupleT<T>::value && IsSimdMaskT<T>::value>::type* = nullptr>
+    template<typename T, typename std::enable_if<IsTupleT<T>::value && (IsSimdCompactMaskT<T>::value || IsSimdBroadMaskT<T>::value)>::type* = nullptr>
 #define OPENVDB_ENABLE_IF_VCL \
     template<typename T, typename std::enable_if<IsSimdT<T>::value && !IsTupleT<T>::value>::type* = nullptr>
 #define OPENVDB_ENABLE_IF_VCL_MASK \
-    template<typename T, typename std::enable_if<IsSimdMaskT<T>::value && !IsTupleT<T>::value>::type* = nullptr>
+    template<typename T, typename std::enable_if<(IsSimdCompactMaskT<T>::value || IsSimdBroadMaskT<T>::value) && !IsTupleT<T>::value>::type* = nullptr>
 
-template <typename T> struct SimdTraits; // fwd declare
+#ifdef OPENVDB_USE_VCL
+
+/// @cond OPENVDB_DOCS_INTERNAL
+namespace simd_internal
+{
+template <int> struct elem;
+//template <> struct elem<1>  { using Type = bool; }; // bits (internal base class)
+template <> struct elem<2>  { using Type = bool; }; // compact
+template <> struct elem<3>  { using Type = bool; }; // broad
+template <> struct elem<4>  { using Type = int8_t; };
+template <> struct elem<5>  { using Type = uint8_t; };
+template <> struct elem<6>  { using Type = int16_t; };
+template <> struct elem<7>  { using Type = uint16_t; };
+template <> struct elem<8>  { using Type = int32_t; };
+template <> struct elem<9>  { using Type = uint32_t; };
+template <> struct elem<10> { using Type = int64_t; };
+template <> struct elem<11> { using Type = uint64_t; };
+//template <> struct elem<15> { using Type = math::half; };
+template <> struct elem<16> { using Type = float; };
+template <> struct elem<17> { using Type = double; };
+}
+/// @endcond
+
+/// @{
+/// @brief Simd Traits. For a compatible simd type, expose various type
+///   information, including its size, element type and equivalent mask type.
+///   Also provides a converter to other simd types of the same size with a
+///   different value type (although these types are not guaranteed to exist).
+/// @note  These traits do not work with compact masks, they are only designed
+///   to work with integer, float, or broad mask vectors.
+template <typename T>
+struct SimdTraits
+{
+    static constexpr size_t size = T::size();
+    using ElementT = typename simd_internal::elem<T::elementtype()>::Type;
+    using MaskT = decltype(std::declval<T>() == std::declval<T>());
+    template <typename S> using ConvertT = typename SimdT<S, size>::Type;
+};
+#else
+template <typename T>
+struct SimdTraits
+{
+    static constexpr size_t size = T::size;
+    using ElementT = typename T::ValueType;
+    using MaskT = decltype(std::declval<T>() == std::declval<T>());
+    template <typename S> using ConvertT = typename SimdT<S, size>::Type;
+};
+/// }@
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -390,7 +461,7 @@ template <typename T> struct SimdTraits; // fwd declare
 /// The follow implements generic APIs for VCL, Tuple and arithmetic POD types.
 /// The idea here is that tools can be written for a templated type, T, whose
 /// interface is implemented via the below methods. For example, the below
-/// will work for all supported openvdb_ext_vcl, openvdb::math::Tuple and
+/// will work for all supported OPENVDB_VCL_NAMESPACE, openvdb::math::Tuple and
 /// arithmetic POD types:
 ///
 /// template <typename T>
@@ -403,100 +474,114 @@ template <typename T> struct SimdTraits; // fwd declare
 
 #ifdef OPENVDB_USE_VCL
 
-template <size_t N, typename T> inline auto load(const T* a) { typename SimdT<T, N>::Type r; r.load(a); return r; }
-template <size_t N, typename T> inline auto load_partial(int C, const T* a)
+/// @{
+/// @brief  Load method for VCL types
+template <size_t N, typename T> inline auto load(const T* a)
 {
-    OPENVDB_ASSERT(C <= int(N));
-    typename SimdT<T, N>::Type r;
-    r.load_partial(C, a);
-    return r;
+    typename SimdT<T, N>::Type r; r.load(a); return r;
 }
+/// @}
 
-OPENVDB_ENABLE_IF_VCL inline auto compress(const T& a) { return openvdb_ext_vcl::compress(a); }
-
-OPENVDB_ENABLE_IF_VCL inline T max(const T& a, const T& b) { return openvdb_ext_vcl::max(a, b); }
-OPENVDB_ENABLE_IF_VCL inline T min(const T& a, const T& b) { return openvdb_ext_vcl::min(a, b); }
-OPENVDB_ENABLE_IF_VCL inline T abs(const T& a) { return openvdb_ext_vcl::abs(a); }
-OPENVDB_ENABLE_IF_VCL inline T sqrt(const T& a) { return openvdb_ext_vcl::sqrt(a); }
-OPENVDB_ENABLE_IF_VCL inline T square(const T& a) { return openvdb_ext_vcl::square(a); }
-OPENVDB_ENABLE_IF_VCL inline T pow2(const T& a) { return openvdb_ext_vcl::square(a); }
-OPENVDB_ENABLE_IF_VCL inline T pow3(const T& a) { return a*openvdb_ext_vcl::square(a); }
-
+/// @{
+/// @brief  Various math for VCL types. These should be extended when necessary
+OPENVDB_ENABLE_IF_VCL inline T min(const T& a, const T& b) { return OPENVDB_VCL_NAMESPACE::min(a, b); }
+OPENVDB_ENABLE_IF_VCL inline T max(const T& a, const T& b) { return OPENVDB_VCL_NAMESPACE::max(a, b); }
+OPENVDB_ENABLE_IF_VCL inline T abs(const T& a) { return OPENVDB_VCL_NAMESPACE::abs(a); }
+OPENVDB_ENABLE_IF_VCL inline T sqrt(const T& a) { return OPENVDB_VCL_NAMESPACE::sqrt(a); }
+OPENVDB_ENABLE_IF_VCL inline T square(const T& a) { return a * a; }
+OPENVDB_ENABLE_IF_VCL inline T pow2(const T& a) { return a * a; }
+OPENVDB_ENABLE_IF_VCL inline T pow3(const T& a) { return a * a * a; }
 template <int N, typename T, typename std::enable_if<IsSimdT<T>::value>::type* = nullptr>
-inline auto pow(const T& a) { return openvdb_ext_vcl::pow_n<T, N>(a); }
+inline auto pow(const T& a) { return OPENVDB_VCL_NAMESPACE::pow_n<T, N>(a); }
+/// @}
 
-OPENVDB_ENABLE_IF_VCL inline T select(const typename SimdTraits<T>::MaskT& m, const T& a, const T& b) {
-    return openvdb_ext_vcl::select(m, a, b);
-}
-
-OPENVDB_ENABLE_IF_VCL inline auto is_finite(const T& a) { return openvdb_ext_vcl::is_finite(a); }
-
-OPENVDB_ENABLE_IF_VCL inline auto horizontal_max(const T& a) { return openvdb_ext_vcl::horizontal_max(a); }
-OPENVDB_ENABLE_IF_VCL inline auto horizontal_min(const T& a) { return openvdb_ext_vcl::horizontal_min(a); }
-OPENVDB_ENABLE_IF_VCL inline auto horizontal_add(const T& a) { return openvdb_ext_vcl::horizontal_add(a); }
-OPENVDB_ENABLE_IF_VCL_MASK inline auto horizontal_and(const T& a) { return openvdb_ext_vcl::horizontal_and(a); }
-OPENVDB_ENABLE_IF_VCL_MASK inline auto horizontal_or(const T& a) { return openvdb_ext_vcl::horizontal_or(a); }
-OPENVDB_ENABLE_IF_VCL_MASK inline int horizontal_count(const T& a) { return openvdb_ext_vcl::horizontal_count(a); }
-OPENVDB_ENABLE_IF_VCL_MASK inline int horizontal_find_first(const T& a) { return openvdb_ext_vcl::horizontal_find_first(a); }
-
-/// @brief  ostream operator for vcl types
-OPENVDB_ENABLE_IF_VCL inline std::ostream& operator<<(std::ostream& os, const T v)
+/// @brief  Select between `a` and `b`, based on the equivalently sized VCL
+///   bool mask, and return the blended VCL type.
+OPENVDB_ENABLE_IF_VCL inline T select(const typename SimdTraits<T>::MaskT& m, const T& a, const T& b)
 {
-    os << "[";
-    for (unsigned j(0); j < T::size(); j++) {
-        if (j) os << ", ";
-        os << PrintCast(v[j]);
-    }
-    os << "]";
-    return os;
+    return OPENVDB_VCL_NAMESPACE::select(m, a, b);
 }
+
+/// @brief  Returns an equivalently sized VCL bool type, where each lane is
+///   true if the corresponding lane was finite, or false otherwise
+OPENVDB_ENABLE_IF_VCL inline auto is_finite(const T& a) { return OPENVDB_VCL_NAMESPACE::is_finite(a); }
+
+/// @{
+/// @brief  Horizontal reductions of VCL types
+OPENVDB_ENABLE_IF_VCL inline auto horizontal_min(const T& a) { return OPENVDB_VCL_NAMESPACE::horizontal_min(a); }
+OPENVDB_ENABLE_IF_VCL inline auto horizontal_max(const T& a) { return OPENVDB_VCL_NAMESPACE::horizontal_max(a); }
+OPENVDB_ENABLE_IF_VCL inline auto horizontal_add(const T& a) { return OPENVDB_VCL_NAMESPACE::horizontal_add(a); }
+OPENVDB_ENABLE_IF_VCL_MASK inline auto horizontal_and(const T& a) { return OPENVDB_VCL_NAMESPACE::horizontal_and(a); }
+OPENVDB_ENABLE_IF_VCL_MASK inline auto horizontal_or(const T& a) { return OPENVDB_VCL_NAMESPACE::horizontal_or(a); }
+OPENVDB_ENABLE_IF_VCL_MASK inline int horizontal_count(const T& a) { return OPENVDB_VCL_NAMESPACE::horizontal_count(a); }
+OPENVDB_ENABLE_IF_VCL_MASK inline int horizontal_find_first(const T& a) { return OPENVDB_VCL_NAMESPACE::horizontal_find_first(a); }
+/// @}
 
 #else
 
 /// Tuple API
 
+/// @cond OPENVDB_DOCS_INTERNAL
 namespace simd_internal
 {
-static auto minop = [](auto x, auto y) { return std::min(x,y); };
-static auto maxop = [](auto x, auto y) { return std::max(x,y); };
-static auto absop = [](auto x) { return std::abs(x); };
-static auto sqrtop = [](auto x) { return std::sqrt(x); };
-static auto compressop = [](auto x) { return typename PromoteType<decltype(x)>::Previous(x); };
 
-template <typename UnaryOpT, typename T> inline auto unaryop(const T& a, const UnaryOpT& op)
+struct MinOp {
+    template <typename T>
+    constexpr T operator()(const T& a, const T& b) const { return std::min(a, b); }
+};
+
+struct MaxOp {
+    template <typename T>
+    constexpr T operator()(const T& a, const T& b) const { return std::max(a, b); }
+};
+
+struct AbsOp {
+    template <typename T>
+    constexpr T operator()(const T& a) const { return T(std::abs(a)); }
+};
+
+struct SqrtOp {
+    template <typename T>
+    constexpr T operator()(const T& a) const { return std::sqrt(a); }
+};
+
+struct IsFiniteOp {
+    template <typename T>
+    constexpr bool operator()(const T& a) const { return std::isfinite(a); }
+};
+
+template <typename UnaryOpT, typename T>
+inline auto unaryop(const T& a, const UnaryOpT& op = UnaryOpT{})
 {
     using ElementT = typename T::ValueType;
-    using RetElementT = typename std::invoke_result<UnaryOpT,ElementT>::type;
+    using RetElementT = std::invoke_result_t<UnaryOpT, ElementT>;
     using RetTupleT = math::Tuple<T::size, RetElementT>;
     RetTupleT r; for (int i = 0; i < T::size; ++i) r[i] = op(a[i]); return r;
 }
 
-template <typename BinaryOpT, typename T> inline auto binop(const T& a, const T& b, const BinaryOpT& op)
+template <typename BinaryOpT, typename T>
+inline auto binop(const T& a, const T& b, const BinaryOpT& op = BinaryOpT{})
 {
     using ElementT = typename T::ValueType;
-    using RetElementT = typename std::invoke_result<BinaryOpT,ElementT,ElementT>::type;
+    using RetElementT = std::invoke_result_t<BinaryOpT, ElementT, ElementT>;
     using RetTupleT = math::Tuple<T::size, RetElementT>;
     RetTupleT r; for (int i = 0; i < T::size; ++i) r[i] = op(a[i], b[i]); return r;
 }
 
-template <template <typename> class BinaryOpT, typename T>
-inline auto binop(const T& a, const T& b) {
-    return binop(a,b,BinaryOpT<typename T::ValueType>{});
-}
-
-template <typename BinaryOpT, typename T> inline auto binop(const T& a, const BinaryOpT& op)
+template <typename BinaryOpT, typename T>
+inline auto hbinop(const T& a, const BinaryOpT& op = BinaryOpT{})
 {
     using ElementT = typename T::ValueType;
-    using RetElementT = typename std::invoke_result<BinaryOpT,ElementT,ElementT>::type;
+    using RetElementT = std::invoke_result_t<BinaryOpT, ElementT, ElementT>;
     RetElementT r = a[0]; for (int i = 1; i < T::size; ++i) r = op(r, a[i]); return r;
 }
 
-template <template <typename> class BinaryOpT, typename T>
-inline auto binop(const T& a) {
-    return binop(a,BinaryOpT<typename T::ValueType>{});
-}
-}
+} // namespace simd_internal
 
+/// @endcond
+
+/// @{
+/// @brief  Equivalent load method for Tuples
 template <size_t N, typename T>
 inline typename SimdT<T, N>::Type load(const T* a)
 {
@@ -504,15 +589,19 @@ inline typename SimdT<T, N>::Type load(const T* a)
     std::memcpy(r.asV(), a, N*sizeof(T));
     return r;
 }
+/// @}
 
-OPENVDB_ENABLE_IF_TUPLE inline auto compress(const T& a) { return simd_internal::unaryop(a,simd_internal::compressop); }
-
-OPENVDB_ENABLE_IF_TUPLE inline auto abs(const T& a) { return simd_internal::unaryop(a,simd_internal::absop); }
-OPENVDB_ENABLE_IF_TUPLE inline auto sqrt(const T& a) { return simd_internal::unaryop(a,simd_internal::sqrtop); }
+/// @{
+/// @brief  Equivalent methods for Tuples
+OPENVDB_ENABLE_IF_TUPLE inline auto min(const T& a, const T& b) { return simd_internal::binop<simd_internal::MinOp>(a, b); }
+OPENVDB_ENABLE_IF_TUPLE inline auto max(const T& a, const T& b) { return simd_internal::binop<simd_internal::MaxOp>(a, b); }
+OPENVDB_ENABLE_IF_TUPLE inline auto abs(const T& a) { return simd_internal::unaryop<simd_internal::AbsOp>(a); }
+OPENVDB_ENABLE_IF_TUPLE inline auto sqrt(const T& a) { return simd_internal::unaryop<simd_internal::SqrtOp>(a); }
 OPENVDB_ENABLE_IF_TUPLE inline auto square(const T& a) { return a * a; }
 OPENVDB_ENABLE_IF_TUPLE inline auto pow2(const T& a) { return a * a; }
 OPENVDB_ENABLE_IF_TUPLE inline auto pow3(const T& a) { return a * a * a; }
-template <typename T, typename ExpT> inline auto pow(const T& a, const ExpT n)
+template <typename T, typename ExpT, typename std::enable_if<IsTupleT<T>::value>::type* = nullptr>
+inline auto pow(const T& a, const ExpT n)
 {
     T r; for (int i = 0; i < T::size; ++i) { r[i] = math::Pow(a[i],n); } return r;
 }
@@ -522,18 +611,11 @@ OPENVDB_ENABLE_IF_TUPLE inline T select(const typename SimdTraits<T>::MaskT& m, 
     T r; for (int i = 0; i < T::size; ++i) { r[i] = m[i] ? a[i] : b[i]; } return r;
 }
 
-OPENVDB_ENABLE_IF_TUPLE inline bool is_finite(const T& a)
-{
-    for (int i = 0; i < T::size; ++i) { if (!std::isfinite(a[i])) return false; } return true;
-}
-
-OPENVDB_ENABLE_IF_TUPLE inline auto min(const T& a, const T& b) { return simd_internal::binop(a,b,simd_internal::minop); }
-OPENVDB_ENABLE_IF_TUPLE inline auto max(const T& a, const T& b) { return simd_internal::binop(a,b,simd_internal::maxop); }
-
-OPENVDB_ENABLE_IF_TUPLE inline auto horizontal_min(const T& a) { return simd_internal::binop(a,simd_internal::minop); }
-OPENVDB_ENABLE_IF_TUPLE inline auto horizontal_max(const T& a) { return simd_internal::binop(a,simd_internal::maxop); }
-OPENVDB_ENABLE_IF_TUPLE_MASK inline auto horizontal_and(const T& a) { return simd_internal::binop<std::logical_and>(a); }
-OPENVDB_ENABLE_IF_TUPLE_MASK inline auto horizontal_or(const T& a)  { return simd_internal::binop<std::logical_or>(a); }
+OPENVDB_ENABLE_IF_TUPLE inline auto is_finite(const T& a) { return simd_internal::unaryop<simd_internal::IsFiniteOp>(a); }
+OPENVDB_ENABLE_IF_TUPLE inline auto horizontal_min(const T& a) { return simd_internal::hbinop<simd_internal::MinOp>(a); }
+OPENVDB_ENABLE_IF_TUPLE inline auto horizontal_max(const T& a) { return simd_internal::hbinop<simd_internal::MaxOp>(a); }
+OPENVDB_ENABLE_IF_TUPLE_MASK inline auto horizontal_and(const T& a) { return simd_internal::hbinop<std::logical_and<>>(a); }
+OPENVDB_ENABLE_IF_TUPLE_MASK inline auto horizontal_or(const T& a)  { return simd_internal::hbinop<std::logical_or<>>(a); }
 OPENVDB_ENABLE_IF_TUPLE_MASK inline int horizontal_count(const T& a)
 {
     int count = 0;
@@ -552,69 +634,27 @@ OPENVDB_ENABLE_IF_TUPLE inline auto horizontal_add(const T& a)
     static_assert((T::size % 2) == 0);
     using ValueType = typename T::ValueType;
     ValueType r(0);
-    for (size_t i = 0; i < T::size; i+=2) {
-        r += (a[i] + a[i+1]);
+    for (int i = 0; i < T::size; i+=2) {
+        r += ValueType(a[i] + a[i+1]);
     }
     return r;
 }
-
-#endif
-
-#ifdef OPENVDB_USE_VCL
-
-namespace simd_internal
-{
-template <int> struct elem;
-template <> struct elem<2>  { using Type = bool; }; // compact
-template <> struct elem<3>  { using Type = bool; }; // broad
-template <> struct elem<4>  { using Type = int8_t; };
-template <> struct elem<5>  { using Type = uint8_t; };
-template <> struct elem<6>  { using Type = int16_t; };
-template <> struct elem<7>  { using Type = uint16_t; };
-template <> struct elem<8>  { using Type = int32_t; };
-template <> struct elem<9>  { using Type = uint32_t; };
-template <> struct elem<10> { using Type = int64_t; };
-template <> struct elem<11> { using Type = uint64_t; };
-template <> struct elem<15> { using Type = math::half; };
-template <> struct elem<16> { using Type = float; };
-template <> struct elem<17> { using Type = double; };
-}
-
-template <typename T>
-struct SimdTraits
-{
-    static constexpr size_t size = T::size();
-    using ElementT = typename simd_internal::elem<T::elementtype()>::Type;
-    using MaskT = decltype(std::declval<T>() == std::declval<T>());
-    template <typename S> using ConvertT = typename SimdT<S, size>::Type;
-};
-
-#else
-
-template <typename T>
-struct SimdTraits
-{
-    static constexpr size_t size = T::size;
-    using ElementT = typename T::ValueType;
-    using MaskT = decltype(std::declval<T>() == std::declval<T>());
-    template <typename S> using ConvertT = typename SimdT<S, size>::Type;
-};
+/// @}
 
 #endif
 
 //// Scalar API
-
-OPENVDB_ENABLE_IF_ARITHMETIC inline T max(const T& a, const T& b) { return std::max(a, b); }
+OPENVDB_ENABLE_IF_ARITHMETIC inline auto load(const T a) { return a; }
 OPENVDB_ENABLE_IF_ARITHMETIC inline T min(const T& a, const T& b) { return std::min(a, b); }
+OPENVDB_ENABLE_IF_ARITHMETIC inline T max(const T& a, const T& b) { return std::max(a, b); }
 OPENVDB_ENABLE_IF_ARITHMETIC inline auto sqrt(const T& a) { return std::sqrt(a); }
+OPENVDB_ENABLE_IF_ARITHMETIC inline T square(const T& a) { return math::Pow2(a); }
 OPENVDB_ENABLE_IF_ARITHMETIC inline T pow2(const T& a) { return math::Pow2(a); }
 OPENVDB_ENABLE_IF_ARITHMETIC inline T pow3(const T& a) { return math::Pow3(a); }
 
-OPENVDB_ENABLE_IF_ARITHMETIC inline auto square(const T& a) { return a * a; }
-OPENVDB_ENABLE_IF_ARITHMETIC inline bool is_finite(const T& a) { return std::isfinite(a); }
-
 OPENVDB_ENABLE_IF_ARITHMETIC inline T select(const bool m, const T& a, const T& b) { return m ? a : b; }
 
+OPENVDB_ENABLE_IF_ARITHMETIC inline bool is_finite(const T& a) { return std::isfinite(a); }
 OPENVDB_ENABLE_IF_ARITHMETIC inline T horizontal_max(const T& a) { return a; }
 OPENVDB_ENABLE_IF_ARITHMETIC inline T horizontal_min(const T& a) { return a; }
 OPENVDB_ENABLE_IF_ARITHMETIC inline T horizontal_add(const T& a) { return a; }
@@ -630,5 +670,23 @@ inline int horizontal_count(const bool a) { return a ? 1 : 0; }
 } // namespace simd
 } // namespace OPENVDB_VERSION_NAME
 } // namespace openvdb
+
+#if defined(OPENVDB_USE_VCL)
+namespace OPENVDB_VCL_NAMESPACE {
+/// @brief  ostream operator for VCL types
+template<typename T, typename std::enable_if<openvdb::simd::IsSimdT<T>::value &&
+    !openvdb::simd::IsTupleT<T>::value>::type* = nullptr>
+inline std::ostream& operator<<(std::ostream& os, const T& v)
+{
+    os << "[";
+    for (unsigned j(0); j < T::size(); j++) {
+        if (j) os << ", ";
+        os << openvdb::math::PrintCast(v[j]);
+    }
+    os << "]";
+    return os;
+}
+} // OPENVDB_VCL_NAMESPACE
+#endif // OPENVDB_USE_VCL
 
 #endif // OPENVDB_SIMD_SIMD_HAS_BEEN_INCLUDED

--- a/openvdb/openvdb/simd/Simd.h
+++ b/openvdb/openvdb/simd/Simd.h
@@ -25,14 +25,24 @@
 
 #if defined(OPENVDB_USE_VCL)
 #if defined(INSTRSET) && INSTRSET != OPENVDB_X86_INSTRSET
-    // If the user has imported their own version of VCL and it's already detected
-    // an architecture, disregard it and select the one OpenVDB was configured for.
-    #pragma message "Mismatching ISA's detected during downstream compilation."
-    #undef INSTRSET
+    // If we're here, then the value of INSTRSET does not match what OpenVDB
+    // was configured with. This can only happen if VCL is included before
+    // simd/Simd.h and detects different x86 compiler flags than what
+    // OPENVDB_X86_INSTRSET was configured for. It's not clear what to do in
+    // this situation as, technically, you can instrument openvdb libs with
+    // ISA A and recompile downstream with ISA B, so long as both are valid for
+    // the target architecture.
+    //
+    // For now we simply use the value of INSTRSET for VCL's selection of
+    // intrinsics, but we continue to use the value of OPENVDB_X86_INSTRSET
+    // for VDB's native vector size selection. Use a #warning directive which
+    // will error with -Werror but can ultimately be suppressed (pragmas won't
+    // show up with isystem etc).
+    #warning "OpenVDB: Mismatching requested ISA's detected during downstream compilation."
+#else
+    /// Tell VCL what instruction set to use.
+    #define INSTRSET OPENVDB_X86_INSTRSET
 #endif
-#define INSTRSET OPENVDB_X86_INSTRSET
-/// Import VCL and wrap it within our private namespace
-#define VCL_NAMESPACE OPENVDB_VCL_NAMESPACE
 #include <openvdb/ext/vcl/vectorclass.h>
 #include <openvdb/ext/vcl/vectorfp16.h>
 #else

--- a/openvdb/openvdb/unittest/CMakeLists.txt
+++ b/openvdb/openvdb/unittest/CMakeLists.txt
@@ -110,8 +110,8 @@ else()
     TestInit.cc
     TestInt32Metadata.cc
     TestInt64Metadata.cc
-    TestInternalOrigin.cc
     TestInternalNode.cc
+    TestInternalOrigin.cc
     TestLaplacian.cc
     TestLeaf.cc
     TestLeafBool.cc
@@ -132,8 +132,8 @@ else()
     TestMerge.cc
     TestMeshToVolume.cc
     TestMetadata.cc
-    TestMetaMap.cc
     TestMetadataIO.cc
+    TestMetaMap.cc
     TestMorphology.cc
     TestMultiResGrid.cc
     TestName.cc
@@ -141,9 +141,9 @@ else()
     TestNodeManager.cc
     TestNodeMask.cc
     TestNodeVisitor.cc
-    TestPCA.cc
     TestParticleAtlas.cc
     TestParticlesToLevelSet.cc
+    TestPCA.cc
     TestPointAdvect.cc
     TestPointAttribute.cc
     TestPointConversion.cc
@@ -172,6 +172,7 @@ else()
     TestQuat.cc
     TestRay.cc
     TestRootNode.cc
+    TestSimd.cc
     TestStats.cc
     TestStencils.cc
     TestStream.cc

--- a/openvdb/openvdb/unittest/TestSimd.cc
+++ b/openvdb/openvdb/unittest/TestSimd.cc
@@ -1,0 +1,270 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+#include <openvdb/version.h>
+ // @note  We leave it to our CI to test VCL On/Off - but if you have a VCL
+//  build, you can simply uncomment these to test the tuple interface.
+// #undef OPENVDB_USE_VCL
+// #undef INSTRSET
+#include <openvdb/Types.h>
+#include <openvdb/simd/Simd.h>
+
+#include <gtest/gtest.h>
+#include <unordered_set>
+
+using namespace openvdb;
+
+template <typename S, typename T, size_t E>
+struct SimdConfig
+{
+    using SimdT = S;
+    using ExpectedElementT = T;
+    static constexpr size_t ExpectedSize = E;
+};
+
+// List of integer and float types to tests. broad masks are tested implicitly
+// via each arithmetic type's test
+using TestTypes = ::testing::Types<
+    // int8
+    SimdConfig<simd::Vec16c, int8_t, 16>,
+    SimdConfig<simd::Vec32c, int8_t, 32>,
+    SimdConfig<simd::Vec64c, int8_t, 64>,
+    // int16
+    SimdConfig<simd::Vec8s, int16_t, 8>,
+    SimdConfig<simd::Vec16s, int16_t, 16>,
+    SimdConfig<simd::Vec32s, int16_t, 32>,
+    // int32
+    SimdConfig<simd::Vec4i, int32_t, 4>,
+    SimdConfig<simd::Vec8i, int32_t, 8>,
+    SimdConfig<simd::Vec16i, int32_t, 16>,
+    // int64
+    SimdConfig<simd::Vec2q, int64_t, 2>,
+    SimdConfig<simd::Vec4q, int64_t, 4>,
+    SimdConfig<simd::Vec8q, int64_t, 8>,
+    // uint8
+    SimdConfig<simd::Vec16uc, uint8_t, 16>,
+    SimdConfig<simd::Vec32uc, uint8_t, 32>,
+    SimdConfig<simd::Vec64uc, uint8_t, 64>,
+    // uint16
+    SimdConfig<simd::Vec8us, uint16_t, 8>,
+    SimdConfig<simd::Vec16us, uint16_t, 16>,
+    SimdConfig<simd::Vec32us, uint16_t, 32>,
+    // uint32
+    SimdConfig<simd::Vec4ui, uint32_t, 4>,
+    SimdConfig<simd::Vec8ui, uint32_t, 8>,
+    SimdConfig<simd::Vec16ui, uint32_t, 16>,
+    // uint64
+    SimdConfig<simd::Vec2uq, uint64_t, 2>,
+    SimdConfig<simd::Vec4uq, uint64_t, 4>,
+    SimdConfig<simd::Vec8uq, uint64_t, 8>,
+    /*
+    SimdConfig<simd::Vec8h, math::half, 8>,
+    SimdConfig<simd::Vec16h, math::half, 16>,
+    SimdConfig<simd::Vec32h, math::half, 32>,
+    */
+    // float
+    SimdConfig<simd::Vec4f, float, 4>,
+    SimdConfig<simd::Vec8f, float, 8>,
+    SimdConfig<simd::Vec16f, float, 16>,
+    // double
+    SimdConfig<simd::Vec2d, double, 2>,
+    SimdConfig<simd::Vec4d, double, 4>,
+    SimdConfig<simd::Vec8d, double, 8>
+>;
+
+template<typename Config>
+class TestSimd : public ::testing::Test {};
+
+TYPED_TEST_SUITE(TestSimd, TestTypes);
+
+struct TestSimdOperators
+{
+    static const std::array<double, 128>& input()
+    {
+        static const std::array<double, 128> data = [](){
+            std::array<double, 128> tmp;
+            // simple trigonometric pattern
+            for (size_t i = 0; i < 128; ++i) {
+                tmp[i] = std::abs(std::sin(double(i)) * 10.0);
+            }
+            // flip the sign of every second value in the second set
+            for (size_t i = 64; i < 128; i+=2) {
+                tmp[i] = -tmp[i];
+            }
+            return tmp;
+        }();
+        return data;
+    }
+
+    template <typename T, size_t Size>
+    static void makeUnique(std::array<T, Size>& a, std::array<T, Size>& b)
+    {
+        std::unordered_set<T> seen;
+        auto op = [&](std::array<T, Size>& data) {
+            for (size_t i = 0; i < Size; ++i) {
+                while (seen.count(data[i])) {
+                    if constexpr (openvdb::is_floating_point<T>::value) {
+                        data[i] = std::nextafter(data[i], std::numeric_limits<T>::infinity());
+                    }
+                    else {
+                        data[i] += static_cast<T>(i + 1);
+                    }
+                }
+                seen.insert(data[i]);
+            }
+        };
+        op(a);
+        op(b);
+    }
+
+    template <typename T>
+    static void ExpectNear(T a, T b)
+    {
+        if constexpr (std::is_floating_point_v<T>) {
+            EXPECT_NEAR(a, b, static_cast<T>(1e-3));
+        } else {
+            EXPECT_EQ(a, b);
+        }
+    }
+
+    template <typename SimdT>
+    static void test()
+    {
+        using T = typename simd::SimdTraits<SimdT>::ElementT;
+        constexpr int Size = simd::SimdTraits<SimdT>::size;
+        const auto& in = input();
+
+        std::array<T, Size> data_a;
+        std::array<T, Size> data_b;
+        std::transform(in.data(),      in.data() + Size,      data_a.begin(), [](double x) { return T(x); });
+        std::transform(in.data() + 64, in.data() + Size + 64, data_b.begin(), [](double x) { return T(x); });
+
+        makeUnique(data_a, data_b);
+
+        // test load
+        const SimdT a = simd::load<Size>(data_a.data());
+        const SimdT b = simd::load<Size>(data_b.data());
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(a[i], data_a[i]);
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(b[i], data_b[i]);
+
+        // ops
+        auto c = a + b;
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(c[i], T(data_a[i] + data_b[i]));
+        c = b - a;
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(c[i], T(data_b[i] - data_a[i]));
+        c = a * b;
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(c[i], T(data_a[i] * data_b[i]));
+
+        // interface
+        c = simd::min(a, b);
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(c[i], std::min(data_a[i], data_b[i]));
+        c = simd::max(a, b);
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(c[i], std::max(data_a[i], data_b[i]));
+        c = simd::pow2(a);
+        for (int i = 0; i < Size; ++i) ExpectNear(c[i], T(data_a[i] * data_a[i]));
+        c = simd::pow3(a);
+        for (int i = 0; i < Size; ++i) ExpectNear(c[i], T(data_a[i] * data_a[i] * data_a[i]));
+
+        // reductions
+        auto r1 = simd::horizontal_min(b);
+        auto r2 = data_b[0];
+        for (int i = 1; i < Size; ++i) r2 = std::min(r2, data_b[i]);
+        EXPECT_EQ(r1, r2);
+
+        r1 = simd::horizontal_max(b);
+        r2 = data_b[0];
+        for (int i = 1; i < Size; ++i) r2 = std::max(r2, data_b[i]);
+        EXPECT_EQ(r1, r2);
+
+        r1 = T(simd::horizontal_add(b));
+        r2 = data_b[0];
+        for (int i = 1; i < Size; ++i) r2 += data_b[i];
+        ExpectNear(r1, r2);
+
+        // signeds ops
+        if constexpr (std::is_signed_v<T>)
+        {
+            c = simd::abs(b);
+            for (int i = 0; i < Size; ++i) EXPECT_EQ(c[i], T(std::abs(data_b[i])));
+        }
+
+        // floating point interface
+        if constexpr (openvdb::is_floating_point<T>::value)
+        {
+            c = simd::sqrt(a);
+            for (int i = 0; i < Size; ++i) ExpectNear(c[i], std::sqrt(data_a[i]));
+            c = a / b;
+            for (int i = 0; i < Size; ++i) EXPECT_EQ(c[i], data_a[i] / data_b[i]);
+
+            EXPECT_TRUE(simd::horizontal_and(simd::is_finite(a)));
+            EXPECT_TRUE(simd::horizontal_and(simd::is_finite(b)));
+            EXPECT_TRUE(simd::horizontal_and(simd::is_finite(c)));
+        }
+
+        // comparisons/masks
+        std::array<bool, Size> expected;
+        auto mask = a == b;
+        for (int i = 0; i < Size; ++i) expected[i] = data_a[i] == data_b[i];
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(mask[i], expected[i]);
+
+        mask = SimdT(simd::horizontal_min(a)) == a;
+        r2 = data_a[0];
+        for (int i = 1; i < Size; ++i) r2 = std::min(r2, data_a[i]);
+        for (int i = 0; i < Size; ++i) expected[i] = r2 == data_a[i];
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(mask[i], expected[i]);
+
+        // lt, lte, gt, gte
+        mask = a < b;
+        for (int i = 0; i < Size; ++i) expected[i] = data_a[i] < data_b[i];
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(mask[i], expected[i]);
+
+        mask = b <= a;
+        for (int i = 0; i < Size; ++i) expected[i] = data_b[i] <= data_a[i];
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(mask[i], expected[i]);
+
+        mask = a > b;
+        for (int i = 0; i < Size; ++i) expected[i] = data_a[i] > data_b[i];
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(mask[i], expected[i]);
+
+        mask = b >= a;
+        for (int i = 0; i < Size; ++i) expected[i] = data_b[i] >= data_a[i];
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(mask[i], expected[i]);
+
+        // selects, blends, horizontal mask ops
+        std::array<T, Size> data_blend;
+        for (int i = 0; i < Size; ++i) data_blend[i] = i % 2 ? data_a[i] : data_b[i];
+        const SimdT blend = simd::load<Size>(data_blend.data());
+
+        mask = blend == a;
+        EXPECT_FALSE(simd::horizontal_and(mask));
+        EXPECT_TRUE(simd::horizontal_or(mask));
+
+        mask = blend == b;
+        EXPECT_FALSE(simd::horizontal_and(mask));
+        EXPECT_TRUE(simd::horizontal_or(mask));
+
+        EXPECT_EQ(simd::horizontal_count(mask), Size/2);
+
+        c = simd::select(mask, b, a);
+        for (int i = 0; i < Size; ++i) EXPECT_EQ(c[i], data_blend[i]);
+
+        mask = SimdT(data_a[Size-1]) == a;
+        EXPECT_EQ(simd::horizontal_find_first(mask), Size-1);
+
+        mask = b == a;
+        EXPECT_EQ(simd::horizontal_find_first(mask), -1);
+    }
+};
+
+TYPED_TEST(TestSimd, Operators)
+{
+    using SimdT = typename TypeParam::SimdT;
+    using ExpectedElementT = typename TypeParam::ExpectedElementT;
+    constexpr size_t ExpectedSize = TypeParam::ExpectedSize;
+
+    // coule be static, but nicer to fail at test runtime
+    EXPECT_TRUE((std::is_same_v<typename simd::SimdTraits<SimdT>::ElementT, ExpectedElementT>));
+    EXPECT_EQ(simd::SimdTraits<SimdT>::size, ExpectedSize);
+
+    TestSimdOperators::test<SimdT>();
+}

--- a/openvdb/openvdb/version.h.in
+++ b/openvdb/openvdb/version.h.in
@@ -164,10 +164,16 @@
 #endif
 
 #ifndef OPENVDB_X86_INSTRSET
-// The instruction set enumerated value that was detected when OpenVDB was
-// configured. When downstream software build against OpenVDB, this value
-// will be checked against the ISA selected and a warning will be issued
-// if the values differ.
+// The instruction set enumerated value that was set when OpenVDB was
+// configured, representing the desired target architecture. The value is used
+// to control how various methods choose appropriate hardware instructions and
+// types. Note however that this value does not currently preclude OpenVDB
+// libraries from containing other types of instructions, especially if these
+// were provided manually at configure time (e.g. -m flags).
+//
+// If you're using VCL, then this value should always match the detected
+// INTRSET define that VCL selects. See simd/Simd.h for more.
+//
 // The following values of OPENVDB_X86_INSTRSET are currently defined and
 // match the existing behaviour in VCL:
 //   0:  Unknown or unspecified
@@ -180,6 +186,7 @@
 //   8:  AVX2
 //   9:  AVX512F
 //   10: AVX512BW/DQ/VL
+//
 // In the future, OPENVDB_X86_INSTRSET = 11 may include AVX512VBMI and
 // AVX512VBMI2, but this decision cannot be made before the market situation
 // for CPUs with these instruction sets is better known


### PR DESCRIPTION
    Changes to internal copy of VCL to improve use with other installs:
    
     - Various defines and guards have been prefixed with OPENVDB_VCL_.
     - VCL_NAMESPACE has been removed in favour of an explicit OPENVDB_VCL_NAMESPACE.
   
    Various improvements to Simd.hh
    
     - Removed unused functions and unused half/base bit vector types
     - Removed global namespaced lambdas
     - Improved documentation
     - More tests for SIMD interface
    
    Added documentation for current ISA targeting and SIMD usage